### PR TITLE
fix(drawin): shadow and border not refreshed on resize

### DIFF
--- a/lua/awful/wibar.lua
+++ b/lua/awful/wibar.lua
@@ -600,7 +600,8 @@ function awfulwibar.new(args)
     -- The C code scans the table directly, so metatable magic cannot be used.
     for _, prop in ipairs {
         "border_width", "border_color", "font", "opacity", "ontop", "cursor",
-        "bgimage", "bg", "fg", "type", "stretch", "shape", "margins", "align"
+        "bgimage", "bg", "fg", "type", "stretch", "shape", "margins", "align",
+        "shadow"
     } do
         if (args[prop] == nil) and beautiful["wibar_"..prop] ~= nil then
             args[prop] = beautiful["wibar_"..prop]

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -1548,6 +1548,10 @@ drawin_moveresize(lua_State *L, int udx, int x, int y, int width, int height)
 	/* Update scene buffer destination size if size changed */
 	if (drawin->scene_buffer && (old_width != drawin->width || old_height != drawin->height))
 		wlr_scene_buffer_set_dest_size(drawin->scene_buffer, drawin->width, drawin->height);
+
+	/* Size change requires border + shadow refresh */
+	if (old_width != drawin->width || old_height != drawin->height)
+		drawin->border_need_update = true;
 }
 
 /** Set drawin geometry (wrapper for external callers)
@@ -2181,6 +2185,9 @@ luaA_drawin_set_shadow(lua_State *L, drawin_t *drawin)
 		/* Match drawin visibility */
 		shadow_set_visible(&drawin->shadow, drawin->visible);
 	}
+
+	/* Ensure shadow gets refreshed with correct geometry on next cycle */
+	drawin->border_need_update = true;
 
 	luaA_object_emit_signal(L, -3, "property::shadow", 0);
 	return 0;


### PR DESCRIPTION
## Summary

- Fix `drawin_moveresize()` not setting `border_need_update` on size change — shadows and borders stuck at initial dimensions after resize
- Fix `luaA_drawin_set_shadow()` not triggering border refresh — shadow config applied before final geometry was never corrected
- Add `"shadow"` to wibar beautiful property whitelist — `beautiful.wibar_shadow` was silently ignored

Fixes #399

## Changes

| File | Change | Lines |
|:-----|:-------|:------|
| `objects/drawin.c` | `border_need_update = true` in `drawin_moveresize()` on size change | +4 |
| `objects/drawin.c` | `border_need_update = true` in `luaA_drawin_set_shadow()` | +3 |
| `lua/awful/wibar.lua` | `"shadow"` added to beautiful property whitelist | +2/-1 |

No effect when shadows are disabled (the default). The `border_need_update` fix in `drawin_moveresize()` independently fixes border refresh on resize.

## Test plan

- [x] Verified shadow renders on wibar in nested compositor (wayland backend)
- [x] Tested with 9-slice (CPU) shadow path
- [x] Tested with SceneFX (GPU) shadow path
- [x] Confirmed no double-creation: `shadow_update_geometry()` early-returns via `last_width/last_height` cache
- [x] Confirmed no regression when shadows are disabled
- [ ] Test on DRM session (real hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)