### PR TITLE
build: Uninstall systemd and session files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,7 @@ install:
 	meson install -C build
 
 uninstall:
-	rm -f /usr/local/bin/somewm /usr/local/bin/somewm-client
-	rm -f /usr/local/share/man/man1/somewm.1
-	rm -f /usr/local/share/wayland-sessions/somewm.desktop
-	rm -f /usr/local/share/xdg-desktop-portal/portals/somewm.portal
-	rm -rf /usr/local/share/somewm
-	rm -rf /usr/local/etc/xdg/somewm
+	ninja -C build uninstall
 
 clean:
 	rm -rf build build-test


### PR DESCRIPTION
## Description
The makefile uninstall target did not add the systemd and session script files. Add them.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)