### PR TITLE
nix: add meson and ninja to nativeBuildInputs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -15,6 +15,8 @@ pkgs.stdenv.mkDerivation {
   strictDeps = true;
 
   nativeBuildInputs = with pkgs; [
+    meson
+    ninja
     pkg-config
     gobject-introspection  # Required for lgi typelib discovery
     makeWrapper


### PR DESCRIPTION
Add meson/ninja to default nix

Refer #143 