### PR TITLE
fix: --check mode ignores commented-out require()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 
 -include .local.mk
 
-.PHONY: all install uninstall clean setup reconfigure test test-unit test-integration test-asan test-one test-visual test-one-visual test-ci test-fast build-test
+.PHONY: all install uninstall clean setup reconfigure test test-unit test-check test-integration test-asan test-one test-visual test-one-visual test-ci test-fast build-test
 
 # Default build: WITH ASAN for development
 all:
@@ -52,12 +52,16 @@ reconfigure:
 # =============================================================================
 
 # Run all tests (fast, no ASAN)
-test: test-unit test-integration
+test: test-unit test-check test-integration
 
 # Unit tests only (busted, no compositor needed)
 # Use - prefix to continue even if unit tests fail (some have known issues)
 test-unit:
 	-@./tests/run-unit.sh
+
+# Check mode tests (no compositor needed, tests somewm --check)
+test-check: build-test
+	@./tests/test-check-mode.sh ./build-test/somewm
 
 # Integration tests (visual mode by default, no ASAN)
 test-integration: build-test

--- a/luaa.c
+++ b/luaa.c
@@ -2745,6 +2745,20 @@ check_mode_scan_requires(const char *content, const char *config_dir,
 			continue;
 		}
 
+		/* Skip if line is a Lua comment (starts with -- after whitespace) */
+		{
+			const char *line_start = pos;
+			while (line_start > content && *(line_start - 1) != '\n')
+				line_start--;
+			const char *p = line_start;
+			while (p < pos && (*p == ' ' || *p == '\t'))
+				p++;
+			if (p[0] == '-' && p[1] == '-') {
+				pos += 7;
+				continue;
+			}
+		}
+
 		pos += 7;
 
 		while (*pos == ' ' || *pos == '\t' || *pos == '(')

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,6 +12,16 @@ Unit tests test individual Lua modules in isolation using the busted framework. 
 **Framework**: busted
 **Runner**: `tests/run-unit.sh`
 
+### Check Mode Tests (`tests/test-check-mode.sh`)
+
+Check mode tests validate `somewm --check` behavior by creating temporary config fixtures and verifying output and exit codes. These tests don't start the compositor — they invoke the binary directly as a CLI tool.
+
+**Location**: `tests/test-check-mode.sh`
+**Framework**: Shell script with assert helpers
+**Runner**: `make test-check`
+
+Covers: X11 pattern detection, require scanning, comment filtering, syntax errors, report formatting, and exit codes.
+
 ### Integration Tests (`tests/`)
 
 Integration tests run somewm in headless mode and execute test scenarios via IPC. These tests verify that the compositor behaves correctly as a whole system.
@@ -39,6 +49,12 @@ Example output:
 Running unit tests...
 ●●●●●●●●●●●●
 12 successes / 0 failures / 0 errors / 0 pending : 0.001234 seconds
+```
+
+### Run Check Mode Tests Only
+
+```bash
+make test-check
 ```
 
 ### Run Integration Tests Only

--- a/tests/test-check-mode.sh
+++ b/tests/test-check-mode.sh
@@ -1,0 +1,398 @@
+#!/usr/bin/env bash
+#
+# Test suite for somewm --check mode
+#
+# Tests the config validator without starting the compositor.
+# Creates temporary config fixtures, runs somewm --check, and
+# verifies stdout content and exit codes.
+#
+# Usage: ./tests/test-check-mode.sh [path-to-somewm-binary]
+
+set -e
+
+SOMEWM="${1:-./build-test/somewm}"
+
+# Verify binary exists
+if [ ! -x "$SOMEWM" ]; then
+    echo "Error: somewm binary not found at $SOMEWM" >&2
+    echo "Run 'make build-test' first" >&2
+    exit 1
+fi
+
+# Setup temp directory
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
+
+# Counters
+test_count=0
+pass_count=0
+fail_count=0
+
+# === Helper Functions ===
+
+write_config() {
+    local name="$1"
+    local content="$2"
+    local dir
+    dir=$(dirname "$TMP_DIR/$name")
+    mkdir -p "$dir"
+    printf '%s\n' "$content" > "$TMP_DIR/$name"
+    echo "$TMP_DIR/$name"
+}
+
+run_check() {
+    local config="$1"
+    set +e
+    CHECK_STDOUT=$("$SOMEWM" --check "$config" 2>"$TMP_DIR/_stderr")
+    CHECK_EXIT=$?
+    set -e
+    CHECK_STDERR=$(cat "$TMP_DIR/_stderr")
+}
+
+pass() {
+    test_count=$((test_count + 1))
+    pass_count=$((pass_count + 1))
+    printf '%s\n' "--- PASS: $1"
+}
+
+fail() {
+    test_count=$((test_count + 1))
+    fail_count=$((fail_count + 1))
+    printf '%s\n' "--- FAIL: $1: $2"
+}
+
+assert_exit() {
+    local name="$1" expected="$2"
+    if [ "$CHECK_EXIT" -ne "$expected" ]; then
+        fail "$name" "expected exit code $expected, got $CHECK_EXIT"
+        return 1
+    fi
+}
+
+assert_contains() {
+    local name="$1" pattern="$2"
+    if ! echo "$CHECK_STDOUT" | grep -qF "$pattern"; then
+        fail "$name" "stdout missing: '$pattern'"
+        return 1
+    fi
+}
+
+assert_not_contains() {
+    local name="$1" pattern="$2"
+    if echo "$CHECK_STDOUT" | grep -qF "$pattern"; then
+        fail "$name" "stdout should not contain: '$pattern'"
+        return 1
+    fi
+}
+
+# === Group 1: Clean Configs ===
+
+test_valid_config() {
+    local name="valid_config"
+    local cfg
+    cfg=$(write_config "clean.lua" "local x = 1
+return x")
+    run_check "$cfg"
+    assert_exit "$name" 0 || return
+    assert_contains "$name" "No compatibility issues found" || return
+    pass "$name"
+}
+
+test_empty_config() {
+    local name="empty_config"
+    local cfg
+    cfg=$(write_config "empty.lua" "")
+    run_check "$cfg"
+    assert_exit "$name" 0 || return
+    assert_contains "$name" "No compatibility issues found" || return
+    pass "$name"
+}
+
+# === Group 2: X11 Pattern Detection ===
+
+test_x11_critical() {
+    local name="x11_critical_xrandr"
+    local cfg
+    cfg=$(write_config "x11_crit.lua" 'local handle = io.popen("xrandr --query")')
+    run_check "$cfg"
+    assert_exit "$name" 2 || return
+    assert_contains "$name" "CRITICAL" || return
+    assert_contains "$name" "xrandr" || return
+    pass "$name"
+}
+
+test_x11_warning() {
+    local name="x11_warning_xclip"
+    local cfg
+    cfg=$(write_config "x11_warn.lua" 'local cmd = "xclip -selection clipboard"')
+    run_check "$cfg"
+    assert_exit "$name" 1 || return
+    assert_contains "$name" "WARNING" || return
+    assert_contains "$name" "xclip" || return
+    pass "$name"
+}
+
+test_x11_commented_ignored() {
+    local name="x11_commented_ignored"
+    local cfg
+    cfg=$(write_config "x11_commented.lua" '-- local handle = io.popen("xrandr --query")
+-- local cmd = "xclip -selection"
+local x = 1
+return x')
+    run_check "$cfg"
+    assert_exit "$name" 0 || return
+    assert_not_contains "$name" "xrandr" || return
+    assert_not_contains "$name" "xclip" || return
+    pass "$name"
+}
+
+test_x11_mixed_severity() {
+    local name="x11_mixed_severity"
+    local cfg
+    cfg=$(write_config "x11_mixed.lua" 'local handle = io.popen("xrandr --query")
+local cmd = "xclip -selection clipboard"')
+    run_check "$cfg"
+    assert_exit "$name" 2 || return
+    assert_contains "$name" "CRITICAL" || return
+    pass "$name"
+}
+
+# === Group 3: Require Scanning ===
+
+test_require_commented_ignored() {
+    local name="require_commented_ignored"
+    local cfg
+    cfg=$(write_config "req_comment.lua" '-- require("nonexistent_module_xyz")
+local x = 1
+return x')
+    run_check "$cfg"
+    assert_exit "$name" 0 || return
+    assert_not_contains "$name" "nonexistent_module_xyz" || return
+    pass "$name"
+}
+
+test_require_missing_reported() {
+    local name="require_missing_reported"
+    local cfg
+    cfg=$(write_config "req_missing.lua" 'local _m = require("totally_missing_module_xyz")
+return true')
+    run_check "$cfg"
+    assert_contains "$name" "totally_missing_module_xyz" || return
+    assert_contains "$name" "module not found" || return
+    pass "$name"
+}
+
+test_require_stdlib_skipped() {
+    local name="require_stdlib_skipped"
+    local cfg
+    # Verify none of these stdlib modules appear as "module not found"
+    cfg=$(write_config "req_stdlib.lua" 'require("string")
+require("table")
+require("math")
+require("io")
+require("os")
+require("debug")
+require("coroutine")
+require("package")')
+    run_check "$cfg"
+    assert_not_contains "$name" "module not found" || return
+    pass "$name"
+}
+
+test_require_awesomewm_skipped() {
+    local name="require_awesomewm_skipped"
+    local cfg
+    # Verify none of these AwesomeWM modules appear as "module not found"
+    cfg=$(write_config "req_awesome.lua" 'require("awful")
+require("gears")
+require("wibox")
+require("naughty")
+require("beautiful")
+require("menubar")
+require("ruled")')
+    run_check "$cfg"
+    assert_not_contains "$name" "module not found" || return
+    pass "$name"
+}
+
+test_require_thirdparty_skipped() {
+    local name="require_thirdparty_skipped"
+    local cfg
+    # Verify none of these known third-party modules appear as "module not found"
+    cfg=$(write_config "req_thirdparty.lua" 'require("lgi")
+require("cairo")
+require("inspect")
+require("lain")
+require("dkjson")')
+    run_check "$cfg"
+    assert_not_contains "$name" "module not found" || return
+    pass "$name"
+}
+
+test_require_method_skipped() {
+    local name="require_method_skipped"
+    local cfg
+    # .require method calls should not be flagged as missing modules
+    cfg=$(write_config "req_method.lua" 'local lgi = require("lgi")
+local Gtk = lgi.require("Gtk")
+return Gtk')
+    run_check "$cfg"
+    assert_not_contains "$name" "module not found" || return
+    pass "$name"
+}
+
+test_require_local_module() {
+    local name="require_local_module"
+    mkdir -p "$TMP_DIR/local_mod"
+    printf 'local mymod = require("mymodule")\nreturn mymod\n' > "$TMP_DIR/local_mod/rc.lua"
+    printf 'return { version = 1 }\n' > "$TMP_DIR/local_mod/mymodule.lua"
+    run_check "$TMP_DIR/local_mod/rc.lua"
+    assert_exit "$name" 0 || return
+    assert_not_contains "$name" "mymodule" || return
+    pass "$name"
+}
+
+test_require_init_module() {
+    local name="require_init_module"
+    mkdir -p "$TMP_DIR/init_mod/mypkg"
+    printf 'local mypkg = require("mypkg")\nreturn mypkg\n' > "$TMP_DIR/init_mod/rc.lua"
+    printf 'return { version = 1 }\n' > "$TMP_DIR/init_mod/mypkg/init.lua"
+    run_check "$TMP_DIR/init_mod/rc.lua"
+    assert_exit "$name" 0 || return
+    assert_not_contains "$name" "mypkg" || return
+    pass "$name"
+}
+
+test_require_indented_comment() {
+    local name="require_indented_comment"
+    local cfg
+    cfg=$(write_config "req_indent.lua" '    -- require("nonexistent_indented_xyz")
+	-- require("nonexistent_tabbed_xyz")
+local x = 1
+return x')
+    run_check "$cfg"
+    assert_exit "$name" 0 || return
+    assert_not_contains "$name" "nonexistent_indented_xyz" || return
+    assert_not_contains "$name" "nonexistent_tabbed_xyz" || return
+    pass "$name"
+}
+
+test_require_both_quotes() {
+    local name="require_both_quotes"
+    local cfg
+    cfg=$(write_config "req_quotes.lua" "local _m1 = require(\"missing_double_xyz\")
+local _m2 = require('missing_single_xyz')
+return true")
+    run_check "$cfg"
+    assert_contains "$name" "missing_double_xyz" || return
+    assert_contains "$name" "missing_single_xyz" || return
+    pass "$name"
+}
+
+# === Group 4: Syntax Errors ===
+
+test_syntax_error() {
+    local name="syntax_error"
+    local cfg
+    cfg=$(write_config "syntax_err.lua" 'local x = {
+    foo = "bar"
+    baz = "qux"
+}')
+    run_check "$cfg"
+    assert_exit "$name" 2 || return
+    assert_contains "$name" "CRITICAL" || return
+    pass "$name"
+}
+
+test_syntax_unterminated() {
+    local name="syntax_unterminated_string"
+    local cfg
+    cfg=$(write_config "syntax_unterm.lua" 'local x = "unterminated string')
+    run_check "$cfg"
+    assert_exit "$name" 2 || return
+    assert_contains "$name" "CRITICAL" || return
+    pass "$name"
+}
+
+# === Group 5: Report Format ===
+
+test_report_header() {
+    local name="report_header"
+    local cfg
+    cfg=$(write_config "header.lua" 'local _m = require("totally_missing_header_xyz")
+return true')
+    run_check "$cfg"
+    assert_contains "$name" "somewm config compatibility report" || return
+    assert_contains "$name" "====================================" || return
+    pass "$name"
+}
+
+test_report_summary() {
+    local name="report_summary"
+    local cfg
+    cfg=$(write_config "summary.lua" 'local _m = require("totally_missing_summary_xyz")
+return true')
+    run_check "$cfg"
+    assert_contains "$name" "Summary:" || return
+    pass "$name"
+}
+
+test_no_ansi_codes() {
+    local name="no_ansi_codes"
+    local cfg
+    cfg=$(write_config "ansi.lua" 'local handle = io.popen("xrandr --query")')
+    run_check "$cfg"
+    # ESC character should not appear in piped output
+    if echo "$CHECK_STDOUT" | grep -qP '\x1b\['; then
+        fail "$name" "stdout contains ANSI escape codes"
+        return
+    fi
+    pass "$name"
+}
+
+# === Group 6: Edge Cases ===
+
+test_nonexistent_file() {
+    local name="nonexistent_file"
+    run_check "$TMP_DIR/does_not_exist.lua"
+    assert_exit "$name" 2 || return
+    assert_contains "$name" "CRITICAL" || return
+    pass "$name"
+}
+
+# === Run All Tests ===
+
+test_valid_config
+test_empty_config
+test_x11_critical
+test_x11_warning
+test_x11_commented_ignored
+test_x11_mixed_severity
+test_require_commented_ignored
+test_require_missing_reported
+test_require_stdlib_skipped
+test_require_awesomewm_skipped
+test_require_thirdparty_skipped
+test_require_method_skipped
+test_require_local_module
+test_require_init_module
+test_require_indented_comment
+test_require_both_quotes
+test_syntax_error
+test_syntax_unterminated
+test_report_header
+test_report_summary
+test_no_ansi_codes
+test_nonexistent_file
+
+# === Summary ===
+
+echo ""
+if [ $fail_count -eq 0 ]; then
+    echo "PASS"
+else
+    echo "FAIL"
+fi
+printf "ok\t%d tests\t%d passed\t%d failed\n" "$test_count" "$pass_count" "$fail_count"
+[ $fail_count -gt 0 ] && exit 1
+exit 0


### PR DESCRIPTION
check_mode_scan_requires() used strstr() to find require() calls but never checked if they were on commented lines. Add the same comment- skipping logic already used by the X11 pattern scanners.

Also adds a test suite for --check mode (make test-check) with 22 tests covering X11 patterns, require scanning, comment filtering, syntax errors, report formatting, and exit codes.


Fixes #234 