### PR TITLE
fix: keyboard focus desyncs from visual focus with sloppy focus

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -2064,13 +2064,13 @@ client_focus(client_t *c)
     /* Update Awesome's internal focus state (borders, signals, etc.) */
     if(client_focus_update(c)) {
         globalconf.focus.need_update = true;
-
-        /* Now update Wayland seat keyboard focus via compositor API.
-         * This is separated from the internal state update to allow
-         * geometry operations to call client_focus_update() directly
-         * without affecting seat focus. */
-        some_set_seat_keyboard_focus(c);
     }
+
+    /* Always sync Wayland seat keyboard focus — it can desync independently
+     * from Lua bookkeeping (e.g. layer surface steals keyboard, popup receives
+     * keyboard enter, XWayland surface recreation). some_set_seat_keyboard_focus()
+     * has its own early return when seat focus already matches (somewm_api.c). */
+    some_set_seat_keyboard_focus(c);
 }
 
 #if 0  /* Unused for Wayland - X11/XWayland only */

--- a/somewm.c
+++ b/somewm.c
@@ -4902,8 +4902,10 @@ unmaplayersurfacenotify(struct wl_listener *listener, void *data)
 
 	l->mapped = 0;
 	wlr_scene_node_set_enabled(&l->scene->node, 0);
-	if (l == exclusive_focus)
+	if (l == exclusive_focus) {
 		exclusive_focus = NULL;
+		focusclient(focustop(selmon), 1);
+	}
 	if (l->layer_surface->output && (l->mon = l->layer_surface->output->data))
 		arrangelayers(l->mon);
 

--- a/tests/test-layer-shell-focus-restore.lua
+++ b/tests/test-layer-shell-focus-restore.lua
@@ -197,7 +197,12 @@ local steps = {
         -- This is the key assertion: focus should return to the MOST RECENT
         -- client in history (B), not just any client
         if client.focus == client_b then
-            io.stderr:write("[TEST] PASS: focus returned to client B (correct focus history)\n")
+            -- Check ACTUAL Wayland seat keyboard focus, not just Lua bookkeeping.
+            -- This catches the bug from issue #237 where client.focus was correct
+            -- but seat->keyboard_state.focused_surface was not restored.
+            assert(client_b:has_keyboard_focus(),
+                "Client B regained visual focus but NOT keyboard focus (seat desync)")
+            io.stderr:write("[TEST] PASS: focus returned to client B (correct focus history + keyboard)\n")
             return true
         end
 

--- a/tests/test-layer-shell-keyboard-focus.lua
+++ b/tests/test-layer-shell-keyboard-focus.lua
@@ -167,6 +167,12 @@ local steps = {
             string.format("Expected client to regain focus after layer close, got %s",
                 client.focus and client.focus.class or "nil"))
 
+        -- Check ACTUAL Wayland seat keyboard focus, not just Lua bookkeeping.
+        -- This catches the bug from issue #237 where client.focus was correct
+        -- but seat->keyboard_state.focused_surface was not restored.
+        assert(my_client:has_keyboard_focus(),
+            "Client regained visual focus but NOT keyboard focus (seat desync)")
+
         io.stderr:write("[TEST] PASS: client regained focus after layer close\n")
         return true
     end,


### PR DESCRIPTION
## Summary

Fixes two related bugs where Wayland seat keyboard focus desyncs from `client.focus` (visual focus):

- **`client_focus()` now always syncs seat keyboard focus**, even when `client_focus_update()` returns false (Lua already considers the client focused). The seat can desync independently via layer surfaces, popups, or XWayland surface recreation.
- **`unmaplayersurfacenotify()` now restores keyboard focus** to the top client after an exclusive layer surface unmaps, matching the pattern used for unmanaged client cleanup.
- **Layer-shell focus tests strengthened** to assert `has_keyboard_focus()` (actual Wayland seat state), not just `client.focus` (Lua bookkeeping).

Root cause analysis and fix approach by @raven2cz in #237.

Closes #237

## Test plan

- [x] `make test-unit` — 629/629 pass
- [x] `make test-integration` — 28/28 pass (includes strengthened layer-shell focus tests)
- [ ] Manual: launch somewm, open two terminals, open/close rofi repeatedly with sloppy focus, verify keyboard input always works after closing rofi