### PR TITLE
feat: add wallpaper caching for instant switching



### DIFF
--- a/globalconf.h
+++ b/globalconf.h
@@ -32,6 +32,21 @@
 #include "x11_compat.h"
 #include "shadow.h"
 
+#define WALLPAPER_CACHE_MAX 16
+
+typedef struct wallpaper_fingerprint {
+    int width, height;
+    uint32_t crc;
+} wallpaper_fingerprint_t;
+
+typedef struct wallpaper_cache_entry {
+    struct wl_list link;
+    char *key;
+    wallpaper_fingerprint_t fp;
+    struct wlr_scene_buffer *scene_node;
+    cairo_surface_t *surface;
+} wallpaper_cache_entry_t;
+
 /* Forward declarations */
 typedef struct client_t client_t;
 typedef struct tag_t tag_t;
@@ -263,10 +278,9 @@ typedef struct
      */
     cairo_surface_t *wallpaper;
 
-    /** Wallpaper scene graph node
-     * Wayland-specific: wlr_scene_buffer in LyrBg layer for display
-     */
     struct wlr_scene_buffer *wallpaper_buffer_node;
+    struct wl_list wallpaper_cache;
+    wallpaper_cache_entry_t *current_wallpaper;
 
     /* ========== SYSTRAY SUPPORT ========== */
 
@@ -392,10 +406,9 @@ void globalconf_init(lua_State *L);
  */
 void globalconf_wipe(void);
 
-/** Update wallpaper from root window (X11-only stub).
- * Wayland wallpaper is set via root_set_wallpaper() or root_set_wallpaper_buffer().
- */
 void root_update_wallpaper(void);
+void wallpaper_cache_init(void);
+void wallpaper_cache_cleanup(void);
 
 #endif /* SOMEWM_GLOBALCONF_H */
 /* vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80 */

--- a/somewm.c
+++ b/somewm.c
@@ -1085,6 +1085,10 @@ cleanup(void)
 	wlr_backend_destroy(backend);
 
 	wl_display_destroy(dpy);
+
+	/* Cleanup wallpaper cache before destroying scene (frees scene nodes) */
+	wallpaper_cache_cleanup();
+
 	/* Destroy after the wayland display (when the monitors are already destroyed)
 	   to avoid destroying them with an invalid scene output. */
 	wlr_scene_node_destroy(&scene->tree.node);
@@ -4341,6 +4345,9 @@ setup(void)
 		layers[i] = wlr_scene_tree_create(&scene->tree);
 	drag_icon = wlr_scene_tree_create(&scene->tree);
 	wlr_scene_node_place_below(&drag_icon->node, &layers[LyrBlock]->node);
+
+	/* Initialize wallpaper cache (must be after layers[] are created) */
+	wallpaper_cache_init();
 
 	/* Autocreates a renderer, either Pixman, GLES2 or Vulkan for us. The user
 	 * can also specify a renderer using the WLR_RENDERER env var.


### PR DESCRIPTION
The long story made short is that wlroots already caches GPU textures in scene buffer nodes, we were just destroying those nodes on every wallpaper switch. So, this is my idea.  We can use wlr_scene_node_set_enabled() to toggle visibility instead of  wlr_scene_node_destroy(), which would preserve the cached textures and make switching instant (or at least more instant).

We chose automatic fingerprint matching (dimensions + hash of first scanline) over requiring explicit cache keys so existing AwesomeWM configs benefit without any changes. The hash seems fast enough (~one scanline) that it doesn't negate the caching benefit, while still being unique enough to distinguish different wallpapers.

Refer #214 