### PR TITLE
Fix use-after-free crash on client:kill()

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -4578,6 +4578,13 @@ unmapnotify(struct wl_listener *listener, void *data)
 
 	wlr_scene_node_destroy(&c->scene->node);
 	c->scene = NULL;  /* Mark as cleaned up so destroynotify won't double-remove */
+
+	/* Clear titlebar scene buffer pointers - they were children of c->scene
+	 * and are now freed. Prevents use-after-free in refresh callbacks. */
+	for (client_titlebar_t bar = CLIENT_TITLEBAR_TOP; bar < CLIENT_TITLEBAR_COUNT; bar++) {
+		c->titlebar[bar].scene_buffer = NULL;
+	}
+
 	printstatus();
 	motionnotify(0, NULL, 0, 0, 0, 0);
 }


### PR DESCRIPTION
Clear titlebar scene_buffer pointers in unmapnotify() after destroying the scene tree. Previously, these pointers remained dangling after wlr_scene_node_destroy() freed the buffers, causing a use-after-free crash if some_refresh() ran before destroynotify() could NULL the drawable pointers.

The race window is timing-dependent - more likely to trigger on systems with slower event dispatch (nvidia, nested wayland, etc...)

Refers #123 