### PR TITLE
Implement drawin property setters and fix shape rendering (issue #23)

### DIFF
--- a/common/luaobject.c
+++ b/common/luaobject.c
@@ -277,10 +277,14 @@ luaA_object_emit_signal(lua_State *L, int oud,
     signal_t *sigfound;
     if(!obj) {
         warn("Trying to emit signal '%s' on non-object", name);
+        /* Still consume args to match successful path behavior */
+        lua_pop(L, nargs);
         return;
     }
     else if(lua_class->checker && !lua_class->checker(obj)) {
         warn("Trying to emit signal '%s' on invalid object", name);
+        /* Still consume args to match successful path behavior */
+        lua_pop(L, nargs);
         return;
     }
     sigfound = signal_array_getbyname(&obj->signals, name);


### PR DESCRIPTION
- Add setters for drawin properties: ontop, cursor, type, border_width
- Fix shape surface lifetime: keep Cairo surfaces alive until C reads them
- Fix mmap buffer initialization: zero buffer before copying Cairo data
- Clear Cairo surfaces to transparent on creation
- Match AwesomeWM signal patterns for property changes
- Add wibar transpacency bug for fun..fml