### PR TITLE
fix(client): emit request::urgent instead of bypassing Lua permissions

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -5976,13 +5976,11 @@ void urgent(struct wl_listener *listener, void *data)
 	luaA_object_emit_signal(L, -2, "request::activate", 1);
 	lua_pop(L, 1);
 
-	/* Set urgent flag if not already focused (via proper API for signal emission) */
-	if (c != focustop(selmon)) {
-		luaA_object_push(L, c);
-		client_set_urgent(L, -1, true);
-		lua_pop(L, 1);
-		printstatus();
-	}
+	/* Emit request::urgent and let Lua decide (matches AwesomeWM) */
+	luaA_object_push(L, c);
+	lua_pushboolean(L, true);
+	luaA_object_emit_signal(L, -2, "request::urgent", 1);
+	lua_pop(L, 1);
 }
 
 void
@@ -6391,7 +6389,6 @@ sethints(struct wl_listener *listener, void *data)
 	Client *c = wl_container_of(listener, c, set_hints);
 	xcb_icccm_wm_hints_t *hints = c->surface.xwayland->hints;
 	lua_State *L;
-	bool dominated;
 
 	if (!hints)
 		return;
@@ -6399,21 +6396,13 @@ sethints(struct wl_listener *listener, void *data)
 	if (c->window == XCB_NONE)
 		return;
 
-	/* Check if this client is currently focused (dominated by focus) */
-	dominated = (c == focustop(selmon));
-
 	/* Get Lua state for signal emission */
 	L = globalconf_get_lua_State();
 	luaA_object_push(L, c);
 
-	/* Handle urgency (AwesomeWM pattern: use client_set_urgent for property::urgent signal)
-	 * Only process urgency if client is not focused */
-	if (!dominated) {
-		bool urgent = xcb_icccm_wm_hints_get_urgency(hints);
-		if (c->urgent != urgent) {
-			client_set_urgent(L, -1, urgent);
-		}
-	}
+	/* Emit request::urgent and let Lua decide (matches AwesomeWM property.c:203-204) */
+	lua_pushboolean(L, xcb_icccm_wm_hints_get_urgency(hints));
+	luaA_object_emit_signal(L, -2, "request::urgent", 1);
 
 	/* Handle input focus hint (XCB_ICCCM_WM_HINT_INPUT)
 	 * If input hint is set and false, client should not receive focus */

--- a/tests/test-urgent-focus-clear.lua
+++ b/tests/test-urgent-focus-clear.lua
@@ -1,0 +1,70 @@
+---------------------------------------------------------------------------
+--- Test: urgency is ignored for focused clients and cleared on focus gain
+--
+-- Verifies that:
+-- 1. request::urgent on a focused client does not set urgency
+-- 2. Urgency set on an unfocused client is cleared when it gains focus
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local async = require("_async")
+local test_client = require("_client")
+
+if not test_client.is_available() then
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+runner.run_async(function()
+    -- Spawn client A (will be in master, gets focus)
+    test_client("urgent_a")
+    local a = async.wait_for_client("urgent_a", 5)
+    assert(a, "Client A did not appear")
+
+    local focused = async.wait_for_focus("urgent_a", 2)
+    assert(focused, "Client A should have focus")
+    assert(not a.urgent, "Focused client should not be urgent")
+
+    -- Emit request::urgent on focused client - should be ignored by permissions
+    a:emit_signal("request::urgent", true)
+    async.sleep(0.1)
+    assert(not a.urgent, "request::urgent should be ignored for focused client")
+
+    -- Spawn client B (gets focus as new client)
+    test_client("urgent_b")
+    local b = async.wait_for_client("urgent_b", 5)
+    assert(b, "Client B did not appear")
+
+    local focused_b = async.wait_for_focus("urgent_b", 2)
+    assert(focused_b, "Client B should have focus")
+
+    -- Make A urgent while B has focus (A is unfocused, so this should stick)
+    a:emit_signal("request::urgent", true)
+    async.sleep(0.1)
+    assert(a.urgent, "Unfocused client A should be urgent")
+
+    -- Focus A - urgency should clear
+    a:emit_signal("request::activate", "test", { raise = true })
+    local focused_a = async.wait_for_focus("urgent_a", 2)
+    assert(focused_a, "Client A should have focus")
+    assert(not a.urgent, "Urgent state should be cleared on focus")
+
+    -- Cleanup
+    a:kill()
+    b:kill()
+
+    local gone = async.wait_for_no_clients(5)
+    if not gone then
+        for _, remaining in ipairs(client.get()) do
+            if remaining.pid then
+                os.execute("kill -9 " .. remaining.pid .. " 2>/dev/null")
+            end
+        end
+        async.sleep(0.5)
+        gone = async.wait_for_no_clients(2)
+        assert(gone, "Clients did not close")
+    end
+
+    runner.done()
+end)


### PR DESCRIPTION
## Description
`urgent()` and `sethints()` bypassed Lua's `permissions.urgent()` by checking focus in C and calling `client_set_urgent()` directly. Now both emit `request::urgent` and let Lua decide.

Closes #354

## Test Plan
- New test `test-urgent-focus-clear.lua` covers focused-client rejection and focus-clears-urgency
- All unit (695) and integration (73) tests pass

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** - if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)