### PR TITLE
fix: defer updatemons() on reentrancy during hotplug scale changes

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -356,6 +356,7 @@ struct wl_list mons;
 static struct wl_list tracked_pointers; /* For runtime libinput config */
 Monitor *selmon;
 static int in_updatemons;
+static int updatemons_pending;
 
 /* global event handlers */
 static struct wl_listener cursor_axis = {.notify = axisnotify};
@@ -365,7 +366,6 @@ static struct wl_listener cursor_motion = {.notify = motionrelative};
 static struct wl_listener cursor_motion_absolute = {.notify = motionabsolute};
 static struct wl_listener gpu_reset = {.notify = gpureset};
 static struct wl_listener layout_change = {.notify = updatemons};
-static int in_updatemons;
 static struct wl_listener new_idle_inhibitor = {.notify = createidleinhibitor};
 static struct wl_listener new_input_device = {.notify = inputdevice};
 static struct wl_listener new_virtual_keyboard = {.notify = virtualkeyboard};
@@ -1340,6 +1340,11 @@ cleanupmon(struct wl_listener *listener, void *data)
 	closemon(m);
 	wlr_scene_node_destroy(&m->fullscreen_bg->node);
 	free(m);
+
+	if (updatemons_pending) {
+		updatemons_pending = 0;
+		updatemons(NULL, NULL);
+	}
 }
 
 void
@@ -5522,8 +5527,10 @@ updatemons(struct wl_listener *listener, void *data)
 	 * emit layout::change which would call us again, causing
 	 * use-after-free in wlroots output_layout_add().
 	 * Also used by cleanupmon() to prevent updatemons during output destruction. */
-	if (in_updatemons)
+	if (in_updatemons) {
+		updatemons_pending = 1;
 		return;
+	}
 	in_updatemons = 1;
 
 	struct wlr_output_configuration_v1 *config
@@ -5751,6 +5758,11 @@ updatemons(struct wl_listener *listener, void *data)
 	in_updatemons = 0;
 	wlr_output_manager_v1_set_configuration(output_mgr, config);
 	in_updatemons = 0;
+
+	if (updatemons_pending) {
+		updatemons_pending = 0;
+		updatemons(NULL, NULL);
+	}
 }
 
 void


### PR DESCRIPTION
## Description
Setting `screen.scale` in a `screen::added` handler works on initial launch but fails on
monitor hotplug. The display shows a cropped top-left portion and the wibar is vertically
enlarged.

During hotplug, `updatemons()` fires the Lua `"added"` signal while `in_updatemons = 1`.
The scale setter calls `updatemons()` to recalculate geometry, but the reentrancy guard
blocks it. The original call finishes with stale scale=1.0 geometry.

Adds an `updatemons_pending` flag so blocked calls are deferred and re-executed once the
current `updatemons()` or `cleanupmon()` completes. Multiple blocked calls coalesce into
a single deferred run.

Closes #323

## Test Plan
- `make test-unit` and `make test-integration` pass (no regressions)
- Manual: hotplug 4K monitor with `screen.connect_signal("added", function(s) s.scale = 1.25 end)`, verify geometry matches scale

## Checklist
- [x] Lua libraries are **not modified**
- [x] Tests pass (`make test-unit && make test-integration`)