### PR TITLE
docs: add contributing guide and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description
+<!-- What does this change and why? -->
+
+
+## Test Plan
+<!-- How did you verify this works? -->
+
+
+## Checklist
+- [ ] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
+- [ ] Tests pass (`make test-unit && make test-integration`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to somewm
+
+## The North Star
+
+**Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) must stay identical to AwesomeWM's.**
+
+These are copied directly from [AwesomeWM](https://github.com/awesomeWM/awesome/tree/master/lib) and must not diverge. If something crashes or misbehaves in Lua, the fix belongs in C — the bug is almost always a missing API, wrong signal timing, or incomplete object lifecycle in the compositor layer.
+
+When in doubt, check AwesomeWM's source at `~/tools/awesome/` for how things are supposed to work.
+
+## Building
+
+```bash
+make                  # Build with ASAN
+make build-test       # Build without ASAN (faster)
+```
+
+## Testing
+
+```bash
+make test-unit        # Busted unit tests
+make test-integration # Full compositor integration tests
+make test-one TEST=tests/test-foo.lua  # Single test (handy for TDD)
+```
+
+## Where to Look
+
+| What | Where |
+|------|-------|
+| AwesomeWM C reference | `~/tools/awesome/objects/`, `~/tools/awesome/luaclass.c` |
+| somewm C bindings | `objects/*.c` |
+| Wayland deviations | `ideas/DEVIATIONS.md` |
+| Integration test examples | `tests/` |
+
+## Submitting a PR
+
+- Fix bugs in C, not by patching Lua libraries
+- Include a test when possible (`tests/test-*.lua`)
+- Run `make test-unit && make test-integration` before pushing
+- If porting an AwesomeWM PR, add an entry to `UPSTREAM_PORTS.md`

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Full documentation at **[somewm.org](https://somewm.org)**:
 
 ## Contributing
 
-Contributions welcome! See [GitHub Issues](https://github.com/trip-zip/somewm/issues) for current work.
+Contributions welcome! Please read the [Contributing Guide](CONTRIBUTING.md) first.
 
 - Report bugs or request features via [Issues](https://github.com/trip-zip/somewm/issues)
 - Questions and discussion at [Discussions](https://github.com/trip-zip/somewm/discussions)


### PR DESCRIPTION
## Summary
- Adds `CONTRIBUTING.md` with the north star rule: Lua libraries are sacred copies from AwesomeWM — if a bug surfaces in Lua, fix it in C
- Adds `.github/pull_request_template.md` with a checklist reminder for the same
- Links `CONTRIBUTING.md` from the README

Motivated by #243 — a contributor reasonably patched Lua code when the root cause was in C. This makes the expectation visible upfront.

## Test Plan
- N/A (docs only)