### PR TITLE
fix: resolve -Werror warnings on newer gcc

### DIFF
--- a/keygrabber.c
+++ b/keygrabber.c
@@ -57,9 +57,10 @@ keygrabber_grab(void)
  * \return True if the input buffer is control character.
  */
 static bool
-is_control(char *buf)
+is_control(const char *buf)
 {
-    return (buf[0] >= 0 && buf[0] < 0x20) || buf[0] == 0x7f;
+    unsigned char c = (unsigned char)buf[0];
+    return c < 0x20 || c == 0x7f;
 }
 
 /** Handle keypress event.

--- a/luaa.c
+++ b/luaa.c
@@ -2838,8 +2838,7 @@ check_mode_scan_requires(const char *content, const char *config_dir,
 			continue;
 
 		/* Save original module name for error reporting */
-		strncpy(module_path, module_name, sizeof(module_path) - 1);
-		module_path[sizeof(module_path) - 1] = '\0';
+		snprintf(module_path, sizeof(module_path), "%s", module_name);
 
 		/* Convert module.name to module/name */
 		for (char *p = module_name; *p; p++) {

--- a/somewm.c
+++ b/somewm.c
@@ -5809,8 +5809,7 @@ get_distro_name(void)
 			/* Strip trailing newline and quote */
 			while (len > 0 && (start[len-1] == '\n' || start[len-1] == '"'))
 				start[--len] = '\0';
-			strncpy(distro, start, sizeof(distro) - 1);
-			distro[sizeof(distro) - 1] = '\0';
+			snprintf(distro, sizeof(distro), "%s", start);
 			break;
 		}
 	}
@@ -5843,15 +5842,13 @@ get_gpu_info(void)
 				size_t len = strlen(start);
 				if (len > 0 && start[len-1] == '\n')
 					start[len-1] = '\0';
-				strncpy(driver, start, sizeof(driver) - 1);
-				driver[sizeof(driver) - 1] = '\0';
+				snprintf(driver, sizeof(driver), "%s", start);
 			} else if (strncmp(line, "PCI_ID=", 7) == 0) {
 				char *start = line + 7;
 				size_t len = strlen(start);
 				if (len > 0 && start[len-1] == '\n')
 					start[len-1] = '\0';
-				strncpy(pci_id, start, sizeof(pci_id) - 1);
-				pci_id[sizeof(pci_id) - 1] = '\0';
+				snprintf(pci_id, sizeof(pci_id), "%s", start);
 			}
 		}
 		fclose(f);


### PR DESCRIPTION
This pr fixes build failures under strict `-Werror` builds on newer gcc toolchains

Reproduced with `gcc (GCC) 15.2.1 20260123 (Red Hat 15.2.1-7)`

The build was stopped on warnings promoted to errors:

- `-Wtype-limits` in keygrabber
- `-Wstringop-truncation` in luaa, somewm