### PR TITLE
sync: port AwesomeWM #4023 - fix maximized geometry with titlebars

### DIFF
--- a/lua/awful/permissions/init.lua
+++ b/lua/awful/permissions/init.lua
@@ -366,6 +366,11 @@ local context_mapper = {
 function permissions.geometry(c, context, hints)
     if not pcommon.check(c, "client", "geometry", context) then return end
 
+    -- Don't update geometry if rules haven't been applied yet (e.g. when processing
+    -- EWMH client hints during client initialization), since a titlebar may perturb
+    -- the intended geometry later
+    if not c._border_geometry_rules_applied then return end
+
     local layout = c.screen.selected_tag and c.screen.selected_tag.layout or nil
 
     context = context or ""

--- a/lua/ruled/client.lua
+++ b/lua/ruled/client.lua
@@ -555,6 +555,18 @@ crules._execute = function(_, c, props, callbacks)
         c._request_titlebars_called = true
     end
 
+    -- Handle deferred maximized geometry from EWMH client hints
+    if not c._border_geometry_rules_applied then
+        c._border_geometry_rules_applied = true
+        if c.maximized then
+            c:emit_signal("request::geometry", "maximized")
+        elseif c.maximized_horizontal then
+            c:emit_signal("request::geometry", "maximized_horizontal")
+        elseif c.maximized_vertical then
+            c:emit_signal("request::geometry", "maximized_vertical")
+        end
+    end
+
     -- Size hints will be re-applied when setting width/height unless it is
     -- disabled first
     if props.size_hints_honor ~= nil then


### PR DESCRIPTION
Defer geometry signals for maximized clients until after titlebars and borders are applied during rule processing. This fixes issue where maximized windows had incorrect geometry when using titlebars.

Changes:
- ruled/client.lua: Emit deferred geometry signal after titlebars applied
- awful/permissions/init.lua: Skip geometry updates before rules applied

Upstream: https://github.com/awesomeWM/awesome/pull/4023