### PR TITLE
fix: update selmon on mouse motion across monitor boundaries

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -209,7 +209,7 @@ static void mapnotify(struct wl_listener *listener, void *data);
 static void maximizenotify(struct wl_listener *listener, void *data);
 void monocle(Monitor *m);
 static void motionabsolute(struct wl_listener *listener, void *data);
-static void motionnotify(uint32_t time, struct wlr_input_device *device, double sx,
+void motionnotify(uint32_t time, struct wlr_input_device *device, double sx,
 		double sy, double sx_unaccel, double sy_unaccel);
 static void motionrelative(struct wl_listener *listener, void *data);
 /* moveresize() removed - move/resize now handled by Lua mousegrabber */

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -65,6 +65,8 @@ struct kb_group_device {
 
 /* Functions from somewm.c that need to be made non-static */
 extern void focusclient(Client *c, int lift);
+extern void motionnotify(uint32_t time, struct wlr_input_device *device,
+		double dx, double dy, double dx_unaccel, double dy_unaccel);
 /* setfloating() removed - Lua manages floating state */
 extern void setfullscreen(Client *c, int fullscreen);
 extern void arrange(Monitor *m);
@@ -1398,6 +1400,20 @@ some_set_cursor_position(double x, double y, int silent)
 	}
 
 	wlr_cursor_warp(cursor, NULL, x, y);
+}
+
+/*
+ * Inject a fake relative pointer motion through the full compositor path.
+ * Unlike raw wlr_cursor_move(), this calls motionnotify() which handles
+ * selmon tracking, pointer focus, Lua signals, and constraint processing.
+ */
+void
+some_fake_motion(double dx, double dy)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	uint32_t time = (uint32_t)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
+	motionnotify(time, NULL, dx, dy, dx, dy);
 }
 
 /*

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -187,6 +187,7 @@ void some_get_button_states(int states[5]);
 Client *some_object_under_cursor(void);
 drawin_t *some_drawin_under_cursor(void);
 void some_warp_cursor_to_monitor(Monitor *m);
+void some_fake_motion(double dx, double dy);
 void some_client_start_move(void);
 void some_client_start_resize(void);
 void some_client_togglefloating(void);

--- a/tests/test-selmon-mouse-motion.lua
+++ b/tests/test-selmon-mouse-motion.lua
@@ -1,0 +1,93 @@
+---------------------------------------------------------------------------
+--- Test: selmon tracks cursor across monitor boundaries
+--
+-- Regression test for #245: selmon was only updated on button press or
+-- focusclient(), so layer-shell clients (rofi) that don't specify an
+-- output appeared on the wrong monitor after moving the mouse.
+--
+-- The fix updates selmon in motionnotify() on monitor boundary crossing.
+-- This test uses root.fake_input("motion_notify") which routes through
+-- motionnotify(), exercising the actual fix.
+--
+-- Requires 2 outputs:
+--   WLR_WL_OUTPUTS=2 make test-one TEST=tests/test-selmon-mouse-motion.lua
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+
+-- Skip if fewer than 2 screens (default headless has 1)
+if screen.count() < 2 then
+    io.stderr:write("SKIP: test-selmon-mouse-motion requires WLR_WL_OUTPUTS=2\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local s1, s2
+
+local steps = {
+    -- Step 1: Identify screens and their geometries
+    function()
+        s1 = screen[1]
+        s2 = screen[2]
+        io.stderr:write(string.format(
+            "[TEST] screen 1: %dx%d+%d+%d, screen 2: %dx%d+%d+%d\n",
+            s1.geometry.width, s1.geometry.height, s1.geometry.x, s1.geometry.y,
+            s2.geometry.width, s2.geometry.height, s2.geometry.x, s2.geometry.y))
+        return true
+    end,
+
+    -- Step 2: Warp cursor to center of screen 1, then verify
+    function()
+        local cx = s1.geometry.x + s1.geometry.width / 2
+        local cy = s1.geometry.y + s1.geometry.height / 2
+        -- Use absolute warp to position cursor
+        root.fake_input("motion_notify", false, cx, cy)
+        local ms = mouse.screen
+        io.stderr:write(string.format(
+            "[TEST] Cursor at (%d,%d), mouse.screen=%d\n", cx, cy, ms.index))
+        assert(ms == s1,
+            string.format("Expected mouse on screen 1, got screen %d", ms.index))
+        return true
+    end,
+
+    -- Step 3: Move cursor to center of screen 2 via relative motion
+    function()
+        -- Calculate relative offset from screen 1 center to screen 2 center
+        local s1cx = s1.geometry.x + s1.geometry.width / 2
+        local s2cx = s2.geometry.x + s2.geometry.width / 2
+        local s1cy = s1.geometry.y + s1.geometry.height / 2
+        local s2cy = s2.geometry.y + s2.geometry.height / 2
+        local dx = s2cx - s1cx
+        local dy = s2cy - s1cy
+        io.stderr:write(string.format(
+            "[TEST] Moving cursor by relative (%d,%d)\n", dx, dy))
+        root.fake_input("motion_notify", true, dx, dy)
+        local ms = mouse.screen
+        io.stderr:write(string.format(
+            "[TEST] mouse.screen=%d (expected %d)\n", ms.index, s2.index))
+        assert(ms == s2,
+            string.format("BUG #245: Expected mouse on screen %d, got screen %d",
+                s2.index, ms.index))
+        io.stderr:write("[TEST] PASS: cursor tracked to screen 2\n")
+        return true
+    end,
+
+    -- Step 4: Move back to screen 1 via relative motion
+    function()
+        local s1cx = s1.geometry.x + s1.geometry.width / 2
+        local s2cx = s2.geometry.x + s2.geometry.width / 2
+        local s1cy = s1.geometry.y + s1.geometry.height / 2
+        local s2cy = s2.geometry.y + s2.geometry.height / 2
+        local dx = s1cx - s2cx
+        local dy = s1cy - s2cy
+        root.fake_input("motion_notify", true, dx, dy)
+        local ms = mouse.screen
+        assert(ms == s1,
+            string.format("Expected mouse back on screen 1, got screen %d", ms.index))
+        io.stderr:write("[TEST] PASS: cursor tracked back to screen 1\n")
+        return true
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })


### PR DESCRIPTION
## Summary

- Update `selmon` in `motionnotify()` when cursor crosses monitor boundaries, so layer-shell clients (rofi, etc.) that don't specify an output appear on the correct monitor
- Fix `root.fake_input("motion_notify")` to route through the full compositor motion path instead of raw `wlr_cursor_move()`, which was skipping pointer focus, Lua signals, and selmon tracking
- Add regression test (requires `WLR_WL_OUTPUTS=2`)

## Root Cause

`selmon` was only updated on button press (clicking empty space) or `focusclient()` calls. Sloppy focus goes through the Lua path (`some_set_seat_keyboard_focus`) which never calls `focusclient()`, so moving the mouse to another monitor left `selmon` stale. `createlayersurface()` assigns layer-shell surfaces without an explicit output to `selmon->wlr_output`, causing them to appear on the wrong monitor.

## Credit

Fix by @raven2cz — cherry-picked from raven2cz/somewm@d230ba9.

Closes #245