### PR TITLE
fix: keep fullscreen client above wibar on cross-screen focus change

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -2597,6 +2597,7 @@ focusclient(Client *c, int lift)
 		/* With no client, all we have left is to clear focus (deferred pattern) */
 		globalconf.focus.client = NULL;
 		globalconf.focus.need_update = true;
+		stack_windows();
 		return;
 	}
 
@@ -2606,6 +2607,11 @@ focusclient(Client *c, int lift)
 	/* Set pending focus change for AwesomeWM compatibility (Lua code may check this) */
 	globalconf.focus.client = c;
 	globalconf.focus.need_update = true;
+
+	/* Trigger stack refresh: client_layer_translator() depends on which
+	 * client has focus (e.g., fullscreen clients only get LyrFS when
+	 * focused or when the focused client is on a different screen). */
+	stack_windows();
 
 	/* Activate the new client */
 	client_activate_surface(client_surface(c), 1);

--- a/stack.c
+++ b/stack.c
@@ -92,9 +92,12 @@ client_layer_translator(Client *c)
 	if (c->ontop)
 		return WINDOW_LAYER_ONTOP;
 
-	/* Fullscreen windows only get their own layer when they have focus */
+	/* Fullscreen windows only get their own layer when they have focus.
+	 * On Wayland, we also keep the fullscreen layer when the focused client
+	 * is on a different screen, since the scene graph uses separate layers
+	 * (unlike X11's flat stacking model where wibars are below all clients). */
 	focused = some_get_focused_client();
-	if (c->fullscreen && focused == c)
+	if (c->fullscreen && (focused == c || !focused || focused->screen != c->screen))
 		return WINDOW_LAYER_FULLSCREEN;
 
 	if (c->above)

--- a/tests/test-fullscreen-wibar-cross-screen.lua
+++ b/tests/test-fullscreen-wibar-cross-screen.lua
@@ -1,0 +1,163 @@
+---------------------------------------------------------------------------
+--- Test: fullscreen client stays above wibar when focus moves to another screen
+--
+-- Regression test: when a fullscreen client on screen 2 loses focus because
+-- the user clicks a window on screen 1, the wibar on screen 2 should NOT
+-- appear above the fullscreen window.
+--
+-- Root cause: client_layer_translator() only assigned WINDOW_LAYER_FULLSCREEN
+-- when the client had focus. On Wayland (unlike X11's flat stacking model),
+-- wlroots scene layers mean that LyrTop (where dock wibars live) is above
+-- LyrTile (where unfocused fullscreen clients were demoted to). The fix keeps
+-- fullscreen clients in WINDOW_LAYER_FULLSCREEN when the focused client is on
+-- a different screen.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local test_client = require("_client")
+local utils = require("_utils")
+local awful = require("awful")
+
+if not test_client.is_available() then
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local fake_screen
+local c_fs, c_other
+local wibar_s2
+
+local steps = {
+    -- Step 1: Add a fake second screen and create a wibar on it
+    function()
+        fake_screen = screen.fake_add(1400, 0, 400, 300)
+        assert(fake_screen and fake_screen.valid, "screen.fake_add failed")
+        assert(screen.count() >= 2, "Need at least 2 screens")
+
+        -- Create a dock-type wibar on screen 2 (goes to LyrTop)
+        wibar_s2 = awful.wibar({ position = "top", screen = fake_screen })
+        assert(wibar_s2 and wibar_s2.visible, "Wibar should be visible")
+
+        io.stderr:write("[TEST] Fake screen and wibar created\n")
+        return true
+    end,
+
+    -- Step 2: Spawn a client that will go fullscreen on screen 2
+    function(count)
+        if count == 1 then
+            test_client("fs_client")
+        end
+        c_fs = utils.find_client_by_class("fs_client")
+        if not c_fs then return nil end
+        io.stderr:write("[TEST] Fullscreen candidate spawned\n")
+        return true
+    end,
+
+    -- Step 3: Move client to screen 2 and make it fullscreen
+    function(count)
+        if count == 1 then
+            c_fs:move_to_screen(fake_screen)
+            c_fs.fullscreen = true
+            c_fs:emit_signal("request::activate", "test", { raise = true })
+        end
+        if not c_fs.fullscreen then return nil end
+        if c_fs.screen ~= fake_screen then return nil end
+        if client.focus ~= c_fs then return nil end
+        io.stderr:write("[TEST] Client is fullscreen on screen 2 with focus\n")
+        return true
+    end,
+
+    -- Step 4: Spawn a second client on screen 1 (it will take focus)
+    function(count)
+        if count == 1 then
+            test_client("other_client")
+        end
+        c_other = utils.find_client_by_class("other_client")
+        if not c_other then return nil end
+        io.stderr:write("[TEST] Second client spawned on screen 1\n")
+        return true
+    end,
+
+    -- Step 5: Ensure other client is on screen 1 and activate it
+    function(count)
+        if count == 1 then
+            local s1 = screen.primary
+            if c_other.screen ~= s1 then
+                c_other:move_to_screen(s1)
+            end
+            c_other:emit_signal("request::activate", "test", { raise = true })
+        end
+        if client.focus ~= c_other then return nil end
+        if c_other.screen == c_fs.screen then return nil end
+        io.stderr:write("[TEST] Focus moved to client on screen 1\n")
+        return true
+    end,
+
+    -- Step 6: Verify fullscreen client on screen 2 is still fullscreen.
+    -- Before the fix, client_layer_translator() would return
+    -- WINDOW_LAYER_NORMAL (-> LyrTile) for this unfocused fullscreen client,
+    -- causing the wibar (at LyrTop) to appear above it. After the fix,
+    -- it returns WINDOW_LAYER_FULLSCREEN (-> LyrFS) because the focused
+    -- client is on a different screen.
+    function()
+        assert(c_fs.valid, "Fullscreen client should still be valid")
+        assert(c_fs.fullscreen,
+            "Client should still be fullscreen after cross-screen focus change")
+        assert(c_fs.screen == fake_screen,
+            "Client should still be on screen 2")
+        assert(client.focus ~= c_fs,
+            "Fullscreen client should NOT have focus")
+        assert(client.focus == c_other,
+            "Other client should have focus")
+
+        io.stderr:write("[TEST] PASS: fullscreen client stays fullscreen " ..
+            "after cross-screen focus change\n")
+        return true
+    end,
+
+    -- Step 7: Verify same-screen behavior is preserved: focusing another
+    -- client on the SAME screen should still demote the fullscreen client
+    -- (matching AwesomeWM behavior).
+    function(count)
+        if count == 1 then
+            c_other:move_to_screen(fake_screen)
+            c_other:emit_signal("request::activate", "test", { raise = true })
+        end
+        if client.focus ~= c_other then return nil end
+        if c_other.screen ~= c_fs.screen then return nil end
+        assert(c_fs.fullscreen,
+            "Fullscreen property should still be set")
+        io.stderr:write("[TEST] PASS: same-screen focus correctly allows " ..
+            "layer demotion for fullscreen client\n")
+        return true
+    end,
+
+    -- Step 8: Cleanup
+    function(count)
+        if count == 1 then
+            if wibar_s2 then wibar_s2.visible = false end
+            if c_fs and c_fs.valid then c_fs:kill() end
+            if c_other and c_other.valid then c_other:kill() end
+        end
+        if #client.get() == 0 then
+            if fake_screen and fake_screen.valid then
+                fake_screen:fake_remove()
+            end
+            return true
+        end
+        if count >= 15 then
+            local pids = test_client.get_spawned_pids()
+            for _, pid in ipairs(pids) do
+                os.execute("kill -9 " .. pid .. " 2>/dev/null")
+            end
+            if fake_screen and fake_screen.valid then
+                fake_screen:fake_remove()
+            end
+            return true
+        end
+        return nil
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })


### PR DESCRIPTION
## Description

When a fullscreen client on screen 2 loses focus because the user activates a window on screen 1, the wibar on screen 2 incorrectly renders above the fullscreen window.

Root cause: `client_layer_translator()` only assigned `WINDOW_LAYER_FULLSCREEN` when the client had focus. On Wayland, wlroots scene layers mean `LyrTop` (where dock wibars live) is above `LyrTile` (where unfocused fullscreen clients were demoted to). Unlike X11's flat stacking model, this causes the wibar to visually cover the fullscreen window.

Two-part fix:
1. **`stack.c`** — `client_layer_translator()` keeps `WINDOW_LAYER_FULLSCREEN` when the focused client is on a different screen (or when there is no focused client)
2. **`somewm.c`** — `focusclient()` calls `stack_windows()` so layer assignments are recalculated on every focus change

Closes #316

## Test Plan

- Added `tests/test-fullscreen-wibar-cross-screen.lua` — spawns two screens, creates a fullscreen client on screen 2, moves focus to screen 1, and verifies the fullscreen client retains its layer
- Same-screen demotion behavior is preserved (matching AwesomeWM)
- `make test-unit && make test-integration` pass

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)