### PR TITLE
fix: guard against null xdg_surface in initialcommitnotify

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -1285,7 +1285,7 @@ initialcommitnotify(struct wl_listener *listener, void *data)
 	Client *c = wl_container_of(listener, c, initial_commit);
 	Monitor *m;
 
-	if (!c->surface.xdg->initial_commit)
+	if (!c->surface.xdg || !c->surface.xdg->initial_commit)
 		return;
 
 	/* Get the monitor this client will be rendered on for initial scale setting.


### PR DESCRIPTION
Race condition where client_unmanage() sets c->surface.xdg = NULL but the initial_commit listener fires before destroynotify() removes it.