### PR TITLE
fix: properly handle output disable/re-enable lifecycle

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -5121,21 +5121,45 @@ updatemons(struct wl_listener *listener, void *data)
 	struct wlr_output_configuration_head_v1 *config_head;
 	Monitor *m;
 
-	/* First remove from the layout the disabled monitors */
+	/* Add disabled monitors to the config. For those still in the layout
+	 * (transitioning to disabled), properly remove the screen and close.
+	 * Already-disabled monitors just get a config_head so output manager
+	 * clients (wlr-randr, wlopm, kanshi) can still see and re-enable
+	 * them. Fixes #269. */
 	wl_list_for_each(m, &mons, link) {
 		if (m->wlr_output->enabled || m->asleep)
 			continue;
-		/* Only process monitors still in the output layout (skip already-processed) */
-		if (!wlr_output_layout_get(output_layout, m->wlr_output))
-			continue;
-		wlr_log(WLR_ERROR, "[HOTPLUG] updatemons disable: %s",
-			m->wlr_output->name);
 		config_head = wlr_output_configuration_head_v1_create(config, m->wlr_output);
 		config_head->state.enabled = 0;
-		/* Remove this output from the layout to avoid cursor enter inside it */
-		wlr_output_layout_remove(output_layout, m->wlr_output);
-		closemon(m);
-		m->m = m->w = (struct wlr_box){0};
+		if (wlr_output_layout_get(output_layout, m->wlr_output)) {
+			wlr_log(WLR_ERROR, "[HOTPLUG] updatemons disable: %s",
+				m->wlr_output->name);
+
+			/* Properly remove the screen object so Lua tears down
+			 * tags/wibars. On re-enable, a fresh screen is created
+			 * and screen_added triggers request::desktop_decoration. */
+			if (globalconf_L) {
+				screen_t *screen = luaA_screen_get_by_monitor(globalconf_L, m);
+				if (screen) {
+					screen_t *old_primary = luaA_screen_get_primary_screen(globalconf_L);
+					bool was_primary = (old_primary == screen);
+
+					screen_removed(globalconf_L, screen);
+					luaA_screen_emit_viewports(globalconf_L);
+
+					if (was_primary) {
+						screen_t *new_primary = luaA_screen_get_primary_screen(globalconf_L);
+						if (new_primary && new_primary != screen)
+							luaA_screen_emit_primary_changed(globalconf_L, new_primary);
+					}
+				}
+			}
+
+			/* Remove this output from the layout to avoid cursor enter inside it */
+			wlr_output_layout_remove(output_layout, m->wlr_output);
+			closemon(m);
+			m->m = m->w = (struct wlr_box){0};
+		}
 	}
 	/* Insert outputs that need to */
 	wl_list_for_each(m, &mons, link) {
@@ -5178,6 +5202,21 @@ updatemons(struct wl_listener *listener, void *data)
 		/* Update screen object geometry and emit property:: signals if changed */
 		{
 			screen_t *screen = luaA_screen_get_by_monitor(globalconf_L, m);
+			if (!screen && globalconf_L) {
+				/* Re-enabled monitor has no screen (removed during disable).
+				 * Create a fresh one — treated like a hotplug. */
+				Monitor *tmp;
+				int screen_index = 1;
+				wl_list_for_each(tmp, &mons, link) {
+					if (tmp != m && luaA_screen_get_by_monitor(globalconf_L, tmp))
+						screen_index++;
+				}
+				screen = luaA_screen_new(globalconf_L, m, screen_index);
+				if (screen) {
+					lua_pop(globalconf_L, 1);
+					m->needs_screen_added = 1;
+				}
+			}
 			if (screen) {
 				if (m->needs_screen_added) {
 					/* New screen: cache geometry silently.


### PR DESCRIPTION
## Description

Fixes #269. Disabled monitors were excluded from the output manager configuration after the first `updatemons()` call, making them invisible to wlr-randr, wlopm, and kanshi ("unknown output" error). Additionally, the screen object was left as a valid ghost with stale geometry on disable — no `screen_removed()` was called, and no `screen_added()` fired on re-enable — causing broken struts, workarea, and tags.

Two changes in `updatemons()`:

1. **Include all disabled monitors in the output config** — a single loop now handles both transitioning and already-disabled monitors, so output manager clients can always see and re-enable them.

2. **Proper screen lifecycle** — call `screen_removed()` on disable to tear down the Lua screen (tags, wibars, signals). On re-enable, create a fresh screen and set `needs_screen_added` so the existing hotplug path fires `screen_added` → `request::desktop_decoration`, reinitializing everything. This makes disable/re-enable behave identically to unplug/replug.

## Test Plan

- `make test-unit` — 629/629 pass
- `make test-integration` — 39/39 pass
- Manual hardware testing with two monitors (eDP-1 + DP-2):
  - Disable one → still listed in `wlr-randr` as disabled → re-enable works, wibar and struts restored
  - Disable both in sequence → both still listed → re-enable both, full state restored
  - Clients respect workarea/struts on re-enabled monitors
  - Clients movable between screens after re-enable

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)