### PR TITLE
fix(screen): delegate emit_signal to standard luaA_object function

### DIFF
--- a/objects/screen.c
+++ b/objects/screen.c
@@ -1892,35 +1892,10 @@ luaA_screen_connect_signal(lua_State *L)
 	return luaA_object_connect_signal_simple(L);
 }
 
-/** screen:emit_signal(name, ...) - Emit a screen signal
- * Emits signal on instance, then forwards to class (AwesomeWM pattern).
- */
 static int
 luaA_screen_emit_signal(lua_State *L)
 {
-	screen_t *screen = luaA_checkscreen(L, 1);
-	const char *name = luaL_checkstring(L, 2);
-	int nargs = lua_gettop(L) - 2;
-	int arg_start = 3;  /* absolute stack index of first extra arg */
-	int j;
-
-	if (screen) {
-		/* Emit on instance signals with fresh copies of args.
-		 * signal_object_emit() pops its nargs from the stack, so we pass
-		 * copies rather than the originals (which we need below for class emit). */
-		for (j = 0; j < nargs; j++)
-			lua_pushvalue(L, arg_start + j);
-		signal_object_emit(L, &screen->signals, name, nargs);
-
-		/* Forward to class signals (AwesomeWM pattern): push screen first,
-		 * then fresh copies of the extra args so handlers receive (s, ...). */
-		lua_pushvalue(L, 1);
-		for (j = 0; j < nargs; j++)
-			lua_pushvalue(L, arg_start + j);
-		luaA_class_emit_signal(L, &screen_class, name, nargs + 1);
-	}
-
-	return 0;
+	return luaA_object_emit_signal_simple(L);
 }
 
 /** screen:disconnect_signal(name, callback) - Disconnect from a screen signal

--- a/tests/test-screen-disconnect-signal.lua
+++ b/tests/test-screen-disconnect-signal.lua
@@ -8,8 +8,7 @@
 local runner = require("_runner")
 
 local steps = {
-    -- Step 1: Test connect + disconnect on screen using property::workarea
-    -- (a signal known to work in the screen signal system)
+    -- Step 1: Test connect + disconnect on screen using custom signals
     function()
         local s = screen.primary
         assert(s, "Primary screen must exist")
@@ -50,20 +49,15 @@ local steps = {
         -- Emit on instance
         s:emit_signal("test::inst_disconnect")
 
-        -- Instance signals are emitted properly
-        if inst_fire_count == 1 then
-            -- Disconnect
-            s:disconnect_signal("test::inst_disconnect", inst_callback)
-
-            -- Emit again
-            s:emit_signal("test::inst_disconnect")
-            assert(inst_fire_count == 1,
-                string.format("Instance signal should not fire after disconnect (fired %d)", inst_fire_count))
-            io.stderr:write("[TEST] PASS: instance-level disconnect_signal works\n")
-        else
-            io.stderr:write(string.format("[TEST] NOTE: Instance emit_signal fired %d times (may use class dispatch)\n",
-                inst_fire_count))
-        end
+        assert(inst_fire_count == 1,
+            string.format("Instance signal should fire once, fired %d times", inst_fire_count))
+        -- Disconnect
+        s:disconnect_signal("test::inst_disconnect", inst_callback)
+        -- Emit again
+        s:emit_signal("test::inst_disconnect")
+        assert(inst_fire_count == 1,
+            string.format("Instance signal should not fire after disconnect (fired %d)", inst_fire_count))
+        io.stderr:write("[TEST] PASS: instance-level disconnect_signal works\n")
 
         return true
     end,


### PR DESCRIPTION
## Description

Replace custom `luaA_screen_emit_signal` with a one-line delegation to `luaA_object_emit_signal_simple(L)`, matching `connect_signal` and `disconnect_signal`. The old implementation used `signal_object_emit()` (wrong lookup path), so instance-level `emit_signal` never fired handlers registered via `connect_signal`.

Also tightens the test: replaces a conditional that silently passed when `emit_signal` was broken with direct asserts.

## Test Plan

- `make test-one TEST=tests/test-screen-disconnect-signal.lua`
- `make test-integration`
- `make test-unit`

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)