### PR TITLE
fix: Respect idle inhibitor in idle timeout handler

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -1770,7 +1770,7 @@ luaA_awesome_index(lua_State *L)
 	}
 
 	if (A_STREQ(key, "idle_inhibited")) {
-		lua_pushboolean(L, some_is_idle_inhibited());
+		lua_pushboolean(L, some_is_idle_inhibited(NULL));
 		return 1;
 	}
 

--- a/luaa.c
+++ b/luaa.c
@@ -192,6 +192,9 @@ static IdleTimeout idle_timeouts[MAX_IDLE_TIMEOUTS];
 static int idle_timeout_count = 0;
 static bool user_is_idle = false;    /* Global idle state */
 
+/* Flag whether idle timers have been inhibited. */
+static bool idle_timers_inhibited = false;
+
 /* D-Bus library functions from dbus.c */
 extern const struct luaL_Reg awesome_dbus_lib[];
 
@@ -1373,6 +1376,35 @@ remove_idle_timeout_at(int idx)
 	idle_timeout_count--;
 }
 
+static void
+reset_idle_timer(IdleTimeout *timeout) {
+	timeout->fired = false;
+	if (timeout->timer) {
+		/* Disable timer if idle timers are inhibited. */
+		int ms_delay = idle_timers_inhibited ? 0 : timeout->seconds * 1000;
+		wl_event_source_timer_update(timeout->timer, ms_delay);
+	}
+}
+
+/* Update all idle timers, i.e., update timer with 0 or timeout depending on
+ * inhibition. */
+static void
+reset_all_idle_timers()
+{
+	for (int i = 0; i < idle_timeout_count; i++) {
+		IdleTimeout *timeout = &idle_timeouts[i];
+		reset_idle_timer(timeout);
+	}
+}
+
+/* Set inhibit state for all idle timers and reset timers. */
+void
+some_idle_timers_set_inhibit(bool inhibit)
+{
+	idle_timers_inhibited = inhibit;
+	reset_all_idle_timers();
+}
+
 /** awesome.set_idle_timeout(name, seconds, callback)
  * Add or update a named idle timeout.
  * Multiple timeouts can be active simultaneously.
@@ -1407,11 +1439,10 @@ luaA_awesome_set_idle_timeout(lua_State *L)
 	timeout->name = strdup(name);
 	timeout->seconds = seconds;
 	timeout->lua_callback_ref = callback_ref;
-	timeout->fired = false;
 
 	/* Create and arm the timer */
 	timeout->timer = wl_event_loop_add_timer(some_get_event_loop(), idle_timeout_callback, timeout);
-	wl_event_source_timer_update(timeout->timer, seconds * 1000);
+	reset_idle_timer(timeout);
 
 	idle_timeout_count++;
 
@@ -1497,12 +1528,8 @@ some_notify_activity(void)
 	}
 
 	/* Reset all idle timers */
-	for (int i = 0; i < idle_timeout_count; i++) {
-		IdleTimeout *timeout = &idle_timeouts[i];
-		timeout->fired = false;
-		if (timeout->timer)
-			wl_event_source_timer_update(timeout->timer, timeout->seconds * 1000);
-	}
+	if (!idle_timers_inhibited)
+		reset_all_idle_timers();
 }
 
 /* ==========================================================================

--- a/somewm.c
+++ b/somewm.c
@@ -158,7 +158,7 @@ static const float *get_focuscolor(void);
 static const float *get_bordercolor(void);
 static const float *get_urgentcolor(void);
 
-static void checkidleinhibitor(struct wlr_surface *exclude);
+static bool checkidleinhibitor(struct wlr_surface *exclude);
 static void cleanup(void);
 static void cleanupmon(struct wl_listener *listener, void *data);
 static void cleanuplisteners(void);
@@ -1181,11 +1181,13 @@ buttonpress(struct wl_listener *listener, void *data)
 			event->time_msec, event->button, event->state);
 }
 
-void
+bool
 checkidleinhibitor(struct wlr_surface *exclude)
 {
 	bool inhibited = some_is_idle_inhibited(exclude);
 	wlr_idle_notifier_v1_set_inhibited(idle_notifier, inhibited);
+
+	return inhibited;
 }
 
 void
@@ -1674,7 +1676,8 @@ createidleinhibitor(struct wl_listener *listener, void *data)
 	struct wlr_idle_inhibitor_v1 *idle_inhibitor = data;
 	LISTEN_STATIC(&idle_inhibitor->events.destroy, destroyidleinhibitor);
 
-	checkidleinhibitor(NULL);
+	bool inhibited = checkidleinhibitor(NULL);
+	some_idle_timers_set_inhibit(inhibited);
 }
 
 void
@@ -2252,7 +2255,9 @@ destroyidleinhibitor(struct wl_listener *listener, void *data)
 {
 	/* `data` is the wlr_surface of the idle inhibitor being destroyed,
 	 * at this point the idle inhibitor is still in the list of the manager */
-	checkidleinhibitor(wlr_surface_get_root_surface(data));
+	bool inhibited = checkidleinhibitor(wlr_surface_get_root_surface(data));
+	some_idle_timers_set_inhibit(inhibited);
+
 	wl_list_remove(&listener->link);
 	free(listener);
 }

--- a/somewm.c
+++ b/somewm.c
@@ -1184,18 +1184,7 @@ buttonpress(struct wl_listener *listener, void *data)
 void
 checkidleinhibitor(struct wlr_surface *exclude)
 {
-	int inhibited = 0, unused_lx, unused_ly;
-	struct wlr_idle_inhibitor_v1 *inhibitor;
-	wl_list_for_each(inhibitor, &idle_inhibit_mgr->inhibitors, link) {
-		struct wlr_surface *surface = wlr_surface_get_root_surface(inhibitor->surface);
-		struct wlr_scene_tree *tree = surface->data;
-		if (exclude != surface && (globalconf.appearance.bypass_surface_visibility || (!tree
-				|| wlr_scene_node_coords(&tree->node, &unused_lx, &unused_ly)))) {
-			inhibited = 1;
-			break;
-		}
-	}
-
+	bool inhibited = some_is_idle_inhibited(exclude);
 	wlr_idle_notifier_v1_set_inhibited(idle_notifier, inhibited);
 }
 
@@ -2445,11 +2434,27 @@ some_is_ext_session_locked(void)
 	return locked;
 }
 
-/** Check if idle is inhibited by any client (for Lua API) */
+/** Check if idle is effectively inhibited (for Lua API and idle timers). */
 bool
-some_is_idle_inhibited(void)
+some_is_idle_inhibited(struct wlr_surface *exclude)
 {
-	return !wl_list_empty(&idle_inhibit_mgr->inhibitors);
+	int unused_lx, unused_ly;
+	struct wlr_idle_inhibitor_v1 *inhibitor;
+
+	if (!idle_inhibit_mgr)
+		return false;
+
+	wl_list_for_each(inhibitor, &idle_inhibit_mgr->inhibitors, link) {
+		struct wlr_surface *surface = wlr_surface_get_root_surface(inhibitor->surface);
+		struct wlr_scene_tree *tree = surface->data;
+
+		if (exclude != surface && (globalconf.appearance.bypass_surface_visibility || (!tree
+				|| wlr_scene_node_coords(&tree->node, &unused_lx, &unused_ly)))) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 void

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -258,7 +258,7 @@ void some_clear_pre_lock_client(client_t *c);
 void some_notify_activity(void);
 
 /* Idle inhibitor query - defined in somewm.c, called from luaa.c */
-bool some_is_idle_inhibited(void);
+bool some_is_idle_inhibited(struct wlr_surface *exclude);
 
 /** Check if the session is locked by any mechanism (ext-session-lock or Lua lock).
  * Use this instead of repeating `locked || some_is_lua_locked()` everywhere. */

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -255,6 +255,7 @@ void some_promote_lock_cover(drawin_t *d);
 void some_clear_pre_lock_client(client_t *c);
 
 /* Idle/activity - defined in luaa.c, called from somewm.c */
+void some_idle_timers_set_inhibit(bool inhibit);
 void some_notify_activity(void);
 
 /* Idle inhibitor query - defined in somewm.c, called from luaa.c */


### PR DESCRIPTION
The some_notify_activity() is called directly in somewm upon user activity. This resets the idle timer as expected. For more elaborate idle inhibition, somewm implements the idle-inhibit-unstable-v1 protocol, which enables tools like wayland-pipewire-idle-inhibit to inhibit the idle mechanism on more complex conditions, e.g., when pipewire plays media.

While checkidleinhibitor() did check for this inhibitor mechanism to call wlr_idle_notifier_v1_set_inhibited(), these checks were not employed when firing the idle::start signal in idle_timeout_callback().

Fix this:

1. Factor the inhibitor check out from checkidleinhibitor() and put it into a generalized some_is_idle_inhibited().

2. Check some_is_idle_inhibited() within idle_timeout_callback().

3. Make some_is_idle_inhibited() robust against idle_inhibit_mgr being NULL.

## Description
<!-- What does this change and why? -->


## Test Plan
<!-- How did you verify this works? -->


## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)
