### PR TITLE
sync: port AwesomeWM #4044 - fix nil reference in clienticon

### DIFF
--- a/lua/awful/widget/clienticon.lua
+++ b/lua/awful/widget/clienticon.lua
@@ -119,7 +119,7 @@ end
 
 client.connect_signal("property::icon", function(c)
     for obj in pairs(instances) do
-        if obj._private.client.valid and obj._private.client == c then
+        if obj._private.client == c and obj._private.client.valid then
             obj:emit_signal("widget::layout_changed")
             obj:emit_signal("widget::redraw_needed")
         end


### PR DESCRIPTION
Swap condition order to check `obj._private.client == c` before accessing `.valid`, preventing crash when clienticon widget is created without a client (e.g., in declarative templates).

Upstream: https://github.com/awesomeWM/awesome/pull/4044