### PR TITLE
fix: emit _added before property::geometry for hotplugged screens

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -974,6 +974,27 @@ luaA_awesome_set_preferred_icon_size(lua_State *L)
 	return 0;
 }
 
+/** awesome._test_add_output: Add a headless output for integration testing.
+ * Triggers the real createmon() → updatemons() code path.
+ * \param width Output width in pixels
+ * \param height Output height in pixels
+ * \return Output name string
+ */
+static int
+luaA_awesome_test_add_output(lua_State *L)
+{
+	unsigned int width = (unsigned int)luaL_checkinteger(L, 1);
+	unsigned int height = (unsigned int)luaL_checkinteger(L, 2);
+
+	const char *name = some_test_add_output(width, height);
+	if (!name)
+		return luaL_error(L, "Failed to add headless output "
+			"(requires headless or multi backend)");
+
+	lua_pushstring(L, name);
+	return 1;
+}
+
 /* awesome module methods */
 static const luaL_Reg awesome_methods[] = {
 	{ "quit", luaA_awesome_quit },
@@ -1000,6 +1021,7 @@ static const luaL_Reg awesome_methods[] = {
 	{ "kill", luaA_kill },
 	{ "load_image", luaA_load_image },
 	{ "restart", luaA_restart },
+	{ "_test_add_output", luaA_awesome_test_add_output },
 	{ NULL, NULL }
 };
 

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -229,4 +229,9 @@ void apply_input_settings_to_all_devices(void);
 void layer_surface_grant_keyboard(LayerSurface *ls);
 void layer_surface_revoke_keyboard(LayerSurface *ls);
 
+/*
+ * Test helpers — headless output hotplug simulation
+ */
+const char *some_test_add_output(unsigned int width, unsigned int height);
+
 #endif /* SOMEWM_API_H */

--- a/tests/test-vt-switch-signal-ordering.lua
+++ b/tests/test-vt-switch-signal-ordering.lua
@@ -1,0 +1,82 @@
+---------------------------------------------------------------------------
+-- Regression test for VT-switch signal ordering (PR #243)
+--
+-- Root cause: updatemons() emitted property::geometry BEFORE _added for
+-- newly hotplugged screens. naughty's property::geometry handler does
+-- pairs(by_position[s]) but init_screen() hadn't run yet, so
+-- by_position[s] was nil → crash.
+--
+-- Fix: somewm.c updatemons() silently caches geometry for
+-- needs_screen_added screens, emitting _added first.
+--
+-- This test uses awesome._test_add_output() to add a headless output,
+-- which triggers the real createmon() → updatemons() code path — the
+-- same path as VT switch-back or monitor hotplug.
+--
+-- Run with: HEADLESS=1 make test-one TEST=tests/test-vt-switch-signal-ordering.lua
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+
+-- Skip if _test_add_output is not available (shouldn't happen, but be safe)
+if not awesome._test_add_output then
+    io.stderr:write("SKIP: awesome._test_add_output not available\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+-- Force naughty.layout.box to load — this registers the
+-- property::geometry handler that crashes when by_position[s] is nil.
+require("naughty.layout.box")
+
+local errors_seen = {}
+awesome.connect_signal("debug::error", function(err)
+    table.insert(errors_seen, tostring(err))
+end)
+
+local initial_screen_count = screen.count()
+
+local steps = {
+    -- Step 1: Add a headless output.
+    -- This triggers createmon() → updatemons() — the real hotplug path.
+    -- Without the fix: property::geometry fires before _added, naughty
+    -- crashes with "bad argument #1 to 'pairs' (table expected, got nil)".
+    function()
+        local name = awesome._test_add_output(800, 600)
+        assert(name, "awesome._test_add_output returned nil")
+        print("TEST: Added headless output: " .. name)
+        return true
+    end,
+
+    -- Step 2: Verify the new screen was created with tags.
+    function()
+        local count = screen.count()
+        assert(count == initial_screen_count + 1,
+            string.format("Expected %d screens, got %d",
+                initial_screen_count + 1, count))
+
+        -- The new screen should have tags (set by rc.lua's added handler)
+        local new_screen = screen[count]
+        assert(new_screen.valid, "New screen is not valid")
+        print("TEST: Screen count=" .. count
+            .. " new_screen=" .. tostring(new_screen)
+            .. " tags=" .. #new_screen.tags)
+        return true
+    end,
+
+    -- Step 3: Verify no Lua errors occurred during hotplug.
+    -- This is the actual regression check — without the fix,
+    -- errors_seen would contain the naughty by_position crash.
+    function()
+        assert(#errors_seen == 0,
+            string.format(
+                "FAIL: %d error(s) during hotplug: %s",
+                #errors_seen,
+                errors_seen[1] or ""))
+        print("TEST: No errors during hotplug — signal ordering is correct")
+        return true
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })


### PR DESCRIPTION
## Summary

Fixes the VT-switch crash diagnosed by @shuber2 in #243.

`updatemons()` had two sequential loops — the geometry loop emitted `property::geometry`, then the screen-added loop emitted `_added`. For newly hotplugged screens, this meant `property::geometry` fired before `init_screen()` had run, leaving naughty's `by_position[s]` nil and crashing `pairs()`.

AwesomeWM avoids this — `screen_refresh()` adds new screens before modifying existing ones, so `_added` always fires before `property::geometry`. This PR matches that ordering.

### What changed

- **`somewm.c` (updatemons)**: For `needs_screen_added` screens, silently cache geometry without emitting `property::geometry`. The screen-added loop fires `_added` first, matching AwesomeWM's signal ordering.
- **`awesome._test_add_output(w, h)`**: New test helper that calls `wlr_headless_add_output()` to trigger the real `createmon()` → `updatemons()` code path from integration tests.
- **Regression test**: `test-vt-switch-signal-ordering.lua` reproduces the exact crash — fails without the fix, passes with it.

No Lua code modified.

## Test plan

- [x] `make test-integration` — all 31 tests pass (including new test)
- [x] Regression test reproduces the exact crash without the fix: `bad argument #1 to 'pairs' (table expected, got nil)` at `naughty/layout/box.lua:142`
- [ ] @shuber2 — would you be able to verify with a VT switch on your hardware? Your debug logging setup is perfect for confirming the signal order is correct.