### PR TITLE
Add missing stdbool.h includes and libdrm for NixOS builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ LDFLAGS += -fsanitize=address,undefined
 endif
 
 # CFLAGS / LDFLAGS
-PKGS      = wayland-server xkbcommon libinput dbus-1 $(XLIBS)
+PKGS      = wayland-server xkbcommon libinput dbus-1 libdrm $(XLIBS)
 SOMECPPFLAGS += $(LUA_CFLAGS) $(CAIRO_CFLAGS) $(GLIB_CFLAGS)
 SOMECFLAGS = `$(PKG_CONFIG) --cflags $(PKGS)` $(WLR_INCS) $(SOMECPPFLAGS) $(SOMEDEVCFLAGS) $(CFLAGS)
 LDLIBS    = `$(PKG_CONFIG) --libs $(PKGS)` $(WLR_LIBS) $(LUA_LIBS) $(CAIRO_LIBS) $(GLIB_LIBS) -lm $(LIBS)

--- a/common/buffer.c
+++ b/common/buffer.c
@@ -29,6 +29,7 @@
 
 #include "common/buffer.h"
 
+#include <stdbool.h>
 #include <sysexits.h>
 #include <stdio.h>
 #include <stdarg.h>

--- a/common/lualib.h
+++ b/common/lualib.h
@@ -22,6 +22,7 @@
 #ifndef AWESOME_COMMON_LUALIB
 #define AWESOME_COMMON_LUALIB
 
+#include <stdbool.h>
 #include <lua.h>
 #include <lauxlib.h>
 #include <assert.h>

--- a/common/signal.h
+++ b/common/signal.h
@@ -22,6 +22,7 @@
 #ifndef AWESOME_COMMON_SIGNAL
 #define AWESOME_COMMON_SIGNAL
 
+#include <stdbool.h>
 #include "common/array.h"
 
 DO_ARRAY(const void *, cptr, DO_NOTHING)

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,40 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.stdenv.mkDerivation {
+  pname = "somewm";
+  version = "dev";
+
+  src = ./.;
+
+  strictDeps = true;
+
+  nativeBuildInputs = with pkgs; [
+    pkg-config
+  ];
+
+  buildInputs = with pkgs; [
+    cairo
+    dbus
+    gdk-pixbuf
+    glib
+    libdrm
+    libinput
+    xorg.libxcb
+    xorg.xcbutilwm
+    xorg.xcbutil
+    libxkbcommon
+    luajit
+    pango
+    wayland
+    wayland-scanner
+    wayland-protocols
+    wlroots_0_19
+    xwayland
+  ];
+
+  # Skip install phase for testing
+  installPhase = ''
+    mkdir -p $out/bin
+    cp somewm somewm-client $out/bin/
+  '';
+}

--- a/spawn.c
+++ b/spawn.c
@@ -15,6 +15,7 @@
 #include "objects/luaa.h"
 #include "objects/signal.h"
 
+#include <stdbool.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>


### PR DESCRIPTION
NixOS uses isolated builds where headers must be explicitly included. Added default.nix for local testing

Refer #30 (please oh please)