### PR TITLE
Fix autofocus not working on tag switch

### DIFF
--- a/lua/awful/widget/common.lua
+++ b/lua/awful/widget/common.lua
@@ -127,9 +127,7 @@ end
 -- @tparam[opt={}] table args
 function common.list_update(w, buttons, label, data, objects, args)
     -- update the widgets, creating them if needed
-    print(string.format("[LIST_UPDATE] Called with %d objects", #objects))
     w:reset()
-    print("[LIST_UPDATE] Layout reset complete")
     for i, o in ipairs(objects) do
         local cache = data[o]
 
@@ -139,10 +137,8 @@ function common.list_update(w, buttons, label, data, objects, args)
         end
 
         if not cache then
-            print(string.format("[LIST_UPDATE] Creating new widget for object %d", i))
             cache = (args and args.widget_template) and
                 custom_template(args) or default_template()
-            print(string.format("[LIST_UPDATE] Widget created: cache.primary=%s", tostring(cache.primary)))
 
             cache.primary.buttons = {common.create_buttons(buttons, o)}
 
@@ -157,13 +153,11 @@ function common.list_update(w, buttons, label, data, objects, args)
             cache._buttons = buttons
             data[o] = cache
         elseif cache.update_callback then
-            print(string.format("[LIST_UPDATE] Updating existing widget for object %d", i))
             cache.update_callback(cache.primary, o, i, objects)
         end
 
         local text, bg, bg_image, icon, item_args = label(o, cache.tb)
         item_args = item_args or {}
-        print(string.format("[LIST_UPDATE] Label for object %d: text='%s'", i, tostring(text)))
 
         -- The text might be invalid, so use pcall.
         if cache.tbm and (text == nil or text == "") then
@@ -210,11 +204,8 @@ function common.list_update(w, buttons, label, data, objects, args)
             cache.ib.forced_width  = nil
         end
 
-        print(string.format("[LIST_UPDATE] Adding widget %d to layout", i))
         w:add(cache.primary)
-        print(string.format("[LIST_UPDATE] Widget %d added successfully", i))
    end
-    print(string.format("[LIST_UPDATE] Complete - added %d widgets to layout", #objects))
 end
 
 return common

--- a/lua/awful/widget/taglist.lua
+++ b/lua/awful/widget/taglist.lua
@@ -684,19 +684,14 @@ function taglist.new(args, filter, buttons, style, update_function, base_widget)
         end
     end
     if instances == nil then
-        print("[TAGLIST_INIT] Initializing taglist signal handlers (first taglist created)")
         instances = setmetatable({}, { __mode = "k" })
         local function u(s)
-            print(string.format("[TAGLIST_UPDATE] Update triggered for screen=%s", tostring(s)))
             local i = instances[get_screen(s)]
             if i then
                 for _, tlist in pairs(i) do
-                    print("[TAGLIST_UPDATE] Calling _do_taglist_update on instance")
                     tlist._do_taglist_update()
                 end
             else
-                -- No screen? Update all taglists
-                print("[TAGLIST_UPDATE] No specific screen, updating all taglists")
                 for _, list in pairs(instances) do
                     for _, tlist in pairs(list) do
                         tlist._do_taglist_update()
@@ -706,13 +701,10 @@ function taglist.new(args, filter, buttons, style, update_function, base_widget)
         end
         local uc = function (c) return u(c.screen) end
         local ut = function (t)
-            print(string.format("[TAGLIST_SIGNAL] property::selected handler called, tag.screen=%s", tostring(t.screen)))
             return u(t.screen)
         end
         capi.client.connect_signal("property::active", uc)
-        print("[TAGLIST_INIT] Connecting to tag signals...")
         tag.attached_connect_signal(nil, "property::selected", ut)
-        print("[TAGLIST_INIT] Connected to property::selected")
         tag.attached_connect_signal(nil, "property::icon", ut)
         tag.attached_connect_signal(nil, "property::hide", ut)
         tag.attached_connect_signal(nil, "property::name", ut)

--- a/lua/wibox/init.lua
+++ b/lua/wibox/init.lua
@@ -303,14 +303,8 @@ end
 
 local function new(args)
     args = args or {}
-    print("[WIBOX.NEW] Creating wibox with args:")
-    print("[WIBOX.NEW]   width = " .. tostring(args.width))
-    print("[WIBOX.NEW]   height = " .. tostring(args.height))
     local ret = object()
     local w = capi.drawin(args)
-    print("[WIBOX.NEW] drawin created, checking geometry:")
-    print("[WIBOX.NEW]   w.width = " .. tostring(w.width))
-    print("[WIBOX.NEW]   w.height = " .. tostring(w.height))
 
     function w.get_wibox()
         return ret
@@ -324,13 +318,9 @@ local function new(args)
         return ret
     end
 
-    print("[WIBOX_INIT] Initial setup - w.visible=" .. tostring(w.visible))
     ret._drawable:_inform_visible(w.visible)
-    print("[WIBOX_INIT] After _inform_visible(" .. tostring(w.visible) .. ")")
     w:connect_signal("property::visible", function()
-        print("[WIBOX_PROPERTY_VISIBLE] Signal received, w.visible=" .. tostring(w.visible))
         ret._drawable:_inform_visible(w.visible)
-        print("[WIBOX_PROPERTY_VISIBLE] After _inform_visible(" .. tostring(w.visible) .. ")")
     end)
 
     --TODO v5 deprecate this and use `wibox.object`.
@@ -372,23 +362,15 @@ local function new(args)
             end
         end,
         __newindex = function(self, k,v)
-            print(string.format("[WIBOX.__newindex] k='%s', v=%s", k, tostring(v)))
             local has_setter = rawget(self, "set_"..k)
-            print(string.format("[WIBOX.__newindex] has set_%s method: %s", k, tostring(has_setter ~= nil)))
             if has_setter then
-                print("[WIBOX.__newindex] Calling set_" .. k)
                 self["set_"..k](self, v)
             else
                 local is_force_forward = force_forward[k]
                 local drawin_value = w[k]
-                print(string.format("[WIBOX.__newindex] force_forward[%s]=%s, w[%s]=%s",
-                      k, tostring(is_force_forward), k, tostring(drawin_value)))
                 if is_force_forward or drawin_value ~= nil then
-                    print("[WIBOX.__newindex] Forwarding to drawin: w." .. k .. " = " .. tostring(v))
                     w[k] = v
-                    print("[WIBOX.__newindex] After forwarding, w." .. k .. " = " .. tostring(w[k]))
                 else
-                    print("[WIBOX.__newindex] Storing in wrapper: rawset(self, " .. k .. ", " .. tostring(v) .. ")")
                     rawset(self, k, v)
                 end
             end

--- a/objects/client.c
+++ b/objects/client.c
@@ -1929,8 +1929,9 @@ client_hasproto(client_t *c, xcb_atom_t atom)
 void client_ban_unfocus(client_t *c)
 {
     /* Wait until the last moment to take away the focus from the window. */
-    if(globalconf.focus.client == c)
+    if(globalconf.focus.client == c) {
         client_unfocus(c);
+    }
 }
 
 /** Ban client and move it out of the viewport.
@@ -2111,9 +2112,6 @@ client_border_refresh(void)
         if(!c->scene || !c->border[0])
             continue;
 
-        fprintf(stderr, "[BORDER_REFRESH] Updating borders for client %p: width=%d\n",
-                (void*)c, c->border_width);
-
         /* Sync wlroots border width (bw) with Lua-facing border_width */
         c->bw = c->border_width;
 
@@ -2140,10 +2138,6 @@ client_border_refresh(void)
             /* Apply color to all 4 border rectangles */
             for(i = 0; i < 4; i++)
                 wlr_scene_rect_set_color(c->border[i], color_floats);
-
-            fprintf(stderr, "[BORDER_REFRESH] Applied color #%02x%02x%02x%02x to client %p\n",
-                    c->border_color.red, c->border_color.green,
-                    c->border_color.blue, c->border_color.alpha, (void*)c);
         }
     }
 }
@@ -2699,19 +2693,12 @@ client_resize_do(client_t *c, area_t geometry)
     area_t old_geometry;
     screen_t *new_screen = c->screen;
 
-    fprintf(stderr, "[CLIENT_RESIZE_DO] Called for client %p: geo=(%d,%d %dx%d)\n",
-            (void*)c, geometry.x, geometry.y, geometry.width, geometry.height);
-
     if(!new_screen || !screen_area_in_screen(new_screen, geometry))
         new_screen = screen_getbycoord(geometry.x, geometry.y);
 
     /* Also store geometry including border */
     old_geometry = c->geometry;
     c->geometry = geometry;
-
-    fprintf(stderr, "[CLIENT_RESIZE_DO] old_geo=(%d,%d %dx%d) new_geo=(%d,%d %dx%d)\n",
-            old_geometry.x, old_geometry.y, old_geometry.width, old_geometry.height,
-            geometry.x, geometry.y, geometry.width, geometry.height);
 
     luaA_object_push(L, c);
     if (!AREA_EQUAL(old_geometry, geometry))

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -760,18 +760,13 @@ luaA_screen_get_bounding_geometry(lua_State *L)
 		lua_getfield(L, 2, "honor_padding");
 		honor_padding = lua_toboolean(L, -1);
 		lua_pop(L, 1);
-
-		fprintf(stderr, "[GET_BOUNDING_GEO_C] honor_workarea=%d honor_padding=%d\n",
-			honor_workarea, honor_padding);
 	}
 
 	/* Use workarea if requested, otherwise full geometry */
 	geo = honor_workarea ? screen->workarea : screen->geometry;
 
-	fprintf(stderr, "[GET_BOUNDING_GEO_C] Returning: %dx%d+%d+%d\n",
-		geo.width, geo.height, geo.x, geo.y);
-
 	/* TODO: Apply honor_padding and margins if needed */
+	(void)honor_padding;
 
 	lua_newtable(L);
 	lua_pushinteger(L, geo.x);

--- a/objects/tag.c
+++ b/objects/tag.c
@@ -50,23 +50,18 @@ static void
 tag_client_emit_signal(tag_t *t, client_t *c, const char *signame)
 {
 	lua_State *L = globalconf_get_lua_State();
-	fprintf(stderr, "[TAG_CLIENT_EMIT] Emitting signal '%s' for client %p and tag %p\n",
-	        signame, (void*)c, (void*)t);
 	luaA_object_push(L, c);
 	luaA_object_push(L, t);
 	/* emit signal on client, with tag as argument */
-	fprintf(stderr, "[TAG_CLIENT_EMIT] Emitting '%s' on client (with tag as arg)\n", signame);
 	luaA_object_emit_signal(L, -2, signame, 1);
 	/* re-push tag */
 	luaA_object_push(L, t);
 	/* move tag before client */
 	lua_insert(L, -2);
 	/* emit signal on tag, with client as argument */
-	fprintf(stderr, "[TAG_CLIENT_EMIT] Emitting '%s' on tag (with client as arg)\n", signame);
 	luaA_object_emit_signal(L, -2, signame, 1);
 	/* Remove tag */
 	lua_pop(L, 1);
-	fprintf(stderr, "[TAG_CLIENT_EMIT] Done emitting signal '%s'\n", signame);
 }
 
 /** Tag a client with the tag on top of the stack.
@@ -221,12 +216,13 @@ luaA_tag_set_selected(lua_State *L, tag_t *tag)
 
 	if (tag->selected != selected) {
 		tag->selected = selected;
+		banning_need_update();
 		luaA_awm_object_emit_signal(L, -3, "property::selected", 0);
 
 		m = some_get_focused_monitor();
 		if (m) {
 			some_monitor_arrange(m);
-			some_focus_top_client(m);
+			/* Note: focus handled by Lua via property::selected signal → awful.permissions.check_focus_tag */
 		}
 	}
 	return 0;


### PR DESCRIPTION
Root cause: Clients were only added to globalconf.stack when they received focus (in focusclient()), not when they were initially managed. This caused focus.history.get() to fail because it uses client.visible(s, true) which queries globalconf.stack.

When switching tags:
1. focus.history.get() calls client.visible(s, stacked=true)
2. This queries globalconf.stack instead of globalconf.clients
3. New clients weren't in globalconf.stack yet
4. history.get() returned nil, so no client got focused

Fix: Add clients to globalconf.stack when managed, matching AwesomeWM's client_manage() behavior (line 2244).