### PR TITLE
Fix SIGSEGV on Lua 5.3/5.4 in luaA_setfuncs

luaL_setfuncs crashes when passed NULL, unlike Lua 5.1's
luaL_register which handles it gracefully. Add NULL guard.

### DIFF
--- a/common/lualib.h
+++ b/common/lualib.h
@@ -151,6 +151,8 @@ luaA_registerlib(lua_State *L, const char *libname, const luaL_Reg *l)
 static inline void
 luaA_setfuncs(lua_State *L, const luaL_Reg *l)
 {
+    if (l == NULL)
+        return;
 #if LUA_VERSION_NUM >= 502
     luaL_setfuncs(L, l, 0);
 #else


### PR DESCRIPTION
refer #72