### PR TITLE
feat: add awful.gesture module with consume-or-forward semantics

### DIFF
--- a/gesture.c
+++ b/gesture.c
@@ -1,0 +1,248 @@
+#include "objects/gesture.h"
+#include "luaa.h"
+#include "common/lualib.h" /* luaA_setfuncs, luaA_default_{index,newindex} */
+#include "common/util.h"
+#include "globalconf.h"
+
+#include <lauxlib.h>
+#include <stdbool.h>
+
+/* Lua registry ref for the gesture handler function */
+static int gesture_handler_ref = LUA_REFNIL;
+
+/** Set the gesture handler function.
+ * Called from Lua: _gesture.set_handler(fn)
+ */
+static int
+luaA_gesture_set_handler(lua_State *L)
+{
+    luaL_checktype(L, 1, LUA_TFUNCTION);
+
+    /* Unref old handler if any */
+    if (gesture_handler_ref != LUA_REFNIL) {
+        luaL_unref(L, LUA_REGISTRYINDEX, gesture_handler_ref);
+    }
+
+    /* Store new handler */
+    lua_pushvalue(L, 1);
+    gesture_handler_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+    return 0;
+}
+
+/** Inject a gesture event for testing.
+ * Called from Lua: _gesture.inject(event_table)
+ * Returns: boolean (consumed)
+ */
+static int
+luaA_gesture_inject(lua_State *L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+
+    if (gesture_handler_ref == LUA_REFNIL) {
+        lua_pushboolean(L, 0);
+        return 1;
+    }
+
+    /* Call handler with the event table */
+    lua_rawgeti(L, LUA_REGISTRYINDEX, gesture_handler_ref);
+    lua_pushvalue(L, 1);
+
+    if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
+        warn("gesture handler error: %s", lua_tostring(L, -1));
+        lua_pop(L, 1);
+        lua_pushboolean(L, 0);
+        return 1;
+    }
+
+    /* Handler returns boolean (consumed) */
+    if (!lua_isboolean(L, -1)) {
+        lua_pop(L, 1);
+        lua_pushboolean(L, 0);
+    }
+
+    return 1;
+}
+
+/** Call the gesture handler with an event table.
+ * Returns 1 if consumed, 0 for passthrough.
+ */
+static int
+gesture_call_handler(lua_State *L)
+{
+    /* Event table is already on top of stack */
+    if (gesture_handler_ref == LUA_REFNIL) {
+        lua_pop(L, 1);
+        return 0;
+    }
+
+    lua_rawgeti(L, LUA_REGISTRYINDEX, gesture_handler_ref);
+    lua_insert(L, -2); /* put handler below event table */
+
+    if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
+        warn("gesture handler error: %s", lua_tostring(L, -1));
+        lua_pop(L, 1);
+        return 0;
+    }
+
+    int consumed = lua_toboolean(L, -1);
+    lua_pop(L, 1);
+    return consumed;
+}
+
+int
+luaA_gesture_check_swipe_begin(uint32_t time_msec, uint32_t fingers)
+{
+    lua_State *L = globalconf_get_lua_State();
+
+    lua_newtable(L);
+    lua_pushstring(L, "swipe_begin");
+    lua_setfield(L, -2, "type");
+    lua_pushinteger(L, time_msec);
+    lua_setfield(L, -2, "time");
+    lua_pushinteger(L, fingers);
+    lua_setfield(L, -2, "fingers");
+
+    return gesture_call_handler(L);
+}
+
+int
+luaA_gesture_check_swipe_update(uint32_t time_msec, uint32_t fingers, double dx, double dy)
+{
+    lua_State *L = globalconf_get_lua_State();
+
+    lua_newtable(L);
+    lua_pushstring(L, "swipe_update");
+    lua_setfield(L, -2, "type");
+    lua_pushinteger(L, time_msec);
+    lua_setfield(L, -2, "time");
+    lua_pushinteger(L, fingers);
+    lua_setfield(L, -2, "fingers");
+    lua_pushnumber(L, dx);
+    lua_setfield(L, -2, "dx");
+    lua_pushnumber(L, dy);
+    lua_setfield(L, -2, "dy");
+
+    return gesture_call_handler(L);
+}
+
+int
+luaA_gesture_check_swipe_end(uint32_t time_msec, bool cancelled)
+{
+    lua_State *L = globalconf_get_lua_State();
+
+    lua_newtable(L);
+    lua_pushstring(L, "swipe_end");
+    lua_setfield(L, -2, "type");
+    lua_pushinteger(L, time_msec);
+    lua_setfield(L, -2, "time");
+    lua_pushboolean(L, cancelled);
+    lua_setfield(L, -2, "cancelled");
+
+    return gesture_call_handler(L);
+}
+
+int
+luaA_gesture_check_pinch_begin(uint32_t time_msec, uint32_t fingers)
+{
+    lua_State *L = globalconf_get_lua_State();
+
+    lua_newtable(L);
+    lua_pushstring(L, "pinch_begin");
+    lua_setfield(L, -2, "type");
+    lua_pushinteger(L, time_msec);
+    lua_setfield(L, -2, "time");
+    lua_pushinteger(L, fingers);
+    lua_setfield(L, -2, "fingers");
+
+    return gesture_call_handler(L);
+}
+
+int
+luaA_gesture_check_pinch_update(uint32_t time_msec, uint32_t fingers, double dx, double dy, double scale, double rotation)
+{
+    lua_State *L = globalconf_get_lua_State();
+
+    lua_newtable(L);
+    lua_pushstring(L, "pinch_update");
+    lua_setfield(L, -2, "type");
+    lua_pushinteger(L, time_msec);
+    lua_setfield(L, -2, "time");
+    lua_pushinteger(L, fingers);
+    lua_setfield(L, -2, "fingers");
+    lua_pushnumber(L, dx);
+    lua_setfield(L, -2, "dx");
+    lua_pushnumber(L, dy);
+    lua_setfield(L, -2, "dy");
+    lua_pushnumber(L, scale);
+    lua_setfield(L, -2, "scale");
+    lua_pushnumber(L, rotation);
+    lua_setfield(L, -2, "rotation");
+
+    return gesture_call_handler(L);
+}
+
+int
+luaA_gesture_check_pinch_end(uint32_t time_msec, bool cancelled)
+{
+    lua_State *L = globalconf_get_lua_State();
+
+    lua_newtable(L);
+    lua_pushstring(L, "pinch_end");
+    lua_setfield(L, -2, "type");
+    lua_pushinteger(L, time_msec);
+    lua_setfield(L, -2, "time");
+    lua_pushboolean(L, cancelled);
+    lua_setfield(L, -2, "cancelled");
+
+    return gesture_call_handler(L);
+}
+
+int
+luaA_gesture_check_hold_begin(uint32_t time_msec, uint32_t fingers)
+{
+    lua_State *L = globalconf_get_lua_State();
+
+    lua_newtable(L);
+    lua_pushstring(L, "hold_begin");
+    lua_setfield(L, -2, "type");
+    lua_pushinteger(L, time_msec);
+    lua_setfield(L, -2, "time");
+    lua_pushinteger(L, fingers);
+    lua_setfield(L, -2, "fingers");
+
+    return gesture_call_handler(L);
+}
+
+int
+luaA_gesture_check_hold_end(uint32_t time_msec, bool cancelled)
+{
+    lua_State *L = globalconf_get_lua_State();
+
+    lua_newtable(L);
+    lua_pushstring(L, "hold_end");
+    lua_setfield(L, -2, "type");
+    lua_pushinteger(L, time_msec);
+    lua_setfield(L, -2, "time");
+    lua_pushboolean(L, cancelled);
+    lua_setfield(L, -2, "cancelled");
+
+    return gesture_call_handler(L);
+}
+
+const struct luaL_Reg awesome_gesture_lib[] =
+{
+    { "set_handler", luaA_gesture_set_handler },
+    { "inject", luaA_gesture_inject },
+    { "__index", luaA_default_index },
+    { "__newindex", luaA_default_newindex },
+    { NULL, NULL }
+};
+
+void
+luaA_gesture_setup(lua_State *L)
+{
+    luaA_setfuncs(L, awesome_gesture_lib);
+}
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lua/awful/gesture.lua
+++ b/lua/awful/gesture.lua
@@ -1,0 +1,305 @@
+---------------------------------------------------------------------------
+--- Touchpad gesture bindings for somewm.
+--
+-- @module awful.gesture
+---------------------------------------------------------------------------
+
+local gesture = {}
+
+--- Direction detection threshold in pixels.
+-- Swipe direction is committed once the accumulated displacement exceeds this.
+-- @tfield number direction_threshold
+gesture.direction_threshold = 30
+
+-- Binding storage, keyed by gesture type
+local bindings = {
+    swipe = {},
+    pinch = {},
+    hold  = {},
+}
+
+-- Active gesture state (nil when no gesture is active)
+local active = nil
+
+-- Binding metatable
+local Binding = {}
+Binding.__index = Binding
+
+--- Remove this gesture binding.
+-- @method remove
+function Binding:remove()
+    local list = bindings[self.type]
+    if not list then return end
+    for i, b in ipairs(list) do
+        if b == self then
+            table.remove(list, i)
+            return
+        end
+    end
+end
+
+--- Check if any binding matches type + fingers (for consume-eagerly).
+-- @tparam string gtype Gesture type
+-- @tparam number fingers Finger count
+-- @treturn boolean True if at least one binding matches
+local function has_candidates(gtype, fingers)
+    local list = bindings[gtype]
+    if not list then return false end
+    for _, b in ipairs(list) do
+        if b.fingers == fingers then
+            return true
+        end
+    end
+    return false
+end
+
+--- Find the first binding matching type + fingers + direction.
+-- @tparam string gtype Gesture type
+-- @tparam number fingers Finger count
+-- @tparam string|nil direction Detected direction (swipe only)
+-- @treturn table|nil The matched binding, or nil
+local function find_binding(gtype, fingers, direction)
+    local list = bindings[gtype]
+    if not list then return nil end
+    for _, b in ipairs(list) do
+        if b.fingers == fingers then
+            if gtype ~= "swipe" or b.direction == nil or b.direction == direction then
+                return b
+            end
+        end
+    end
+    return nil
+end
+
+--- Build the gesture state table passed to callbacks.
+-- @treturn table The gesture state
+local function build_state()
+    if not active then return {} end
+    local s = {
+        type      = active.type,
+        fingers   = active.fingers,
+        dx        = active.dx,
+        dy        = active.dy,
+        scale     = active.scale,
+        rotation  = active.rotation,
+        direction = active.direction,
+        cancelled = active.cancelled or false,
+        time      = active.time,
+    }
+    return s
+end
+
+--- Detect swipe direction from accumulated deltas.
+-- @treturn string|nil Direction string or nil if threshold not reached
+local function detect_direction(dx, dy)
+    local abs_dx = math.abs(dx)
+    local abs_dy = math.abs(dy)
+    if math.max(abs_dx, abs_dy) < gesture.direction_threshold then
+        return nil
+    end
+    if abs_dx >= abs_dy then
+        return dx < 0 and "left" or "right"
+    else
+        return dy < 0 and "up" or "down"
+    end
+end
+
+--- Main event handler called from C via _gesture.set_handler().
+-- @tparam table event Event table from C
+-- @treturn boolean True if consumed
+local function handler(event)
+    local etype = event.type
+
+    -- SWIPE
+    if etype == "swipe_begin" then
+        local consumed = has_candidates("swipe", event.fingers)
+        if consumed then
+            active = {
+                type = "swipe",
+                fingers = event.fingers,
+                dx = 0, dy = 0,
+                scale = 1.0, rotation = 0.0,
+                direction = nil,
+                matched = nil,
+                time = event.time,
+            }
+            -- Fire on_trigger immediately for non-direction bindings
+            local b = find_binding("swipe", event.fingers, nil)
+            if b and not b.direction then
+                active.matched = b
+                if b.on_trigger then
+                    b.on_trigger(build_state())
+                end
+            end
+        end
+        return consumed
+
+    elseif etype == "swipe_update" then
+        if not active or active.type ~= "swipe" then return false end
+        active.dx = active.dx + event.dx
+        active.dy = active.dy + event.dy
+        active.time = event.time
+
+        -- Detect direction if not yet committed
+        if not active.direction then
+            active.direction = detect_direction(active.dx, active.dy)
+            if active.direction and not active.matched then
+                -- Try matching a direction binding now
+                local b = find_binding("swipe", active.fingers, active.direction)
+                if b then
+                    active.matched = b
+                end
+            end
+        end
+
+        -- Fire on_update for matched binding
+        if active.matched and active.matched.on_update then
+            active.matched.on_update(build_state())
+        end
+        return true
+
+    elseif etype == "swipe_end" then
+        if not active or active.type ~= "swipe" then return false end
+        active.cancelled = event.cancelled
+        active.time = event.time
+
+        -- For direction bindings, on_trigger fires on end (if matched and not cancelled)
+        if active.matched and active.matched.direction and not event.cancelled then
+            if active.matched.on_trigger then
+                active.matched.on_trigger(build_state())
+            end
+        end
+
+        -- Fire on_end for matched binding
+        if active.matched and active.matched.on_end then
+            active.matched.on_end(build_state())
+        end
+
+        active = nil
+        return true
+
+    -- PINCH
+    elseif etype == "pinch_begin" then
+        local consumed = has_candidates("pinch", event.fingers)
+        if consumed then
+            active = {
+                type = "pinch",
+                fingers = event.fingers,
+                dx = 0, dy = 0,
+                scale = 1.0, rotation = 0.0,
+                direction = nil,
+                matched = nil,
+                time = event.time,
+            }
+            local b = find_binding("pinch", event.fingers)
+            if b then
+                active.matched = b
+                if b.on_trigger then
+                    b.on_trigger(build_state())
+                end
+            end
+        end
+        return consumed
+
+    elseif etype == "pinch_update" then
+        if not active or active.type ~= "pinch" then return false end
+        active.dx = active.dx + event.dx
+        active.dy = active.dy + event.dy
+        active.scale = event.scale
+        active.rotation = active.rotation + event.rotation
+        active.time = event.time
+
+        if active.matched and active.matched.on_update then
+            active.matched.on_update(build_state())
+        end
+        return true
+
+    elseif etype == "pinch_end" then
+        if not active or active.type ~= "pinch" then return false end
+        active.cancelled = event.cancelled
+        active.time = event.time
+
+        if active.matched and active.matched.on_end then
+            active.matched.on_end(build_state())
+        end
+
+        active = nil
+        return true
+
+    -- HOLD
+    elseif etype == "hold_begin" then
+        local consumed = has_candidates("hold", event.fingers)
+        if consumed then
+            active = {
+                type = "hold",
+                fingers = event.fingers,
+                dx = 0, dy = 0,
+                scale = 1.0, rotation = 0.0,
+                direction = nil,
+                matched = nil,
+                time = event.time,
+            }
+            local b = find_binding("hold", event.fingers)
+            if b then
+                active.matched = b
+                if b.on_trigger then
+                    b.on_trigger(build_state())
+                end
+            end
+        end
+        return consumed
+
+    elseif etype == "hold_end" then
+        if not active or active.type ~= "hold" then return false end
+        active.cancelled = event.cancelled
+        active.time = event.time
+
+        if active.matched and active.matched.on_end then
+            active.matched.on_end(build_state())
+        end
+
+        active = nil
+        return true
+    end
+
+    return false
+end
+
+-- Register handler with C bridge
+_gesture.set_handler(handler)
+
+-- Constructor metamethod
+setmetatable(gesture, {
+    __call = function(_, args)
+        assert(type(args) == "table", "awful.gesture: argument must be a table")
+        assert(args.type == "swipe" or args.type == "pinch" or args.type == "hold",
+            "awful.gesture: type must be 'swipe', 'pinch', or 'hold'")
+        assert(type(args.fingers) == "number" and args.fingers >= 1,
+            "awful.gesture: fingers must be a positive number")
+        if args.direction then
+            assert(args.type == "swipe",
+                "awful.gesture: direction is only valid for swipe gestures")
+            assert(args.direction == "left" or args.direction == "right"
+                or args.direction == "up" or args.direction == "down",
+                "awful.gesture: direction must be 'left', 'right', 'up', or 'down'")
+        end
+
+        local binding = setmetatable({
+            type        = args.type,
+            fingers     = args.fingers,
+            direction   = args.direction,
+            on_trigger  = args.on_trigger,
+            on_update   = args.on_update,
+            on_end      = args.on_end,
+            description = args.description,
+            group       = args.group,
+        }, Binding)
+
+        table.insert(bindings[args.type], binding)
+        return binding
+    end,
+})
+
+return gesture
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lua/awful/init.lua
+++ b/lua/awful/init.lua
@@ -24,6 +24,7 @@ local ret = {
     widget = require("awful.widget");
     keygrabber = require("awful.keygrabber");
     input = require("awful.input");
+    gesture = require("awful.gesture");
     menu = require("awful.menu");
     mouse = require("awful.mouse");
     remote = require("awful.remote");

--- a/luaa.c
+++ b/luaa.c
@@ -24,6 +24,7 @@
 #include "objects/keybinding.h"
 #include "objects/keygrabber.h"
 #include "objects/mousegrabber.h"
+#include "objects/gesture.h"
 /* objects/awesome.h merged into this file */
 #include "objects/wibox.h"
 #include "objects/ipc.h"
@@ -1777,6 +1778,11 @@ luaA_init(void)
 	lua_newtable(globalconf_L);  /* Create mousegrabber module table */
 	luaA_mousegrabber_setup(globalconf_L);
 	lua_setglobal(globalconf_L, "mousegrabber");  /* mousegrabber = module */
+
+	/* Setup gesture module (somewm-specific: touchpad gesture bridge) */
+	lua_newtable(globalconf_L);
+	luaA_gesture_setup(globalconf_L);
+	lua_setglobal(globalconf_L, "_gesture");
 
 	/* NOTE: The C-based key class is now set up by key_class_setup() above (line 88).
 	 * The old Lua-based implementation below has been disabled to let the C implementation work.
@@ -3636,6 +3642,11 @@ luaA_create_fresh_state(void)
 	lua_newtable(L);
 	luaA_mousegrabber_setup(L);
 	lua_setglobal(L, "mousegrabber");
+
+	/* Gesture */
+	lua_newtable(L);
+	luaA_gesture_setup(L);
+	lua_setglobal(L, "_gesture");
 
 	return L;
 }

--- a/meson.build
+++ b/meson.build
@@ -283,6 +283,7 @@ somewm_sources = [
   'spawn.c',
   'keygrabber.c',
   'mousegrabber.c',
+  'gesture.c',
   'selection.c',
   # Common
   'common/luaclass.c',

--- a/objects/gesture.h
+++ b/objects/gesture.h
@@ -1,0 +1,19 @@
+#ifndef AWESOME_GESTURE_H
+#define AWESOME_GESTURE_H
+
+#include <lua.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+void luaA_gesture_setup(lua_State *L);
+int luaA_gesture_check_swipe_begin(uint32_t time_msec, uint32_t fingers);
+int luaA_gesture_check_swipe_update(uint32_t time_msec, uint32_t fingers, double dx, double dy);
+int luaA_gesture_check_swipe_end(uint32_t time_msec, bool cancelled);
+int luaA_gesture_check_pinch_begin(uint32_t time_msec, uint32_t fingers);
+int luaA_gesture_check_pinch_update(uint32_t time_msec, uint32_t fingers, double dx, double dy, double scale, double rotation);
+int luaA_gesture_check_pinch_end(uint32_t time_msec, bool cancelled);
+int luaA_gesture_check_hold_begin(uint32_t time_msec, uint32_t fingers);
+int luaA_gesture_check_hold_end(uint32_t time_msec, bool cancelled);
+
+#endif
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/spec/awful/gesture_spec.lua
+++ b/spec/awful/gesture_spec.lua
@@ -1,0 +1,452 @@
+---------------------------------------------------------------------------
+-- @author somewm contributors
+-- @copyright 2026 somewm contributors
+---------------------------------------------------------------------------
+
+-- Mock _gesture C table before requiring the module
+local handler_fn = nil
+_G._gesture = {
+    set_handler = function(fn)
+        handler_fn = fn
+    end,
+    inject = function(event)
+        if handler_fn then
+            return handler_fn(event)
+        end
+        return false
+    end,
+}
+
+local gesture = require("awful.gesture")
+
+describe("awful.gesture", function()
+    -- Helper: simulate a full gesture sequence through handler_fn
+    local function send(event)
+        return handler_fn(event)
+    end
+
+    before_each(function()
+        -- Re-register all bindings fresh by reloading
+        -- Instead, we'll track and remove bindings manually
+    end)
+
+    describe("registration", function()
+        it("registers a swipe binding and returns an object", function()
+            local b = gesture {
+                type = "swipe", fingers = 3, direction = "left",
+                on_trigger = function() end,
+            }
+            assert.is_not_nil(b)
+            assert.is.equal("swipe", b.type)
+            assert.is.equal(3, b.fingers)
+            assert.is.equal("left", b.direction)
+            b:remove()
+        end)
+
+        it("registers a hold binding", function()
+            local b = gesture {
+                type = "hold", fingers = 3,
+                on_trigger = function() end,
+            }
+            assert.is.equal("hold", b.type)
+            b:remove()
+        end)
+
+        it("registers a pinch binding", function()
+            local b = gesture {
+                type = "pinch", fingers = 2,
+                on_update = function() end,
+            }
+            assert.is.equal("pinch", b.type)
+            b:remove()
+        end)
+
+        it("rejects invalid type", function()
+            assert.has_error(function()
+                gesture { type = "tap", fingers = 1 }
+            end)
+        end)
+
+        it("rejects direction on non-swipe", function()
+            assert.has_error(function()
+                gesture { type = "hold", fingers = 3, direction = "left" }
+            end)
+        end)
+
+        it("rejects invalid direction", function()
+            assert.has_error(function()
+                gesture { type = "swipe", fingers = 3, direction = "diagonal" }
+            end)
+        end)
+    end)
+
+    describe("removal", function()
+        it("remove() stops binding from matching", function()
+            local triggered = false
+            local b = gesture {
+                type = "hold", fingers = 3,
+                on_trigger = function() triggered = true end,
+            }
+            b:remove()
+
+            local consumed = send({type = "hold_begin", time = 100, fingers = 3})
+            assert.is_false(consumed)
+            assert.is_false(triggered)
+        end)
+
+        it("double remove() is safe", function()
+            local b = gesture {
+                type = "hold", fingers = 3,
+                on_trigger = function() end,
+            }
+            b:remove()
+            assert.has_no_errors(function() b:remove() end)
+        end)
+    end)
+
+    describe("hold gesture", function()
+        it("fires on_trigger on begin", function()
+            local state = nil
+            local b = gesture {
+                type = "hold", fingers = 3,
+                on_trigger = function(s) state = s end,
+            }
+
+            local consumed = send({type = "hold_begin", time = 100, fingers = 3})
+            assert.is_true(consumed)
+            assert.is_not_nil(state)
+            assert.is.equal("hold", state.type)
+            assert.is.equal(3, state.fingers)
+            assert.is.equal(100, state.time)
+
+            send({type = "hold_end", time = 200, cancelled = false})
+            b:remove()
+        end)
+
+        it("fires on_end on end", function()
+            local end_state = nil
+            local b = gesture {
+                type = "hold", fingers = 3,
+                on_trigger = function() end,
+                on_end = function(s) end_state = s end,
+            }
+
+            send({type = "hold_begin", time = 100, fingers = 3})
+            send({type = "hold_end", time = 200, cancelled = false})
+            assert.is_not_nil(end_state)
+            assert.is_false(end_state.cancelled)
+            b:remove()
+        end)
+
+        it("passes cancelled flag", function()
+            local end_state = nil
+            local b = gesture {
+                type = "hold", fingers = 3,
+                on_trigger = function() end,
+                on_end = function(s) end_state = s end,
+            }
+
+            send({type = "hold_begin", time = 100, fingers = 3})
+            send({type = "hold_end", time = 200, cancelled = true})
+            assert.is_true(end_state.cancelled)
+            b:remove()
+        end)
+
+        it("does not consume non-matching finger count", function()
+            local b = gesture {
+                type = "hold", fingers = 3,
+                on_trigger = function() end,
+            }
+
+            local consumed = send({type = "hold_begin", time = 100, fingers = 4})
+            assert.is_false(consumed)
+            b:remove()
+        end)
+    end)
+
+    describe("swipe with direction", function()
+        it("fires on_trigger on end when direction matches", function()
+            local trigger_state = nil
+            local b = gesture {
+                type = "swipe", fingers = 3, direction = "left",
+                on_trigger = function(s) trigger_state = s end,
+            }
+
+            send({type = "swipe_begin", time = 100, fingers = 3})
+            -- Swipe left (negative dx)
+            send({type = "swipe_update", time = 110, fingers = 3, dx = -20, dy = 0})
+            send({type = "swipe_update", time = 120, fingers = 3, dx = -20, dy = 0})
+            assert.is_nil(trigger_state) -- not triggered yet (direction just committed)
+
+            send({type = "swipe_end", time = 130, cancelled = false})
+            assert.is_not_nil(trigger_state)
+            assert.is.equal("left", trigger_state.direction)
+            assert.is.equal(-40, trigger_state.dx)
+            b:remove()
+        end)
+
+        it("does not fire on_trigger when direction doesn't match", function()
+            local triggered = false
+            local b = gesture {
+                type = "swipe", fingers = 3, direction = "left",
+                on_trigger = function() triggered = true end,
+            }
+
+            send({type = "swipe_begin", time = 100, fingers = 3})
+            send({type = "swipe_update", time = 110, fingers = 3, dx = 20, dy = 0})
+            send({type = "swipe_update", time = 120, fingers = 3, dx = 20, dy = 0})
+            send({type = "swipe_end", time = 130, cancelled = false})
+            assert.is_false(triggered)
+            b:remove()
+        end)
+
+        it("does not fire on_trigger when cancelled", function()
+            local triggered = false
+            local b = gesture {
+                type = "swipe", fingers = 3, direction = "left",
+                on_trigger = function() triggered = true end,
+            }
+
+            send({type = "swipe_begin", time = 100, fingers = 3})
+            send({type = "swipe_update", time = 110, fingers = 3, dx = -40, dy = 0})
+            send({type = "swipe_end", time = 130, cancelled = true})
+            assert.is_false(triggered)
+            b:remove()
+        end)
+
+        it("fires on_end even when direction doesn't match", function()
+            local end_called = false
+            local b_left = gesture {
+                type = "swipe", fingers = 3, direction = "left",
+                on_trigger = function() end,
+                on_end = function() end_called = true end,
+            }
+
+            send({type = "swipe_begin", time = 100, fingers = 3})
+            send({type = "swipe_update", time = 110, fingers = 3, dx = -40, dy = 0})
+            send({type = "swipe_end", time = 130, cancelled = false})
+            -- on_end fires because there IS a matched binding (direction matches)
+            assert.is_true(end_called)
+            b_left:remove()
+        end)
+    end)
+
+    describe("swipe without direction", function()
+        it("fires on_trigger immediately on begin", function()
+            local trigger_state = nil
+            local b = gesture {
+                type = "swipe", fingers = 3,
+                on_trigger = function(s) trigger_state = s end,
+            }
+
+            send({type = "swipe_begin", time = 100, fingers = 3})
+            assert.is_not_nil(trigger_state)
+            assert.is.equal("swipe", trigger_state.type)
+
+            send({type = "swipe_end", time = 130, cancelled = false})
+            b:remove()
+        end)
+
+        it("fires on_update on each update", function()
+            local updates = {}
+            local b = gesture {
+                type = "swipe", fingers = 3,
+                on_trigger = function() end,
+                on_update = function(s) table.insert(updates, s) end,
+            }
+
+            send({type = "swipe_begin", time = 100, fingers = 3})
+            send({type = "swipe_update", time = 110, fingers = 3, dx = -10, dy = 5})
+            send({type = "swipe_update", time = 120, fingers = 3, dx = -15, dy = 3})
+            assert.is.equal(2, #updates)
+            assert.is.equal(-25, updates[2].dx)
+            assert.is.equal(8, updates[2].dy)
+
+            send({type = "swipe_end", time = 130, cancelled = false})
+            b:remove()
+        end)
+    end)
+
+    describe("pinch gesture", function()
+        it("fires on_trigger on begin and on_update with scale", function()
+            local trigger_state = nil
+            local update_states = {}
+            local b = gesture {
+                type = "pinch", fingers = 2,
+                on_trigger = function(s) trigger_state = s end,
+                on_update = function(s) table.insert(update_states, s) end,
+            }
+
+            send({type = "pinch_begin", time = 100, fingers = 2})
+            assert.is_not_nil(trigger_state)
+            assert.is.equal("pinch", trigger_state.type)
+
+            send({type = "pinch_update", time = 110, fingers = 2,
+                dx = 1, dy = 0, scale = 1.5, rotation = 10})
+            assert.is.equal(1, #update_states)
+            assert.is.equal(1.5, update_states[1].scale)
+            assert.is.equal(10, update_states[1].rotation)
+
+            send({type = "pinch_end", time = 130, cancelled = false})
+            b:remove()
+        end)
+    end)
+
+    describe("direction detection", function()
+        it("detects up direction", function()
+            local trigger_state = nil
+            local b = gesture {
+                type = "swipe", fingers = 3, direction = "up",
+                on_trigger = function(s) trigger_state = s end,
+            }
+
+            send({type = "swipe_begin", time = 100, fingers = 3})
+            send({type = "swipe_update", time = 110, fingers = 3, dx = 0, dy = -40})
+            send({type = "swipe_end", time = 130, cancelled = false})
+            assert.is_not_nil(trigger_state)
+            assert.is.equal("up", trigger_state.direction)
+            b:remove()
+        end)
+
+        it("detects down direction", function()
+            local trigger_state = nil
+            local b = gesture {
+                type = "swipe", fingers = 3, direction = "down",
+                on_trigger = function(s) trigger_state = s end,
+            }
+
+            send({type = "swipe_begin", time = 100, fingers = 3})
+            send({type = "swipe_update", time = 110, fingers = 3, dx = 0, dy = 40})
+            send({type = "swipe_end", time = 130, cancelled = false})
+            assert.is_not_nil(trigger_state)
+            assert.is.equal("down", trigger_state.direction)
+            b:remove()
+        end)
+
+        it("detects right direction", function()
+            local trigger_state = nil
+            local b = gesture {
+                type = "swipe", fingers = 3, direction = "right",
+                on_trigger = function(s) trigger_state = s end,
+            }
+
+            send({type = "swipe_begin", time = 100, fingers = 3})
+            send({type = "swipe_update", time = 110, fingers = 3, dx = 40, dy = 0})
+            send({type = "swipe_end", time = 130, cancelled = false})
+            assert.is_not_nil(trigger_state)
+            assert.is.equal("right", trigger_state.direction)
+            b:remove()
+        end)
+
+        it("respects direction_threshold", function()
+            local b = gesture {
+                type = "swipe", fingers = 3, direction = "left",
+                on_trigger = function() end,
+            }
+
+            send({type = "swipe_begin", time = 100, fingers = 3})
+            -- Below threshold (default 30)
+            send({type = "swipe_update", time = 110, fingers = 3, dx = -25, dy = 0})
+            -- Check that direction isn't committed yet by ending
+            local triggered = false
+            b:remove()
+
+            local b2 = gesture {
+                type = "swipe", fingers = 3, direction = "left",
+                on_trigger = function() triggered = true end,
+            }
+            send({type = "swipe_begin", time = 200, fingers = 3})
+            send({type = "swipe_update", time = 210, fingers = 3, dx = -25, dy = 0})
+            send({type = "swipe_end", time = 220, cancelled = false})
+            -- Direction was not committed (25 < 30), so on_trigger doesn't fire
+            assert.is_false(triggered)
+            b2:remove()
+        end)
+
+        it("direction_threshold can be changed", function()
+            local old = gesture.direction_threshold
+            gesture.direction_threshold = 10
+
+            local triggered = false
+            local b = gesture {
+                type = "swipe", fingers = 3, direction = "left",
+                on_trigger = function() triggered = true end,
+            }
+
+            send({type = "swipe_begin", time = 100, fingers = 3})
+            send({type = "swipe_update", time = 110, fingers = 3, dx = -15, dy = 0})
+            send({type = "swipe_end", time = 120, cancelled = false})
+            assert.is_true(triggered)
+
+            gesture.direction_threshold = old
+            b:remove()
+        end)
+    end)
+
+    describe("consume-eagerly", function()
+        it("consumes all gestures matching type+fingers", function()
+            local b = gesture {
+                type = "swipe", fingers = 3, direction = "left",
+                on_trigger = function() end,
+            }
+
+            -- 3-finger swipe right should still be consumed (because 3-finger
+            -- swipe bindings exist), even though direction won't match
+            local consumed = send({type = "swipe_begin", time = 100, fingers = 3})
+            assert.is_true(consumed)
+
+            send({type = "swipe_update", time = 110, fingers = 3, dx = 40, dy = 0})
+            send({type = "swipe_end", time = 120, cancelled = false})
+            b:remove()
+        end)
+
+        it("does not consume unmatched finger counts", function()
+            local b = gesture {
+                type = "swipe", fingers = 3, direction = "left",
+                on_trigger = function() end,
+            }
+
+            local consumed = send({type = "swipe_begin", time = 100, fingers = 4})
+            assert.is_false(consumed)
+            b:remove()
+        end)
+    end)
+
+    describe("first match wins", function()
+        it("matches the first registered binding", function()
+            local first_triggered = false
+            local second_triggered = false
+
+            local b1 = gesture {
+                type = "hold", fingers = 3,
+                on_trigger = function() first_triggered = true end,
+            }
+            local b2 = gesture {
+                type = "hold", fingers = 3,
+                on_trigger = function() second_triggered = true end,
+            }
+
+            send({type = "hold_begin", time = 100, fingers = 3})
+            assert.is_true(first_triggered)
+            assert.is_false(second_triggered)
+
+            send({type = "hold_end", time = 200, cancelled = false})
+            b1:remove()
+            b2:remove()
+        end)
+    end)
+
+    describe("metadata", function()
+        it("stores description and group", function()
+            local b = gesture {
+                type = "swipe", fingers = 3, direction = "left",
+                on_trigger = function() end,
+                description = "view previous tag",
+                group = "tag",
+            }
+            assert.is.equal("view previous tag", b.description)
+            assert.is.equal("tag", b.group)
+            b:remove()
+        end)
+    end)
+end)

--- a/tests/test-gesture-bindings.lua
+++ b/tests/test-gesture-bindings.lua
@@ -1,0 +1,100 @@
+-- Test: awful.gesture bindings with _gesture.inject() C test helper.
+--
+-- Verifies that gesture bindings work end-to-end through the C↔Lua bridge:
+-- swipe direction matching, hold immediate trigger, pinch updates with scale,
+-- and passthrough for unbound gestures.
+
+local runner = require("_runner")
+local gesture = require("awful.gesture")
+
+local steps = {
+    -- Test 1: 3-finger swipe left binding fires correctly
+    function()
+        local triggered = false
+        local trigger_state = nil
+
+        local b = gesture {
+            type = "swipe", fingers = 3, direction = "left",
+            on_trigger = function(s)
+                triggered = true
+                trigger_state = s
+            end,
+        }
+
+        -- Simulate via C inject
+        _gesture.inject({type = "swipe_begin", time = 1000, fingers = 3})
+        _gesture.inject({type = "swipe_update", time = 1010, fingers = 3, dx = -20, dy = 0})
+        _gesture.inject({type = "swipe_update", time = 1020, fingers = 3, dx = -20, dy = 0})
+        _gesture.inject({type = "swipe_end", time = 1030, cancelled = false})
+
+        assert(triggered, "swipe left should have triggered")
+        assert(trigger_state.direction == "left",
+            "direction should be 'left', got: " .. tostring(trigger_state.direction))
+        assert(trigger_state.dx == -40,
+            "dx should be -40, got: " .. tostring(trigger_state.dx))
+
+        b:remove()
+        return true
+    end,
+
+    -- Test 2: Non-matching gestures pass through (returns false)
+    function()
+        local b = gesture {
+            type = "swipe", fingers = 3, direction = "left",
+            on_trigger = function() end,
+        }
+
+        -- 4-finger swipe should not be consumed
+        local consumed = _gesture.inject({type = "swipe_begin", time = 2000, fingers = 4})
+        assert(not consumed, "4-finger swipe should not be consumed by 3-finger binding")
+
+        b:remove()
+        return true
+    end,
+
+    -- Test 3: Hold fires immediately on begin
+    function()
+        local triggered = false
+        local ended = false
+
+        local b = gesture {
+            type = "hold", fingers = 3,
+            on_trigger = function() triggered = true end,
+            on_end = function() ended = true end,
+        }
+
+        local consumed = _gesture.inject({type = "hold_begin", time = 3000, fingers = 3})
+        assert(consumed, "hold should be consumed")
+        assert(triggered, "hold on_trigger should fire on begin")
+        assert(not ended, "hold on_end should not fire yet")
+
+        _gesture.inject({type = "hold_end", time = 3500, cancelled = false})
+        assert(ended, "hold on_end should fire on end")
+
+        b:remove()
+        return true
+    end,
+
+    -- Test 4: Pinch with on_update receives scale
+    function()
+        local scale_received = nil
+
+        local b = gesture {
+            type = "pinch", fingers = 2,
+            on_trigger = function() end,
+            on_update = function(s) scale_received = s.scale end,
+        }
+
+        _gesture.inject({type = "pinch_begin", time = 4000, fingers = 2})
+        _gesture.inject({type = "pinch_update", time = 4010, fingers = 2,
+            dx = 0, dy = 0, scale = 1.75, rotation = 0})
+        assert(scale_received == 1.75,
+            "pinch scale should be 1.75, got: " .. tostring(scale_received))
+
+        _gesture.inject({type = "pinch_end", time = 4020, cancelled = false})
+        b:remove()
+        return true
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })


### PR DESCRIPTION
## Description

Builds on @shuber2's `pointer_gestures_v1` protocol plumbing from #296, which wires up libinput swipe/pinch/hold events and forwards them to the focused client via the Wayland protocol. This PR adds an `awful.gesture` Lua module that gives `rc.lua` full control over those events.

### The API

Gestures are bound by calling `awful.gesture` as a constructor:

```lua
-- Switch tags with 3-finger swipe
awful.gesture {
    type      = "swipe",
    fingers   = 3,
    direction = "left",
    on_trigger = function() awful.tag.viewprev() end,
}

-- Pinch-to-zoom with continuous updates
awful.gesture {
    type      = "pinch",
    fingers   = 2,
    on_update = function(state)
        -- state.scale tracks cumulative pinch factor
    end,
}
```

Each binding specifies a **type** (`swipe`, `pinch`, `hold`), a **finger count**, and optionally a **direction** (swipe only: `up`/`down`/`left`/`right`). Three callbacks cover the gesture lifecycle:

- **`on_trigger`** fires when the gesture is recognized. For directional swipes this waits until the swipe direction is committed (displacement exceeds `gesture.direction_threshold`); for everything else it fires on begin.
- **`on_update`** fires on each update event with a state table containing `dx`, `dy`, `scale`, `rotation`, and the detected `direction`. Useful for continuous effects like live workspace peeking or zoom.
- **`on_end`** fires when fingers lift. State includes a `cancelled` flag so you can roll back incomplete gestures.

Bindings are first-class objects with a `:remove()` method, so they can be managed dynamically.

### Consume-or-forward

The key design choice: the WM decides **at gesture begin** whether to consume or forward. If any binding matches the type + finger count, the entire gesture is consumed and no events reach the client. If nothing matches, all events pass through to the client transparently. This is an all-or-nothing decision per gesture, which avoids the UX problem of forwarding the first few events and then swallowing the rest mid-gesture.

### What this enables

Users can bind workspace switching, window tiling, overview triggers, or any Lua action to touchpad gestures from `rc.lua`. Unbound gestures (e.g., browser pinch-to-zoom) pass through to the client untouched.

## Checklist
- [x] Lua libraries not modified
- [x] Tests pass