### PR TITLE
Fix urgent highlighting getting stuck

### DIFF
--- a/ewmh.c
+++ b/ewmh.c
@@ -227,8 +227,12 @@ ewmh_client_check_hints(client_t *c)
                 c->below = true;
             else if (atoms[i] == _NET_WM_STATE_MODAL)
                 c->modal = true;
-            else if (atoms[i] == _NET_WM_STATE_DEMANDS_ATTENTION)
-                c->urgent = true;
+            else if (atoms[i] == _NET_WM_STATE_DEMANDS_ATTENTION) {
+                lua_State *L = globalconf_get_lua_State();
+                luaA_object_push(L, c);
+                client_set_urgent(L, -1, true);
+                lua_pop(L, 1);
+            }
             else if (atoms[i] == _NET_WM_STATE_SKIP_TASKBAR)
                 c->skip_taskbar = true;
             else if (atoms[i] == _NET_WM_STATE_HIDDEN)

--- a/property.c
+++ b/property.c
@@ -273,8 +273,8 @@ property_update_xwayland_properties(client_t *c)
 		if (hints->flags & XCB_ICCCM_WM_HINT_WINDOW_GROUP)
 			client_set_group_window(L, -1, hints->window_group);
 
-		/* Urgency (handled by sethints listener for changes) */
-		c->urgent = xcb_icccm_wm_hints_get_urgency(hints);
+		/* Urgency (use proper API for signal emission) */
+		client_set_urgent(L, -1, xcb_icccm_wm_hints_get_urgency(hints));
 	}
 
 	/* Transient-for relationship */

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -577,9 +577,15 @@ some_client_get_floating(Client *c)
 void
 some_client_set_urgent(Client *c, int urgent)
 {
+	lua_State *L;
+
 	if (!c)
 		return;
-	c->urgent = urgent;
+	/* Use proper API for signal emission */
+	L = globalconf_get_lua_State();
+	luaA_object_push(L, c);
+	client_set_urgent(L, -1, urgent);
+	lua_pop(L, 1);
 	printstatus();
 }
 


### PR DESCRIPTION
Route all c->urgent assignments through client_set_urgent() to emit property::urgent signal. Keeps Lua border state in sync with C.

Closes #39 