### PR TITLE
fix(naughty): box layout may access nil table

### DIFF
--- a/lua/naughty/layout/box.lua
+++ b/lua/naughty/layout/box.lua
@@ -139,6 +139,9 @@ end
 -- screen is resized or the notification is moved, it causes side effects.
 -- Better listen to geometry changes and reflow.
 capi.screen.connect_signal("property::geometry", function(s)
+    if not by_position[s] then
+        return
+    end
     for pos, notifs in pairs(by_position[s]) do
         if #notifs > 0 then
             update_position(pos, notifs[1].preset)


### PR DESCRIPTION
Switching from the VT of somewm causes by_position[s] to be reset to nil. Switching back to it causes a race between re-initializing by_position[s] and handling the signal property::geometry. The latter enumerates by_position[s] when it may be nil.