### PR TITLE
fix: implement awesome.startup property (#253)

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -1125,6 +1125,11 @@ luaA_awesome_index(lua_State *L)
 		return 1;
 	}
 
+	if (A_STREQ(key, "startup")) {
+		lua_pushboolean(L, globalconf.loop == NULL);
+		return 1;
+	}
+
 	lua_rawget(L, 1);
 	return 1;
 }

--- a/tests/test-startup-property.lua
+++ b/tests/test-startup-property.lua
@@ -1,0 +1,24 @@
+-- Test: awesome.startup returns a boolean indicating whether rc.lua is
+-- still being evaluated (true) or the event loop has started (false).
+-- AwesomeWM returns globalconf.loop == NULL. Since tests run after startup,
+-- awesome.startup must be false (not nil) at test time.
+
+local runner = require("_runner")
+
+local steps = {
+    function()
+        -- awesome.startup must be a boolean, not nil.
+        assert(type(awesome.startup) == "boolean",
+            string.format(
+                "Expected awesome.startup to be boolean, got %s",
+                type(awesome.startup)))
+
+        -- Tests run after the event loop starts, so startup is over.
+        assert(awesome.startup == false,
+            "Expected awesome.startup == false after startup")
+
+        return true
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })


### PR DESCRIPTION
## Description
Implements the `awesome.startup` read-only property. Returns `true` while the compositor is still initializing (before the event loop starts) and `false` once the event loop is running. This matches AwesomeWM's behavior where `awesome.startup` lets Lua code distinguish between initial configuration and runtime changes.

The implementation adds a `"startup"` case to `luaA_awesome_index` in `luaa.c` that pushes `globalconf.loop == NULL` as a boolean.

## Test Plan
- Added `tests/test-startup-property.lua` integration test that verifies `awesome.startup` is `false` after the event loop starts
- Matches AwesomeWM behavior (`~/tools/awesome/luaa.c`)

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)