### PR TITLE
fix: read api_level from globalconf via __index

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -1120,6 +1120,11 @@ luaA_awesome_index(lua_State *L)
 		return 1;
 	}
 
+	if (A_STREQ(key, "api_level")) {
+		lua_pushinteger(L, globalconf.api_level);
+		return 1;
+	}
+
 	if (A_STREQ(key, "bypass_surface_visibility")) {
 		lua_pushboolean(L, globalconf.appearance.bypass_surface_visibility);
 		return 1;
@@ -1217,9 +1222,6 @@ luaA_awesome_setup(lua_State *L)
 
 	lua_newtable(L);
 	lua_setfield(L, -2, "_active_modifiers");
-
-	lua_pushnumber(L, 5);
-	lua_setfield(L, -2, "api_level");
 
 	lua_pushboolean(L, 1);
 	lua_setfield(L, -2, "composite_manager_running");

--- a/tests/test-api-level.lua
+++ b/tests/test-api-level.lua
@@ -1,0 +1,30 @@
+-- Test: api_level consistency.
+--
+-- Bug: awesome.api_level was set as a raw Lua table field with value 5, while
+-- globalconf.api_level was initialized to 4 in C. AwesomeWM uses a single
+-- source of truth (globalconf.api_level = 4) exposed dynamically via __index.
+-- The mismatch caused Lua libraries to behave as if running under a future
+-- API level, enabling features and deprecation paths not present in AwesomeWM.
+--
+-- Reproduction: read awesome.api_level and verify it matches the expected
+-- AwesomeWM default of 4.
+
+local runner = require("_runner")
+
+local steps = {
+    function()
+        -- awesome.api_level must reflect globalconf.api_level (default: 4),
+        -- not a stale raw table field.
+        assert(awesome.api_level == 4,
+            string.format("Expected api_level 4, got %s", tostring(awesome.api_level)))
+
+        -- Verify it is served dynamically via __index, not as a raw field.
+        -- rawget on the awesome table should return nil for api_level.
+        assert(rawget(awesome, "api_level") == nil,
+            "api_level should not be a raw table field (must come from __index)")
+
+        return true
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })


### PR DESCRIPTION
## Description

`awesome.api_level` was set as a raw Lua table field with value `5`, while `globalconf.api_level` was correctly initialized to `4`. Since the `__index` handler didn't handle `api_level`, Lua always read the stale raw value. This caused behavioral differences from AwesomeWM in `awful.permissions` (sloppy focus enabled), `awful.autofocus` (false deprecation warning), and `wibox.widget.base` (wrong widget property defaults).

Removed the raw table field and added `api_level` to `luaA_awesome_index`, matching AwesomeWM's pattern exactly.

## Test Plan

- `tests/test-api-level.lua` — verifies `awesome.api_level == 4` and that it comes from `__index` (not a raw field)
- `make test-unit` — 629 passing
- `make test-integration` — 43 passing
- Manual: confirmed `somewm-client eval 'return awesome.api_level'` returns `4` and `rawget` returns nil

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)