### PR TITLE
fix --check warning for require("cjson.safe")

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -2929,6 +2929,7 @@ check_mode_scan_requires(const char *content, const char *config_dir,
 		    strcmp(module_name, "posix") == 0 ||
 		    strncmp(module_name, "posix.", 6) == 0 ||
 		    strcmp(module_name, "cjson") == 0 ||
+		    strncmp(module_name, "cjson.", 6) == 0 ||
 		    strcmp(module_name, "dkjson") == 0 ||
 		    strcmp(module_name, "json") == 0 ||
 		    strcmp(module_name, "socket") == 0 ||


### PR DESCRIPTION
## Description
somewm --check warns when require("cjson.safe") is in rc.lua, not anymore


## Test Plan
Building it and running somewm --check against my config.


## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
