### PR TITLE
fix(hidpi): support fractional scaling for widgets

### DIFF
--- a/objects/drawable.h
+++ b/objects/drawable.h
@@ -46,6 +46,9 @@ typedef struct drawable_t {
 	/* Surface has been drawn to and is ready to display */
 	bool refreshed;
 
+	/* Scale factor the surface was created at (for HiDPI) */
+	float surface_scale;
+
 	/* Object validity flag - false when being garbage collected */
 	bool valid;
 


### PR DESCRIPTION
Fix blurry widgets and incorrect backgrounds at fractional scales (e.g., 1.5x, 2.5x) by properly handling HiDPI scaling throughout the drawable/drawin rendering pipeline.

Key changes:
- Track surface_scale in drawable_t to detect when scale changes
- Use floorf for physical dimensions to match Cairo's device_scale
- Scale shape mask coordinates when applying to HiDPI surfaces
- Emit property::scale signal to trigger widget redraws on scale change
- Recreate surfaces when drawins become visible at different scale

Refer #134