### PR TITLE
fix: clear suspended state when unminimizing clients (#329)

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -2820,6 +2820,13 @@ client_set_minimized(lua_State *L, int cidx, bool s)
         if(c->scene)
             wlr_scene_node_set_enabled(&c->scene->node, !s);
 
+        /* Wayland: Sync suspended state with minimized state.
+         * The C arrange() also sets this, but runs asynchronously via
+         * timer.delayed_call. Set it immediately so the client can start
+         * rendering at the new size before the deferred arrange fires. */
+        if(c->client_type == XDGShell)
+            wlr_xdg_toplevel_set_suspended(c->surface.xdg->toplevel, s);
+
         if(c->toplevel_handle)
             wlr_foreign_toplevel_handle_v1_set_minimized(c->toplevel_handle, s);
 

--- a/somewm.c
+++ b/somewm.c
@@ -4225,7 +4225,7 @@ rendermon(struct wl_listener *listener, void *data)
 	 * this monitor. */
 	foreach(client, globalconf.clients) {
 		c = *client;
-		if (c->resize && !some_client_get_floating(c) && client_is_rendered_on_mon(c, m) && !client_is_stopped(c))
+		if (c->resize && !some_client_get_floating(c) && c->mon == m && !client_is_stopped(c))
 			goto skip;
 	}
 

--- a/tests/test-minimized-restore-geometry.lua
+++ b/tests/test-minimized-restore-geometry.lua
@@ -1,0 +1,152 @@
+---------------------------------------------------------------------------
+--- Test: minimized clients restore to full size after other clients close
+--
+-- Regression test for #329: when a tiled client is minimized, the other
+-- client is closed, and the minimized client is restored, the window frame
+-- occupies the full layout area but the client's rendered content stays at
+-- the old (half) size because the suspended state was never cleared.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local test_client = require("_client")
+local utils = require("_utils")
+local awful = require("awful")
+
+if not test_client.is_available() then
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local c1, c2
+local tag
+
+local steps = {
+    -- Step 1: Spawn first client
+    function(count)
+        if count == 1 then
+            tag = screen.primary.tags[1]
+            tag:view_only()
+            tag.layout = awful.layout.suit.tile
+            io.stderr:write("[TEST] Spawning client 1...\n")
+            test_client("restore_a")
+        end
+        c1 = utils.find_client_by_class("restore_a")
+        if c1 then
+            io.stderr:write("[TEST] Client 1 spawned\n")
+            return true
+        end
+        return nil
+    end,
+
+    -- Step 2: Spawn second client
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning client 2...\n")
+            test_client("restore_b")
+        end
+        c2 = utils.find_client_by_class("restore_b")
+        if c2 then
+            io.stderr:write("[TEST] Client 2 spawned\n")
+            return true
+        end
+        return nil
+    end,
+
+    -- Step 3: Both clients should be tiled, each taking half the screen
+    function()
+        assert(#tag:clients() == 2, "Expected 2 clients on tag")
+        assert(not c1.floating, "Client 1 should be tiled")
+        assert(not c2.floating, "Client 2 should be tiled")
+        io.stderr:write("[TEST] Both clients tiled\n")
+        return true
+    end,
+
+    -- Step 4: Minimize client 1
+    function()
+        io.stderr:write("[TEST] Minimizing client 1...\n")
+        c1.minimized = true
+        assert(c1.minimized, "Client 1 should be minimized")
+        return true
+    end,
+
+    -- Step 5: Close client 2
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Closing client 2...\n")
+            if c2.pid then
+                os.execute("kill -9 " .. c2.pid .. " 2>/dev/null")
+            else
+                c2:kill()
+            end
+        end
+        -- Wait for client 2 to be gone
+        if #client.get() <= 1 then
+            io.stderr:write("[TEST] Client 2 closed\n")
+            return true
+        end
+        return nil
+    end,
+
+    -- Step 6: Restore client 1
+    function()
+        io.stderr:write("[TEST] Restoring client 1...\n")
+        c1.minimized = false
+        assert(not c1.minimized, "Client 1 should be unminimized")
+        return true
+    end,
+
+    -- Step 7: Wait a frame for layout to settle, then verify geometry
+    function()
+        -- After restore, c1 should be the only client and should fill
+        -- the full layout area (the workarea minus any gaps/borders).
+        local wa = tag.screen.workarea
+
+        -- The client geometry should approximately fill the workarea.
+        -- Use the width as the primary check: it should be close to the
+        -- full workarea width, not half of it.
+        local geo = c1:geometry()
+        local bw = c1.border_width or 0
+        local total_w = geo.width + 2 * bw
+
+        io.stderr:write(string.format(
+            "[TEST] Client geometry: %dx%d+%d+%d (bw=%d), workarea: %dx%d+%d+%d\n",
+            geo.width, geo.height, geo.x, geo.y, bw,
+            wa.width, wa.height, wa.x, wa.y))
+
+        -- The client should use at least 80% of the workarea width.
+        -- (Exact match depends on gaps/useless_gap settings, but half-width
+        -- would be ~50%, so 80% is a safe threshold.)
+        assert(total_w > wa.width * 0.8,
+            string.format(
+                "Client width %d is too small (workarea width %d). " ..
+                "Client did not restore to full size after unminimize.",
+                total_w, wa.width))
+
+        io.stderr:write("[TEST] PASS: client restored to full layout size\n")
+        return true
+    end,
+
+    -- Step 8: Cleanup
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Cleanup: killing remaining clients\n")
+            if c1 and c1.valid then
+                c1:kill()
+            end
+        end
+        if #client.get() == 0 then
+            return true
+        end
+        if count >= 10 then
+            local pids = test_client.get_spawned_pids()
+            for _, pid in ipairs(pids) do
+                os.execute("kill -9 " .. pid .. " 2>/dev/null")
+            end
+            return true
+        end
+        return nil
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })


### PR DESCRIPTION
## Description

When a tiled client is minimized, the other client is closed, and the minimized
client is restored, the window frame occupies the full layout area but the
rendered content stays at the old (half) size. This happens because the XDG
toplevel `suspended` state is never cleared on unminimize, so clients acknowledge
the new geometry but do not re-render.

- Sync suspended state with minimized state in `client_set_minimized()` so
  clients start rendering immediately on restore
- Use `c->mon == m` instead of `client_is_rendered_on_mon()` in `rendermon()`
  to prevent a one-frame flash of the old buffer for just-unminimized clients
- Add integration test for the minimize-close-restore scenario

## Test Plan

- `make test-unit` (670 pass)
- `make test-integration` (65 pass, including new `test-minimized-restore-geometry.lua`)
- Manual test: two tiled kitty terminals, minimize one, close the other, restore

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified**
- [x] Tests pass (`make test-unit && make test-integration`)