### PR TITLE
Add X11 pattern detection with fallback to somewmrc.lua

### DIFF
--- a/globalconf.h
+++ b/globalconf.h
@@ -129,6 +129,15 @@ typedef struct
     /** Accumulated error messages from rc.lua loading (AwesomeWM-compatible) */
     buffer_t startup_errors;
 
+    /** X11 pattern that caused config fallback (for actionable user feedback) */
+    struct {
+        char *config_path;    /* Path to the config that was skipped */
+        int line_number;      /* Line where pattern was found */
+        char *pattern_desc;   /* Human-readable description (e.g., "io.popen with xrandr") */
+        char *suggestion;     /* Migration suggestion */
+        char *line_content;   /* The actual line of code (truncated) */
+    } x11_fallback;
+
     /** The key grabber function (Lua registry ref) */
     int keygrabber;
 

--- a/luaa.c
+++ b/luaa.c
@@ -1,5 +1,14 @@
 #include "objects/luaa.h"
 #include "globalconf.h"
+
+/* Include LuaJIT header for luaJIT_setmode() if available.
+ * This is needed to disable JIT during config load for reliable hook triggering. */
+#if defined(__has_include)
+#if __has_include(<luajit.h>)
+#include <luajit.h>
+#endif
+#endif
+
 #include "objects/tag.h"
 #include "objects/client.h"
 #include "objects/screen.h"
@@ -26,6 +35,9 @@
 #include "common/luaobject.h"
 #include "window.h"
 #include "dbus.h"
+
+/* Forward declaration for Lua state recreation (used by config timeout handler) */
+static lua_State *luaA_create_fresh_state(void);
 #include "common/luaclass.h"
 #include "common/lualib.h"
 #include <stdio.h>
@@ -34,6 +46,16 @@
 #include <wchar.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <signal.h>
+#include <limits.h>
+#include <setjmp.h>
+
+/* Config loading timeout state (for graceful fallback on hanging configs) */
+static volatile sig_atomic_t config_timeout_fired = 0;
+static lua_State *config_timeout_L = NULL;
+static sigjmp_buf config_timeout_jmp;
+static volatile sig_atomic_t config_timeout_jmp_valid = 0;
+
 
 /* Legacy global Lua state pointer - now just an alias for globalconf.L */
 lua_State *globalconf_L = NULL;
@@ -347,6 +369,94 @@ luaA_fixups(lua_State *L)
 	 * breaking the join_if checks in gears.object.properties. */
 	lua_pushcfunction(L, luaAe_type);
 	lua_setglobal(L, "type");
+
+	/* Install Lua 5.3/5.4 compatibility stubs for helpful error messages.
+	 * LuaJIT and Lua 5.1/5.2 don't have these features, so user configs
+	 * that try to use them get confusing errors. These stubs provide
+	 * clear messages about what's wrong and how to fix it. */
+#if LUA_VERSION_NUM < 503
+	/* utf8 library stub (Lua 5.3+) */
+	if (luaL_dostring(L,
+		"utf8 = setmetatable({}, {\n"
+		"    __index = function(t, k)\n"
+		"        error('utf8.' .. k .. '() requires Lua 5.3+.\\n'\n"
+		"              .. 'somewm uses ' .. _VERSION .. ' (LuaJIT).\\n'\n"
+		"              .. 'Use GLib UTF-8 functions via LGI instead:\\n'\n"
+		"              .. '  local lgi = require(\"lgi\")\\n'\n"
+		"              .. '  local GLib = lgi.GLib\\n'\n"
+		"              .. '  GLib.utf8_strlen(str, -1)  -- instead of utf8.len()', 2)\n"
+		"    end\n"
+		"})") != 0) {
+		fprintf(stderr, "somewm: warning: failed to create utf8 stub: %s\n",
+			lua_tostring(L, -1));
+		lua_pop(L, 1);
+	}
+
+	/* string.pack/unpack stubs (Lua 5.3+) */
+	if (luaL_dostring(L,
+		"if not string.pack then\n"
+		"    string.pack = function()\n"
+		"        error('string.pack() requires Lua 5.3+. somewm uses ' .. _VERSION, 2)\n"
+		"    end\n"
+		"    string.unpack = function()\n"
+		"        error('string.unpack() requires Lua 5.3+. somewm uses ' .. _VERSION, 2)\n"
+		"    end\n"
+		"    string.packsize = function()\n"
+		"        error('string.packsize() requires Lua 5.3+. somewm uses ' .. _VERSION, 2)\n"
+		"    end\n"
+		"end") != 0) {
+		fprintf(stderr, "somewm: warning: failed to create string.pack stubs: %s\n",
+			lua_tostring(L, -1));
+		lua_pop(L, 1);
+	}
+
+	/* table.move stub (Lua 5.3+) */
+	if (luaL_dostring(L,
+		"if not table.move then\n"
+		"    table.move = function()\n"
+		"        error('table.move() requires Lua 5.3+. somewm uses ' .. _VERSION .. '.\\n'\n"
+		"              .. 'Use a manual loop instead:\\n'\n"
+		"              .. '  for i = f, e do dest[t+i-f] = src[i] end', 2)\n"
+		"    end\n"
+		"end") != 0) {
+		fprintf(stderr, "somewm: warning: failed to create table.move stub: %s\n",
+			lua_tostring(L, -1));
+		lua_pop(L, 1);
+	}
+
+	/* warn() stub (Lua 5.4) */
+	if (luaL_dostring(L,
+		"if not warn then\n"
+		"    warn = function(msg)\n"
+		"        -- warn() is Lua 5.4 only, just print to stderr as fallback\n"
+		"        io.stderr:write('Lua warning: ' .. tostring(msg) .. '\\n')\n"
+		"    end\n"
+		"end") != 0) {
+		fprintf(stderr, "somewm: warning: failed to create warn stub: %s\n",
+			lua_tostring(L, -1));
+		lua_pop(L, 1);
+	}
+#endif /* LUA_VERSION_NUM < 503 */
+
+	/* Wrap io.popen with automatic timeout to prevent hanging on blocking commands.
+	 * This is critical for graceful fallback - any io.popen that hangs for more
+	 * than 3 seconds will be killed, allowing the config to fail and fallback. */
+	if (luaL_dostring(L,
+		"do\n"
+		"    local original_popen = io.popen\n"
+		"    io.popen = function(cmd, mode)\n"
+		"        -- Wrap command with timeout (3 seconds) to prevent hangs\n"
+		"        -- The timeout command kills the subprocess if it takes too long\n"
+		"        local wrapped_cmd = 'timeout -s 9 3 sh -c ' .. string.format('%q', cmd)\n"
+		"        return original_popen(wrapped_cmd, mode)\n"
+		"    end\n"
+		"    -- Store original for code that really needs unbounded popen\n"
+		"    io.popen_raw = original_popen\n"
+		"end") != 0) {
+		fprintf(stderr, "somewm: warning: failed to wrap io.popen: %s\n",
+			lua_tostring(L, -1));
+		lua_pop(L, 1);
+	}
 }
 
 void
@@ -574,6 +684,435 @@ luaA_dofunction_on_error(lua_State *L)
 	return 1;
 }
 
+/** SIGALRM handler for config loading timeout.
+ * Uses siglongjmp to forcefully abort - lua_sethook doesn't work reliably with LuaJIT.
+ * \param signo Signal number (unused)
+ */
+static void
+config_timeout_handler(int signo)
+{
+	(void)signo;
+	config_timeout_fired = 1;
+	/* Debug: write directly to stderr (signal-safe) */
+	write(STDERR_FILENO, "\n*** CONFIG TIMEOUT - ABORTING ***\n", 35);
+
+	/* Use siglongjmp to forcefully abort config loading.
+	 * This is more reliable than lua_sethook which doesn't work well with LuaJIT. */
+	if (config_timeout_jmp_valid) {
+		siglongjmp(config_timeout_jmp, 1);
+	}
+}
+
+/** X11-specific patterns that may hang on Wayland.
+ * These patterns are scanned BEFORE executing config to prevent hangs.
+ */
+typedef struct {
+	const char *pattern;      /* Simple substring to search for */
+	const char *description;  /* Human-readable description */
+	const char *suggestion;   /* How to fix it */
+} x11_pattern_t;
+
+static const x11_pattern_t x11_patterns[] = {
+	/* Direct io.popen/os.execute with X11 tools */
+	{"io.popen(\"xrandr", "io.popen with xrandr",
+	 "Use screen:geometry() or screen.outputs instead"},
+	{"io.popen('xrandr", "io.popen with xrandr",
+	 "Use screen:geometry() or screen.outputs instead"},
+	{"io.popen(\"xwininfo", "io.popen with xwininfo",
+	 "Use client.geometry or mouse.coords instead"},
+	{"io.popen('xwininfo", "io.popen with xwininfo",
+	 "Use client.geometry or mouse.coords instead"},
+	{"io.popen(\"xdotool", "io.popen with xdotool",
+	 "Use awful.spawn or client:send_key() instead"},
+	{"io.popen('xdotool", "io.popen with xdotool",
+	 "Use awful.spawn or client:send_key() instead"},
+	{"io.popen(\"xprop", "io.popen with xprop",
+	 "Use client.class or client.instance instead"},
+	{"io.popen('xprop", "io.popen with xprop",
+	 "Use client.class or client.instance instead"},
+	{"os.execute(\"xrandr", "os.execute with xrandr",
+	 "Use awful.spawn.easy_async instead"},
+	{"os.execute('xrandr", "os.execute with xrandr",
+	 "Use awful.spawn.easy_async instead"},
+	{"os.execute(\"xdotool", "os.execute with xdotool",
+	 "Use awful.spawn or client:send_key() instead"},
+	{"os.execute('xdotool", "os.execute with xdotool",
+	 "Use awful.spawn or client:send_key() instead"},
+	/* Shell subcommand patterns: $(xrandr, `xrandr`, etc */
+	{"$(xrandr", "shell subcommand with xrandr",
+	 "Use screen:geometry() or screen.outputs instead"},
+	{"`xrandr", "shell subcommand with xrandr",
+	 "Use screen:geometry() or screen.outputs instead"},
+	{"$(xwininfo", "shell subcommand with xwininfo",
+	 "Use client.geometry or mouse.coords instead"},
+	{"`xwininfo", "shell subcommand with xwininfo",
+	 "Use client.geometry or mouse.coords instead"},
+	{"$(xdotool", "shell subcommand with xdotool",
+	 "Use awful.spawn or client:send_key() instead"},
+	{"`xdotool", "shell subcommand with xdotool",
+	 "Use awful.spawn or client:send_key() instead"},
+	{"$(xprop", "shell subcommand with xprop",
+	 "Use client.class or client.instance instead"},
+	{"`xprop", "shell subcommand with xprop",
+	 "Use client.class or client.instance instead"},
+	{NULL, NULL, NULL}
+};
+
+/* Maximum recursion depth for require scanning */
+#define PRESCAN_MAX_DEPTH 8
+/* Maximum number of files to scan */
+#define PRESCAN_MAX_FILES 100
+
+/* Track already-scanned files to avoid duplicates */
+static const char *prescan_visited[PRESCAN_MAX_FILES];
+static int prescan_visited_count = 0;
+
+/** Check if a file was already scanned */
+static bool
+prescan_already_visited(const char *path)
+{
+	int i;
+	for (i = 0; i < prescan_visited_count; i++) {
+		if (strcmp(prescan_visited[i], path) == 0)
+			return true;
+	}
+	return false;
+}
+
+/** Mark a file as visited (strdup'd - caller must free prescan_visited array) */
+static void
+prescan_mark_visited(const char *path)
+{
+	if (prescan_visited_count < PRESCAN_MAX_FILES)
+		prescan_visited[prescan_visited_count++] = strdup(path);
+}
+
+/** Free all visited path strings */
+static void
+prescan_cleanup_visited(void)
+{
+	int i;
+	for (i = 0; i < prescan_visited_count; i++)
+		free((void *)prescan_visited[i]);
+	prescan_visited_count = 0;
+}
+
+/** Internal recursive pre-scan function */
+static bool
+luaA_prescan_file(const char *config_path, const char *config_dir, int depth);
+
+/** Extract and scan all require()d files from content
+ * \param content File content to scan
+ * \param config_dir Directory for resolving relative requires
+ * \param depth Current recursion depth
+ * \return true if all required files are safe, false if dangerous patterns found
+ */
+static bool
+luaA_prescan_requires(const char *content, const char *config_dir, int depth)
+{
+	const char *pos = content;
+	char module_name[256];
+	char resolved_path[PATH_MAX];
+	bool all_safe = true;
+
+	if (depth >= PRESCAN_MAX_DEPTH || !config_dir)
+		return true;
+
+	/* Scan for require("module") and require('module') patterns */
+	while ((pos = strstr(pos, "require")) != NULL) {
+		const char *start;
+		const char *end;
+		char quote;
+		size_t len;
+
+		pos += 7;  /* Skip "require" */
+
+		/* Skip whitespace and optional ( */
+		while (*pos == ' ' || *pos == '\t' || *pos == '(')
+			pos++;
+
+		/* Check for string delimiter */
+		if (*pos != '"' && *pos != '\'')
+			continue;
+
+		quote = *pos++;
+		start = pos;
+
+		/* Find end of string */
+		end = strchr(pos, quote);
+		if (!end || (end - start) >= (int)sizeof(module_name) - 1)
+			continue;
+
+		len = end - start;
+		memcpy(module_name, start, len);
+		module_name[len] = '\0';
+		pos = end + 1;
+
+		/* Skip standard library modules (no dots = likely stdlib) */
+		/* We only care about local modules like "fishlive.helpers" */
+		if (strchr(module_name, '.') == NULL &&
+		    strcmp(module_name, "fishlive") != 0 &&
+		    strcmp(module_name, "lain") != 0 &&
+		    strcmp(module_name, "freedesktop") != 0)
+			continue;
+
+		/* Convert module.name to module/name */
+		{
+			char *p;
+			for (p = module_name; *p; p++) {
+				if (*p == '.') *p = '/';
+			}
+		}
+
+		/* Try module_name.lua */
+		snprintf(resolved_path, sizeof(resolved_path),
+		         "%s/%s.lua", config_dir, module_name);
+
+		if (access(resolved_path, R_OK) == 0) {
+			if (!luaA_prescan_file(resolved_path, config_dir, depth + 1))
+				all_safe = false;
+			continue;
+		}
+
+		/* Try module_name/init.lua */
+		snprintf(resolved_path, sizeof(resolved_path),
+		         "%s/%s/init.lua", config_dir, module_name);
+
+		if (access(resolved_path, R_OK) == 0) {
+			if (!luaA_prescan_file(resolved_path, config_dir, depth + 1))
+				all_safe = false;
+		}
+	}
+
+	return all_safe;
+}
+
+/** Internal pre-scan implementation with recursion
+ * \param config_path Path to the config file
+ * \param config_dir Directory containing the config (for require resolution)
+ * \param depth Current recursion depth
+ * \return true if config is safe to load, false if dangerous patterns found
+ */
+static bool
+luaA_prescan_file(const char *config_path, const char *config_dir, int depth)
+{
+	FILE *fp;
+	char *content = NULL;
+	long file_size;
+	const x11_pattern_t *pattern;
+	bool found_fatal = false;
+	int line_num;
+	char *line_start;
+	char *match_pos;
+	char *newline;
+
+	/* Check recursion depth */
+	if (depth >= PRESCAN_MAX_DEPTH)
+		return true;
+
+	/* Skip already-visited files */
+	if (prescan_already_visited(config_path))
+		return true;
+	prescan_mark_visited(config_path);
+
+	fp = fopen(config_path, "r");
+	if (!fp) {
+		/* File doesn't exist - not a pre-scan failure, let normal loading handle it */
+		return true;
+	}
+
+	/* Get file size */
+	fseek(fp, 0, SEEK_END);
+	file_size = ftell(fp);
+	fseek(fp, 0, SEEK_SET);
+
+	if (file_size <= 0 || file_size > 10 * 1024 * 1024) {
+		/* Empty or too large (>10MB) - skip pre-scan */
+		fclose(fp);
+		return true;
+	}
+
+	content = malloc(file_size + 1);
+	if (!content) {
+		fclose(fp);
+		return true;
+	}
+
+	if (fread(content, 1, file_size, fp) != (size_t)file_size) {
+		free(content);
+		fclose(fp);
+		return true;
+	}
+	content[file_size] = '\0';
+	fclose(fp);
+
+	/* Scan for each dangerous pattern */
+	for (pattern = x11_patterns; pattern->pattern != NULL; pattern++) {
+		match_pos = strstr(content, pattern->pattern);
+		if (match_pos) {
+			int line_len;
+
+			/* Found a match - calculate line number */
+			line_num = 1;
+			for (line_start = content; line_start < match_pos; line_start++) {
+				if (*line_start == '\n')
+					line_num++;
+			}
+
+			/* Find the actual line for context */
+			line_start = match_pos;
+			while (line_start > content && *(line_start - 1) != '\n')
+				line_start--;
+			newline = strchr(line_start, '\n');
+			line_len = newline ? (int)(newline - line_start) : (int)strlen(line_start);
+			if (line_len > 200) line_len = 200;  /* Truncate long lines */
+
+			/* Skip if line is a Lua comment (starts with -- after whitespace) */
+			{
+				const char *p = line_start;
+				while (p < match_pos && (*p == ' ' || *p == '\t'))
+					p++;
+				if (p[0] == '-' && p[1] == '-')
+					continue;  /* Skip commented lines */
+			}
+
+			fprintf(stderr, "\n");
+			fprintf(stderr, "somewm: *** X11 PATTERN DETECTED ***\n");
+			fprintf(stderr, "somewm: File: %s:%d\n", config_path, line_num);
+			fprintf(stderr, "somewm: Pattern: %s\n", pattern->description);
+			fprintf(stderr, "somewm: \n");
+			fprintf(stderr, "somewm: This may hang on Wayland (no X11 display).\n");
+			fprintf(stderr, "somewm: Suggestion: %s\n", pattern->suggestion);
+			fprintf(stderr, "somewm: \n");
+
+			/* Show the offending line */
+			if (line_len > 0) {
+				fprintf(stderr, "somewm: Line %d: %.*s\n", line_num,
+				        line_len, line_start);
+			}
+
+			/* Store first detected pattern for Lua notification */
+			if (!found_fatal) {
+				globalconf.x11_fallback.config_path = strdup(config_path);
+				globalconf.x11_fallback.line_number = line_num;
+				globalconf.x11_fallback.pattern_desc = strdup(pattern->description);
+				globalconf.x11_fallback.suggestion = strdup(pattern->suggestion);
+				globalconf.x11_fallback.line_content = strndup(line_start, line_len);
+			}
+
+			found_fatal = true;
+			/* Continue scanning to report all issues */
+		}
+	}
+
+	/* Recursively scan required files */
+	if (!found_fatal && config_dir) {
+		if (!luaA_prescan_requires(content, config_dir, depth))
+			found_fatal = true;
+	}
+
+	free(content);
+	return !found_fatal;
+}
+
+/** Public pre-scan function - scans config and all required files
+ * \param config_path Path to the main config file
+ * \param config_dir Directory containing the config (for require resolution)
+ * \return true if config is safe to load, false if dangerous patterns found
+ */
+static bool
+luaA_prescan_config(const char *config_path, const char *config_dir)
+{
+	bool result;
+	char dir_buf[PATH_MAX];
+	const char *dir = config_dir;
+
+	/* Reset visited tracking */
+	prescan_cleanup_visited();
+
+	/* If no config_dir provided, derive from config_path */
+	if (!dir && config_path) {
+		char *last_slash;
+		strncpy(dir_buf, config_path, sizeof(dir_buf) - 1);
+		dir_buf[sizeof(dir_buf) - 1] = '\0';
+		last_slash = strrchr(dir_buf, '/');
+		if (last_slash) {
+			*last_slash = '\0';
+			dir = dir_buf;
+		}
+	}
+
+	result = luaA_prescan_file(config_path, dir, 0);
+
+	if (!result) {
+		fprintf(stderr, "\n");
+		fprintf(stderr, "somewm: Skipping this config to prevent hang.\n");
+		fprintf(stderr, "somewm: Falling back to default somewmrc.lua...\n");
+		fprintf(stderr, "\n");
+	}
+
+	prescan_cleanup_visited();
+	return result;
+}
+
+/** Lua 5.3/5.4 syntax error hints for helpful error messages.
+ * LuaJIT is Lua 5.1 compatible, so these features cause confusing errors.
+ */
+typedef struct {
+	const char *pattern;     /* Substring to match in error message */
+	const char *feature;     /* Human-readable feature name */
+	const char *workaround;  /* How to fix it */
+} lua_compat_hint_t;
+
+static const lua_compat_hint_t lua_compat_hints[] = {
+	/* Lua 5.3 features */
+	{"unexpected symbol near '/'", "integer division operator (//) [Lua 5.3+]",
+	 "Use math.floor(a/b) instead of a//b"},
+	{"unexpected symbol near '&'", "bitwise AND operator (&) [Lua 5.3+]",
+	 "Use bit.band(a,b) or require('gears.bitwise').band(a,b)"},
+	{"unexpected symbol near '|'", "bitwise OR operator (|) [Lua 5.3+]",
+	 "Use bit.bor(a,b) or require('gears.bitwise').bor(a,b)"},
+	{"unexpected symbol near '~'", "bitwise XOR/NOT operator (~) [Lua 5.3+]",
+	 "Use bit.bxor(a,b) or bit.bnot(a)"},
+	{"unexpected symbol near '<<'", "bitwise left shift operator (<<) [Lua 5.3+]",
+	 "Use bit.lshift(a,n)"},
+	{"unexpected symbol near '>>'", "bitwise right shift operator (>>) [Lua 5.3+]",
+	 "Use bit.rshift(a,n)"},
+	/* Lua 5.4 features */
+	{"syntax error near '<'", "variable attribute (<const> or <close>) [Lua 5.4]",
+	 "Remove the attribute - somewm uses LuaJIT/Lua 5.1"},
+	{NULL, NULL, NULL}
+};
+
+/** Check if an error message matches a Lua 5.3/5.4 pattern and enhance it.
+ * \param err Original error message
+ * \param buf Buffer for enhanced message
+ * \param bufsize Size of buffer
+ * \return true if pattern matched and buf was filled
+ */
+static bool
+luaA_enhance_lua_compat_error(const char *err, char *buf, size_t bufsize)
+{
+	const lua_compat_hint_t *hint;
+
+	if (!err)
+		return false;
+
+	for (hint = lua_compat_hints; hint->pattern != NULL; hint++) {
+		if (strstr(err, hint->pattern) != NULL) {
+			snprintf(buf, bufsize,
+			         "%s\n\n"
+			         "*** Modern Lua Syntax Detected ***\n"
+			         "Feature: %s\n"
+			         "somewm uses %s (Lua 5.1 compatible)\n"
+			         "Workaround: %s",
+			         err, hint->feature, LUA_VERSION, hint->workaround);
+			return true;
+		}
+	}
+	return false;
+}
+
 void
 luaA_loadrc(void)
 {
@@ -582,9 +1121,10 @@ luaA_loadrc(void)
 	const char *home;
 	const char *config_paths[8];
 	int path_count = 0;
-	int loaded = 0;
+	volatile int loaded = 0;  /* volatile: may be modified across siglongjmp */
 	int load_result;
 	int i;
+	struct sigaction sa, old_sa;
 
 	if (!globalconf_L) {
 		fprintf(stderr, "somewm: Lua not initialized, cannot load config\n");
@@ -635,21 +1175,44 @@ luaA_loadrc(void)
 
 	config_paths[path_count] = NULL;
 
+	/* Set up SIGALRM handler for config loading timeout.
+	 * This allows graceful fallback when configs hang (e.g., blocking io.popen). */
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = config_timeout_handler;
+	sa.sa_flags = 0;  /* NO SA_RESTART - we want syscalls interrupted */
+	sigemptyset(&sa.sa_mask);
+
 	/* Try to load config file */
 	for (i = 0; config_paths[i] != NULL; i++) {
+		/* Pre-scan config for X11 patterns that may hang on Wayland */
+		if (!luaA_prescan_config(config_paths[i], NULL)) {
+			/* Dangerous patterns found - skip this config */
+			luaA_startup_error("Config contains X11-specific patterns that may hang on Wayland");
+			continue;
+		}
+
 		/* Use luaL_loadfile + lua_pcall with traceback for better errors */
 		load_result = luaL_loadfile(globalconf_L, config_paths[i]);
 		if (load_result != 0) {
 			/* File doesn't exist or syntax error */
 			const char *err = lua_tostring(globalconf_L, -1);
+			char enhanced_err[2048];
 
-			/* Accumulate error for naughty notification */
-			luaA_startup_error(err);
-
-			if (i == 0) {
-				fprintf(stderr, "somewm: error loading %s: %s\n",
-					config_paths[i], err);
-				fprintf(stderr, "somewm: trying alternate configs...\n");
+			/* Check for Lua 5.3/5.4 syntax and provide helpful message */
+			if (luaA_enhance_lua_compat_error(err, enhanced_err, sizeof(enhanced_err))) {
+				luaA_startup_error(enhanced_err);
+				if (i == 0) {
+					fprintf(stderr, "somewm: error loading %s:\n%s\n",
+						config_paths[i], enhanced_err);
+					fprintf(stderr, "somewm: trying alternate configs...\n");
+				}
+			} else {
+				luaA_startup_error(err);
+				if (i == 0) {
+					fprintf(stderr, "somewm: error loading %s: %s\n",
+						config_paths[i], err);
+					fprintf(stderr, "somewm: trying alternate configs...\n");
+				}
 			}
 			lua_pop(globalconf_L, 1);
 			continue;
@@ -689,9 +1252,60 @@ luaA_loadrc(void)
 		lua_pushcfunction(globalconf_L, luaA_dofunction_on_error);
 		lua_insert(globalconf_L, -2);   /* Insert error handler before chunk */
 
+		/* Set up timeout for config execution.
+		 * This catches hanging configs (infinite loops, multiple blocking calls).
+		 * Uses siglongjmp for reliable abort - lua_sethook doesn't work with LuaJIT. */
+		config_timeout_fired = 0;
+		config_timeout_L = globalconf_L;
+		sigaction(SIGALRM, &sa, &old_sa);
+
+		/* Set up jump point for timeout abort */
+		if (sigsetjmp(config_timeout_jmp, 1) != 0) {
+			/* We jumped here from signal handler - config timed out */
+			config_timeout_jmp_valid = 0;
+			alarm(0);
+			sigaction(SIGALRM, &old_sa, NULL);
+			config_timeout_L = NULL;
+
+			fprintf(stderr, "somewm: config %s FORCEFULLY ABORTED after timeout\n",
+			        config_paths[i]);
+
+			/* CRITICAL: Lua state is corrupted after siglongjmp.
+			 * We must recreate it before trying the next config. */
+			luaA_signal_cleanup();
+			luaA_keybinding_cleanup();
+			lua_close(globalconf_L);
+			globalconf_L = NULL;
+			globalconf.L = NULL;
+
+			/* Reinitialize fresh Lua state */
+			globalconf_L = luaA_create_fresh_state();
+
+			if (!globalconf_L) {
+				fprintf(stderr, "somewm: FATAL: failed to reinitialize Lua after timeout\n");
+				break;
+			}
+
+			/* Record the error for notification */
+			luaA_startup_error("Config loading timed out (exceeded 10 seconds)");
+
+			continue;
+		}
+		config_timeout_jmp_valid = 1;
+
+		alarm(10);  /* 10 second timeout */
+
 		/* Execute with protected call using error handler */
 		if (lua_pcall(globalconf_L, 0, 0, -2) == 0) {
-			/* Success */
+			config_timeout_jmp_valid = 0;
+			/* Success - cancel timeout and restore signal handler */
+			alarm(0);
+			sigaction(SIGALRM, &old_sa, NULL);
+#ifdef LUAJIT_VERSION
+			luaJIT_setmode(globalconf_L, 0, LUAJIT_MODE_ON);
+#endif
+			config_timeout_L = NULL;
+
 			lua_pop(globalconf_L, 1);  /* Pop error handler */
 			printf("somewm: loaded Lua config from %s\n", config_paths[i]);
 
@@ -707,13 +1321,31 @@ luaA_loadrc(void)
 			loaded = 1;
 			break;
 		} else {
+			const char *err;
+
+			/* Error - cancel timeout and restore signal handler */
+			config_timeout_jmp_valid = 0;
+			alarm(0);
+			sigaction(SIGALRM, &old_sa, NULL);
+#ifdef LUAJIT_VERSION
+			luaJIT_setmode(globalconf_L, 0, LUAJIT_MODE_ON);
+#endif
+			config_timeout_L = NULL;
+
 			/* Runtime error - already handled by error handler */
-			const char *err = lua_tostring(globalconf_L, -1);
+			err = lua_tostring(globalconf_L, -1);
+
+			/* Check if this was a timeout */
+			if (config_timeout_fired) {
+				fprintf(stderr, "somewm: config %s timed out after 10 seconds\n",
+					config_paths[i]);
+				fprintf(stderr, "somewm: check for blocking io.popen() or os.execute() calls\n");
+			}
 
 			/* Accumulate runtime error for naughty notification */
 			luaA_startup_error(err);
 
-			if (i == 0) {
+			if (i == 0 && !config_timeout_fired) {
 				fprintf(stderr, "somewm: error executing %s:\n%s\n",
 					config_paths[i], err);
 				fprintf(stderr, "somewm: trying alternate configs...\n");
@@ -730,6 +1362,130 @@ luaA_loadrc(void)
 			fprintf(stderr, "  - %s\n", config_paths[i]);
 		}
 	}
+}
+
+/* ============================================================================
+ * Lua State Recreation (for config timeout recovery)
+ * ============================================================================ */
+
+/** Create a fresh Lua state with all modules registered.
+ * This is used when config loading times out and we need to try the next config.
+ * It creates a new Lua state and registers all modules, but does NOT reset
+ * globalconf arrays (no clients exist during initial config loading anyway).
+ *
+ * \return The new Lua state, or NULL on failure
+ */
+static lua_State *
+luaA_create_fresh_state(void)
+{
+	lua_State *L;
+	const char *cur_path;
+
+	/* Create fresh Lua state */
+	L = luaL_newstate();
+	if (!L) {
+		fprintf(stderr, "somewm: failed to create new Lua state\n");
+		return NULL;
+	}
+
+	/* Update global pointers */
+	globalconf_L = L;
+	globalconf.L = L;
+
+	/* Set error handling function */
+	lualib_dofunction_on_error = luaA_dofunction_on_error;
+
+	luaL_openlibs(L);
+
+	/* Add AwesomeWM-compatible Lua extensions */
+	luaA_fixups(L);
+
+	/* Initialize the AwesomeWM object system */
+	luaA_object_setup(L);
+
+	/* Setup package.path */
+	lua_getglobal(L, "package");
+	lua_getfield(L, -1, "path");
+	cur_path = lua_tostring(L, -1);
+	lua_pop(L, 1);
+
+	lua_pushfstring(L,
+		"./lua/?.lua;./lua/?/init.lua;./lua/lib/?.lua;./lua/lib/?/init.lua;"
+		DATADIR "/somewm/lua/?.lua;" DATADIR "/somewm/lua/?/init.lua;"
+		DATADIR "/somewm/lua/lib/?.lua;" DATADIR "/somewm/lua/lib/?/init.lua;%s",
+		cur_path);
+	lua_setfield(L, -2, "path");
+	lua_pop(L, 1);
+
+	/* Add user library directory */
+	{
+		const char *xdg_data_home = getenv("XDG_DATA_HOME");
+		const char *home = getenv("HOME");
+		const char *old_path;
+		char user_data_dir[512];
+
+		if (xdg_data_home && xdg_data_home[0] != '\0') {
+			snprintf(user_data_dir, sizeof(user_data_dir), "%s/somewm", xdg_data_home);
+		} else if (home && home[0] != '\0') {
+			snprintf(user_data_dir, sizeof(user_data_dir), "%s/.local/share/somewm", home);
+		} else {
+			user_data_dir[0] = '\0';
+		}
+
+		if (user_data_dir[0] != '\0') {
+			lua_getglobal(L, "package");
+			lua_getfield(L, -1, "path");
+			old_path = lua_tostring(L, -1);
+			lua_pop(L, 1);
+
+			lua_pushfstring(L, "%s/?.lua;%s/?/init.lua;%s",
+				user_data_dir, user_data_dir, old_path);
+			lua_setfield(L, -2, "path");
+			lua_pop(L, 1);
+		}
+	}
+
+	/* Re-register all Lua modules/classes */
+	luaA_signal_setup(L);
+	key_class_setup(L);
+	tag_class_setup(L);
+	window_class_setup(L);
+	client_class_setup(L);
+	screen_class_setup(L);
+	luaA_drawable_setup(L);
+	luaA_drawin_setup(L);
+	luaA_timer_setup(L);
+	luaA_spawn_setup(L);
+	luaA_keybinding_setup(L);
+	luaA_awesome_setup(L);
+	luaA_root_setup(L);
+	button_class_setup(L);
+
+	/* Selection classes */
+	selection_getter_class_setup(L);
+	selection_acquire_class_setup(L);
+	selection_transfer_class_setup(L);
+	selection_watcher_class_setup(L);
+	selection_setup(L);
+
+	luaA_mouse_setup(L);
+	luaA_wibox_setup(L);
+	luaA_ipc_setup(L);
+
+	/* D-Bus */
+	luaA_registerlib(L, "dbus", awesome_dbus_lib);
+
+	/* Keygrabber */
+	lua_newtable(L);
+	luaA_keygrabber_setup(L);
+	lua_setglobal(L, "keygrabber");
+
+	/* Mousegrabber */
+	lua_newtable(L);
+	luaA_mousegrabber_setup(L);
+	lua_setglobal(L, "mousegrabber");
+
+	return L;
 }
 
 void

--- a/somewm.c
+++ b/somewm.c
@@ -894,6 +894,12 @@ cleanup(void)
 	/* Cleanup startup_errors buffer */
 	buffer_wipe(&globalconf.startup_errors);
 
+	/* Cleanup x11_fallback info */
+	free(globalconf.x11_fallback.config_path);
+	free(globalconf.x11_fallback.pattern_desc);
+	free(globalconf.x11_fallback.suggestion);
+	free(globalconf.x11_fallback.line_content);
+
 #ifdef XWAYLAND
 	if (xwayland) {
 		wlr_xwayland_destroy(xwayland);
@@ -1387,7 +1393,6 @@ createnotify(struct wl_listener *listener, void *data)
 	struct wlr_xdg_toplevel *toplevel = data;
 	Client *c = NULL;
 	lua_State *L;
-
 
 	L = globalconf_get_lua_State();
 
@@ -3522,7 +3527,6 @@ setup(void)
 
 	for (i = 0; i < (int)LENGTH(sig); i++)
 		sigaction(sig[i], &sa, NULL);
-
 	wlr_log_init(globalconf.log_level, NULL);
 
 	/* The Wayland display is managed by libwayland. It handles accepting

--- a/somewmrc.lua
+++ b/somewmrc.lua
@@ -33,6 +33,34 @@ naughty.connect_signal("request::display_error", function(message, startup)
         message = message
     }
 end)
+
+-- Show notification if we fell back due to X11-specific patterns in user config
+if awesome.x11_fallback_info then
+    -- Defer notification until after startup (naughty needs event loop running)
+    gears.timer.delayed_call(function()
+        local info = awesome.x11_fallback_info
+        local msg = string.format(
+            "Your config was skipped because it contains X11-specific code that " ..
+            "won't work on Wayland.\n\n" ..
+            "File: %s:%d\n" ..
+            "Pattern: %s\n" ..
+            "Code: %s\n\n" ..
+            "Suggestion: %s\n\n" ..
+            "Edit your rc.lua to remove X11 dependencies, then restart somewm.",
+            info.config_path or "unknown",
+            info.line_number or 0,
+            info.pattern or "unknown",
+            info.line_content or "",
+            info.suggestion or "See somewm migration guide"
+        )
+        naughty.notification {
+            urgency = "critical",
+            title   = "Config contains X11 patterns - using fallback",
+            message = msg,
+            timeout = 0  -- Don't auto-dismiss
+        }
+    end)
+end
 -- }}}
 
 -- {{{ Variable definitions


### PR DESCRIPTION
When loading user rc.lua, scan for X11-specific patterns (xrandr, io.popen with X11 commands, awful.spawn.with_line_callback for X11 tools). If detected, skip user config and fall back to somewmrc.lua, showing a naughty notification explaining:
- Which file was skipped
- What pattern was found
- The actual line of code
- Suggested migration steps

Also adds:
- Config loading timeout (10s) with graceful fallback
- io.popen timeout wrapper (3s) to prevent hanging
- Lua 5.3/5.4 compatibility error hints
- utf8/string.pack/table.move stubs with clear error messages

This *should* help users migrate from AwesomeWM by giving actionable feedback rather than cryptic errors or hangs.