### PR TITLE
Fix widget hover signals not working

### DIFF
--- a/event.h
+++ b/event.h
@@ -41,4 +41,9 @@ void event_emit_button(lua_State *L, button_event_t *ev);
 /* Handle mousegrabber if active - returns true if event consumed */
 bool event_handle_mousegrabber(double x, double y, int button_states[5]);
 
+/** Record that the given drawable contains the pointer.
+ * Emits mouse::enter/leave signals on drawables for widget hover events.
+ */
+void event_drawable_under_mouse(lua_State *L, int ud);
+
 #endif /* SOMEWM_EVENT_H */

--- a/globalconf.h
+++ b/globalconf.h
@@ -36,6 +36,7 @@ typedef struct client_t client_t;
 typedef struct tag_t tag_t;
 typedef struct screen_t screen_t;
 typedef struct drawin_t drawin_t;
+typedef struct drawable_t drawable_t;
 typedef struct keyb_t keyb_t;
 
 /* Forward declare button types */
@@ -286,8 +287,8 @@ typedef struct
     } ewmh;
 #endif
 
-    /** Drawable under mouse (stub) */
-    void *drawable_under_mouse;
+    /** Drawable under mouse for enter/leave signals */
+    drawable_t *drawable_under_mouse;
 
     /** X11 colormap (stub for XWayland) */
     uint32_t default_cmap;

--- a/objects/client.c
+++ b/objects/client.c
@@ -104,6 +104,7 @@
 /* #include "../somewm_types.h" - not needed, causes Client/client_t conflict */
 #include "../stack.h"
 #include "../util.h"
+#include "../event.h"
 
 /* Forward declaration - applies client geometry to wlroots scene graph */
 void apply_geometry_to_wlroots(client_t *c);

--- a/x11_compat.h
+++ b/x11_compat.h
@@ -626,11 +626,6 @@ static inline void *cairo_xcb_surface_create_for_bitmap(void *conn, void *screen
     return NULL;  /* Stub: Returns NULL on Wayland (X11-only function) */
 }
 
-static inline void *event_drawable_under_mouse(void *L, int idx) {
-    (void)L; (void)idx;
-    return NULL;  /* TODO: Get drawable under mouse */
-}
-
 static inline void cairo_surface_array_wipe(cairo_surface_array_t *arr) {
     if (arr->tab) {
         free(arr->tab);


### PR DESCRIPTION
Emit mouse::enter/leave signals on drawable instead of drawin, matching AwesomeWM behavior that Lua wibox/drawable.lua expects.\

Closes #78 