### PR TITLE
feat: runtime cursor theme and size configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to somewm will be documented in this file.
 ### Added
 
 - ASAN/UBSAN build support via `make asan` for debugging memory issues
+- Runtime cursor theme and size changing via `root.cursor_theme()` and `root.cursor_size()` (#177)
+- Startup now respects `XCURSOR_THEME` and `XCURSOR_SIZE` environment variables (#177)
 
 ## [0.4.0] - 2025-12-28
 
@@ -29,7 +31,7 @@ All notable changes to somewm will be documented in this file.
 - Dynamic keybinding removal (#15)
 - Scroll wheel support in mousebinds (#16)
 - Complete button press/release signals on clients (#17)
-- Cursor theme changing via `root.cursor()` (#18)
+- Cursor shape changing via `root.cursor()` (#18)
 
 ### Notes
 - XKB layout switching moved to 0.5.0 (Wayland limitation with documented workaround)

--- a/root.c
+++ b/root.c
@@ -771,6 +771,46 @@ luaA_root_cursor(lua_State *L)
 	return 0;
 }
 
+/** root.cursor_theme([name]) - Get or set cursor theme
+ * Called with no arguments, returns the current cursor theme name.
+ * Called with a theme name, changes the cursor theme at runtime.
+ * \param name (optional) Name of cursor theme (e.g., "Adwaita", "macOS")
+ * \return Current theme name if called as getter
+ */
+static int
+luaA_root_cursor_theme(lua_State *L)
+{
+	if (lua_gettop(L) >= 1) {
+		const char *theme = luaL_checkstring(L, 1);
+		some_update_cursor_theme(theme, some_get_cursor_size());
+		return 0;
+	}
+	lua_pushstring(L, some_get_cursor_theme());
+	return 1;
+}
+
+/** root.cursor_size([size]) - Get or set cursor size
+ * Called with no arguments, returns the current cursor size.
+ * Called with a size, changes the cursor size at runtime.
+ * \param size (optional) Cursor size in pixels (e.g., 24, 32, 48)
+ * \return Current size if called as getter
+ */
+static int
+luaA_root_cursor_size(lua_State *L)
+{
+	if (lua_gettop(L) >= 1) {
+		int size = luaL_checkinteger(L, 1);
+		if (size > 0) {
+			some_update_cursor_theme(some_get_cursor_theme(), size);
+		} else {
+			luaA_warn(L, "cursor size must be positive");
+		}
+		return 0;
+	}
+	lua_pushinteger(L, some_get_cursor_size());
+	return 1;
+}
+
 /** root.tags() - Get all tags
  * AwesomeWM compatibility: returns array of all tag objects
  * \return Table containing all tags
@@ -1929,6 +1969,8 @@ static const luaL_Reg root_methods[] = {
 	{ "wallpaper_cache_clear", luaA_root_wallpaper_cache_clear },
 	{ "wallpaper_cache_preload", luaA_root_wallpaper_cache_preload },
 	{ "cursor", luaA_root_cursor },
+	{ "cursor_theme", luaA_root_cursor_theme },
+	{ "cursor_size", luaA_root_cursor_size },
 	{ "fake_input", luaA_root_fake_input },
 	{ "drawins", luaA_root_drawins },
 	{ "size", luaA_root_size },

--- a/somewm.c
+++ b/somewm.c
@@ -381,7 +381,7 @@ static void sethints(struct wl_listener *listener, void *data);
 static void xwaylandready(struct wl_listener *listener, void *data);
 static struct wl_listener new_xwayland_surface = {.notify = createnotifyx11};
 static struct wl_listener xwayland_ready = {.notify = xwaylandready};
-static struct wlr_xwayland *xwayland;
+struct wlr_xwayland *xwayland;
 #endif
 
 /* Helper functions to expose layouts array to somewm_api.c */
@@ -4479,8 +4479,16 @@ setup(void)
 	 * Xcursor themes to source cursor images from and makes sure that cursor
 	 * images are available at all scale factors on the screen (necessary for
 	 * HiDPI support). Scaled cursors will be loaded with each output. */
-	cursor_mgr = wlr_xcursor_manager_create(NULL, 24);
-	setenv("XCURSOR_SIZE", "24", 1);
+	const char *cursor_theme = getenv("XCURSOR_THEME");
+	const char *cursor_size_str = getenv("XCURSOR_SIZE");
+	int cursor_size = 24;
+	if (cursor_size_str) {
+		int parsed = atoi(cursor_size_str);
+		if (parsed > 0) {
+			cursor_size = parsed;
+		}
+	}
+	cursor_mgr = wlr_xcursor_manager_create(cursor_theme, cursor_size);
 
 	/*
 	 * wlr_cursor *only* displays an image on screen. It does not move around

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -173,6 +173,14 @@ struct wlr_seat *some_get_seat(void);
 int some_has_exclusive_focus(void);
 struct wlr_cursor *some_get_cursor(void);
 struct wl_list *some_get_keyboard_groups(void);
+
+/*
+ * Cursor Theme API
+ * Runtime cursor theme and size configuration
+ */
+const char *some_get_cursor_theme(void);
+uint32_t some_get_cursor_size(void);
+void some_update_cursor_theme(const char *theme_name, uint32_t size);
 void some_get_cursor_position(double *x, double *y);
 void some_set_cursor_position(double x, double y, int silent);
 void some_get_button_states(int states[5]);


### PR DESCRIPTION
Add Lua APIs to change cursor theme and size without restarting:
- root.cursor_theme([name]) - get/set cursor theme (e.g., "Adwaita")
- root.cursor_size([size]) - get/set cursor size in pixels

Also fixes startup to respect XCURSOR_THEME and XCURSOR_SIZE environment variables, which were previously ignored.