### PR TITLE
fix: per-screen wallpaper caching for multi-monitor setups

### DIFF
--- a/root.c
+++ b/root.c
@@ -21,6 +21,7 @@
 #include "objects/drawable.h"
 #include "objects/drawin.h"
 #include "objects/client.h"
+#include "objects/screen.h"
 #include "somewm_types.h"
 #include <xkbcommon/xkbcommon.h>
 #include <wlr/types/wlr_seat.h>
@@ -820,7 +821,9 @@ luaA_root_drawins(lua_State *L)
 void wallpaper_cache_init(void)
 {
 	wl_list_init(&globalconf.wallpaper_cache);
-	globalconf.current_wallpaper = NULL;
+	for (int i = 0; i < WALLPAPER_MAX_SCREENS; i++) {
+		globalconf.current_wallpaper_per_screen[i] = NULL;
+	}
 }
 
 void wallpaper_cache_cleanup(void)
@@ -835,18 +838,21 @@ void wallpaper_cache_cleanup(void)
 		free(entry->path);
 		free(entry);
 	}
-	globalconf.current_wallpaper = NULL;
+	for (int i = 0; i < WALLPAPER_MAX_SCREENS; i++) {
+		globalconf.current_wallpaper_per_screen[i] = NULL;
+	}
 }
 
 static wallpaper_cache_entry_t *
-wallpaper_cache_lookup(const char *path)
+wallpaper_cache_lookup(const char *path, int screen_index)
 {
 	if (!path || !globalconf.wallpaper_cache.next)
 		return NULL;
 
 	wallpaper_cache_entry_t *entry;
 	wl_list_for_each(entry, &globalconf.wallpaper_cache, link) {
-		if (entry->path && strcmp(entry->path, path) == 0)
+		if (entry->path && strcmp(entry->path, path) == 0 &&
+		    entry->screen_index == screen_index)
 			return entry;
 	}
 	return NULL;
@@ -862,16 +868,26 @@ static int wallpaper_cache_count(void)
 	return count;
 }
 
+/** Check if entry is currently displayed on any screen */
+static bool wallpaper_cache_entry_is_current(wallpaper_cache_entry_t *entry)
+{
+	for (int i = 0; i < WALLPAPER_MAX_SCREENS; i++) {
+		if (globalconf.current_wallpaper_per_screen[i] == entry)
+			return true;
+	}
+	return false;
+}
+
 static void wallpaper_cache_evict_oldest(void)
 {
 	if (wallpaper_cache_count() < WALLPAPER_CACHE_MAX)
 		return;
 
-	/* Find oldest (last in list, since we insert at head) */
+	/* Find oldest (last in list, since we insert at head) that isn't currently shown */
 	wallpaper_cache_entry_t *oldest = NULL;
 	wallpaper_cache_entry_t *entry;
 	wl_list_for_each(entry, &globalconf.wallpaper_cache, link) {
-		if (entry != globalconf.current_wallpaper)
+		if (!wallpaper_cache_entry_is_current(entry))
 			oldest = entry;
 	}
 
@@ -886,29 +902,41 @@ static void wallpaper_cache_evict_oldest(void)
 	}
 }
 
+/** Show a cached wallpaper for a specific screen.
+ * Only hides/shows wallpapers for that screen, leaving other screens untouched.
+ * \param entry The cache entry to show
+ * \param screen_index The screen index (0-based)
+ * \return true on success
+ */
 static bool
-wallpaper_cache_show(wallpaper_cache_entry_t *entry)
+wallpaper_cache_show(wallpaper_cache_entry_t *entry, int screen_index)
 {
 	if (!entry || !entry->scene_node)
 		return false;
+	if (screen_index < 0 || screen_index >= WALLPAPER_MAX_SCREENS)
+		return false;
 
-	/* Hide current wallpaper */
-	if (globalconf.current_wallpaper && globalconf.current_wallpaper != entry) {
-		wlr_scene_node_set_enabled(&globalconf.current_wallpaper->scene_node->node, false);
+	/* Hide current wallpaper for THIS screen only */
+	wallpaper_cache_entry_t *current = globalconf.current_wallpaper_per_screen[screen_index];
+	if (current && current != entry && current->scene_node) {
+		wlr_scene_node_set_enabled(&current->scene_node->node, false);
 	}
-	/* Also hide legacy wallpaper node if present */
-	if (globalconf.wallpaper_buffer_node &&
-	    (!globalconf.current_wallpaper ||
-	     globalconf.wallpaper_buffer_node != globalconf.current_wallpaper->scene_node)) {
+
+	/* Also hide legacy wallpaper node if present (global, not per-screen) */
+	if (globalconf.wallpaper_buffer_node) {
 		wlr_scene_node_set_enabled(&globalconf.wallpaper_buffer_node->node, false);
 	}
 
 	/* Show requested wallpaper */
 	wlr_scene_node_set_enabled(&entry->scene_node->node, true);
-	globalconf.current_wallpaper = entry;
+	globalconf.current_wallpaper_per_screen[screen_index] = entry;
 
-	/* Update globalconf.wallpaper for getter compatibility */
-	cairo_surface_destroy(globalconf.wallpaper);
+	/* Update globalconf.wallpaper for getter compatibility
+	 * Note: This is a single surface, so multi-screen gets the last one set.
+	 * This matches AwesomeWM behavior where root.wallpaper() returns one surface.
+	 */
+	if (globalconf.wallpaper)
+		cairo_surface_destroy(globalconf.wallpaper);
 	globalconf.wallpaper = cairo_surface_reference(entry->surface);
 
 	luaA_emit_signal_global("wallpaper_changed");
@@ -928,56 +956,251 @@ get_wallpaper_path_from_lua(lua_State *L)
 	return path;
 }
 
-/** Clear the wallpaper path Lua global after using it */
-static void
-clear_wallpaper_path_in_lua(lua_State *L)
+/** Screen info from Lua table */
+typedef struct {
+	int index;   /* 0-based screen index */
+	int x, y;    /* Screen position */
+	int width, height;  /* Screen size */
+	bool valid;
+} wallpaper_screen_info_t;
+
+#define MAX_PENDING_SCREENS 8
+
+/** Get ALL screen infos for a path from Lua nested table
+ * Table structure: _somewm_wallpaper_screen_info[path][screen_index] = {x, y, width, height}
+ * Returns count of valid screens found (up to MAX_PENDING_SCREENS)
+ */
+static int
+get_all_wallpaper_screen_infos_from_lua(lua_State *L, const char *path,
+                                        wallpaper_screen_info_t *infos, int max_infos)
 {
+	int count = 0;
+
+	if (!path || !infos || max_infos <= 0)
+		return 0;
+
+	/* Look up the nested table: _somewm_wallpaper_screen_info[path] */
+	lua_getglobal(L, "_somewm_wallpaper_screen_info");
+	if (!lua_istable(L, -1)) {
+		lua_pop(L, 1);
+		return 0;
+	}
+
+	lua_getfield(L, -1, path);
+	if (!lua_istable(L, -1)) {
+		lua_pop(L, 2);
+		return 0;
+	}
+
+	/* Iterate over all screen indices in the path's table */
+	lua_pushnil(L);  /* first key */
+	while (lua_next(L, -2) != 0 && count < max_infos) {
+		/* key is screen_index (Lua 1-based), value is geometry table */
+		if (lua_isnumber(L, -2) && lua_istable(L, -1)) {
+			int screen_index = (int)lua_tointeger(L, -2) - 1;  /* Convert to 0-based */
+
+			wallpaper_screen_info_t *info = &infos[count];
+			info->index = screen_index;
+			info->valid = false;
+
+			lua_getfield(L, -1, "x");
+			info->x = lua_isnumber(L, -1) ? (int)lua_tointeger(L, -1) : 0;
+			lua_pop(L, 1);
+
+			lua_getfield(L, -1, "y");
+			info->y = lua_isnumber(L, -1) ? (int)lua_tointeger(L, -1) : 0;
+			lua_pop(L, 1);
+
+			lua_getfield(L, -1, "width");
+			info->width = lua_isnumber(L, -1) ? (int)lua_tointeger(L, -1) : 0;
+			lua_pop(L, 1);
+
+			lua_getfield(L, -1, "height");
+			info->height = lua_isnumber(L, -1) ? (int)lua_tointeger(L, -1) : 0;
+			lua_pop(L, 1);
+
+			if (screen_index >= 0 && info->width > 0 && info->height > 0) {
+				info->valid = true;
+				count++;
+			}
+		}
+		lua_pop(L, 1);  /* pop value, keep key for next iteration */
+	}
+
+	lua_pop(L, 2);  /* pop path table and screen_info table */
+	return count;
+}
+
+/** Clear the wallpaper path and screen Lua globals after using them */
+static void
+clear_wallpaper_info_in_lua(lua_State *L)
+{
+	/* Get path first so we can clear its entry from the screen info table */
+	lua_getglobal(L, "_somewm_last_wallpaper_path");
+	if (lua_isstring(L, -1)) {
+		const char *path = lua_tostring(L, -1);
+		/* Clear the screen info table entry for this path */
+		lua_getglobal(L, "_somewm_wallpaper_screen_info");
+		if (lua_istable(L, -1)) {
+			lua_pushnil(L);
+			lua_setfield(L, -2, path);
+		}
+		lua_pop(L, 1);  /* pop table */
+	}
+	lua_pop(L, 1);  /* pop path */
+
+	/* Clear the path global */
 	lua_pushnil(L);
 	lua_setglobal(L, "_somewm_last_wallpaper_path");
 }
 
 /* ========== WALLPAPER API ========== */
 
-/** Set wallpaper with caching by filepath
- * Cache hit: toggle visibility (fast, ~0.05ms)
- * Cache miss: create buffer+scene node, add to cache (~5ms)
+/** Create a cache entry for one screen
+ * Returns true on success, false on failure
+ */
+static bool
+create_wallpaper_cache_entry(const char *path, cairo_pattern_t *pattern,
+                             wallpaper_screen_info_t *info)
+{
+	cairo_surface_t *surface = NULL;
+	cairo_t *cr = NULL;
+	struct wlr_buffer *buffer = NULL;
+	struct wlr_scene_buffer *scene_node = NULL;
+
+	int x = info->x;
+	int y = info->y;
+	int width = info->width;
+	int height = info->height;
+	int screen_index = info->index;
+
+	surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+	if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS)
+		goto fail;
+
+	/* Paint pattern to surface, offsetting to extract the screen region */
+	cr = cairo_create(surface);
+	cairo_translate(cr, -x, -y);
+	cairo_set_source(cr, pattern);
+	cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+	cairo_paint(cr);
+	cairo_destroy(cr);
+	cr = NULL;
+	cairo_surface_flush(surface);
+
+	buffer = drawable_create_buffer_from_data(
+		width, height,
+		cairo_image_surface_get_data(surface),
+		cairo_image_surface_get_stride(surface)
+	);
+	if (!buffer)
+		goto fail;
+
+	scene_node = wlr_scene_buffer_create(layers[0], buffer);
+	if (!scene_node)
+		goto fail;
+
+	wlr_scene_node_set_position(&scene_node->node, x, y);
+	wlr_scene_node_set_enabled(&scene_node->node, false);  /* Hidden until shown */
+
+	wallpaper_cache_evict_oldest();
+
+	wallpaper_cache_entry_t *entry = calloc(1, sizeof(*entry));
+	if (!entry)
+		goto fail;
+
+	entry->path = strdup(path);
+	entry->screen_index = screen_index;
+	entry->scene_node = scene_node;
+	entry->surface = surface;
+	wl_list_insert(&globalconf.wallpaper_cache, &entry->link);
+
+	wlr_buffer_drop(buffer);
+
+	/* Show this wallpaper */
+	wallpaper_cache_show(entry, screen_index);
+	return true;
+
+fail:
+	if (scene_node)
+		wlr_scene_node_destroy(&scene_node->node);
+	if (buffer)
+		wlr_buffer_drop(buffer);
+	if (surface)
+		cairo_surface_destroy(surface);
+	return false;
+}
+
+/** Set wallpaper with per-screen caching
+ * Creates cache entries for ALL screens that requested this wallpaper path.
+ * This handles the case where the same wallpaper is used on multiple screens.
  */
 static bool
 root_set_wallpaper_cached(lua_State *L, cairo_pattern_t *pattern)
 {
 	const char *path = get_wallpaper_path_from_lua(L);
 	bool cache_enabled = globalconf.wallpaper_cache.next != NULL;
+	bool result = false;
 
-	/* Check cache first */
+	/* Get ALL pending screens for this path */
+	wallpaper_screen_info_t screen_infos[MAX_PENDING_SCREENS];
+	int screen_count = 0;
+
 	if (cache_enabled && path) {
-		wallpaper_cache_entry_t *entry = wallpaper_cache_lookup(path);
-		if (entry) {
-			bool ok = wallpaper_cache_show(entry);
-			clear_wallpaper_path_in_lua(L);
-			return ok;
-		}
+		screen_count = get_all_wallpaper_screen_infos_from_lua(L, path,
+			screen_infos, MAX_PENDING_SCREENS);
 	}
 
-	/* Cache miss - need to create the wallpaper */
+	/* Create cache entries for all pending screens */
+	if (screen_count > 0) {
+		for (int i = 0; i < screen_count; i++) {
+			wallpaper_screen_info_t *info = &screen_infos[i];
+			if (!info->valid)
+				continue;
+
+			/* Check if already cached */
+			wallpaper_cache_entry_t *existing = wallpaper_cache_lookup(path, info->index);
+			if (existing) {
+				wallpaper_cache_show(existing, info->index);
+				result = true;
+				continue;
+			}
+
+			/* Create new cache entry */
+			if (create_wallpaper_cache_entry(path, pattern, info))
+				result = true;
+		}
+
+		clear_wallpaper_info_in_lua(L);
+		if (result)
+			return true;
+	}
+
+	/* Fallback: no caching (cache not ready, no path, or no screens) */
+	/* Use full layout geometry */
+	struct wlr_box layout_box;
+	wlr_output_layout_get_box(output_layout, NULL, &layout_box);
+	int x = 0, y = 0;
+	int width = layout_box.width;
+	int height = layout_box.height;
+
+	if (width <= 0 || height <= 0) {
+		clear_wallpaper_info_in_lua(L);
+		return false;
+	}
+
+	/* Create single wallpaper for full layout (legacy path) */
 	cairo_surface_t *surface = NULL;
 	cairo_t *cr = NULL;
 	struct wlr_buffer *buffer = NULL;
 	struct wlr_scene_buffer *scene_node = NULL;
-	struct wlr_box layout_box;
-	bool result = false;
-
-	wlr_output_layout_get_box(output_layout, NULL, &layout_box);
-	int width = layout_box.width;
-	int height = layout_box.height;
-
-	if (width <= 0 || height <= 0)
-		goto cleanup;
 
 	surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
 	if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS)
 		goto cleanup;
 
 	cr = cairo_create(surface);
+	cairo_translate(cr, -x, -y);
 	cairo_set_source(cr, pattern);
 	cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
 	cairo_paint(cr);
@@ -996,35 +1219,19 @@ root_set_wallpaper_cached(lua_State *L, cairo_pattern_t *pattern)
 	scene_node = wlr_scene_buffer_create(layers[0], buffer);
 	if (!scene_node)
 		goto cleanup;
-	wlr_scene_node_set_position(&scene_node->node, 0, 0);
+	wlr_scene_node_set_position(&scene_node->node, x, y);
 
-	/* Add to cache if enabled and we have a path */
-	if (cache_enabled && path) {
-		wlr_scene_node_set_enabled(&scene_node->node, false);
-		wallpaper_cache_evict_oldest();
-
-		wallpaper_cache_entry_t *entry = calloc(1, sizeof(*entry));
-		if (entry) {
-			entry->path = strdup(path);
-			entry->scene_node = scene_node;
-			entry->surface = surface;
-			wl_list_insert(&globalconf.wallpaper_cache, &entry->link);
-
-			wlr_buffer_drop(buffer);
-			result = wallpaper_cache_show(entry);
-			clear_wallpaper_path_in_lua(L);
-			return result;
-		}
-	}
-
-	/* Fallback: no caching (cache not ready or no path) */
 	if (globalconf.wallpaper_buffer_node)
 		wlr_scene_node_destroy(&globalconf.wallpaper_buffer_node->node);
 	globalconf.wallpaper_buffer_node = scene_node;
 
-	cairo_surface_destroy(globalconf.wallpaper);
+	if (globalconf.wallpaper)
+		cairo_surface_destroy(globalconf.wallpaper);
 	globalconf.wallpaper = surface;
 	surface = NULL;
+
+	wlr_buffer_drop(buffer);
+	buffer = NULL;
 
 	luaA_emit_signal_global("wallpaper_changed");
 	result = true;
@@ -1033,7 +1240,7 @@ cleanup:
 	if (cr) cairo_destroy(cr);
 	if (surface) cairo_surface_destroy(surface);
 	if (buffer) wlr_buffer_drop(buffer);
-	if (path) clear_wallpaper_path_in_lua(L);
+	clear_wallpaper_info_in_lua(L);
 	return result;
 }
 
@@ -1077,32 +1284,61 @@ luaA_root_wallpaper(lua_State *L)
 
 /* ========== END WALLPAPER SUPPORT ========== */
 
-/** root.wallpaper_cache_has(path) - Check if wallpaper is cached
+/** root.wallpaper_cache_has(path, screen) - Check if wallpaper is cached for screen
  * \param path Wallpaper file path
- * \return true if path is in cache
+ * \param screen Screen object or index (1-based)
+ * \return true if (path, screen) is in cache
  */
 static int
 luaA_root_wallpaper_cache_has(lua_State *L)
 {
 	const char *path = luaL_checkstring(L, 1);
-	bool has = wallpaper_cache_lookup(path) != NULL;
+	int screen_index = -1;
+
+	/* Get screen index from screen object or number */
+	if (lua_isnumber(L, 2)) {
+		screen_index = (int)lua_tointeger(L, 2) - 1;  /* Lua is 1-based */
+	} else {
+		screen_t *screen = luaA_toscreen(L, 2);
+		if (screen)
+			screen_index = screen->index - 1;  /* screen->index is 1-based */
+	}
+
+	bool has = (screen_index >= 0) && wallpaper_cache_lookup(path, screen_index) != NULL;
 	lua_pushboolean(L, has);
 	return 1;
 }
 
-/** root.wallpaper_cache_show(path) - Show cached wallpaper directly
- * Skips all Lua/cairo work if wallpaper is cached.
+/** root.wallpaper_cache_show(path, screen) - Show cached wallpaper directly
+ * Skips all Lua/cairo work if wallpaper is cached for the given screen.
  * \param path Wallpaper file path
+ * \param screen Screen object or index (1-based)
  * \return true if cache hit and wallpaper shown, false otherwise
  */
 static int
 luaA_root_wallpaper_cache_show(lua_State *L)
 {
 	const char *path = luaL_checkstring(L, 1);
-	wallpaper_cache_entry_t *entry = wallpaper_cache_lookup(path);
+	int screen_index = -1;
 
+	/* Get screen index from screen object or number */
+	if (lua_isnumber(L, 2)) {
+		screen_index = (int)lua_tointeger(L, 2) - 1;  /* Lua is 1-based */
+	} else {
+		screen_t *screen = luaA_toscreen(L, 2);
+		if (screen) {
+			screen_index = screen->index - 1;  /* screen->index is 1-based */
+		}
+	}
+
+	if (screen_index < 0) {
+		lua_pushboolean(L, false);
+		return 1;
+	}
+
+	wallpaper_cache_entry_t *entry = wallpaper_cache_lookup(path, screen_index);
 	if (entry) {
-		bool ok = wallpaper_cache_show(entry);
+		bool ok = wallpaper_cache_show(entry, screen_index);
 		lua_pushboolean(L, ok);
 		return 1;
 	}
@@ -1133,20 +1369,35 @@ luaA_root_wallpaper_cache_clear(lua_State *L)
 		free(entry);
 	}
 
-	globalconf.current_wallpaper = NULL;
+	for (int i = 0; i < WALLPAPER_MAX_SCREENS; i++) {
+		globalconf.current_wallpaper_per_screen[i] = NULL;
+	}
 	return 0;
 }
 
-/** Preload a single wallpaper into cache (internal helper) */
+/** Preload a single wallpaper into cache for a specific screen (internal helper) */
 static bool
-wallpaper_cache_preload_path(const char *path)
+wallpaper_cache_preload_path(const char *path, int screen_index)
 {
 	if (!path || !globalconf.wallpaper_cache.next)
 		return false;
+	if (screen_index < 0 || screen_index >= (int)globalconf.screens.len)
+		return false;
 
-	/* Already cached? */
-	if (wallpaper_cache_lookup(path))
+	/* Already cached for this screen? */
+	if (wallpaper_cache_lookup(path, screen_index))
 		return true;
+
+	/* Get screen geometry */
+	screen_t *screen = globalconf.screens.tab[screen_index];
+	if (!screen)
+		return false;
+	int scr_x = screen->geometry.x;
+	int scr_y = screen->geometry.y;
+	int scr_width = screen->geometry.width;
+	int scr_height = screen->geometry.height;
+	if (scr_width <= 0 || scr_height <= 0)
+		return false;
 
 	/* Load image via gdk-pixbuf */
 	GError *error = NULL;
@@ -1156,25 +1407,34 @@ wallpaper_cache_preload_path(const char *path)
 		return false;
 	}
 
-	int width = gdk_pixbuf_get_width(pixbuf);
-	int height = gdk_pixbuf_get_height(pixbuf);
+	int img_width = gdk_pixbuf_get_width(pixbuf);
+	int img_height = gdk_pixbuf_get_height(pixbuf);
 	int rowstride = gdk_pixbuf_get_rowstride(pixbuf);
 	int n_channels = gdk_pixbuf_get_n_channels(pixbuf);
 	guchar *pixels = gdk_pixbuf_get_pixels(pixbuf);
 
-	cairo_surface_t *surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+	/* Create a screen-sized surface */
+	cairo_surface_t *surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, scr_width, scr_height);
 	if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) {
 		g_object_unref(pixbuf);
 		return false;
 	}
 
-	/* Copy pixbuf (RGB/RGBA) to cairo surface (ARGB) */
-	unsigned char *dest = cairo_image_surface_get_data(surface);
-	int dest_stride = cairo_image_surface_get_stride(surface);
-	for (int y = 0; y < height; y++) {
+	/* Create intermediate surface for the source image */
+	cairo_surface_t *img_surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, img_width, img_height);
+	if (cairo_surface_status(img_surface) != CAIRO_STATUS_SUCCESS) {
+		cairo_surface_destroy(surface);
+		g_object_unref(pixbuf);
+		return false;
+	}
+
+	/* Copy pixbuf to image surface */
+	unsigned char *dest = cairo_image_surface_get_data(img_surface);
+	int dest_stride = cairo_image_surface_get_stride(img_surface);
+	for (int y = 0; y < img_height; y++) {
 		guchar *src_row = pixels + y * rowstride;
 		uint32_t *dest_row = (uint32_t *)(dest + y * dest_stride);
-		for (int x = 0; x < width; x++) {
+		for (int x = 0; x < img_width; x++) {
 			guchar r = src_row[x * n_channels + 0];
 			guchar g = src_row[x * n_channels + 1];
 			guchar b = src_row[x * n_channels + 2];
@@ -1182,12 +1442,28 @@ wallpaper_cache_preload_path(const char *path)
 			dest_row[x] = (a << 24) | (r << 16) | (g << 8) | b;
 		}
 	}
-	cairo_surface_mark_dirty(surface);
+	cairo_surface_mark_dirty(img_surface);
 	g_object_unref(pixbuf);
+
+	/* Scale image to fit screen (maximized style) */
+	cairo_t *cr = cairo_create(surface);
+	double scale_x = (double)scr_width / img_width;
+	double scale_y = (double)scr_height / img_height;
+	double scale = (scale_x > scale_y) ? scale_x : scale_y;  /* Cover (max scale) */
+	double offset_x = (scr_width - img_width * scale) / 2.0;
+	double offset_y = (scr_height - img_height * scale) / 2.0;
+	cairo_translate(cr, offset_x, offset_y);
+	cairo_scale(cr, scale, scale);
+	cairo_set_source_surface(cr, img_surface, 0, 0);
+	cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+	cairo_paint(cr);
+	cairo_destroy(cr);
+	cairo_surface_destroy(img_surface);
+	cairo_surface_flush(surface);
 
 	/* Create wlr_buffer */
 	struct wlr_buffer *buffer = drawable_create_buffer_from_data(
-		width, height,
+		scr_width, scr_height,
 		cairo_image_surface_get_data(surface),
 		cairo_image_surface_get_stride(surface)
 	);
@@ -1196,14 +1472,14 @@ wallpaper_cache_preload_path(const char *path)
 		return false;
 	}
 
-	/* Create scene node (hidden) */
+	/* Create scene node at screen position (hidden) */
 	struct wlr_scene_buffer *scene_node = wlr_scene_buffer_create(layers[0], buffer);
 	if (!scene_node) {
 		wlr_buffer_drop(buffer);
 		cairo_surface_destroy(surface);
 		return false;
 	}
-	wlr_scene_node_set_position(&scene_node->node, 0, 0);
+	wlr_scene_node_set_position(&scene_node->node, scr_x, scr_y);
 	wlr_scene_node_set_enabled(&scene_node->node, false);
 	wlr_buffer_drop(buffer);
 
@@ -1218,6 +1494,7 @@ wallpaper_cache_preload_path(const char *path)
 		return false;
 	}
 	entry->path = strdup(path);
+	entry->screen_index = screen_index;
 	entry->scene_node = scene_node;
 	entry->surface = surface;
 	wl_list_insert(&globalconf.wallpaper_cache, &entry->link);
@@ -1225,8 +1502,9 @@ wallpaper_cache_preload_path(const char *path)
 	return true;
 }
 
-/** root.wallpaper_cache_preload(paths) - Preload wallpapers into cache
+/** root.wallpaper_cache_preload(paths, screen) - Preload wallpapers into cache
  * \param paths Array of file paths to preload
+ * \param screen Screen object or index (1-based). If omitted, preloads for primary screen.
  * \return Number of successfully preloaded wallpapers
  */
 static int
@@ -1234,12 +1512,24 @@ luaA_root_wallpaper_cache_preload(lua_State *L)
 {
 	luaA_checktable(L, 1);
 
+	/* Get screen index (default to primary/screen 0) */
+	int screen_index = 0;
+	if (lua_gettop(L) >= 2) {
+		if (lua_isnumber(L, 2)) {
+			screen_index = (int)lua_tointeger(L, 2) - 1;  /* Lua is 1-based */
+		} else {
+			screen_t *screen = luaA_toscreen(L, 2);
+			if (screen)
+				screen_index = screen->index - 1;
+		}
+	}
+
 	int count = 0;
 	lua_pushnil(L);
 	while (lua_next(L, 1) != 0) {
 		if (lua_isstring(L, -1)) {
 			const char *path = lua_tostring(L, -1);
-			if (wallpaper_cache_preload_path(path))
+			if (wallpaper_cache_preload_path(path, screen_index))
 				count++;
 		}
 		lua_pop(L, 1);


### PR DESCRIPTION
The initial wallpaper caching implementation had issues with multi-monitor:
- Same wallpaper on multiple screens would overwrite cache info
- globalconf.screens was empty during timer.delayed_call
- Only one screen's wallpaper would be cached

Changes:
- Store screen geometry in nested Lua table: [path][screen_index] = {geometry}
- Read geometry directly from Lua instead of globalconf.screens
- Create cache entries for ALL screens requesting the same wallpaper
- Each screen independently toggles its own cached scene node