### PR TITLE
fix: send projected motion events during drag over wibars

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -3678,6 +3678,25 @@ motionnotify(uint32_t time, struct wlr_input_device *device, double dx, double d
 	/* Update drag icon's position */
 	wlr_scene_node_set_position(&drag_icon->node, (int)round(cursor->x), (int)round(cursor->y));
 
+	/* During active drag over compositor surfaces (wibars), don't clear
+	 * drag focus — that would cancel the drag on drop. Instead, keep
+	 * sending motion events with coordinates projected onto the focused
+	 * surface so the source app knows the pointer is outside its window
+	 * (e.g., Firefox uses out-of-bounds coords to trigger tab detach). */
+	if (seat->drag && !surface) {
+		struct wlr_surface *focused = seat->drag->focus;
+		if (focused) {
+			Client *fc = NULL;
+			LayerSurface *fl = NULL;
+			if (toplevel_from_wlr_surface(focused, &fc, &fl) >= 0) {
+				double fx = cursor->x - (fl ? fl->scene->node.x : fc->geometry.x);
+				double fy = cursor->y - (fl ? fl->scene->node.y : fc->geometry.y);
+				wlr_seat_pointer_notify_motion(seat, time, fx, fy);
+			}
+		}
+		return;
+	}
+
 	/* If mousegrabber is active, route event to Lua callback (AwesomeWM behavior:
 	 * check mousegrabber BEFORE enter/leave signals to filter them during grabs) */
 	if (mousegrabber_isrunning()) {


### PR DESCRIPTION
## Description

When dragging over a wibar (no `wlr_surface`), the source app never learned the pointer left its window — drops either cancelled or landed at stale coordinates. Now we forward motion events with projected coordinates onto the drag-focused surface, giving the app out-of-bounds values so it can react (e.g. Firefox tab detach).

Closes #318

## Test Plan

- `make test-unit` — 657 pass
- `make test-integration` — `test-drag-border-refocus.lua` passes
- Manual: Firefox tab drag over wibar → tab detaches into new window

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)