### PR TITLE
Fix dynamic keybinding removal

### DIFF
--- a/lua/awful/root.lua
+++ b/lua/awful/root.lua
@@ -104,6 +104,9 @@ for _, type_name in ipairs { "button", "key" } do
         assert(value[1])
 
         table.insert(removed, value)
+
+        -- Trigger delayed sync to C layer (fix: upstream AwesomeWM is missing this)
+        delay()
     end
 
     capi.root["has_"..type_name] = function(item)


### PR DESCRIPTION
awful/root.lua's _remove_key function was adding to the `removed` table but never calling delay() to trigger the sync to the C layer. This meant keybinding removals only took effect if a subsequent append happened.

Add delay() call to _remove_key to match _append_key behavior.

Note: This appears to be a bug in upstream AwesomeWM's lib/awful/root.lua.

Closes #15 