### PR TITLE
Implement root.drawins() to return all drawin objects

### DIFF
--- a/root.c
+++ b/root.c
@@ -605,9 +605,15 @@ luaA_root_tags(lua_State *L)
 static int
 luaA_root_drawins(lua_State *L)
 {
-	/* TODO: Implement once we track all drawin objects globally
-	 * For now, return empty table as placeholder */
-	lua_newtable(L);
+	int i;
+
+	lua_createtable(L, globalconf.drawins.len, 0);
+
+	for (i = 0; i < globalconf.drawins.len; i++) {
+		luaA_object_push(L, globalconf.drawins.tab[i]);
+		lua_rawseti(L, -2, i + 1);
+	}
+
 	return 1;
 }
 


### PR DESCRIPTION
Previously returned an empty table. Now iterates globalconf.drawins and returns all drawin (wibox) objects, matching AwesomeWM behavior.

Closes #20 