### PR TITLE
implement wlr-foreign-toplevel-management protocol

### DIFF
--- a/client.h
+++ b/client.h
@@ -104,6 +104,10 @@ client_activate_surface(struct wlr_surface *s, int activated)
 	struct wlr_xdg_toplevel *toplevel;
 #ifdef XWAYLAND
 	struct wlr_xwayland_surface *xsurface;
+#endif
+	if (!s)
+		return;
+#ifdef XWAYLAND
 	if ((xsurface = wlr_xwayland_surface_try_from_wlr_surface(s))) {
 		wlr_xwayland_surface_activate(xsurface, activated);
 		return;

--- a/objects/client.h
+++ b/objects/client.h
@@ -38,6 +38,7 @@
 typedef struct screen_t screen_t;
 typedef struct drawable_t drawable_t;
 typedef struct Monitor Monitor;
+struct wlr_foreign_toplevel_handle_v1;
 
 /* Type compatibility - map AwesomeWM types to Wayland types */
 typedef struct wlr_box area_t;
@@ -175,6 +176,12 @@ struct client_t
 #endif
     /** Decoration */
     struct wlr_xdg_toplevel_decoration_v1 *decoration;
+    struct wlr_foreign_toplevel_handle_v1 *toplevel_handle;
+    struct wl_listener foreign_request_activate;
+    struct wl_listener foreign_request_close;
+    struct wl_listener foreign_request_fullscreen;
+    struct wl_listener foreign_request_maximize;
+    struct wl_listener foreign_request_minimize;
     /** Pending resize serial for Wayland configure */
     uint32_t resize;
     /** Previous geometry for restore */

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -165,6 +165,7 @@ void some_compositor_quit(void);
  * These return pointers to internal state - use carefully
  */
 struct wlr_seat *some_get_seat(void);
+int some_has_exclusive_focus(void);
 struct wlr_cursor *some_get_cursor(void);
 struct wl_list *some_get_keyboard_groups(void);
 void some_get_cursor_position(double *x, double *y);


### PR DESCRIPTION
- Create toplevel handles with title, app_id, and output info for each client
- Handle activate, close, fullscreen, maximize, and minimize requests
- Update state when clients change (focus, output, title, window states)

Bug fixes discovered during implementation:
- Fix xytonode() crash when clicking layer-shell surfaces (incorrect struct offset check for LayerSurface vs Client type field)
- Fix layer-shell keyboard focus being cleared by client_focus_refresh() when no client is focused (add some_has_exclusive_focus() check)
- Add NULL check in client_activate_surface() for invalid surfaces

Thank you @vredesbyyrd for tracking this stuff down.

Closes: #28 