### PR TITLE
fix: first XWayland client in session now receives keyboard focus

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -3332,6 +3332,24 @@ luaA_client_isvisible(lua_State *L)
     return 1;
 }
 
+/** Check if a client has actual keyboard focus (wlroots seat focus).
+ *
+ * This checks the real Wayland seat keyboard focus, not just Lua bookkeeping
+ * (client.focus). Use this in tests to verify keyboard input will actually
+ * go to the client.
+ *
+ * @treturn boolean True if client has real keyboard focus, false otherwise.
+ * @method has_keyboard_focus
+ */
+static int
+luaA_client_has_keyboard_focus(lua_State *L)
+{
+    extern int some_client_has_keyboard_focus(client_t *c);
+    client_t *c = luaA_checkudata(L, 1, &client_class);
+    lua_pushboolean(L, some_client_has_keyboard_focus(c));
+    return 1;
+}
+
 /** Set client icons.
  * \param L The Lua VM state.
  * \param array Array of icons to set.
@@ -5015,6 +5033,7 @@ client_class_setup(lua_State *L)
         /* _buttons inherited from window_class */
         /* _isfloating removed - no longer needed, Lua property system is authoritative */
         { "isvisible", luaA_client_isvisible },
+        { "has_keyboard_focus", luaA_client_has_keyboard_focus },
         { "geometry", luaA_client_geometry },
         { "apply_size_hints", luaA_client_apply_size_hints },
         { "tags", luaA_client_tags },

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -103,6 +103,7 @@ Client *some_client_get_parent(Client *c);
 int some_client_has_children(Client *c);
 int some_client_is_visible(Client *c, Monitor *m);
 int some_client_is_focused(Client *c);
+int some_client_has_keyboard_focus(Client *c);  /* Check actual wlroots seat keyboard focus */
 int some_client_is_stopped(Client *c);
 int some_client_is_float_type(Client *c);
 int some_client_get_floating(Client *c);

--- a/tests/_x11_client.lua
+++ b/tests/_x11_client.lua
@@ -1,0 +1,190 @@
+---------------------------------------------------------------------------
+--- X11/XWayland test client helper for somewm integration tests.
+--
+-- This module provides a way to spawn X11 applications for testing XWayland
+-- support. It mirrors the _client.lua API but spawns X11 apps via XWayland.
+--
+-- @author somewm contributors
+-- @copyright 2025 somewm contributors
+-- @module _x11_client
+---------------------------------------------------------------------------
+
+local awful = require("awful")
+local gears = require("gears")
+
+local module = {}
+
+-- Track spawned test client PIDs for cleanup
+local spawned_pids = {}
+
+-- Detect which X11 terminal/app is available for spawning test clients
+local x11_app_cmd = nil
+local x11_detected = false
+
+local function detect_x11_app()
+    if x11_detected then
+        return x11_app_cmd ~= nil
+    end
+    x11_detected = true
+
+    -- Try X11 terminals/apps in order of preference
+    -- Each entry: { executable, class_flag, exec_flag, default_class }
+    -- xterm is preferred because it's widely available and has reliable -class
+    local apps = {
+        -- xterm: -class sets WM_CLASS resource class, -name sets instance
+        { "xterm", "-class", "-e", "XTerm" },
+        -- xeyes: simple X11 app, good for visual tests (no exec flag)
+        { "xeyes", nil, nil, "XEyes" },
+        -- xclock: another simple X11 app
+        { "xclock", nil, nil, "XClock" },
+    }
+
+    for _, app in ipairs(apps) do
+        local exe = app[1]
+        local handle = io.popen("which " .. exe .. " 2>/dev/null")
+        if handle then
+            local result = handle:read("*a")
+            handle:close()
+            if result and result:match(exe) then
+                x11_app_cmd = app
+                return true
+            end
+        end
+    end
+
+    io.stderr:write("WARNING: No X11 application found for XWayland tests\n")
+    io.stderr:write("  Tried: xterm, xeyes, xclock\n")
+    io.stderr:write("  Install one of these to run XWayland tests\n")
+    return false
+end
+
+--- Spawn an X11 test client with the given class.
+-- @tparam[opt="xwayland_test"] string class The WM_CLASS for the client
+-- @tparam[opt] string title The window title (may not be honored by all apps)
+-- @treturn number|nil The PID of the spawned process, or nil on failure
+local function spawn_x11_client(_, class, title)
+    class = class or "xwayland_test"
+
+    if not detect_x11_app() then
+        io.stderr:write("ERROR: Cannot spawn X11 test client - no X11 app available\n")
+        return nil
+    end
+
+    local exe = x11_app_cmd[1]
+    local class_flag = x11_app_cmd[2]
+    local exec_flag = x11_app_cmd[3]
+
+    -- Build command based on what app we're using
+    local cmd
+    if exe == "xterm" then
+        -- xterm: -class CLASS -name INSTANCE -T TITLE -e CMD
+        cmd = string.format(
+            "xterm -class %s -name %s -T '%s' -e 'sleep infinity'",
+            class, class:lower(), title or class
+        )
+    elseif exe == "xeyes" or exe == "xclock" then
+        -- These simple apps don't support class override easily,
+        -- but we can still spawn them for basic XWayland testing
+        cmd = exe
+        io.stderr:write(string.format(
+            "WARNING: %s doesn't support custom WM_CLASS, using default\n", exe
+        ))
+    else
+        -- Generic fallback
+        if class_flag then
+            cmd = string.format("%s %s %s", exe, class_flag, class)
+        else
+            cmd = exe
+        end
+    end
+
+    io.stderr:write(string.format("[X11] Spawning: %s\n", cmd))
+
+    -- Spawn the client
+    local pid = awful.spawn(cmd)
+
+    if pid and type(pid) == "number" and pid > 0 then
+        table.insert(spawned_pids, pid)
+        return pid
+    else
+        io.stderr:write("ERROR: Failed to spawn X11 test client: " .. tostring(pid) .. "\n")
+        return nil
+    end
+end
+
+--- Terminate all spawned X11 test clients.
+-- This should be called at the end of tests to clean up.
+function module.terminate()
+    for _, pid in ipairs(spawned_pids) do
+        os.execute("kill " .. pid .. " 2>/dev/null")
+    end
+    spawned_pids = {}
+end
+
+--- Get the list of spawned PIDs.
+-- @treturn table List of PIDs for spawned X11 test clients
+function module.get_spawned_pids()
+    return gears.table.clone(spawned_pids)
+end
+
+--- Check if an X11 application is available for spawning.
+-- @treturn boolean True if an X11 app was detected
+function module.is_available()
+    return detect_x11_app()
+end
+
+--- Get info about the detected X11 application.
+-- @treturn table|nil Table with app info or nil
+function module.get_app_info()
+    if detect_x11_app() then
+        return {
+            executable = x11_app_cmd[1],
+            class_flag = x11_app_cmd[2],
+            exec_flag = x11_app_cmd[3],
+            default_class = x11_app_cmd[4],
+        }
+    end
+    return nil
+end
+
+--- Get the default WM_CLASS for spawned X11 clients.
+-- This is useful when the app doesn't support custom class names.
+-- @treturn string|nil The default class name
+function module.get_default_class()
+    if detect_x11_app() then
+        -- For xterm with custom class, return what we'll set
+        if x11_app_cmd[1] == "xterm" then
+            return nil -- We set custom class
+        end
+        return x11_app_cmd[4]
+    end
+    return nil
+end
+
+--- Check if a client is an XWayland client.
+-- @tparam client c The client to check
+-- @treturn boolean True if client is XWayland
+function module.is_xwayland(c)
+    -- XWayland clients have a window ID (X11 window)
+    -- Native Wayland clients don't
+    return c and c.window and c.window > 0
+end
+
+--- Find X11 clients by class.
+-- @tparam string class The WM_CLASS to search for
+-- @treturn table List of matching X11 clients
+function module.find_by_class(class)
+    local results = {}
+    for _, c in ipairs(client.get()) do
+        if c.class == class and module.is_xwayland(c) then
+            table.insert(results, c)
+        end
+    end
+    return results
+end
+
+-- Make the module callable for spawning clients
+-- Usage: x11_client("MyXApp", "Window Title")
+return setmetatable(module, { __call = spawn_x11_client })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-xwayland-configure.lua
+++ b/tests/test-xwayland-configure.lua
@@ -1,0 +1,186 @@
+---------------------------------------------------------------------------
+--- Test: XWayland configure/geometry handling
+--
+-- Verifies that XWayland (X11) clients properly receive geometry updates
+-- and that programmatic geometry changes work correctly.
+--
+-- This tests that:
+-- 1. X11 clients can have their geometry changed programmatically
+-- 2. X11 clients respect geometry constraints
+-- 3. X11 clients are properly positioned on screen
+--
+-- NOTE: This test requires visual mode (HEADLESS=0) because XWayland
+-- needs a display.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local test_client = require("_client")
+local x11_client = require("_x11_client")
+local utils = require("_utils")
+
+-- Check if we're in headless mode
+local function is_headless()
+    local backend = os.getenv("WLR_BACKENDS")
+    return backend == "headless"
+end
+
+-- Skip test if requirements not met
+if is_headless() then
+    io.stderr:write("SKIP: XWayland tests require visual mode (HEADLESS=0)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+if not x11_client.is_available() then
+    io.stderr:write("SKIP: no X11 application available (install xterm)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local my_x11_client
+
+local steps = {
+    -- Step 1: Spawn an X11 client
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning X11 client...\n")
+            x11_client("xw_configure_test")
+        end
+
+        for _, c in ipairs(client.get()) do
+            if c.class == "xw_configure_test" or
+               (c.class == "XTerm" and x11_client.is_xwayland(c)) then
+                my_x11_client = c
+                io.stderr:write(string.format(
+                    "[TEST] X11 client spawned: class=%s, geom=%dx%d+%d+%d\n",
+                    c.class, c.width, c.height, c.x, c.y
+                ))
+                return true
+            end
+        end
+
+        if count > 50 then
+            error("X11 client did not spawn within timeout")
+        end
+
+        return nil
+    end,
+
+    -- Step 2: Wait for client to settle
+    function(count)
+        if count < 5 then
+            return nil
+        end
+
+        -- Verify client has valid geometry
+        assert(my_x11_client.width > 0, "Client width should be > 0")
+        assert(my_x11_client.height > 0, "Client height should be > 0")
+
+        io.stderr:write(string.format(
+            "[TEST] Initial geometry: %dx%d+%d+%d\n",
+            my_x11_client.width, my_x11_client.height,
+            my_x11_client.x, my_x11_client.y
+        ))
+        return true
+    end,
+
+    -- Step 3: Change geometry programmatically
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Setting geometry to 400x300+100+100...\n")
+            my_x11_client:geometry({ x = 100, y = 100, width = 400, height = 300 })
+        end
+
+        if count < 5 then
+            return nil
+        end
+
+        local geom = my_x11_client:geometry()
+        io.stderr:write(string.format(
+            "[TEST] After geometry set: %dx%d+%d+%d\n",
+            geom.width, geom.height, geom.x, geom.y
+        ))
+
+        -- Allow some tolerance for window decorations/borders
+        local width_ok = math.abs(geom.width - 400) <= 10
+        local height_ok = math.abs(geom.height - 300) <= 10
+
+        if width_ok and height_ok then
+            io.stderr:write("[TEST] PASS: Geometry change applied\n")
+            return true
+        end
+
+        if count > 20 then
+            error(string.format(
+                "FAIL: Geometry not applied. Expected ~400x300, got %dx%d",
+                geom.width, geom.height
+            ))
+        end
+
+        return nil
+    end,
+
+    -- Step 4: Test moving the window
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Moving window to 200,200...\n")
+            my_x11_client.x = 200
+            my_x11_client.y = 200
+        end
+
+        if count < 5 then
+            return nil
+        end
+
+        local x_ok = math.abs(my_x11_client.x - 200) <= 10
+        local y_ok = math.abs(my_x11_client.y - 200) <= 10
+
+        if x_ok and y_ok then
+            io.stderr:write(string.format(
+                "[TEST] PASS: Window moved to %d,%d\n",
+                my_x11_client.x, my_x11_client.y
+            ))
+            return true
+        end
+
+        if count > 20 then
+            error(string.format(
+                "FAIL: Window not moved. Expected ~200,200, got %d,%d",
+                my_x11_client.x, my_x11_client.y
+            ))
+        end
+
+        return nil
+    end,
+
+    -- Step 5: Cleanup
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Cleanup: killing X11 client\n")
+            if my_x11_client and my_x11_client.valid then
+                my_x11_client:kill()
+            end
+            os.execute("pkill -9 xterm 2>/dev/null")
+        end
+
+        if #client.get() == 0 then
+            io.stderr:write("[TEST] Cleanup: done\n")
+            return true
+        end
+
+        if count >= 10 then
+            io.stderr:write("[TEST] Cleanup: force killing\n")
+            local pids = x11_client.get_spawned_pids()
+            for _, pid in ipairs(pids) do
+                os.execute("kill -9 " .. pid .. " 2>/dev/null")
+            end
+            return true
+        end
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-xwayland-focus-restore.lua
+++ b/tests/test-xwayland-focus-restore.lua
@@ -1,0 +1,220 @@
+---------------------------------------------------------------------------
+--- Test: XWayland focus restoration
+--
+-- Verifies that when an XWayland (X11) client closes, focus returns to the
+-- correct client from focus history (the most recently focused client).
+--
+-- This test mirrors test-layer-shell-focus-restore.lua but for X11 clients.
+--
+-- NOTE: This test requires visual mode (HEADLESS=0) because XWayland
+-- needs a display.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local test_client = require("_client")
+local x11_client = require("_x11_client")
+local utils = require("_utils")
+
+-- Check if we're in headless mode
+local function is_headless()
+    local backend = os.getenv("WLR_BACKENDS")
+    return backend == "headless"
+end
+
+-- Skip test if requirements not met
+if is_headless() then
+    io.stderr:write("SKIP: XWayland tests require visual mode (HEADLESS=0)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+if not x11_client.is_available() then
+    io.stderr:write("SKIP: no X11 application available (install xterm)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+if not test_client.is_available() then
+    io.stderr:write("SKIP: no Wayland terminal available for test clients\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local wayland_client
+local x11_client_instance
+
+local steps = {
+    -- Step 1: Spawn Wayland client A
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning Wayland client A...\n")
+            test_client("xw_restore_wayland")
+        end
+        wayland_client = utils.find_client_by_class("xw_restore_wayland")
+        if wayland_client then
+            io.stderr:write("[TEST] Wayland client A spawned\n")
+            return true
+        end
+        return nil
+    end,
+
+    -- Step 2: Wait for Wayland client to have focus
+    function(count)
+        if client.focus == wayland_client then
+            io.stderr:write("[TEST] Wayland client A has focus\n")
+            return true
+        end
+        if count > 20 then
+            error(string.format("Expected Wayland client to have focus, got %s",
+                client.focus and client.focus.class or "nil"))
+        end
+        return nil
+    end,
+
+    -- Step 3: Spawn X11 client B
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning X11 client B...\n")
+            x11_client("xw_restore_x11")
+        end
+
+        -- Look for the X11 client
+        for _, c in ipairs(client.get()) do
+            if c.class == "xw_restore_x11" or
+               (c.class == "XTerm" and x11_client.is_xwayland(c) and c ~= wayland_client) then
+                x11_client_instance = c
+                io.stderr:write("[TEST] X11 client B spawned\n")
+                return true
+            end
+        end
+
+        if count > 50 then
+            error("X11 client did not spawn within timeout")
+        end
+        return nil
+    end,
+
+    -- Step 4: Wait for X11 client to have focus (Wayland client is now in history)
+    function(count)
+        -- Give focus time to transfer
+        if count < 5 then
+            return nil
+        end
+
+        if client.focus == x11_client_instance then
+            io.stderr:write("[TEST] X11 client B has focus, Wayland A is in history\n")
+            return true
+        end
+
+        if count > 30 then
+            -- This may fail due to the focus bug we're testing
+            io.stderr:write(string.format(
+                "[TEST] WARNING: X11 client does not have focus (got %s). " ..
+                "This may indicate the XWayland focus bug.\n",
+                client.focus and client.focus.class or "nil"
+            ))
+            -- Continue anyway to test restoration behavior
+            return true
+        end
+        return nil
+    end,
+
+    -- Step 5: Close the X11 client
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Closing X11 client B...\n")
+            if x11_client_instance and x11_client_instance.valid then
+                x11_client_instance:kill()
+            end
+            os.execute("pkill -9 xterm 2>/dev/null")
+        end
+
+        -- Wait for X11 client to be gone
+        local x11_still_exists = false
+        for _, c in ipairs(client.get()) do
+            if c == x11_client_instance or
+               (c.class == "xw_restore_x11") or
+               (c.class == "XTerm" and x11_client.is_xwayland(c)) then
+                x11_still_exists = true
+                break
+            end
+        end
+
+        if not x11_still_exists then
+            io.stderr:write("[TEST] X11 client B closed\n")
+            return true
+        end
+
+        if count > 20 then
+            io.stderr:write("[TEST] X11 client close timeout, continuing...\n")
+            return true
+        end
+
+        return nil
+    end,
+
+    -- Step 6: Verify focus returns to Wayland client A
+    function(count)
+        -- Give focus restoration a moment
+        if count < 3 then
+            return nil
+        end
+
+        io.stderr:write(string.format(
+            "[TEST] Checking focus after X11 close (attempt %d): client.focus=%s\n",
+            count, client.focus and client.focus.class or "nil"
+        ))
+
+        -- THE KEY ASSERTION: Focus should return to Wayland client A
+        if client.focus == wayland_client then
+            io.stderr:write("[TEST] PASS: Focus returned to Wayland client A\n")
+            return true
+        end
+
+        if count > 15 then
+            error(string.format(
+                "FAIL: Focus did not return to Wayland client. Expected '%s', got '%s'",
+                wayland_client and wayland_client.class or "nil",
+                client.focus and client.focus.class or "nil"
+            ))
+        end
+
+        return nil
+    end,
+
+    -- Step 7: Cleanup
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Cleanup: killing remaining clients\n")
+            if wayland_client and wayland_client.valid then
+                wayland_client:kill()
+            end
+            os.execute("pkill -9 xterm 2>/dev/null")
+        end
+
+        if #client.get() == 0 then
+            io.stderr:write("[TEST] Cleanup: done\n")
+            return true
+        end
+
+        if count >= 10 then
+            io.stderr:write("[TEST] Cleanup: force killing\n")
+            local pids = test_client.get_spawned_pids()
+            for _, pid in ipairs(pids) do
+                os.execute("kill -9 " .. pid .. " 2>/dev/null")
+            end
+            pids = x11_client.get_spawned_pids()
+            for _, pid in ipairs(pids) do
+                os.execute("kill -9 " .. pid .. " 2>/dev/null")
+            end
+            return true
+        end
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-xwayland-focus-transfer.lua
+++ b/tests/test-xwayland-focus-transfer.lua
@@ -1,0 +1,258 @@
+---------------------------------------------------------------------------
+--- Test: XWayland focus transfer
+--
+-- Verifies that focus can be programmatically transferred between XWayland
+-- (X11) clients and native Wayland clients in both directions.
+--
+-- This tests that:
+-- 1. Focus can transfer from Wayland to X11 client
+-- 2. Focus can transfer from X11 to Wayland client
+-- 3. Keyboard events go to the correct client after transfer
+--
+-- NOTE: This test requires visual mode (HEADLESS=0) because XWayland
+-- needs a display.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local test_client = require("_client")
+local x11_client = require("_x11_client")
+local utils = require("_utils")
+
+-- Check if we're in headless mode
+local function is_headless()
+    local backend = os.getenv("WLR_BACKENDS")
+    return backend == "headless"
+end
+
+-- Skip test if requirements not met
+if is_headless() then
+    io.stderr:write("SKIP: XWayland tests require visual mode (HEADLESS=0)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+if not x11_client.is_available() then
+    io.stderr:write("SKIP: no X11 application available (install xterm)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+if not test_client.is_available() then
+    io.stderr:write("SKIP: no Wayland terminal available for test clients\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local wayland_client
+local x11_client_instance
+
+local steps = {
+    -- Step 1: Spawn Wayland client
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning Wayland client...\n")
+            test_client("xw_transfer_wayland")
+        end
+        wayland_client = utils.find_client_by_class("xw_transfer_wayland")
+        if wayland_client then
+            io.stderr:write("[TEST] Wayland client spawned\n")
+            return true
+        end
+        return nil
+    end,
+
+    -- Step 2: Wait for Wayland client to have focus
+    function(count)
+        if client.focus == wayland_client then
+            io.stderr:write("[TEST] Wayland client has initial focus\n")
+            return true
+        end
+        if count > 20 then
+            error("Wayland client did not receive focus")
+        end
+        return nil
+    end,
+
+    -- Step 3: Spawn X11 client
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning X11 client...\n")
+            x11_client("xw_transfer_x11")
+        end
+
+        for _, c in ipairs(client.get()) do
+            if c.class == "xw_transfer_x11" or
+               (c.class == "XTerm" and x11_client.is_xwayland(c) and c ~= wayland_client) then
+                x11_client_instance = c
+                io.stderr:write("[TEST] X11 client spawned\n")
+                return true
+            end
+        end
+
+        if count > 50 then
+            error("X11 client did not spawn within timeout")
+        end
+        return nil
+    end,
+
+    -- Step 4: Wait for X11 client to have focus (or not, if bug exists)
+    function(count)
+        if count < 5 then
+            return nil
+        end
+
+        io.stderr:write(string.format(
+            "[TEST] After X11 spawn: focus=%s (X11=%s, Wayland=%s)\n",
+            client.focus and client.focus.class or "nil",
+            x11_client_instance and x11_client_instance.class or "nil",
+            wayland_client and wayland_client.class or "nil"
+        ))
+
+        -- Continue regardless of current focus state
+        return true
+    end,
+
+    -- Step 5: Programmatically activate Wayland client
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Activating Wayland client via request::activate...\n")
+            wayland_client:emit_signal("request::activate", "test", { raise = true })
+        end
+
+        if count < 3 then
+            return nil
+        end
+
+        -- Verify Wayland client got focus
+        if client.focus == wayland_client then
+            io.stderr:write("[TEST] PASS: Wayland client received focus via activate\n")
+            return true
+        end
+
+        if count > 15 then
+            error(string.format(
+                "FAIL: Could not activate Wayland client. Focus is on '%s'",
+                client.focus and client.focus.class or "nil"
+            ))
+        end
+
+        return nil
+    end,
+
+    -- Step 6: Programmatically activate X11 client
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Activating X11 client via request::activate...\n")
+            x11_client_instance:emit_signal("request::activate", "test", { raise = true })
+        end
+
+        if count < 3 then
+            return nil
+        end
+
+        -- Verify X11 client got focus
+        if client.focus == x11_client_instance then
+            io.stderr:write("[TEST] PASS: X11 client received focus via activate\n")
+            return true
+        end
+
+        if count > 15 then
+            error(string.format(
+                "FAIL: Could not activate X11 client. Focus is on '%s'. " ..
+                "This indicates the XWayland focus bug.",
+                client.focus and client.focus.class or "nil"
+            ))
+        end
+
+        return nil
+    end,
+
+    -- Step 7: Transfer back to Wayland via client.focus setter
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Setting client.focus to Wayland client...\n")
+            client.focus = wayland_client
+        end
+
+        if count < 3 then
+            return nil
+        end
+
+        if client.focus == wayland_client then
+            io.stderr:write("[TEST] PASS: Focus transferred back to Wayland via setter\n")
+            return true
+        end
+
+        if count > 15 then
+            error("Could not transfer focus back to Wayland client")
+        end
+
+        return nil
+    end,
+
+    -- Step 8: Transfer to X11 via client.focus setter
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Setting client.focus to X11 client...\n")
+            client.focus = x11_client_instance
+        end
+
+        if count < 3 then
+            return nil
+        end
+
+        if client.focus == x11_client_instance then
+            io.stderr:write("[TEST] PASS: Focus transferred to X11 via setter\n")
+            return true
+        end
+
+        if count > 15 then
+            error(string.format(
+                "FAIL: Could not transfer focus to X11 client via setter. " ..
+                "Focus is on '%s'. This indicates the XWayland focus bug.",
+                client.focus and client.focus.class or "nil"
+            ))
+        end
+
+        return nil
+    end,
+
+    -- Step 9: Cleanup
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Cleanup: killing clients\n")
+            if wayland_client and wayland_client.valid then
+                wayland_client:kill()
+            end
+            if x11_client_instance and x11_client_instance.valid then
+                x11_client_instance:kill()
+            end
+            os.execute("pkill -9 xterm 2>/dev/null")
+        end
+
+        if #client.get() == 0 then
+            io.stderr:write("[TEST] Cleanup: done\n")
+            return true
+        end
+
+        if count >= 10 then
+            io.stderr:write("[TEST] Cleanup: force killing\n")
+            local pids = test_client.get_spawned_pids()
+            for _, pid in ipairs(pids) do
+                os.execute("kill -9 " .. pid .. " 2>/dev/null")
+            end
+            pids = x11_client.get_spawned_pids()
+            for _, pid in ipairs(pids) do
+                os.execute("kill -9 " .. pid .. " 2>/dev/null")
+            end
+            return true
+        end
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-xwayland-keyboard-focus.lua
+++ b/tests/test-xwayland-keyboard-focus.lua
@@ -1,0 +1,153 @@
+---------------------------------------------------------------------------
+--- Test: XWayland keyboard focus
+--
+-- Verifies that XWayland (X11) clients properly receive keyboard focus
+-- when they are spawned/activated, without requiring mouse hover.
+--
+-- This test validates the fix for the XWayland focus bug where X11 apps
+-- wouldn't receive keyboard input until the user hovered over them.
+--
+-- NOTE: This test requires visual mode (HEADLESS=0) because XWayland
+-- needs a display.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local test_client = require("_client")
+local x11_client = require("_x11_client")
+local utils = require("_utils")
+
+-- Check if we're in headless mode (XWayland won't work properly)
+local function is_headless()
+    local backend = os.getenv("WLR_BACKENDS")
+    return backend == "headless"
+end
+
+-- Skip test if requirements not met
+if is_headless() then
+    io.stderr:write("SKIP: XWayland tests require visual mode (HEADLESS=0)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+if not x11_client.is_available() then
+    io.stderr:write("SKIP: no X11 application available (install xterm)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local my_x11_client
+
+local steps = {
+    -- Step 1: Spawn an X11 client
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning X11 client...\n")
+            x11_client("xwayland_focus_test")
+        end
+
+        -- Look for the X11 client
+        -- Note: xterm sets WM_CLASS to what we specify
+        for _, c in ipairs(client.get()) do
+            if c.class == "xwayland_focus_test" or
+               (c.class == "XTerm" and x11_client.is_xwayland(c)) then
+                my_x11_client = c
+                io.stderr:write(string.format(
+                    "[TEST] X11 client spawned: class=%s, window=%s, is_x11=%s\n",
+                    c.class, tostring(c.window), tostring(x11_client.is_xwayland(c))
+                ))
+                return true
+            end
+        end
+
+        -- Timeout after ~5 seconds
+        if count > 50 then
+            io.stderr:write("[TEST] ERROR: X11 client did not appear\n")
+            error("X11 client did not spawn within timeout")
+        end
+
+        return nil
+    end,
+
+    -- Step 2: Verify the X11 client is an XWayland client
+    function()
+        assert(x11_client.is_xwayland(my_x11_client),
+            "Expected client to be XWayland (have X11 window ID)")
+        io.stderr:write(string.format(
+            "[TEST] Confirmed XWayland client: window=%d\n",
+            my_x11_client.window or 0
+        ))
+        return true
+    end,
+
+    -- Step 3: Wait a moment for focus to settle, then verify X11 client has REAL keyboard focus
+    function(count)
+        -- Give focus a moment to be set (this is the bug we're testing!)
+        if count < 5 then
+            return nil
+        end
+
+        -- Check ACTUAL keyboard focus, not just client.focus (Lua bookkeeping)
+        -- has_keyboard_focus() checks wlroots seat->keyboard_state.focused_surface
+        local has_real_focus = my_x11_client:has_keyboard_focus()
+
+        io.stderr:write(string.format(
+            "[TEST] Checking focus (attempt %d): client.focus=%s, has_keyboard_focus=%s\n",
+            count,
+            client.focus and client.focus.class or "nil",
+            tostring(has_real_focus)
+        ))
+
+        -- THE KEY ASSERTION: X11 client should have REAL keyboard focus immediately
+        -- without requiring mouse hover. This is the actual wlroots seat focus,
+        -- not just Lua bookkeeping.
+        if has_real_focus then
+            io.stderr:write("[TEST] PASS: X11 client has REAL keyboard focus\n")
+            return true
+        end
+
+        -- Timeout - this is the failure case that indicates the bug
+        if count > 20 then
+            error(string.format(
+                "FAIL: X11 client does not have REAL keyboard focus. " ..
+                "client.focus=%s but has_keyboard_focus()=%s. " ..
+                "This indicates the XWayland focus bug is present.",
+                client.focus and client.focus.class or "nil",
+                tostring(has_real_focus)
+            ))
+        end
+
+        return nil
+    end,
+
+    -- Step 4: Cleanup
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Cleanup: killing X11 client\n")
+            if my_x11_client and my_x11_client.valid then
+                my_x11_client:kill()
+            end
+            -- Also kill via pkill as backup
+            os.execute("pkill -9 xterm 2>/dev/null")
+        end
+
+        if #client.get() == 0 then
+            io.stderr:write("[TEST] Cleanup: done\n")
+            return true
+        end
+
+        if count >= 10 then
+            io.stderr:write("[TEST] Cleanup: force killing\n")
+            local pids = x11_client.get_spawned_pids()
+            for _, pid in ipairs(pids) do
+                os.execute("kill -9 " .. pid .. " 2>/dev/null")
+            end
+            return true
+        end
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-xwayland-properties.lua
+++ b/tests/test-xwayland-properties.lua
@@ -1,0 +1,215 @@
+---------------------------------------------------------------------------
+--- Test: XWayland properties
+--
+-- Verifies that XWayland (X11) clients properly expose their properties
+-- to Lua, including WM_CLASS, WM_NAME, etc.
+--
+-- This tests that:
+-- 1. X11 client.class and client.instance are populated from WM_CLASS
+-- 2. X11 client.name is populated from WM_NAME / _NET_WM_NAME
+-- 3. X11 client.pid is populated (if available)
+-- 4. Property change signals fire when properties change
+--
+-- NOTE: This test requires visual mode (HEADLESS=0) because XWayland
+-- needs a display.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local test_client = require("_client")
+local x11_client = require("_x11_client")
+local utils = require("_utils")
+
+-- Check if we're in headless mode
+local function is_headless()
+    local backend = os.getenv("WLR_BACKENDS")
+    return backend == "headless"
+end
+
+-- Skip test if requirements not met
+if is_headless() then
+    io.stderr:write("SKIP: XWayland tests require visual mode (HEADLESS=0)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+if not x11_client.is_available() then
+    io.stderr:write("SKIP: no X11 application available (install xterm)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local my_x11_client
+
+local steps = {
+    -- Step 1: Spawn an X11 client with a specific class
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning X11 client with class 'xw_props_test'...\n")
+            -- xterm -class sets the WM_CLASS resource class
+            x11_client("xw_props_test")
+        end
+
+        for _, c in ipairs(client.get()) do
+            if c.class == "xw_props_test" or
+               (c.class == "XTerm" and x11_client.is_xwayland(c)) then
+                my_x11_client = c
+                io.stderr:write(string.format(
+                    "[TEST] X11 client spawned: class=%s\n", c.class
+                ))
+                return true
+            end
+        end
+
+        if count > 50 then
+            error("X11 client did not spawn within timeout")
+        end
+
+        return nil
+    end,
+
+    -- Step 2: Wait for properties to populate
+    function(count)
+        if count < 5 then
+            return nil
+        end
+        return true
+    end,
+
+    -- Step 3: Verify WM_CLASS property (class)
+    function()
+        io.stderr:write(string.format(
+            "[TEST] Checking client.class: '%s'\n",
+            my_x11_client.class or "(nil)"
+        ))
+
+        -- xterm should honor -class flag
+        local expected_class = "xw_props_test"
+        if my_x11_client.class == expected_class then
+            io.stderr:write(string.format(
+                "[TEST] PASS: client.class = '%s'\n", my_x11_client.class
+            ))
+        elseif my_x11_client.class == "XTerm" then
+            -- xterm didn't honor -class, but class is still set
+            io.stderr:write(string.format(
+                "[TEST] INFO: client.class = 'XTerm' (xterm didn't honor -class flag)\n"
+            ))
+        else
+            error(string.format(
+                "FAIL: client.class is nil or unexpected: '%s'",
+                my_x11_client.class or "(nil)"
+            ))
+        end
+
+        -- class should never be nil for X11 clients
+        assert(my_x11_client.class ~= nil and my_x11_client.class ~= "",
+            "client.class should not be nil/empty for X11 clients")
+
+        return true
+    end,
+
+    -- Step 4: Verify instance property (from WM_CLASS instance name)
+    function()
+        io.stderr:write(string.format(
+            "[TEST] Checking client.instance: '%s'\n",
+            my_x11_client.instance or "(nil)"
+        ))
+
+        -- instance should be set (xterm -name sets this, or defaults to xterm)
+        -- We use lowercase class as instance: xw_props_test -> xw_props_test
+        if my_x11_client.instance ~= nil and my_x11_client.instance ~= "" then
+            io.stderr:write(string.format(
+                "[TEST] PASS: client.instance = '%s'\n", my_x11_client.instance
+            ))
+            return true
+        end
+
+        -- instance might be nil if not implemented
+        io.stderr:write("[TEST] WARNING: client.instance is nil/empty\n")
+        return true  -- Continue testing other properties
+    end,
+
+    -- Step 5: Verify name property (WM_NAME or _NET_WM_NAME)
+    function()
+        io.stderr:write(string.format(
+            "[TEST] Checking client.name: '%s'\n",
+            my_x11_client.name or "(nil)"
+        ))
+
+        -- name should be set - xterm sets WM_NAME
+        assert(my_x11_client.name ~= nil and my_x11_client.name ~= "",
+            "client.name should not be nil/empty for X11 clients")
+
+        io.stderr:write(string.format(
+            "[TEST] PASS: client.name = '%s'\n", my_x11_client.name
+        ))
+        return true
+    end,
+
+    -- Step 6: Check pid property (_NET_WM_PID)
+    function()
+        io.stderr:write(string.format(
+            "[TEST] Checking client.pid: %s\n",
+            tostring(my_x11_client.pid)
+        ))
+
+        -- pid might be nil if the X11 app doesn't set _NET_WM_PID
+        -- or if we don't read it. xterm typically sets it.
+        if my_x11_client.pid ~= nil and my_x11_client.pid > 0 then
+            io.stderr:write(string.format(
+                "[TEST] PASS: client.pid = %d\n", my_x11_client.pid
+            ))
+        else
+            io.stderr:write("[TEST] INFO: client.pid is nil (may not be implemented or app doesn't set it)\n")
+        end
+
+        return true
+    end,
+
+    -- Step 7: Check that client is recognized as XWayland
+    function()
+        local is_x11 = x11_client.is_xwayland(my_x11_client)
+        io.stderr:write(string.format(
+            "[TEST] is_xwayland(client) = %s, window = %s\n",
+            tostring(is_x11),
+            tostring(my_x11_client.window)
+        ))
+
+        assert(is_x11, "Client should be detected as XWayland")
+        assert(my_x11_client.window ~= nil and my_x11_client.window > 0,
+            "XWayland client should have a window ID")
+
+        io.stderr:write("[TEST] PASS: Client is properly identified as XWayland\n")
+        return true
+    end,
+
+    -- Step 8: Cleanup
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Cleanup: killing X11 client\n")
+            if my_x11_client and my_x11_client.valid then
+                my_x11_client:kill()
+            end
+            os.execute("pkill -9 xterm 2>/dev/null")
+        end
+
+        if #client.get() == 0 then
+            io.stderr:write("[TEST] Cleanup: done\n")
+            return true
+        end
+
+        if count >= 10 then
+            io.stderr:write("[TEST] Cleanup: force killing\n")
+            local pids = x11_client.get_spawned_pids()
+            for _, pid in ipairs(pids) do
+                os.execute("kill -9 " .. pid .. " 2>/dev/null")
+            end
+            return true
+        end
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-xwayland-signals.lua
+++ b/tests/test-xwayland-signals.lua
@@ -1,0 +1,256 @@
+---------------------------------------------------------------------------
+--- Test: XWayland signal parity
+--
+-- Verifies that XWayland (X11) clients emit the same lifecycle and property
+-- signals as native Wayland (XDG) clients.
+--
+-- This tests that:
+-- 1. request::manage signal fires when X11 client is created
+-- 2. manage signal fires after request::manage
+-- 3. request::unmanage signal fires when X11 client closes
+-- 4. unmanage signal fires after request::unmanage
+-- 5. property::name signal fires when title changes (if possible)
+--
+-- NOTE: This test requires visual mode (HEADLESS=0) because XWayland
+-- needs a display.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local test_client = require("_client")
+local x11_client = require("_x11_client")
+local utils = require("_utils")
+
+-- Check if we're in headless mode
+local function is_headless()
+    local backend = os.getenv("WLR_BACKENDS")
+    return backend == "headless"
+end
+
+-- Skip test if requirements not met
+if is_headless() then
+    io.stderr:write("SKIP: XWayland tests require visual mode (HEADLESS=0)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+if not x11_client.is_available() then
+    io.stderr:write("SKIP: no X11 application available (install xterm)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local my_x11_client
+
+-- Signal tracking
+local signals_received = {
+    request_manage = false,
+    manage = false,
+    request_unmanage = false,
+    unmanage = false,
+}
+
+local signal_clients = {
+    request_manage = nil,
+    manage = nil,
+    request_unmanage = nil,
+    unmanage = nil,
+}
+
+-- Connect signal handlers
+client.connect_signal("request::manage", function(c)
+    if x11_client.is_xwayland(c) then
+        io.stderr:write(string.format(
+            "[SIGNAL] request::manage fired for X11 client: %s\n",
+            c.class or "(no class)"
+        ))
+        signals_received.request_manage = true
+        signal_clients.request_manage = c
+    end
+end)
+
+client.connect_signal("manage", function(c)
+    if x11_client.is_xwayland(c) then
+        io.stderr:write(string.format(
+            "[SIGNAL] manage fired for X11 client: %s\n",
+            c.class or "(no class)"
+        ))
+        signals_received.manage = true
+        signal_clients.manage = c
+    end
+end)
+
+client.connect_signal("request::unmanage", function(c)
+    if x11_client.is_xwayland(c) then
+        io.stderr:write(string.format(
+            "[SIGNAL] request::unmanage fired for X11 client: %s\n",
+            c.class or "(no class)"
+        ))
+        signals_received.request_unmanage = true
+        signal_clients.request_unmanage = c
+    end
+end)
+
+client.connect_signal("unmanage", function(c)
+    if x11_client.is_xwayland(c) then
+        io.stderr:write(string.format(
+            "[SIGNAL] unmanage fired for X11 client: %s\n",
+            c.class or "(no class)"
+        ))
+        signals_received.unmanage = true
+        signal_clients.unmanage = c
+    end
+end)
+
+local steps = {
+    -- Step 1: Spawn an X11 client
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning X11 client...\n")
+            x11_client("xw_signals_test")
+        end
+
+        for _, c in ipairs(client.get()) do
+            if c.class == "xw_signals_test" or
+               (c.class == "XTerm" and x11_client.is_xwayland(c)) then
+                my_x11_client = c
+                io.stderr:write("[TEST] X11 client spawned\n")
+                return true
+            end
+        end
+
+        if count > 50 then
+            error("X11 client did not spawn within timeout")
+        end
+
+        return nil
+    end,
+
+    -- Step 2: Wait for signals to settle
+    function(count)
+        if count < 5 then
+            return nil
+        end
+        return true
+    end,
+
+    -- Step 3: Verify request::manage signal was received
+    function()
+        io.stderr:write(string.format(
+            "[TEST] Checking request::manage: received=%s\n",
+            tostring(signals_received.request_manage)
+        ))
+
+        assert(signals_received.request_manage,
+            "FAIL: request::manage signal was not fired for X11 client")
+        assert(signal_clients.request_manage == my_x11_client,
+            "FAIL: request::manage was fired for wrong client")
+
+        io.stderr:write("[TEST] PASS: request::manage signal received\n")
+        return true
+    end,
+
+    -- Step 4: Verify manage signal was received
+    function()
+        io.stderr:write(string.format(
+            "[TEST] Checking manage: received=%s\n",
+            tostring(signals_received.manage)
+        ))
+
+        assert(signals_received.manage,
+            "FAIL: manage signal was not fired for X11 client")
+        assert(signal_clients.manage == my_x11_client,
+            "FAIL: manage was fired for wrong client")
+
+        io.stderr:write("[TEST] PASS: manage signal received\n")
+        return true
+    end,
+
+    -- Step 5: Close the X11 client to test unmanage signals
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Closing X11 client to test unmanage signals...\n")
+            if my_x11_client and my_x11_client.valid then
+                my_x11_client:kill()
+            end
+            os.execute("pkill -9 xterm 2>/dev/null")
+        end
+
+        -- Wait for client to be gone
+        local found = false
+        for _, c in ipairs(client.get()) do
+            if c == my_x11_client or c.class == "xw_signals_test" then
+                found = true
+                break
+            end
+        end
+
+        if not found then
+            io.stderr:write("[TEST] X11 client closed\n")
+            return true
+        end
+
+        if count > 20 then
+            io.stderr:write("[TEST] X11 client close timeout, continuing...\n")
+            return true
+        end
+
+        return nil
+    end,
+
+    -- Step 6: Wait for unmanage signals
+    function(count)
+        if count < 3 then
+            return nil
+        end
+        return true
+    end,
+
+    -- Step 7: Verify request::unmanage signal was received
+    function()
+        io.stderr:write(string.format(
+            "[TEST] Checking request::unmanage: received=%s\n",
+            tostring(signals_received.request_unmanage)
+        ))
+
+        assert(signals_received.request_unmanage,
+            "FAIL: request::unmanage signal was not fired for X11 client")
+
+        io.stderr:write("[TEST] PASS: request::unmanage signal received\n")
+        return true
+    end,
+
+    -- Step 8: Verify unmanage signal was received
+    function()
+        io.stderr:write(string.format(
+            "[TEST] Checking unmanage: received=%s\n",
+            tostring(signals_received.unmanage)
+        ))
+
+        assert(signals_received.unmanage,
+            "FAIL: unmanage signal was not fired for X11 client")
+
+        io.stderr:write("[TEST] PASS: unmanage signal received\n")
+        return true
+    end,
+
+    -- Step 9: Final cleanup
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Final cleanup\n")
+            os.execute("pkill -9 xterm 2>/dev/null")
+        end
+
+        if #client.get() == 0 or count >= 5 then
+            io.stderr:write("[TEST] All signal tests PASSED\n")
+            return true
+        end
+
+        return nil
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-xwayland-state.lua
+++ b/tests/test-xwayland-state.lua
@@ -1,0 +1,234 @@
+---------------------------------------------------------------------------
+--- Test: XWayland state handling (fullscreen, maximized)
+--
+-- Verifies that XWayland (X11) clients properly handle state changes
+-- like fullscreen and maximized modes.
+--
+-- This tests that:
+-- 1. X11 clients can be set to fullscreen programmatically
+-- 2. X11 clients can be set to maximized programmatically
+-- 3. State changes are reflected in client properties
+--
+-- NOTE: This test requires visual mode (HEADLESS=0) because XWayland
+-- needs a display.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local test_client = require("_client")
+local x11_client = require("_x11_client")
+local utils = require("_utils")
+
+-- Check if we're in headless mode
+local function is_headless()
+    local backend = os.getenv("WLR_BACKENDS")
+    return backend == "headless"
+end
+
+-- Skip test if requirements not met
+if is_headless() then
+    io.stderr:write("SKIP: XWayland tests require visual mode (HEADLESS=0)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+if not x11_client.is_available() then
+    io.stderr:write("SKIP: no X11 application available (install xterm)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local my_x11_client
+local initial_geom
+
+local steps = {
+    -- Step 1: Spawn an X11 client
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning X11 client...\n")
+            x11_client("xw_state_test")
+        end
+
+        for _, c in ipairs(client.get()) do
+            if c.class == "xw_state_test" or
+               (c.class == "XTerm" and x11_client.is_xwayland(c)) then
+                my_x11_client = c
+                io.stderr:write(string.format(
+                    "[TEST] X11 client spawned: class=%s\n", c.class
+                ))
+                return true
+            end
+        end
+
+        if count > 50 then
+            error("X11 client did not spawn within timeout")
+        end
+
+        return nil
+    end,
+
+    -- Step 2: Wait for client to settle and record initial geometry
+    function(count)
+        if count < 5 then
+            return nil
+        end
+
+        initial_geom = my_x11_client:geometry()
+        io.stderr:write(string.format(
+            "[TEST] Initial geometry: %dx%d+%d+%d, fullscreen=%s, maximized=%s\n",
+            initial_geom.width, initial_geom.height,
+            initial_geom.x, initial_geom.y,
+            tostring(my_x11_client.fullscreen),
+            tostring(my_x11_client.maximized)
+        ))
+
+        -- Verify client is not fullscreen/maximized initially
+        assert(not my_x11_client.fullscreen, "Client should not start fullscreen")
+        assert(not my_x11_client.maximized, "Client should not start maximized")
+
+        return true
+    end,
+
+    -- Step 3: Set client to maximized
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Setting maximized = true...\n")
+            my_x11_client.maximized = true
+        end
+
+        if count < 5 then
+            return nil
+        end
+
+        if my_x11_client.maximized then
+            local geom = my_x11_client:geometry()
+            io.stderr:write(string.format(
+                "[TEST] PASS: Client is maximized, geometry: %dx%d+%d+%d\n",
+                geom.width, geom.height, geom.x, geom.y
+            ))
+            -- Maximized window should be larger than initial
+            assert(geom.width >= initial_geom.width,
+                "Maximized width should be >= initial")
+            assert(geom.height >= initial_geom.height,
+                "Maximized height should be >= initial")
+            return true
+        end
+
+        if count > 15 then
+            error(string.format(
+                "FAIL: maximized property not set. maximized=%s",
+                tostring(my_x11_client.maximized)
+            ))
+        end
+
+        return nil
+    end,
+
+    -- Step 4: Unmaximize
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Setting maximized = false...\n")
+            my_x11_client.maximized = false
+        end
+
+        if count < 5 then
+            return nil
+        end
+
+        if not my_x11_client.maximized then
+            io.stderr:write("[TEST] PASS: Client unmaximized\n")
+            return true
+        end
+
+        if count > 15 then
+            error("FAIL: Could not unmaximize client")
+        end
+
+        return nil
+    end,
+
+    -- Step 5: Set client to fullscreen
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Setting fullscreen = true...\n")
+            my_x11_client.fullscreen = true
+        end
+
+        if count < 5 then
+            return nil
+        end
+
+        if my_x11_client.fullscreen then
+            local geom = my_x11_client:geometry()
+            local screen_geom = screen[1].geometry
+            io.stderr:write(string.format(
+                "[TEST] PASS: Client is fullscreen, geometry: %dx%d (screen: %dx%d)\n",
+                geom.width, geom.height,
+                screen_geom.width, screen_geom.height
+            ))
+            return true
+        end
+
+        if count > 15 then
+            error(string.format(
+                "FAIL: fullscreen property not set. fullscreen=%s",
+                tostring(my_x11_client.fullscreen)
+            ))
+        end
+
+        return nil
+    end,
+
+    -- Step 6: Exit fullscreen
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Setting fullscreen = false...\n")
+            my_x11_client.fullscreen = false
+        end
+
+        if count < 5 then
+            return nil
+        end
+
+        if not my_x11_client.fullscreen then
+            io.stderr:write("[TEST] PASS: Client exited fullscreen\n")
+            return true
+        end
+
+        if count > 15 then
+            error("FAIL: Could not exit fullscreen")
+        end
+
+        return nil
+    end,
+
+    -- Step 7: Cleanup
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Cleanup: killing X11 client\n")
+            if my_x11_client and my_x11_client.valid then
+                my_x11_client:kill()
+            end
+            os.execute("pkill -9 xterm 2>/dev/null")
+        end
+
+        if #client.get() == 0 then
+            io.stderr:write("[TEST] Cleanup: done\n")
+            return true
+        end
+
+        if count >= 10 then
+            io.stderr:write("[TEST] Cleanup: force killing\n")
+            local pids = x11_client.get_spawned_pids()
+            for _, pid in ipairs(pids) do
+                os.execute("kill -9 " .. pid .. " 2>/dev/null")
+            end
+            return true
+        end
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
The first XWayland client spawned in a compositor session would not receive keyboard focus until the user manually clicked on it. All subsequent XWayland clients would then work correctly.

Root cause: wlr_xwayland_surface_activate() was only called in the activatex11() handler (triggered by user clicks), never during mapnotify() when the client first appears.

Changes:
- Call wlr_xwayland_surface_activate() in mapnotify() before emitting request::activate for XWayland clients
- Add has_keyboard_focus() method to check actual wlroots seat focus (vs client.focus which is Lua bookkeeping)
- Fix surface readiness check for XWayland: use c->scene != NULL instead of surface->mapped since XWayland map timing differs
- Add comprehensive XWayland test suite covering focus, signals, properties, and state management

Refers #160 and #155 