### PR TITLE
Use -c for config file to match AwesomeWM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to somewm will be documented in this file.
+
+## [Unreleased]
+
+### Breaking Changes
+
+- **CLI flags changed for AwesomeWM compatibility** (#4):
+  - `-c` now specifies config file (was `-C`)
+  - `-k` now runs config check (was `-c`)
+  - If you were using `-C /path/to/config`, change to `-c /path/to/config`
+  - If you were using `-c /path/to/config` for checking, change to `-k /path/to/config`
+
+## [0.4.0] - 2025-12-28
+
+### Added
+- Dynamic keybinding removal (#15)
+- Scroll wheel support in mousebinds (#16)
+- Complete button press/release signals on clients (#17)
+- Cursor theme changing via `root.cursor()` (#18)
+
+### Notes
+- XKB layout switching moved to 0.5.0 (Wayland limitation with documented workaround)
+
+## [0.3.0] - 2025-12-21
+
+Initial public release with core AwesomeWM compatibility.
+
+[Unreleased]: https://github.com/trip-zip/somewm/compare/0.4.0...HEAD
+[0.4.0]: https://github.com/trip-zip/somewm/compare/0.3.0...0.4.0
+[0.3.0]: https://github.com/trip-zip/somewm/releases/tag/0.3.0

--- a/somewm.c
+++ b/somewm.c
@@ -5531,22 +5531,22 @@ main(int argc, char *argv[])
 		{"help",    no_argument,       0, 'h'},
 		{"version", no_argument,       0, 'v'},
 		{"debug",   no_argument,       0, 'd'},
-		{"config",  required_argument, 0, 'C'},
+		{"config",  required_argument, 0, 'c'},
 		{"search",  required_argument, 0, 'L'},
 		{"startup", required_argument, 0, 's'},
-		{"check",   required_argument, 0, 'c'},
+		{"check",   required_argument, 0, 'k'},
 		{0, 0, 0, 0}
 	};
 
-	while ((c = getopt_long(argc, argv, "C:s:L:hdvc:", long_options, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "c:s:L:hdvk:", long_options, NULL)) != -1) {
 		switch (c) {
-		case 'C':
+		case 'c':
 			luaA_set_confpath(optarg);
 			break;
 		case 's':
 			startup_cmd = optarg;
 			break;
-		case 'c':
+		case 'k':
 			check_config = optarg;
 			break;
 		case 'L':
@@ -5594,11 +5594,11 @@ main(int argc, char *argv[])
 	return EXIT_SUCCESS;
 
 usage:
-	die("Usage: %s [-v] [-d] [-C config] [-L search_path] [-s startup_command] [-c config]\n"
+	die("Usage: %s [-v] [-d] [-c config] [-L search_path] [-s startup_command] [-k config]\n"
 	    "  -v, --version      Show version and diagnostic info\n"
 	    "  -d, --debug        Enable debug logging\n"
-	    "  -C, --config FILE  Use specified config file\n"
+	    "  -c, --config FILE  Use specified config file (AwesomeWM compatible)\n"
 	    "  -L, --search DIR   Add directory to Lua module search path\n"
 	    "  -s, --startup CMD  Run command after startup\n"
-	    "  -c, --check CONFIG Check config for Wayland compatibility issues", argv[0]);
+	    "  -k, --check CONFIG Check config for Wayland compatibility issues", argv[0]);
 }


### PR DESCRIPTION
BREAKING CHANGE: CLI flags changed for AwesomeWM compatibility
- `-c` now specifies config file (was `-C`)
- `-k` now runs config check (was `-c`)

Also adds CHANGELOG.md to track breaking changes.

Closes #4