### PR TITLE
nix: fix build failing due to pam missing

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -18,6 +18,7 @@
   makeWrapper,
   meson,
   ninja,
+  pam,
   pango,
   pkg-config,
   wayland,
@@ -74,6 +75,7 @@ stdenv.mkDerivation {
       libxkbcommon
       luajit
       luaEnv
+      pam
       pango
       wayland
       wayland-protocols


### PR DESCRIPTION
## Description
This pull request adds the missing pam dependency to the Nix derivation, which was causing the build to fail with the error: 

`meson.build:148:10: ERROR: Dependency "pam" not found, tried pkgconfig`

## Test Plan
- [x] Verified that `nix-build` completes without errors.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)