### PR TITLE
fix(lock): cover all screens during Lua lock

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -1242,6 +1242,9 @@ luaA_awesome_add_lock_cover(lua_State *L)
 	lua_lock_covers[lua_lock_cover_count] = d;
 	lua_lock_cover_count++;
 
+	if (lua_locked)
+		some_promote_lock_cover(d);
+
 	return 0;
 }
 
@@ -1597,6 +1600,15 @@ drawin_t *some_get_lua_lock_surface(void) { return lua_lock_surface; }
 drawin_t **some_get_lua_lock_covers(int *count) {
 	*count = lua_lock_cover_count;
 	return lua_lock_covers;
+}
+bool some_is_lock_drawin(drawin_t *d) {
+	if (!d) return false;
+	if (d == lua_lock_surface) return true;
+	for (int i = 0; i < lua_lock_cover_count; i++) {
+		if (lua_lock_covers[i] == d)
+			return true;
+	}
+	return false;
 }
 
 /* awesome module methods */

--- a/somewm.c
+++ b/somewm.c
@@ -2398,6 +2398,21 @@ some_deactivate_lua_lock(void)
 	motionnotify(0, NULL, 0, 0, 0, 0);
 }
 
+/** Promote a single cover to LyrBlock during an active lock.
+ * Re-raises the interactive lock surface above the new cover so it
+ * stays on top of all covers. */
+void
+some_promote_lock_cover(drawin_t *d)
+{
+	if (d && d->scene_tree) {
+		wlr_scene_node_reparent(&d->scene_tree->node, layers[LyrBlock]);
+		wlr_scene_node_raise_to_top(&d->scene_tree->node);
+		drawin_t *lock_surface = some_get_lua_lock_surface();
+		if (lock_surface && lock_surface->scene_tree)
+			wlr_scene_node_raise_to_top(&lock_surface->scene_tree->node);
+	}
+}
+
 /** Clear pre_lock_focused_client if it matches the given client.
  * Called from client_unmanage() to prevent use-after-free on unlock. */
 void

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -245,11 +245,13 @@ void some_notify_drawin_destroyed(drawin_t *w);
 int some_is_lua_locked(void);
 drawin_t *some_get_lua_lock_surface(void);
 drawin_t **some_get_lua_lock_covers(int *count);
+bool some_is_lock_drawin(drawin_t *d);
 int some_is_ext_session_locked(void);
 
 /* Lock activation/deactivation - defined in somewm.c, called from luaa.c */
 void some_activate_lua_lock(void);
 void some_deactivate_lua_lock(void);
+void some_promote_lock_cover(drawin_t *d);
 void some_clear_pre_lock_client(client_t *c);
 
 /* Idle/activity - defined in luaa.c, called from somewm.c */

--- a/stack.c
+++ b/stack.c
@@ -258,6 +258,13 @@ stack_refresh(void)
 		if (!(*drawin)->scene_tree)
 			continue;
 
+		/* Lock drawins are managed by some_activate_lua_lock() /
+		 * some_promote_lock_cover() and must stay in LyrBlock while the
+		 * session is locked. Without this skip, the normal ontop/type
+		 * logic below would reparent them out of LyrBlock. */
+		if (session_is_locked() && some_is_lock_drawin(*drawin))
+			continue;
+
 		/* Determine layer based on type and ontop (AwesomeWM compatibility) */
 		if ((*drawin)->type == WINDOW_TYPE_DESKTOP ||
 		    (*drawin)->type == WINDOW_TYPE_SPLASH) {

--- a/tests/test-lock-cover-hotplug.lua
+++ b/tests/test-lock-cover-hotplug.lua
@@ -1,0 +1,104 @@
+---------------------------------------------------------------------------
+-- Test: Lock cover hotplug
+--
+-- Verifies that adding a lock cover while the session is already locked
+-- correctly promotes it to the blocking layer, and that unlock properly
+-- removes it.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local wibox = require("wibox")
+local lock = require("_lock_helper")
+
+-- Skip if _test_add_output is not available
+if not awesome._test_add_output then
+    io.stderr:write("SKIP: awesome._test_add_output not available\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local initial_screen_count = screen.count()
+local interactive_wb
+local cover_wbs = {}
+
+runner.run_steps({
+    -- Step 1: Set up interactive lock surface on screen[1]
+    function()
+        interactive_wb = lock.setup()
+        return true
+    end,
+
+    -- Step 2: Lock the session
+    function()
+        awesome.lock()
+        assert(awesome.locked, "should be locked")
+        interactive_wb.visible = true
+        return true
+    end,
+
+    -- Step 3: Add a new output while locked
+    function()
+        local name = awesome._test_add_output(800, 600)
+        assert(name, "_test_add_output returned nil")
+        return true
+    end,
+
+    -- Step 4: Wait for the new screen, then register a cover for it
+    function()
+        if screen.count() < initial_screen_count + 1 then return end
+        local s = screen[screen.count()]
+        local cover = wibox({
+            x = s.geometry.x, y = s.geometry.y,
+            width = s.geometry.width, height = s.geometry.height,
+            visible = true, ontop = true, bg = "#222222",
+        })
+        awesome.add_lock_cover(cover)
+        table.insert(cover_wbs, cover)
+        assert(cover.visible, "hotplugged cover should be visible while locked")
+        return true
+    end,
+
+    -- Step 5: Unlock and verify the cover is hidden after we hide it
+    function()
+        awesome.authenticate(lock.TEST_PASSWORD)
+        awesome.unlock()
+        assert(not awesome.locked, "should be unlocked")
+        interactive_wb.visible = false
+        for _, wb in ipairs(cover_wbs) do
+            wb.visible = false
+        end
+        -- Verify they are actually hidden (not ghost panes)
+        assert(not interactive_wb.visible, "interactive should be hidden")
+        for _, wb in ipairs(cover_wbs) do
+            assert(not wb.visible, "cover should be hidden after unlock")
+        end
+        return true
+    end,
+
+    -- Step 6: Re-lock and unlock to verify session still works
+    function()
+        awesome.lock()
+        assert(awesome.locked, "re-lock should succeed")
+        interactive_wb.visible = true
+        for _, wb in ipairs(cover_wbs) do
+            wb.visible = true
+        end
+        awesome.authenticate(lock.TEST_PASSWORD)
+        awesome.unlock()
+        assert(not awesome.locked, "re-unlock should succeed")
+        interactive_wb.visible = false
+        for _, wb in ipairs(cover_wbs) do
+            wb.visible = false
+        end
+        return true
+    end,
+
+    -- Cleanup
+    function()
+        lock.teardown()
+        return true
+    end,
+}, { kill_clients = false })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
## Description

Fixes #352. When a screen is hotplugged while the session is locked via the Lua lock API, desktop content (wallpaper, wibar) was visible on the new screen.

Two issues:

1. The Lua lock never enabled `locked_bg`, the compositor-level opaque rect in `LyrBlock` that spans all outputs. The ext-session-lock path already used it, but the Lua lock path did not. This is the primary fix: the compositor now guarantees no desktop content is visible during lock, regardless of whether Lua covers exist for every screen.

2. `awesome.add_lock_cover()` during an active lock appended the cover to the array but never promoted it to `LyrBlock`. Additionally, `stack_refresh()` unconditionally reparented all drawins to their normal layer on every frame, undoing any promotion. This is fixed by promoting on add and skipping lock drawins in `stack_refresh()` while locked.

## Test Plan

- `make test-integration` (72/72 pass)
- `make test-one TEST=tests/test-lock-cover-hotplug.lua` (new test)
- Manual: lock session, plug HDMI, verify new screen is covered

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** -- if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)