### PR TITLE
fix: update border colors when drag ends

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -5178,6 +5178,54 @@ luaA_client_set_xproperty(lua_State *L)
     return 0;
 }
 
+/** client:_border_is_focus_color() -> boolean
+ *
+ * Returns true if the client's rendered border color matches the
+ * compositor's focus color. Reads directly from wlr_scene_rect.
+ */
+static int
+luaA_client_border_is_focus_color(lua_State *L)
+{
+    client_t *c = luaA_checkudata(L, 1, &client_class);
+    if (!c || !c->border[0]) {
+        lua_pushboolean(L, 0);
+        return 1;
+    }
+
+    const float *focus = globalconf.appearance.focuscolor;
+    const float *actual = c->border[0]->color;
+
+    int matches = (actual[0] == focus[0] && actual[1] == focus[1] &&
+                   actual[2] == focus[2] && actual[3] == focus[3]);
+
+    lua_pushboolean(L, matches);
+    return 1;
+}
+
+/** client:_border_is_normal_color() -> boolean
+ *
+ * Returns true if the client's rendered border color matches the
+ * compositor's normal (unfocused) border color.
+ */
+static int
+luaA_client_border_is_normal_color(lua_State *L)
+{
+    client_t *c = luaA_checkudata(L, 1, &client_class);
+    if (!c || !c->border[0]) {
+        lua_pushboolean(L, 0);
+        return 1;
+    }
+
+    const float *normal = globalconf.appearance.bordercolor;
+    const float *actual = c->border[0]->color;
+
+    int matches = (actual[0] == normal[0] && actual[1] == normal[1] &&
+                   actual[2] == normal[2] && actual[3] == normal[3]);
+
+    lua_pushboolean(L, matches);
+    return 1;
+}
+
 void
 client_class_setup(lua_State *L)
 {
@@ -5214,6 +5262,8 @@ client_class_setup(lua_State *L)
         { "get_icon", luaA_client_get_some_icon },
         { "get_xproperty", luaA_client_get_xproperty },
         { "set_xproperty", luaA_client_set_xproperty },
+        { "_border_is_focus_color", luaA_client_border_is_focus_color },
+        { "_border_is_normal_color", luaA_client_border_is_normal_color },
         { NULL, NULL }
     };
 

--- a/root.c
+++ b/root.c
@@ -25,6 +25,7 @@
 #include "somewm_types.h"
 #include <xkbcommon/xkbcommon.h>
 #include <wlr/types/wlr_seat.h>
+#include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <linux/input-event-codes.h>
@@ -668,6 +669,55 @@ luaA_root_fake_input(lua_State *L)
 		return luaL_error(L, "Unknown event type: %s (expected key_press, key_release, "
 			"button_press, button_release, or motion_notify)", event_type);
 	}
+
+	return 0;
+}
+
+/* Mock drag stored between fake_drag_start/fake_drag_end calls */
+static struct wlr_drag *test_drag = NULL;
+
+/** root.fake_drag_start() — simulate a drag starting.
+ *
+ * Creates a mock wlr_drag, sets seat->drag, and emits seat->events.start_drag
+ * to trigger the compositor's startdrag() handler.
+ */
+static int
+luaA_root_fake_drag_start(lua_State *L)
+{
+	if (test_drag)
+		return luaL_error(L, "root.fake_drag_start(): drag already active");
+
+	test_drag = ecalloc(1, sizeof(*test_drag));
+
+	wl_signal_init(&test_drag->events.destroy);
+	wl_signal_init(&test_drag->events.focus);
+	wl_signal_init(&test_drag->events.motion);
+	wl_signal_init(&test_drag->events.drop);
+
+	seat->drag = test_drag;
+	wl_signal_emit_mutable(&seat->events.start_drag, test_drag);
+
+	return 0;
+}
+
+/** root.fake_drag_end() — simulate a drag ending.
+ *
+ * Mimics wlroots' drag_destroy() sequence: clears seat->drag, emits
+ * drag->events.destroy. This triggers the compositor's destroydrag() handler.
+ */
+static int
+luaA_root_fake_drag_end(lua_State *L)
+{
+	if (!test_drag)
+		return luaL_error(L, "root.fake_drag_end(): no drag active");
+
+	struct wlr_drag *drag = test_drag;
+	test_drag = NULL;
+
+	seat->drag = NULL;
+	wl_signal_emit_mutable(&drag->events.destroy, drag);
+
+	free(drag);
 
 	return 0;
 }
@@ -1978,6 +2028,8 @@ const luaL_Reg root_methods[] = {
 	{ "cursor_theme", luaA_root_cursor_theme },
 	{ "cursor_size", luaA_root_cursor_size },
 	{ "fake_input", luaA_root_fake_input },
+	{ "fake_drag_start", luaA_root_fake_drag_start },
+	{ "fake_drag_end", luaA_root_fake_drag_end },
 	{ "drawins", luaA_root_drawins },
 	{ "size", luaA_root_size },
 	{ "size_mm", luaA_root_size_mm },

--- a/somewm.c
+++ b/somewm.c
@@ -181,6 +181,7 @@ static void cursorconstrain(struct wlr_pointer_constraint_v1 *constraint);
 static void cursorframe(struct wl_listener *listener, void *data);
 static void cursorwarptohint(void);
 static void destroydecoration(struct wl_listener *listener, void *data);
+static void destroydrag(struct wl_listener *listener, void *data);
 static void destroydragicon(struct wl_listener *listener, void *data);
 static void destroyidleinhibitor(struct wl_listener *listener, void *data);
 static void destroylayersurfacenotify(struct wl_listener *listener, void *data);
@@ -2190,11 +2191,28 @@ destroydecoration(struct wl_listener *listener, void *data)
 }
 
 void
+destroydrag(struct wl_listener *listener, void *data)
+{
+	Client *c = focustop(selmon);
+
+	/* seat->drag is already NULL at this point (wlroots clears it before
+	 * emitting destroy). Re-focus so border colors are properly updated.
+	 *
+	 * focusclient() skips border color updates when the same client is
+	 * already focused (early return at surface == old check), so explicitly
+	 * apply the focus color here for the common case where the focused
+	 * client didn't change during the drag. */
+	if (c && !client_is_unmanaged(c))
+		client_set_border_color(c, get_focuscolor());
+	focusclient(c, 0);
+	motionnotify(0, NULL, 0, 0, 0, 0);
+	wl_list_remove(&listener->link);
+	free(listener);
+}
+
+void
 destroydragicon(struct wl_listener *listener, void *data)
 {
-	/* Focus enter isn't sent during drag, so refocus the focused node. */
-	focusclient(focustop(selmon), 1);
-	motionnotify(0, NULL, 0, 0, 0, 0);
 	wl_list_remove(&listener->link);
 	free(listener);
 }
@@ -5066,6 +5084,12 @@ void
 startdrag(struct wl_listener *listener, void *data)
 {
 	struct wlr_drag *drag = data;
+
+	/* Listen for drag destroy to refocus after drag ends.
+	 * wlroots clears seat->drag BEFORE emitting this signal,
+	 * so focusclient() will properly update border colors. */
+	LISTEN_STATIC(&drag->events.destroy, destroydrag);
+
 	if (!drag->icon)
 		return;
 

--- a/tests/test-drag-border-refocus.lua
+++ b/tests/test-drag-border-refocus.lua
@@ -1,0 +1,118 @@
+---------------------------------------------------------------------------
+--- Test: border colors update correctly after drag ends
+--
+-- Regression test for issue #308: when a drag operation ends, the focused
+-- client's border should return to the correct focus color. Previously,
+-- destroydragicon() fired while seat->drag was still set, so the border
+-- color guard in focusclient() blocked the update.
+--
+-- Uses root.fake_drag_start()/fake_drag_end() to simulate drag operations
+-- without needing real Wayland data device protocol interaction.
+--
+-- Key insight: the Lua focus path (client.focus = c) does NOT set C-level
+-- border colors. Only the C-level focusclient() does. So before drag,
+-- borders are normal color (Lua path was used). After root.fake_drag_end(),
+-- destroydrag() calls focusclient() (C path) which sets the focus color.
+-- This is exactly what the fix ensures.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local test_client = require("_client")
+local utils = require("_utils")
+
+if not test_client.is_available() then
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local c1, c2
+
+local steps = {
+    -- Step 1: Spawn first client
+    function(count)
+        if count == 1 then
+            test_client("drag_border_a")
+        end
+        c1 = utils.find_client_by_class("drag_border_a")
+        return c1 and true or nil
+    end,
+
+    -- Step 2: Spawn second client (gets focus)
+    function(count)
+        if count == 1 then
+            test_client("drag_border_b")
+        end
+        c2 = utils.find_client_by_class("drag_border_b")
+        if not c2 then return nil end
+        -- Wait for c2 to have focus
+        if client.focus ~= c2 then return nil end
+        return true
+    end,
+
+    -- Step 3: Verify initial state - Lua focus path does NOT set C-level
+    -- border colors, so both clients have normal (creation) color
+    function()
+        assert(client.focus == c2, "c2 should be focused")
+        assert(c1:_border_is_normal_color(),
+            "c1 should have normal border color initially")
+        assert(c2:_border_is_normal_color(),
+            "c2 should have normal border color initially (Lua focus path)")
+        return true
+    end,
+
+    -- Step 4: Simulate drag without icon (the secondary bug path).
+    -- After drag ends, destroydrag() calls C-level focusclient() which
+    -- sets the focused client's border to focus color.
+    function()
+        root.fake_drag_start()
+        root.fake_drag_end()
+
+        -- destroydrag() called focusclient(focustop(selmon), 0).
+        -- Since seat->drag is NULL, the border color guard passes and
+        -- the focused client gets the focus color.
+        assert(client.focus == c2,
+            "c2 should still be focused after drag ends")
+        assert(c2:_border_is_focus_color(),
+            "c2 border should be focus color after drag ends (no icon)")
+        assert(c1:_border_is_normal_color(),
+            "c1 border should be normal color after drag ends (no icon)")
+
+        io.stderr:write("[TEST] PASS: border colors correct after drag without icon\n")
+        return true
+    end,
+
+    -- Step 5: Simulate a second drag cycle to verify listener cleanup
+    function()
+        root.fake_drag_start()
+        root.fake_drag_end()
+
+        assert(c2:_border_is_focus_color(),
+            "c2 border should be focus color after second drag cycle")
+        assert(c1:_border_is_normal_color(),
+            "c1 border should be normal color after second drag cycle")
+
+        io.stderr:write("[TEST] PASS: border colors correct after repeated drag\n")
+        return true
+    end,
+
+    -- Step 6: Cleanup
+    function(count)
+        if count == 1 then
+            if c1 and c1.valid then c1:kill() end
+            if c2 and c2.valid then c2:kill() end
+        end
+
+        if #client.get() == 0 then return true end
+
+        if count >= 15 then
+            local pids = test_client.get_spawned_pids()
+            for _, pid in ipairs(pids) do
+                os.execute("kill -9 " .. pid .. " 2>/dev/null")
+            end
+            return true
+        end
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })


### PR DESCRIPTION
Closes #308

## Description

Border colors were not updated when a drag operation ended because the old `destroydragicon()` handler ran while `seat->drag` was still set, causing `focusclient()` to skip the border color update.

This adds a `destroydrag()` listener on `drag->events.destroy` (which wlroots fires after clearing `seat->drag`) so the focused client's border is properly restored to the focus color after a drag ends. The old `destroydragicon()` is simplified to just clean up its listener.

Drag simulation helpers (`root.fake_drag_start()`/`root.fake_drag_end()`) are added to `root.c` alongside `root.fake_input()`, and border color query methods (`client:_border_is_focus_color()`/`client:_border_is_normal_color()`) are added to `objects/client.c`, following AwesomeWM's pattern of placing test-useful APIs in production files.

## Test Plan

- `make build-test` compiles cleanly
- `make test-unit` — 657 successes, 0 failures
- `make test-integration` — 53/53 pass, including `test-drag-border-refocus`

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)