### PR TITLE
fix: Firefox renders at saved geometry instead of tiled geometry

### DIFF
--- a/client.h
+++ b/client.h
@@ -392,9 +392,25 @@ client_set_size(Client *c, uint32_t width, uint32_t height)
 		return 0;
 	}
 #endif
-	if ((int32_t)width == c->surface.xdg->toplevel->current.width
-			&& (int32_t)height == c->surface.xdg->toplevel->current.height)
+	/* Compare against actual surface geometry, not the acked configure state.
+	 * This catches clients that ack a configure but render at a different size
+	 * (e.g. Firefox using its saved geometry on relaunch). */
+	struct wlr_box _geo = COMPAT_XDG_SURFACE_GEOMETRY(c->surface.xdg);
+	if ((int32_t)width == _geo.width && (int32_t)height == _geo.height) {
+		c->configure_resent = false;
 		return 0;
+	}
+	/* If the client already acked this size but rendered differently (e.g.
+	 * terminals rounding to cell boundaries), re-send once then accept it
+	 * to avoid an infinite configure loop. */
+	if ((int32_t)width == c->surface.xdg->toplevel->current.width
+			&& (int32_t)height == c->surface.xdg->toplevel->current.height) {
+		if (c->configure_resent)
+			return 0;
+		c->configure_resent = true;
+	} else {
+		c->configure_resent = false;
+	}
 	return wlr_xdg_toplevel_set_size(c->surface.xdg->toplevel, (int32_t)width, (int32_t)height);
 }
 

--- a/objects/client.h
+++ b/objects/client.h
@@ -192,6 +192,10 @@ struct client_t
     struct wl_listener foreign_request_minimize;
     /** Pending resize serial for Wayland configure */
     uint32_t resize;
+    /** Set when we re-sent a configure because actual geometry didn't match
+     *  the acked configure. Prevents infinite loop with clients that
+     *  intentionally render smaller (e.g. terminals rounding to cell size). */
+    bool configure_resent;
     /** Previous geometry for restore */
     area_t prev;
     /** Size bounds */

--- a/somewm.c
+++ b/somewm.c
@@ -1507,7 +1507,12 @@ initialcommitnotify(struct wl_listener *listener, void *data)
 			WLR_XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN);
 	if (c->decoration)
 		requestdecorationmode(&c->set_decoration_mode, c->decoration);
-	wlr_xdg_toplevel_set_size(c->surface.xdg->toplevel, 0, 0);
+	if (m && !client_is_unmanaged(c)) {
+		wlr_xdg_toplevel_set_size(c->surface.xdg->toplevel,
+			m->w.width - 2 * c->bw, m->w.height - 2 * c->bw);
+	} else {
+		wlr_xdg_toplevel_set_size(c->surface.xdg->toplevel, 0, 0);
+	}
 }
 
 /* Handle subsequent XDG commits - resizing and opacity.


### PR DESCRIPTION
## Description

Fixes #319. Firefox saves window geometry across sessions. When relaunched on a tiling layout, its content renders at the old (partial) size instead of filling the tiled area.

Two root causes:
1. `initialcommitnotify` sent `set_size(0, 0)`, letting Firefox pick its saved geometry for its first buffer. Now sends the monitor workarea size minus borders.
2. `client_set_size` compared against the acked configure state, not the actual surface geometry. Firefox acked the tiled configure but rendered at its saved size, and the compositor thought it was already correct. Now compares against actual XDG surface geometry, with a one-retry guard to avoid infinite configure loops with clients that intentionally round down (e.g. terminals rounding to cell boundaries).
3. Flushes deferred layout arrange before applying geometry at map time, so `c->geometry` holds the correct tiled dimensions.

## Test Plan

- `make test-unit && make test-integration` pass
- Launch Firefox on an empty tag with tiling layout, verify it fills the tiled area immediately
- Open Firefox when another client is already tiled (50/50 split), verify Firefox fills its half
- Verify terminals (Alacritty/kitty) still tile correctly without configure churn

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)