### PR TITLE
fix: add drawin.surface_scale for HiDPI screenshot perf

### DIFF
--- a/objects/drawin.h
+++ b/objects/drawin.h
@@ -46,6 +46,11 @@ typedef struct drawin_t {
 	bool ontop;                    /* Should drawin be above other windows? */
 	char *cursor;                  /* Mouse cursor name (e.g., "left_ptr") */
 
+	/* Surface scale override (somewm extension, not in AwesomeWM).
+	 * 0.0 = auto (use output scale), >0.0 = force this scale for drawable surface.
+	 * Avoids HiDPI CPU upscaling for content like screenshot overlays. */
+	float scale_override;
+
 	/* Screen assignment */
 	struct screen_t *screen;       /* Which screen this drawin belongs to */
 


### PR DESCRIPTION
## Description

At HiDPI scales (e.g. `s.scale = 1.5`), interactive screenshot overlays repaint at ~1 FPS. On every mouse move, Cairo CPU-upscales the full-screen image (1707×960 → 2560×1440) via bilinear interpolation (~50-100ms per frame). Bisected to `e0f84bd` which introduced HiDPI surface creation for drawables.

Adds a `drawin.surface_scale` property (somewm extension) that overrides the drawable's HiDPI scale factor. Setting `surface_scale = 1.0` forces the surface to logical resolution, letting the GPU handle the upscale instead of Cairo CPU-rendering it every frame.

Also removes a redundant 14.7 MB `memset` from SHM buffer creation — every byte was already overwritten by the subsequent `memcpy`.

Usage in rc.lua:
```lua
local ss = awful.screenshot({ interactive = true })
ss:connect_signal("snipping::start", function(self)
    if self._private.frame then
        self._private.frame.surface_scale = 1.0
    end
end)
s:refresh()
```

Closes #167

## Test Plan

- `make test-unit` — 629 pass
- `make test-integration` — 37 pass, 0 regressions
- Manual test at `s.scale = 1.5`: interactive screenshot overlay is smooth with `surface_scale = 1.0`, saved screenshots are visually correct

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)