### PR TITLE
fix: translate button codes in root button check

### DIFF
--- a/objects/button.c
+++ b/objects/button.c
@@ -392,7 +392,7 @@ luaA_button_check(uint32_t mods, uint32_t button)
  * BTN_SIDE (0x113/275) -> 8
  * BTN_EXTRA (0x114/276) -> 9
  */
-static uint32_t
+uint32_t
 translate_button_code(uint32_t linux_button)
 {
 	switch (linux_button) {

--- a/objects/button.h
+++ b/objects/button.h
@@ -96,6 +96,9 @@ void luaA_drawable_button_emit(void *client_ptr, void *drawable_ptr, int x, int 
 int luaA_client_button_check(void *client_ptr, int x, int y, uint32_t button,
                              uint32_t mods, bool is_press);
 
+/* Translate Linux input button code to X11-style button number */
+uint32_t translate_button_code(uint32_t linux_button);
+
 /* Button class setup (AwesomeWM class system) */
 void button_class_setup(lua_State *L);
 

--- a/root.c
+++ b/root.c
@@ -473,16 +473,20 @@ luaA_root_button_check(lua_State *L, uint32_t button, uint32_t mods,
 	button_array_t *buttons = (button_array_t *)&globalconf.buttons;
 	const char *signal_name = is_press ? "press" : "release";
 	int matched = 0;
+	uint32_t translated_button;
 
 	(void)x;
 	(void)y;
+
+	/* Translate Linux input code to X11-style button number */
+	translated_button = translate_button_code(button);
 
 	/* Iterate through root button array */
 	for (int i = 0; i < buttons->len; i++) {
 		button_t *btn = buttons->tab[i];
 
-		/* Match button number (0 = any button) */
-		bool button_matches = (btn->button == 0 || btn->button == button);
+		/* Match button number (0 = any button) - use translated code */
+		bool button_matches = (btn->button == 0 || btn->button == translated_button);
 
 		/* Match modifiers (0 = any modifiers) */
 		bool mods_match = (btn->modifiers == 0 || btn->modifiers == mods);

--- a/somewm.c
+++ b/somewm.c
@@ -5257,6 +5257,10 @@ xytonode(double x, double y, struct wlr_surface **psurface,
 					}
 				}
 			}
+		} else {
+			/* Skip parent walk for non-buffer nodes (e.g., scene rects) -
+			 * these are background elements that shouldn't intercept input */
+			continue;
 		}
 		/* Walk the tree to find a node that knows the client */
 		for (pnode = node; pnode && !c && !d; ) {


### PR DESCRIPTION
Root buttons use X11-style numbers (3=right) but wlroots sends Linux input codes (BTN_RIGHT=273). Add translate_button_code() call to luaA_root_button_check() so button matching works correctly.

Also skip parent walk for non-BUFFER scene nodes in xytonode() as a defensive fix to prevent stale data from intercepting input.