### PR TITLE
fix(xwayland): read _NET_WM_WINDOW_TYPE for non-transient clients

### DIFF
--- a/property.c
+++ b/property.c
@@ -332,6 +332,51 @@ property_update_xwayland_properties(client_t *c)
 		client_find_transient_for(c);
 	}
 
+	/* _NET_WM_WINDOW_TYPE - use wlroots cached data (no XCB roundtrip).
+	 * Matches AwesomeWM's ewmh_client_check_hints() window type logic. */
+	if (wlr_xwayland_surface_has_window_type(xsurface,
+			WLR_XWAYLAND_NET_WM_WINDOW_TYPE_DESKTOP))
+		c->type = WINDOW_TYPE_DESKTOP;
+	else if (wlr_xwayland_surface_has_window_type(xsurface,
+			WLR_XWAYLAND_NET_WM_WINDOW_TYPE_DOCK))
+		c->type = WINDOW_TYPE_DOCK;
+	else if (wlr_xwayland_surface_has_window_type(xsurface,
+			WLR_XWAYLAND_NET_WM_WINDOW_TYPE_SPLASH))
+		c->type = WINDOW_TYPE_SPLASH;
+	else if (wlr_xwayland_surface_has_window_type(xsurface,
+			WLR_XWAYLAND_NET_WM_WINDOW_TYPE_DIALOG))
+		c->type = WINDOW_TYPE_DIALOG;
+	else if (wlr_xwayland_surface_has_window_type(xsurface,
+			WLR_XWAYLAND_NET_WM_WINDOW_TYPE_UTILITY))
+		c->type = WINDOW_TYPE_UTILITY;
+	else if (wlr_xwayland_surface_has_window_type(xsurface,
+			WLR_XWAYLAND_NET_WM_WINDOW_TYPE_TOOLBAR))
+		c->type = WINDOW_TYPE_TOOLBAR;
+	else if (wlr_xwayland_surface_has_window_type(xsurface,
+			WLR_XWAYLAND_NET_WM_WINDOW_TYPE_MENU))
+		c->type = WINDOW_TYPE_MENU;
+	else if (wlr_xwayland_surface_has_window_type(xsurface,
+			WLR_XWAYLAND_NET_WM_WINDOW_TYPE_DROPDOWN_MENU))
+		c->type = WINDOW_TYPE_DROPDOWN_MENU;
+	else if (wlr_xwayland_surface_has_window_type(xsurface,
+			WLR_XWAYLAND_NET_WM_WINDOW_TYPE_POPUP_MENU))
+		c->type = WINDOW_TYPE_POPUP_MENU;
+	else if (wlr_xwayland_surface_has_window_type(xsurface,
+			WLR_XWAYLAND_NET_WM_WINDOW_TYPE_TOOLTIP))
+		c->type = WINDOW_TYPE_TOOLTIP;
+	else if (wlr_xwayland_surface_has_window_type(xsurface,
+			WLR_XWAYLAND_NET_WM_WINDOW_TYPE_NOTIFICATION))
+		c->type = WINDOW_TYPE_NOTIFICATION;
+	else if (wlr_xwayland_surface_has_window_type(xsurface,
+			WLR_XWAYLAND_NET_WM_WINDOW_TYPE_COMBO))
+		c->type = WINDOW_TYPE_COMBO;
+	else if (wlr_xwayland_surface_has_window_type(xsurface,
+			WLR_XWAYLAND_NET_WM_WINDOW_TYPE_DND))
+		c->type = WINDOW_TYPE_DND;
+	else if (wlr_xwayland_surface_has_window_type(xsurface,
+			WLR_XWAYLAND_NET_WM_WINDOW_TYPE_NORMAL))
+		c->type = WINDOW_TYPE_NORMAL;
+
 	lua_pop(L, 1);
 }
 

--- a/tests/helpers/x11_window_type.py
+++ b/tests/helpers/x11_window_type.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""X11 test helper: create a window with a specific _NET_WM_WINDOW_TYPE.
+
+Usage: python3 x11_window_type.py <WM_CLASS> <WINDOW_TYPE>
+
+WINDOW_TYPE is one of: dialog, splash, utility, toolbar, dock, desktop,
+    menu, dropdown_menu, popup_menu, tooltip, notification, combo, dnd, normal
+
+The window stays mapped until SIGTERM is received.
+"""
+
+import ctypes
+import ctypes.util
+import signal
+import sys
+
+# --- Load libX11 via ctypes ---
+
+_x11_path = ctypes.util.find_library("X11")
+if not _x11_path:
+    print("ERROR: libX11 not found", file=sys.stderr)
+    sys.exit(1)
+
+x11 = ctypes.cdll.LoadLibrary(_x11_path)
+
+# Type aliases
+Display_p = ctypes.c_void_p
+Window = ctypes.c_ulong
+Atom = ctypes.c_ulong
+
+# XClassHint structure
+class XClassHint(ctypes.Structure):
+    _fields_ = [
+        ("res_name", ctypes.c_char_p),
+        ("res_class", ctypes.c_char_p),
+    ]
+
+# Function prototypes
+x11.XOpenDisplay.argtypes = [ctypes.c_char_p]
+x11.XOpenDisplay.restype = Display_p
+
+x11.XDefaultScreen.argtypes = [Display_p]
+x11.XDefaultScreen.restype = ctypes.c_int
+
+x11.XRootWindow.argtypes = [Display_p, ctypes.c_int]
+x11.XRootWindow.restype = Window
+
+x11.XCreateSimpleWindow.argtypes = [
+    Display_p, Window,
+    ctypes.c_int, ctypes.c_int,   # x, y
+    ctypes.c_uint, ctypes.c_uint, # width, height
+    ctypes.c_uint,                 # border_width
+    ctypes.c_ulong,               # border
+    ctypes.c_ulong,               # background
+]
+x11.XCreateSimpleWindow.restype = Window
+
+x11.XSetClassHint.argtypes = [Display_p, Window, ctypes.POINTER(XClassHint)]
+x11.XSetClassHint.restype = ctypes.c_int
+
+x11.XStoreName.argtypes = [Display_p, Window, ctypes.c_char_p]
+x11.XStoreName.restype = ctypes.c_int
+
+x11.XMapWindow.argtypes = [Display_p, Window]
+x11.XMapWindow.restype = ctypes.c_int
+
+x11.XFlush.argtypes = [Display_p]
+x11.XFlush.restype = ctypes.c_int
+
+x11.XDestroyWindow.argtypes = [Display_p, Window]
+x11.XDestroyWindow.restype = ctypes.c_int
+
+x11.XCloseDisplay.argtypes = [Display_p]
+x11.XCloseDisplay.restype = ctypes.c_int
+
+x11.XInternAtom.argtypes = [Display_p, ctypes.c_char_p, ctypes.c_int]
+x11.XInternAtom.restype = Atom
+
+x11.XChangeProperty.argtypes = [
+    Display_p, Window, Atom, Atom,
+    ctypes.c_int,   # format (bits per element: 8, 16, or 32)
+    ctypes.c_int,   # mode (PropModeReplace=0)
+    ctypes.c_void_p, # data
+    ctypes.c_int,   # nelements
+]
+x11.XChangeProperty.restype = ctypes.c_int
+
+# --- Constants ---
+
+PropModeReplace = 0
+XA_ATOM = 4  # X11 predefined atom type for ATOM
+
+# Map of window type names to their _NET_WM_WINDOW_TYPE_* atom names
+WINDOW_TYPE_ATOMS = {
+    "dialog":        "_NET_WM_WINDOW_TYPE_DIALOG",
+    "splash":        "_NET_WM_WINDOW_TYPE_SPLASH",
+    "utility":       "_NET_WM_WINDOW_TYPE_UTILITY",
+    "toolbar":       "_NET_WM_WINDOW_TYPE_TOOLBAR",
+    "dock":          "_NET_WM_WINDOW_TYPE_DOCK",
+    "desktop":       "_NET_WM_WINDOW_TYPE_DESKTOP",
+    "menu":          "_NET_WM_WINDOW_TYPE_MENU",
+    "dropdown_menu": "_NET_WM_WINDOW_TYPE_DROPDOWN_MENU",
+    "popup_menu":    "_NET_WM_WINDOW_TYPE_POPUP_MENU",
+    "tooltip":       "_NET_WM_WINDOW_TYPE_TOOLTIP",
+    "notification":  "_NET_WM_WINDOW_TYPE_NOTIFICATION",
+    "combo":         "_NET_WM_WINDOW_TYPE_COMBO",
+    "dnd":           "_NET_WM_WINDOW_TYPE_DND",
+    "normal":        "_NET_WM_WINDOW_TYPE_NORMAL",
+}
+
+# --- Globals ---
+
+dpy = None
+win = None
+
+def handle_term(signum, frame):
+    """SIGTERM: Clean exit."""
+    if dpy and win:
+        x11.XDestroyWindow(dpy, win)
+        x11.XCloseDisplay(dpy)
+    sys.exit(0)
+
+def main():
+    global dpy, win
+
+    if len(sys.argv) < 3:
+        print("Usage: %s <WM_CLASS> <WINDOW_TYPE>" % sys.argv[0], file=sys.stderr)
+        sys.exit(1)
+
+    wm_class = sys.argv[1]
+    window_type_name = sys.argv[2]
+
+    if window_type_name not in WINDOW_TYPE_ATOMS:
+        print("ERROR: unknown window type '%s'" % window_type_name, file=sys.stderr)
+        print("Valid types: %s" % ", ".join(sorted(WINDOW_TYPE_ATOMS)), file=sys.stderr)
+        sys.exit(1)
+
+    # Open display
+    dpy = x11.XOpenDisplay(None)
+    if not dpy:
+        print("ERROR: Cannot open X display", file=sys.stderr)
+        sys.exit(1)
+
+    screen = x11.XDefaultScreen(dpy)
+    root = x11.XRootWindow(dpy, screen)
+
+    # Create window
+    win = x11.XCreateSimpleWindow(dpy, root, 0, 0, 200, 200, 0, 0, 0)
+
+    # Set WM_CLASS
+    hint = XClassHint()
+    hint.res_name = wm_class.lower().encode()
+    hint.res_class = wm_class.encode()
+    x11.XSetClassHint(dpy, win, ctypes.byref(hint))
+
+    # Set title
+    x11.XStoreName(dpy, win, wm_class.encode())
+
+    # Set _NET_WM_WINDOW_TYPE BEFORE mapping (like a real app would)
+    atom_name = WINDOW_TYPE_ATOMS[window_type_name]
+    wm_window_type = x11.XInternAtom(dpy, b"_NET_WM_WINDOW_TYPE", 0)
+    type_atom = x11.XInternAtom(dpy, atom_name.encode(), 0)
+
+    type_data = (Atom * 1)(type_atom)
+    x11.XChangeProperty(
+        dpy, win, wm_window_type, XA_ATOM,
+        32, PropModeReplace,
+        ctypes.cast(type_data, ctypes.c_void_p),
+        1,
+    )
+
+    # Map window
+    x11.XMapWindow(dpy, win)
+    x11.XFlush(dpy)
+
+    print("[x11_window_type] mapped: class=%s type=%s" % (wm_class, window_type_name),
+          file=sys.stderr)
+
+    # Install signal handlers
+    signal.signal(signal.SIGTERM, handle_term)
+
+    # Block until killed
+    while True:
+        signal.pause()
+
+if __name__ == "__main__":
+    main()

--- a/tests/test-xwayland-dialog-type.lua
+++ b/tests/test-xwayland-dialog-type.lua
@@ -1,0 +1,142 @@
+---------------------------------------------------------------------------
+--- Test: XWayland _NET_WM_WINDOW_TYPE detection
+--
+-- Verifies that XWayland clients with _NET_WM_WINDOW_TYPE set (without
+-- transient_for) get the correct client.type in Lua. This exercises the
+-- property_update_xwayland_properties() window type detection path.
+--
+-- Regression test for #337: XWayland dialogs tile instead of float because
+-- _NET_WM_WINDOW_TYPE was never read for non-transient X11 clients.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local x11_client = require("_x11_client")
+
+-- Skip if headless (XWayland needs a display)
+local function is_headless()
+    local backend = os.getenv("WLR_BACKENDS")
+    return backend == "headless"
+end
+
+if is_headless() then
+    io.stderr:write("SKIP: XWayland dialog type test requires visual mode\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+-- Skip if python3 not available
+local python3_check = os.execute("which python3 >/dev/null 2>&1")
+if not python3_check then
+    io.stderr:write("SKIP: python3 not available for X11 helper\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local awful = require("awful")
+
+-- Resolve helper script path
+local script_dir = debug.getinfo(1, "S").source:match("@(.*/)")
+local helper_path = script_dir .. "helpers/x11_window_type.py"
+
+-- Test cases: each entry is { class, window_type_arg, expected_lua_type }
+local test_cases = {
+    { class = "xw_type_dialog",  type_arg = "dialog",  expected = "dialog" },
+    { class = "xw_type_splash",  type_arg = "splash",  expected = "splash" },
+    { class = "xw_type_utility", type_arg = "utility", expected = "utility" },
+    { class = "xw_type_normal",  type_arg = "normal",  expected = "normal" },
+}
+
+local current_test = 1
+local helper_pid = nil
+local my_client = nil
+local manage_count = 0
+
+client.connect_signal("manage", function(c)
+    if current_test <= #test_cases then
+        local tc = test_cases[current_test]
+        if x11_client.is_xwayland(c) and c.class == tc.class then
+            manage_count = manage_count + 1
+            my_client = c
+        end
+    end
+end)
+
+-- Build steps: for each test case, spawn -> wait -> verify -> cleanup
+local steps = {}
+
+for i, tc in ipairs(test_cases) do
+    -- Spawn helper with the window type
+    steps[#steps + 1] = function(count)
+        if count == 1 then
+            current_test = i
+            my_client = nil
+            local cmd = string.format(
+                "python3 %s %s %s", helper_path, tc.class, tc.type_arg
+            )
+            io.stderr:write(string.format(
+                "[TEST] Spawning X11 window: class=%s type=%s\n",
+                tc.class, tc.type_arg
+            ))
+            helper_pid = awful.spawn(cmd)
+            if not helper_pid or type(helper_pid) ~= "number" or helper_pid <= 0 then
+                error("Failed to spawn helper: " .. tostring(helper_pid))
+            end
+        end
+        return true
+    end
+
+    -- Wait for client to appear
+    steps[#steps + 1] = function(count)
+        if my_client then
+            return true
+        end
+        if count > 80 then
+            error(string.format(
+                "X11 client did not appear: class=%s", tc.class
+            ))
+        end
+        return nil
+    end
+
+    -- Verify the type
+    steps[#steps + 1] = function()
+        assert(my_client.valid,
+            string.format("client must be valid: class=%s", tc.class))
+        assert(x11_client.is_xwayland(my_client),
+            string.format("client must be XWayland: class=%s", tc.class))
+        assert(my_client.type == tc.expected,
+            string.format(
+                "regression #337: expected type '%s', got '%s' for class=%s",
+                tc.expected, tostring(my_client.type), tc.class
+            ))
+
+        io.stderr:write(string.format(
+            "[TEST] PASS: class=%s type=%s (expected %s)\n",
+            tc.class, my_client.type, tc.expected
+        ))
+        return true
+    end
+
+    -- Kill helper and wait for unmanage
+    steps[#steps + 1] = function(count)
+        if count == 1 then
+            os.execute("kill " .. helper_pid .. " 2>/dev/null")
+        end
+
+        -- Wait for client to disappear or timeout
+        if not my_client or not my_client.valid then
+            return true
+        end
+        if count > 30 then
+            os.execute("kill -9 " .. helper_pid .. " 2>/dev/null")
+            return true
+        end
+        return nil
+    end
+end
+
+runner.run_steps(steps, { kill_clients = false })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
## Description

Closes #337

XWayland clients never had their `_NET_WM_WINDOW_TYPE` read, so every XWayland window arrived as `WINDOW_TYPE_NORMAL`. This caused dialogs, splash screens, docks, and other special window types to tile instead of float, breaking `awful.rules` floating logic for XWayland apps like Steam, GIMP, and Firefox.

Read the window type from wlroots' cached `_NET_WM_WINDOW_TYPE` data in `property_update_xwayland_properties()`, matching AwesomeWM's `ewmh_client_check_hints()` priority order. No XCB roundtrip needed.

## Test Plan

- Added `tests/test-xwayland-dialog-type.lua` covering DIALOG, SPLASH, UTILITY, and NORMAL window types
- All 95 tests pass (`make test-unit && make test-integration`)

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)