### PR TITLE
Set fullscreen xdg-shell property for clients when somewm sets c.fullscreen = true

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -2943,8 +2943,6 @@ client_set_fullscreen(lua_State *L, int cidx, bool s)
         luaA_object_emit_signal(L, abs_cidx, "property::fullscreen", 0);
         if(c->toplevel_handle)
             wlr_foreign_toplevel_handle_v1_set_fullscreen(c->toplevel_handle, s);
-        /* Set the xdg-shell fullscreen property for the client */
-        some_client_set_fullscreen(c, s);
         /* Force a client resize, so that titlebars get shown/hidden */
         client_resize_do(c, c->geometry, false);
         stack_windows();

--- a/somewm.c
+++ b/somewm.c
@@ -4413,6 +4413,15 @@ apply_geometry_to_wlroots(Client *c)
 	 * Without this check, we flood the client with configure events on every refresh cycle,
 	 * which crashes Firefox and other clients that can't handle rapid configure floods. */
 	if (!c->resize) {
+		/* If fullscreen is changing, inform client of new state */
+#ifdef XWAYLAND
+		if (c->client_type == X11) {
+			if (c->fullscreen != c->surface.xwayland->fullscreen)
+				client_set_fullscreen_internal(c, c->fullscreen);
+		} else
+#endif
+		if (c->fullscreen != c->surface.xdg->toplevel->pending.fullscreen)
+			client_set_fullscreen_internal(c, c->fullscreen);
 		if (c->fullscreen) {
 			/* Fullscreen: client gets full geometry minus borders only */
 			c->resize = client_set_size(c,
@@ -4944,7 +4953,6 @@ setfullscreen(Client *c, int fullscreen)
 	}
 
 	c->bw = fullscreen ? 0 : get_border_width();
-	client_set_fullscreen_internal(c, fullscreen);
 	wlr_scene_node_reparent(&c->scene->node, layers[c->fullscreen ? LyrFS : LyrTile]);
 
 	if (fullscreen) {


### PR DESCRIPTION
## Description
Clients do not receive fullscreen xdg-shell property when fullscreen is triggered by somewm. Lua calls client_set_fullscreen(), which never sets the xdg-shell property. Calling some_client_set_fullscreen() correctly sets this property and clients enter fullscreen state as expected. Resolves #372.


## Test Plan
## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)
