### PR TITLE
Fix focus desync, floating stacking, and border corruption

### DIFF
--- a/somewm_api.c
+++ b/somewm_api.c
@@ -413,14 +413,17 @@ some_set_seat_keyboard_focus(Client *c)
 	struct wlr_keyboard *kb;
 
 	if (!c) {
-		/* NULL client = clear focus (handled in client_focus_refresh) */
+		/* NULL client = clear keyboard focus */
+		wlr_seat_keyboard_notify_clear_focus(seat);
 		return;
 	}
 
 	/* Get the client's surface */
 	surface = some_client_get_surface(c);
 	if (!surface || !surface->mapped) {
-		/* Surface not ready - skip seat focus update */
+		/* Surface not ready - clear seat focus to prevent input going to old window.
+		 * When surface maps, mapnotify() will call focusclient() to set focus. */
+		wlr_seat_keyboard_notify_clear_focus(seat);
 		return;
 	}
 

--- a/stack.c
+++ b/stack.c
@@ -199,6 +199,10 @@ client_get_layer(Client *c)
 		break;
 	}
 
+	/* Floating windows go above tiled windows */
+	if (some_client_get_floating(c))
+		return WINDOW_LAYER_FLOATING;
+
 	return WINDOW_LAYER_NORMAL;
 }
 
@@ -220,8 +224,9 @@ get_scene_layer(window_layer_t layer)
 	case WINDOW_LAYER_BELOW:
 		return LyrBottom;
 	case WINDOW_LAYER_NORMAL:
-		/* Return LyrTile for now; floating is handled elsewhere */
 		return LyrTile;
+	case WINDOW_LAYER_FLOATING:
+		return LyrFloat;
 	case WINDOW_LAYER_ABOVE:
 		return LyrTop;
 	case WINDOW_LAYER_FULLSCREEN:

--- a/stack.h
+++ b/stack.h
@@ -17,7 +17,8 @@ typedef enum {
 	WINDOW_LAYER_IGNORE,      /* Special: transient windows (follow parent) */
 	WINDOW_LAYER_DESKTOP,     /* Desktop windows (wallpaper) -> LyrBg */
 	WINDOW_LAYER_BELOW,       /* Below normal -> LyrBottom */
-	WINDOW_LAYER_NORMAL,      /* Normal windows -> LyrTile/LyrFloat */
+	WINDOW_LAYER_NORMAL,      /* Tiled windows -> LyrTile */
+	WINDOW_LAYER_FLOATING,    /* Floating windows -> LyrFloat */
 	WINDOW_LAYER_ABOVE,       /* Above normal (panels, docks) -> LyrTop */
 	WINDOW_LAYER_FULLSCREEN,  /* Fullscreen (only when focused) -> LyrFS */
 	WINDOW_LAYER_ONTOP,       /* Always on top -> LyrOverlay */


### PR DESCRIPTION
- Clear mouse tracking in client_unmanage() before signals
- Add WINDOW_LAYER_FLOATING for proper floating client stacking
- Clear seat focus when target surface is unmapped

Fixes #109 and #110 

Also refer #108 (but only a couple of those problems)