### PR TITLE
feat(screen): add screen.scale property for fractional scaling

### DIFF
--- a/somewm-client.c
+++ b/somewm-client.c
@@ -91,7 +91,8 @@ print_usage(const char *progname)
 	fprintf(stderr, "  screen list                    List all screens/monitors\n");
 	fprintf(stderr, "  screen focused                 Get focused screen info\n");
 	fprintf(stderr, "  screen count                   Get number of screens\n");
-	fprintf(stderr, "  screen clients <ID>            List clients on a screen\n\n");
+	fprintf(stderr, "  screen clients <ID>            List clients on a screen\n");
+	fprintf(stderr, "  screen scale [screen] [value]  Get or set screen scale\n\n");
 
 	fprintf(stderr, "SCREENSHOT COMMANDS:\n");
 	fprintf(stderr, "  screenshot save <path> [--transparent]\n");


### PR DESCRIPTION
Add read/write screen.scale Lua property to configure output scale. Apps supporting wp_fractional_scale_v1 will render at native resolution. Add `screen scale` command to somewm-client

It's not perfect, I think there are still some HiDPI things to work out, but I am not on a good enough monitor until Monday to really dig in further.

## screen.scale Usage

  ### CLI (somewm-client)

  #### Get current scale
  somewm-client screen scale

  #### Set focused screen to 1.5x
  somewm-client screen scale 1.5

  #### Get scale of screen 1
  somewm-client screen scale 1

  #### Set screen 1 to 1.5x
  somewm-client screen scale 1 1.5

  ### rc.lua

  -- Set on startup (in request::desktop_decoration)
  screen.connect_signal("request::desktop_decoration", function(s)
    if s.index == 1 then s.scale = 1.5 end
    -- ... rest of your config
  end)

  -- Or set dynamically anytime
  screen.primary.scale = 1.5
  screen[2].scale = 1.25

  Notes

  - Apps supporting wp_fractional_scale_v1 render at native resolution
  - Wibars use HiDPI surfaces for sharp text at fractional scales
  - Workarea/struts automatically recalculate after scale changes

Refers #134

