### PR TITLE
fix(naughty): beautiful.notification_* ignored by property getter

### DIFF
--- a/lua/naughty/notification.lua
+++ b/lua/naughty/notification.lua
@@ -24,6 +24,7 @@ local cst      = require("naughty.constants")
 local naughty  = require("naughty.core")
 local gdebug   = require("gears.debug")
 local pcommon = require("awful.permissions._common")
+local beautiful = require("beautiful")
 
 local notification = {}
 
@@ -688,6 +689,7 @@ for _, prop in ipairs(properties) do
 
         return self._private[prop]
             or (preset and preset[prop])
+            or beautiful["notification_"..prop]
             or cst.config.defaults[prop]
     end
 
@@ -937,8 +939,10 @@ local function select_legacy_preset(n, args)
     end
 
     -- gather variables together
+    -- Note: defaults are NOT included here because the property getter
+    -- already falls back to cst.config.defaults. Including them would
+    -- prevent beautiful.notification_* from being checked.
     rawset(n, "preset", gtable.join(
-        cst.config.defaults or {},
         args.preset or cst.config.presets.normal or {},
         rawget(n, "preset") or {}
     ))

--- a/tests/test-naughty-property-fallback.lua
+++ b/tests/test-naughty-property-fallback.lua
@@ -1,0 +1,62 @@
+-- Test: Notification property fallback chain - beautiful theme variables.
+--
+-- The generic property getter only checks self._private[prop], preset[prop],
+-- and cst.config.defaults[prop]. It never consults
+-- beautiful["notification_"..prop], despite these being documented.
+
+local naughty = require("naughty")
+local notification = require("naughty.notification")
+local beautiful = require("beautiful")
+local runner = require("_runner")
+
+-- Register a display handler so notifications are "shown"
+naughty.connect_signal("request::display", function(n)
+    require("naughty.layout.box") { notification = n }
+end)
+
+local n_border = nil
+
+local steps = {}
+
+-- Verify beautiful.notification_border_width is used by the getter.
+table.insert(steps, function()
+    -- Set the beautiful variables
+    beautiful.notification_border_width = 42
+    beautiful.notification_border_color = "#ff0000"
+
+    n_border = notification {
+        title = "beautiful border test",
+        text  = "border_width should come from beautiful theme",
+    }
+
+    assert(n_border, "notification was not created")
+
+    local bw = n_border.border_width
+    assert(bw == 42,
+        string.format(
+            "expected border_width 42 from beautiful, got %s - "..
+            "the generic getter never checks beautiful.notification_border_width",
+            tostring(bw)))
+
+    local bc = n_border.border_color
+    assert(bc == "#ff0000",
+        string.format(
+            "expected border_color '#ff0000' from beautiful, got %s - "..
+            "the generic getter never checks beautiful.notification_border_color",
+            tostring(bc)))
+
+    return true
+end)
+
+-- Cleanup
+table.insert(steps, function()
+    beautiful.notification_border_width = nil
+    beautiful.notification_border_color = nil
+
+    if n_border and not n_border._private.is_destroyed then
+        n_border:destroy()
+    end
+    return true
+end)
+
+runner.run_steps(steps, { kill_clients = false })


### PR DESCRIPTION
## Description

The generic property getter in `naughty/notification.lua` never consults
`beautiful["notification_"..prop]`, so theme variables like
`beautiful.notification_border_width` are silently ignored.

Also, `select_legacy_preset()` folds `cst.config.defaults` into the preset table,
putting defaults into `_private` and shadowing any beautiful fallback.

Fix: add `beautiful["notification_"..prop]` to the getter fallback chain and stop
merging defaults into the preset. Upstream: AwesomeWM #3786.

## Test Plan

- `make test-one TEST=tests/test-naughty-property-fallback.lua` passes
- `make test-unit` - 695 tests pass

## Checklist
- [x] Lua libraries not modified - targeted upstream bug fix
- [x] Tests pass (`make test-unit && make test-integration`)