### PR TITLE
fix(build): use absolute path for DATADIR in meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -192,7 +192,7 @@ add_project_arguments(
   '-D_POSIX_C_SOURCE=200809L',
   '-DVERSION="' + version + '"',
   '-DCOMMIT_DATE="' + commit_date + '"',
-  '-DDATADIR="' + get_option('datadir') + '"',
+  '-DDATADIR="' + get_option('prefix') / get_option('datadir') + '"',
   '-DSYSCONFDIR="' + get_option('sysconfdir') + '"',
   '-DWLROOTS_VERSION="' + wlroots_version + '"',
   '-DLGI_VERSION="' + lgi_version + '"',


### PR DESCRIPTION
get_option('datadir') returns a relative path ('share') by default, causing Lua module loading to fail. 

Prepend prefix to get the full absolute path, matching the old Makefile behavior.

Refer #151 