### PR TITLE
fix: lockscreen needs utf-8 translated keycode from keygrabber (#328)

### DIFF
--- a/keygrabber.c
+++ b/keygrabber.c
@@ -63,6 +63,26 @@ is_control(const char *buf)
     return c < 0x20 || c == 0x7f;
 }
 
+/* Convert a key event to a human-readable string, preferring UTF-8 text when
+ * available and falling back to keysym names for control/non-printable keys.
+ */
+static void
+key_to_text(struct xkb_state* state, xkb_keycode_t keycode, char *buf,
+            size_t buflen)
+{
+    xkb_keysym_t keysym;
+    /* Get the keysym */
+    keysym = xkb_state_key_get_one_sym(state, keycode);
+
+    /* Prefer translated UTF-8 text and fall back to keysym names for
+     * control/non-printable keys. */
+    if (xkb_state_key_get_utf8(state, keycode, buf, buflen) <= 0 ||
+        is_control(buf)) {
+        /* Use text names for control characters */
+        xkb_keysym_get_name(keysym, buf, buflen);
+    }
+}
+
 /** Handle keypress event.
  * \param L Lua stack to push the key pressed.
  * \param keycode The keycode of the pressed key.
@@ -74,19 +94,10 @@ bool
 keygrabber_handlekpress(lua_State *L, xkb_keycode_t keycode,
                         struct xkb_state *state, bool is_press)
 {
-    char buf[64];
-    xkb_keysym_t keysym;
+    char buf[64] = {0};
 
-    /* Get the keysym */
-    keysym = xkb_state_key_get_one_sym(state, keycode);
-
-    /* Get UTF-8 representation */
-    xkb_state_key_get_utf8(state, keycode, buf, sizeof(buf));
-
-    if (is_control(buf)) {
-        /* Use text names for control characters */
-        xkb_keysym_get_name(keysym, buf, sizeof(buf));
-    }
+    /* Convert key event to human-readable string. */
+    key_to_text(state, keycode, buf, sizeof(buf));
 
     /* Push modifiers table */
     luaA_pushmodifiers(L, xkb_state_serialize_mods(state, XKB_STATE_MODS_EFFECTIVE));
@@ -176,20 +187,12 @@ some_keygrabber_handle_key(uint32_t modifiers, xkb_keycode_t keycode, struct xkb
 {
     lua_State *L;
     char keyname[64] = {0};
-    xkb_keysym_t keysym;
 
     if (!state)
         return false;
 
-    keysym = xkb_state_key_get_one_sym(state, keycode);
-
-    /* Prefer translated UTF-8 text and fall back to keysym names for
-     * control/non-printable keys. */
-    if (xkb_state_key_get_utf8(state, keycode, keyname, sizeof(keyname)) <= 0
-        || is_control(keyname)) {
-        /* Use text names for control characters */
-        xkb_keysym_get_name(keysym, keyname, sizeof(keyname));
-    }
+    /* Convert key event to human-readable string. */
+    key_to_text(state, keycode, keyname, sizeof(keyname));
 
     if (globalconf.keygrabber == LUA_REFNIL)
         return false;

--- a/keygrabber.c
+++ b/keygrabber.c
@@ -172,11 +172,24 @@ some_keygrabber_is_running(void)
  * Used by somewm.c keyboard event handling
  */
 bool
-some_keygrabber_handle_key(uint32_t modifiers, uint32_t keysym, const char *keyname)
+some_keygrabber_handle_key(uint32_t modifiers, xkb_keycode_t keycode, struct xkb_state *state)
 {
     lua_State *L;
+    char keyname[64] = {0};
+    xkb_keysym_t keysym;
 
-    (void)keysym;  /* Unused */
+    if (!state)
+        return false;
+
+    keysym = xkb_state_key_get_one_sym(state, keycode);
+
+    /* Prefer translated UTF-8 text and fall back to keysym names for
+     * control/non-printable keys. */
+    if (xkb_state_key_get_utf8(state, keycode, keyname, sizeof(keyname)) <= 0
+        || is_control(keyname)) {
+        /* Use text names for control characters */
+        xkb_keysym_get_name(keysym, keyname, sizeof(keyname));
+    }
 
     if (globalconf.keygrabber == LUA_REFNIL)
         return false;

--- a/lua/lockscreen.lua
+++ b/lua/lockscreen.lua
@@ -326,6 +326,10 @@ function lockscreen.init(opts)
         grabber = awful.keygrabber({
             autostart = true,
             stop_key = nil,
+            -- The code path "append input key to password" below can deal with
+            -- modkey input as well, i.e., it is filtered out. However, by masking
+            -- them right away, it is computationally more efficient.
+            mask_modkeys = true,
             keypressed_callback = function(_, mod, key, _)
                 if key == "Return" then
                     set_status("Verifying...", false)
@@ -363,6 +367,7 @@ function lockscreen.init(opts)
                 elseif key == "Escape" then
                     password = ""
                     if password_dots then password_dots.text = "" end
+                -- Append input key to password
                 elseif #key >= 1 and key:byte(1) >= 0x20 then
                     if #password > 256 then return end
                     -- Only append single-character keys (which may still have

--- a/lua/lockscreen.lua
+++ b/lua/lockscreen.lua
@@ -365,6 +365,10 @@ function lockscreen.init(opts)
                     if password_dots then password_dots.text = "" end
                 elseif #key >= 1 and key:byte(1) >= 0x20 then
                     if #password > 256 then return end
+                    -- Only append single-character keys (which may still have
+                    -- a multi-byte UTF-8 encoding), but do not add control
+                    -- keys like "Shift_R" to password.
+                    if utf8_len(key) > 1 then return end
                     password = password .. key
                     if password_dots then
                         password_dots.text = string.rep("\xE2\x97\x8F", utf8_len(password))

--- a/objects/keygrabber.h
+++ b/objects/keygrabber.h
@@ -32,7 +32,7 @@ bool keygrabber_handlekpress(lua_State *, xkb_keycode_t, struct xkb_state *, boo
 
 /* somewm-specific */
 bool some_keygrabber_is_running(void);
-bool some_keygrabber_handle_key(uint32_t modifiers, uint32_t keysym, const char *keyname);
+bool some_keygrabber_handle_key(uint32_t modifiers, xkb_keycode_t keycode, struct xkb_state *state);
 void luaA_keygrabber_setup(lua_State *L);
 
 #endif

--- a/somewm.c
+++ b/somewm.c
@@ -3172,12 +3172,8 @@ keypress(struct wl_listener *listener, void *data)
 	 * Note: Keygrabber is allowed when Lua-locked (for lock screen password input)
 	 * but NOT when externally locked (session-lock-v1 protocol handles that). */
 	if (!locked && event->state == WL_KEYBOARD_KEY_STATE_PRESSED && some_keygrabber_is_running()) {
-		/* Get the key name from the keysym */
-		char keyname[64];
-		xkb_keysym_get_name(base_sym, keyname, sizeof(keyname));
-
 		/* Route to keygrabber callback */
-		if (some_keygrabber_handle_key(mods, base_sym, keyname)) {
+		if (some_keygrabber_handle_key(mods, keycode, group->wlr_group->keyboard.xkb_state)) {
 			/* Keygrabber handled the event, disable key repeat and return */
 			group->nsyms = 0;
 			wl_event_source_timer_update(group->key_repeat_source, 0);


### PR DESCRIPTION
The keypressd_callback within lockscreen.lua appends upon each key press the key to the password. For this a keycode needs to be UTF-8 translated instead of appending control names, like Shift_L.

Add xkb_state_key_get_utf8() code to translate keycode to keyname accordingly.

Fixes issue #328

## Description
<!-- What does this change and why? -->


## Test Plan
<!-- How did you verify this works? -->


## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)

The lock tests did not pass. Have not looked at it yet.
