### PR TITLE
fix(mouse): correct button state mapping in mousegrabber

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -762,8 +762,8 @@ buttonpress(struct wl_listener *listener, void *data)
 		int idx = -1;
 		switch (event->button) {
 		case 0x110: idx = 0; break;  /* BTN_LEFT -> button 1 */
-		case 0x111: idx = 1; break;  /* BTN_RIGHT -> button 2 */
-		case 0x112: idx = 2; break;  /* BTN_MIDDLE -> button 3 */
+		case 0x112: idx = 1; break;  /* BTN_MIDDLE -> button 2 */
+		case 0x111: idx = 2; break;  /* BTN_RIGHT -> button 3 */
 		case 0x113: idx = 3; break;  /* BTN_SIDE -> button 4 */
 		case 0x114: idx = 4; break;  /* BTN_EXTRA -> button 5 */
 		}

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -1270,8 +1270,8 @@ some_set_cursor_position(double x, double y, int silent)
 
 /*
  * Get mouse button states
- * Returns pressed state for buttons 1-5 (left, right, middle, side1, side2)
- * Button mapping: BTN_LEFT=1, BTN_RIGHT=2, BTN_MIDDLE=3, BTN_SIDE=4, BTN_EXTRA=5
+ * Returns pressed state for buttons 1-5 (left, middle, right, side1, side2)
+ * Button mapping: BTN_LEFT=1, BTN_MIDDLE=2, BTN_RIGHT=3, BTN_SIDE=4, BTN_EXTRA=5
  *
  * NOTE: We use globalconf.button_state which is tracked in buttonpress(),
  * NOT seat->pointer_state. This is critical for mousegrabber to work correctly.


### PR DESCRIPTION
The button state array sent to mousegrabber callbacks was using hardware order (left, right, middle) instead of X11 button number order (left, middle, right).

This caused coords.buttons[2] to report the right button state instead of middle, breaking any Lua code that checked middle button state in mousegrabber callbacks.

Fixes the mapping to match X11/AwesomeWM convention:
- buttons[1] = BTN_LEFT
- buttons[2] = BTN_MIDDLE
- buttons[3] = BTN_RIGHT