### PR TITLE
fix: round drawin geometry to match AwesomeWM

### DIFF
--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -1880,22 +1880,22 @@ luaA_drawin_geometry(lua_State *L)
 
 		lua_getfield(L, 2, "x");
 		if (!lua_isnil(L, -1))
-			x = (int)lua_tonumber(L, -1);
+			x = (int)round(lua_tonumber(L, -1));
 		lua_pop(L, 1);
 
 		lua_getfield(L, 2, "y");
 		if (!lua_isnil(L, -1))
-			y = (int)lua_tonumber(L, -1);
+			y = (int)round(lua_tonumber(L, -1));
 		lua_pop(L, 1);
 
 		lua_getfield(L, 2, "width");
 		if (!lua_isnil(L, -1))
-			width = (int)lua_tonumber(L, -1);
+			width = (int)ceil(lua_tonumber(L, -1));
 		lua_pop(L, 1);
 
 		lua_getfield(L, 2, "height");
 		if (!lua_isnil(L, -1))
-			height = (int)lua_tonumber(L, -1);
+			height = (int)ceil(lua_tonumber(L, -1));
 		lua_pop(L, 1);
 
 		drawin_moveresize(L, 1, x, y, width, height);
@@ -2043,7 +2043,7 @@ luaA_drawin_set_surface_scale(lua_State *L, drawin_t *drawin)
 static int
 luaA_drawin_set_x(lua_State *L, drawin_t *drawin)
 {
-	int x = (int)lua_tonumber(L, -1);
+	int x = (int)round(lua_tonumber(L, -1));
 	drawin_moveresize(L, -3, x, drawin->y, drawin->width, drawin->height);
 	return 0;
 }
@@ -2056,7 +2056,7 @@ luaA_drawin_set_x(lua_State *L, drawin_t *drawin)
 static int
 luaA_drawin_set_y(lua_State *L, drawin_t *drawin)
 {
-	int y = (int)lua_tonumber(L, -1);
+	int y = (int)round(lua_tonumber(L, -1));
 	drawin_moveresize(L, -3, drawin->x, y, drawin->width, drawin->height);
 	return 0;
 }

--- a/tests/test-drawin-geometry-rounding.lua
+++ b/tests/test-drawin-geometry-rounding.lua
@@ -1,0 +1,79 @@
+---------------------------------------------------------------------------
+-- Test: Drawin geometry rounding (fractional coordinates)
+--
+-- Verifies that fractional geometry values are correctly rounded:
+--   x, y   → round()  (C99 round, away from zero at .5)
+--   w, h   → ceil()   (C99 ceil, always rounds up)
+--
+-- Regression test for #200.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local awful = require("awful")
+local wibox = require("wibox")
+
+local test_wibox = nil
+
+local steps = {
+    -- Step 1: Create wibox for testing
+    function()
+        test_wibox = wibox {
+            x = 100,
+            y = 100,
+            width = 200,
+            height = 100,
+            visible = true,
+            screen = awful.screen.focused(),
+        }
+        assert(test_wibox, "wibox creation failed")
+        return true
+    end,
+
+    -- Step 2: Test geometry table setter with fractional values
+    function()
+        test_wibox:geometry({
+            x = 10.7,
+            y = 10.3,
+            width = 100.1,
+            height = 100.9,
+        })
+
+        local geo = test_wibox:geometry()
+        assert(geo.x == 11, "x: expected 11 (round 10.7), got " .. geo.x)
+        assert(geo.y == 10, "y: expected 10 (round 10.3), got " .. geo.y)
+        assert(geo.width == 101, "width: expected 101 (ceil 100.1), got " .. geo.width)
+        assert(geo.height == 101, "height: expected 101 (ceil 100.9), got " .. geo.height)
+        io.stderr:write("[PASS] Geometry table setter rounding\n")
+        return true
+    end,
+
+    -- Step 3: Test property setters with fractional values
+    function()
+        test_wibox.x = 20.5
+        test_wibox.y = -3.7
+        test_wibox.width = 50.01
+        test_wibox.height = 200.0
+
+        local geo = test_wibox:geometry()
+        assert(geo.x == 21, "x: expected 21 (round 20.5), got " .. geo.x)
+        assert(geo.y == -4, "y: expected -4 (round -3.7), got " .. geo.y)
+        assert(geo.width == 51, "width: expected 51 (ceil 50.01), got " .. geo.width)
+        assert(geo.height == 200, "height: expected 200 (ceil 200.0), got " .. geo.height)
+        io.stderr:write("[PASS] Property setter rounding\n")
+        return true
+    end,
+
+    -- Step 4: Cleanup
+    function()
+        if test_wibox then
+            test_wibox.visible = false
+            test_wibox = nil
+        end
+        io.stderr:write("[TEST] Cleanup complete\n")
+        return true
+    end,
+}
+
+runner.run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
## Description

When Lua placement code produces fractional pixel coordinates (e.g., `awful.placement.centered` computing `x = 412.5`), somewm was truncating them toward zero via `(int)lua_tonumber()`, while AwesomeWM uses `round()` for position and `ceil()` for dimensions. The 1px discrepancy causes widgets to land at wrong positions, breaking bitmap font rendering and introducing anti-aliasing artifacts.

This applies `round()` for x/y and `ceil()` for width/height in `objects/drawin.c`, matching AwesomeWM's rounding behavior exactly. Fixes #200.

## Test Plan

- Added `tests/test-drawin-geometry-rounding.lua` regression test covering geometry table setters and property setters with fractional values
- `make test-integration` passes (41/41)
- Verified live via `somewm-client eval` with fractional coordinates

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)