### PR TITLE
Implement AwesomeWM-compatible screenshot API

### DIFF
--- a/objects/drawable.h
+++ b/objects/drawable.h
@@ -83,4 +83,7 @@ struct wlr_buffer *drawable_create_buffer(drawable_t *d);
 /* Buffer creation from raw Cairo pixel data (for non-drawable Cairo surfaces) */
 struct wlr_buffer *drawable_create_buffer_from_data(int width, int height, const void *cairo_data, size_t cairo_stride);
 
+/* Create empty buffer for rendering into (for screenshots) */
+struct wlr_buffer *drawable_create_empty_buffer(int width, int height);
+
 #endif /* DRAWABLE_H */


### PR DESCRIPTION
- Add root.content() for full desktop capture
- Add screen.content for per-monitor screenshots
- Fix client.content to properly read GPU textures
- Composite widgets directly from Cairo surfaces

Closes #5
Closes #12 
Closes #13 
Closes #14 

*I know this seems trivial when I have bigger issues with the compositor, but I keep wanting to take screenshots and I'm too stubborn to install a 3rd party tool when I know I can implement it here natively.  Now I can start sharing images with others.