### PR TITLE
Fix nil _border_width on drawin causing placement errors

### DIFF
--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -1902,6 +1902,11 @@ luaA_drawin_class_setup(lua_State *L)
 	                        (lua_class_propfunc_t) luaA_drawin_set_border_width,
 	                        (lua_class_propfunc_t) luaA_drawin_get_border_width,
 	                        (lua_class_propfunc_t) luaA_drawin_set_border_width);
+	/* AwesomeWM pattern: _border_width alias used by placement.lua */
+	luaA_class_add_property(&drawin_class, "_border_width",
+	                        (lua_class_propfunc_t) luaA_drawin_set_border_width,
+	                        (lua_class_propfunc_t) luaA_drawin_get_border_width,
+	                        (lua_class_propfunc_t) luaA_drawin_set_border_width);
 	luaA_class_add_property(&drawin_class, "border_color",
 	                        (lua_class_propfunc_t) luaA_drawin_set_border_color,
 	                        (lua_class_propfunc_t) luaA_drawin_get_border_color,


### PR DESCRIPTION
Add _border_width property alias to drawin class