### PR TITLE
feat: --check mode improvements (suppression, severity filter, GTK detection)

### DIFF
--- a/luaa.h
+++ b/luaa.h
@@ -112,7 +112,7 @@ void luaA_awesome_setup(lua_State *L);
 void luaA_awesome_set_conffile(lua_State *L, const char *conffile);
 
 /* Config scanner (somewm --check) */
-int luaA_check_config(const char *config_path, bool use_color);
+int luaA_check_config(const char *config_path, bool use_color, int min_severity);
 
 /* Note: luaA_checkudata and luaA_toudata are functions declared in common/luaclass.h
  * They use the AwesomeWM lua_class_t system for type-safe userdata access.


### PR DESCRIPTION
## Description

Three enhancements to `somewm --check` addressing #74 and discussion #210:

1. **Inline suppression (`-- somewm:ignore`)** — Add to any line to skip pattern detection for that line. Works in both `--check` mode and runtime prescan. Solves false positives for users with X11 tools behind runtime guards (e.g. `if false then ... end`).

2. **Severity filter (`--check-level`)** — New flag `--check-level=critical|warning|info` controls which severity triggers a non-zero exit code. Default is `warning` (backwards compatible). `--check-level=critical` lets users try somewm immediately when their config only has warnings.

3. **GTK/GDK deadlock detection** — `lgi.require("Gtk")` flagged as WARNING (somewm already mitigates via `lgi.override.Gtk` preload). `lgi.require("Gdk")` flagged as CRITICAL (no mitigation, will deadlock). Tested against 8 real AwesomeWM user configs — caught real deadlock-causing GDK loads in raven2cz/nice and GTK loads in KwesomeDE and crylia-theme.

Closes #74.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified**
- [x] Tests pass (`make test-unit && make test-integration`)