### PR TITLE
Fix floating client stacking: match AwesomeWM stack semantics

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -1853,8 +1853,12 @@ focusclient(Client *c, int lift)
 		return;
 
 	/* Raise client in stacking order if requested */
-	if (c && lift)
-		wlr_scene_node_raise_to_top(&c->scene->node);
+	if (c && lift) {
+		if (!client_is_unmanaged(c))
+			stack_client_append(c);
+		else
+			wlr_scene_node_raise_to_top(&c->scene->node);
+	}
 
 	if (c && client_surface(c) == old)
 		return;
@@ -3446,8 +3450,7 @@ setfullscreen(Client *c, int fullscreen)
 
 	c->bw = fullscreen ? 0 : get_border_width();
 	client_set_fullscreen_internal(c, fullscreen);
-	wlr_scene_node_reparent(&c->scene->node, layers[c->fullscreen
-			? LyrFS : some_client_get_floating(c) ? LyrFloat : LyrTile]);
+	wlr_scene_node_reparent(&c->scene->node, layers[c->fullscreen ? LyrFS : LyrTile]);
 
 	if (fullscreen) {
 		c->prev = c->geometry;

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -919,7 +919,7 @@ some_client_raise(Client *c)
 {
 	if (!c)
 		return;
-	stack_client_push(c);
+	stack_client_append(c);
 	stack_refresh();
 }
 
@@ -928,7 +928,7 @@ some_client_lower(Client *c)
 {
 	if (!c)
 		return;
-	stack_client_append(c);
+	stack_client_push(c);
 	stack_refresh();
 }
 

--- a/stack.c
+++ b/stack.c
@@ -102,6 +102,8 @@ stack_client_remove(Client *c)
 void
 stack_client_push(Client *c)
 {
+	size_t i;
+
 	/* Remove if already in stack */
 	stack_remove_internal(c);
 
@@ -113,8 +115,14 @@ stack_client_push(Client *c)
 			die("stack_client_push: realloc failed");
 	}
 
-	/* Add to end (top of stack) */
-	stack[stack_len++] = c;
+	/* Shift all elements up to make room at beginning */
+	for (i = stack_len; i > 0; i--) {
+		stack[i] = stack[i - 1];
+	}
+
+	/* Add to beginning (bottom of stack) - matches AwesomeWM */
+	stack[0] = c;
+	stack_len++;
 
 	/* TODO: ewmh_update_net_client_list_stacking(); */
 	stack_windows();
@@ -123,8 +131,6 @@ stack_client_push(Client *c)
 void
 stack_client_append(Client *c)
 {
-	size_t i;
-
 	/* Remove if already in stack */
 	stack_remove_internal(c);
 
@@ -136,14 +142,8 @@ stack_client_append(Client *c)
 			die("stack_client_append: realloc failed");
 	}
 
-	/* Shift all elements up to make room at beginning */
-	for (i = stack_len; i > 0; i--) {
-		stack[i] = stack[i - 1];
-	}
-
-	/* Add to beginning (bottom of stack) */
-	stack[0] = c;
-	stack_len++;
+	/* Add to end (top of stack) - matches AwesomeWM */
+	stack[stack_len++] = c;
 
 	/* TODO: ewmh_update_net_client_list_stacking(); */
 	stack_windows();


### PR DESCRIPTION
Swap stack_client_push/append to match AwesomeWM (push=bottom, append=top). Remove C floating property interception, let Lua handle it entirely. Not sure how I messed this up earlier, but I guess I don't toggle to floating often enough to notice it...