### PR TITLE
fix: reject static system wlroots to prevent stale .a breaking rebuild

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -121,7 +121,7 @@ message('Found LGI version: ' + lgi_version)
 
 # wlroots 0.19 only - use system if available, otherwise build from subproject
 # We only support 0.19+ due to Xwayland bugs in earlier versions
-wlroots = dependency('wlroots-0.19', required: false)
+wlroots = dependency('wlroots-0.19', static: false, required: false)
 
 if not wlroots.found()
   message('System wlroots 0.19 not found, building from subproject...')


### PR DESCRIPTION
## Description
When the PKGBUILD installs the wlroots subproject's static `.a` and `.pc` files onto the system, subsequent rebuilds find the `.pc`, pick up the `.a`, declare "system wlroots found", skip the subproject, then linking fails because static archives don't carry transitive deps.

Adding `static: false` to the `dependency()` call makes meson skip any stale static `.a` and fall through to the subproject. The root cause fix (`--skip-subprojects wlroots` in the PKGBUILD) is committed separately in the AUR repo.

Closes #295

## Test Plan
- `make build-test` passes with the change

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)