### PR TITLE
fix: Put fullscreen window above wibar (#368)

### DIFF
--- a/somewm_api.c
+++ b/somewm_api.c
@@ -269,7 +269,7 @@ some_client_swapstack(int direction)
 Client *
 some_get_focused_client(void)
 {
-	return focustop(selmon);
+	return globalconf.focus.client;
 }
 
 Client *


### PR DESCRIPTION
A client in WINDOW_LAYER_FULLSCREEN is shown above wibar. However, a fullscreen client c is translated to WINDOW_LAYER_FULLSCREEN in client_layer_translater() only if it has focus (or there is no focus or focused client is on a different screen), i.e., if c equals some_get_focused_client().

However, some_get_focused_client() does not actually return the client with focus, but focustop(selmon), which does return the first client from globalconf.stack on selmon and a selected tag, which may not be the focused client.

Fix this by returning the client with focus for
some_get_focused_client() instead.

## Description
<!-- What does this change and why? -->


## Test Plan
<!-- How did you verify this works? -->


## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)
