### PR TITLE
fix: apply keyboard_repeat_rate/delay settings to keyboard device

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -934,8 +934,10 @@ luaA_awesome_set_keyboard_setting(lua_State *L)
 
 	if (strcmp(key, "keyboard_repeat_rate") == 0) {
 		globalconf.keyboard.repeat_rate = luaL_checkinteger(L, 2);
+		some_apply_keyboard_repeat_info();
 	} else if (strcmp(key, "keyboard_repeat_delay") == 0) {
 		globalconf.keyboard.repeat_delay = luaL_checkinteger(L, 2);
+		some_apply_keyboard_repeat_info();
 	} else if (strcmp(key, "xkb_layout") == 0) {
 		const char *val = lua_isnil(L, 2) ? "" : luaL_checkstring(L, 2);
 		free(globalconf.keyboard.xkb_layout);

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -1594,6 +1594,17 @@ some_rebuild_keyboard_keymap(void)
 	xkb_context_unref(context);
 }
 
+/* Apply keyboard repeat info from current globalconf settings */
+void
+some_apply_keyboard_repeat_info(void)
+{
+	if (!kb_group || !kb_group->wlr_group)
+		return;
+
+	wlr_keyboard_set_repeat_info(&kb_group->wlr_group->keyboard,
+		globalconf.keyboard.repeat_rate, globalconf.keyboard.repeat_delay);
+}
+
 /*
  * Layer Surface Focus API
  */

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -205,6 +205,7 @@ struct xkb_keymap *some_xkb_get_keymap(void);
 int some_xkb_set_layout_group(xkb_layout_index_t group);
 const char *some_xkb_get_group_names(void);
 void some_rebuild_keyboard_keymap(void);
+void some_apply_keyboard_repeat_info(void);
 
 /*
  * Input Device Configuration API


### PR DESCRIPTION
Previously, setting keyboard_repeat_rate or keyboard_repeat_delay via awful.input would store the values in globalconf but never apply them to the actual wlroots keyboard. The settings appeared to work (values were stored and queryable) but had no effect on keyboard behavior.

Add some_apply_keyboard_repeat_info() which calls wlr_keyboard_set_repeat_info() to apply the current globalconf settings, and call it when either setting changes.

Fixes #208