### PR TITLE
fix: validate cairo surface before accessing in drawin_accepts_input_at

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -5158,6 +5158,10 @@ drawin_accepts_input_at(drawin_t *d, double local_x, double local_y)
 	if (!shape)
 		return true;
 
+	/* Verify surface is valid before accessing (fixes issue #197) */
+	if (cairo_surface_status(shape) != CAIRO_STATUS_SUCCESS)
+		return true;
+
 	/* Get shape dimensions */
 	width = cairo_image_surface_get_width(shape);
 	height = cairo_image_surface_get_height(shape);


### PR DESCRIPTION
Add cairo_surface_status() check before calling cairo_image_surface_get_width() to prevent potential SIGSEGV when shape_input surface is in an error state.

This is a defensive fix for issue #197 where a crash was reported during rapid resize operations with nested compositors.  Still can't reproduce that specific issue, but this is my best hypothesis and worth checking in any case.

Refer #197