### PR TITLE
feat: add numeric client IDs for somewm-client (fixes #188)

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -4377,6 +4377,7 @@ LUA_OBJECT_EXPORT_PROPERTY(client, client_t, skip_taskbar, lua_pushboolean)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, leader_window, lua_pushinteger)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, group_window, lua_pushinteger)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, window, lua_pushinteger)
+LUA_OBJECT_EXPORT_PROPERTY(client, client_t, id, lua_pushinteger)
 LUA_OBJECT_EXPORT_OPTIONAL_PROPERTY(client, client_t, pid, lua_pushinteger, 0)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, hidden, lua_pushboolean)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, minimized, lua_pushboolean)
@@ -5175,6 +5176,10 @@ client_class_setup(lua_State *L)
     luaA_class_add_property(&client_class, "window",
                             NULL,
                             (lua_class_propfunc_t) luaA_client_get_window,
+                            NULL);
+    luaA_class_add_property(&client_class, "id",
+                            NULL,
+                            (lua_class_propfunc_t) luaA_client_get_id,
                             NULL);
     luaA_class_add_property(&client_class, "machine",
                             NULL,

--- a/objects/client.h
+++ b/objects/client.h
@@ -141,6 +141,8 @@ struct client_t
     WINDOW_OBJECT_HEADER
 
     /* === Wayland/wlroots specific fields (not in AwesomeWM) === */
+    /** Unique client ID (auto-incrementing, Sway-style) */
+    uint32_t id;
     /** X11 no-focus window (0 for native Wayland) - not in WINDOW_OBJECT_HEADER */
     uint32_t nofocus_window;
     /** Client type: XDGShell, LayerShell, or X11 */

--- a/somewm.c
+++ b/somewm.c
@@ -255,6 +255,7 @@ void zoom(const Arg *arg);
 
 /* variables */
 static pid_t child_pid = -1;
+static uint32_t next_client_id = 1;
 
 static int locked;
 int running = 1;  /* Non-static so somewm_api.c can access it */
@@ -1711,6 +1712,9 @@ createnotify(struct wl_listener *listener, void *data)
 	/* Create Lua client object (matches AwesomeWM client_manage line 2138) */
 	c = client_new(L);
 	/* client_new() leaves the client on the Lua stack at index -1 */
+
+	/* Assign unique client ID (Sway-style incrementing counter) */
+	c->id = next_client_id++;
 
 	/* Initialize opacity to -1 (unset) so commitnotify doesn't apply 0% opacity.
 	 * -1 means "use default" (fully opaque). 0 would mean fully transparent. */
@@ -5432,6 +5436,9 @@ createnotifyx11(struct wl_listener *listener, void *data)
 	/* Create Lua client object (matches AwesomeWM client_manage line 2138) */
 	c = client_new(L);
 	/* client_new() leaves the client on the Lua stack at index -1 */
+
+	/* Assign unique client ID (Sway-style incrementing counter) */
+	c->id = next_client_id++;
 
 	/* Link to XWayland surface (adapts X11 window linkage to XWayland) */
 	xsurface->data = c;


### PR DESCRIPTION
Add Sway-style auto-incrementing IDs to clients, replacing the raw Lua userdata pointers (e.g., "window/client(...):0x7ff038ffdc38").

Changes:
- Add `uint32_t id` field to client_t struct
- Add static counter in somewm.c, assign IDs in createnotify/createnotifyx11
- Expose `id` as read-only Lua property
- Update IPC commands to use numeric IDs in output
- Add find_client_by_id() helper for client lookups

Now `somewm-client client list` shows:
  id=1 title="Firefox" class="firefox" ... id=2 title="Terminal" class="ghostty" ...

Closes #188