### PR TITLE
fix(wibox): propagate opacity/border to underlying C drawin

### DIFF
--- a/lua/wibox/init.lua
+++ b/lua/wibox/init.lua
@@ -297,6 +297,10 @@ for _, prop in ipairs { "border_width", "border_color", "opacity" } do
     wibox["set_"..prop] = function(self, value)
         self._private["_user_"..prop] = true
         self["_"..prop] = value
+        -- Propagate to underlying C drawin (Wayland compositing)
+        if self.drawin then
+            self.drawin["_"..prop] = value
+        end
     end
 end
 


### PR DESCRIPTION
## Summary

- Wibox property setters for `opacity`, `border_width`, and `border_color` stored values only in the Lua table but never propagated them to the underlying C drawin object
- On Wayland, this means `wlr_scene_buffer_set_opacity()` is never called — `wibox.opacity`, `awful.popup.opacity`, and `naughty.layout.box.opacity` have **zero visual effect**
- The C drawin properties are registered with underscore prefix (`_opacity`, `_border_width`, `_border_color`) via `luaA_class_add_property()`. Setting `drawin.opacity` from Lua creates a plain Lua field, bypassing the C setter entirely
- Fix: propagate each value to `self.drawin["_"..prop]` in the wibox setter (4 lines)

Affects all wibox-based surfaces: panels, popups, notifications, tooltips, and any widget using `awful.popup` or `wibox` directly.

## Reproduction

```lua
-- In rc.lua or via IPC:
local wibox = require("wibox")
local w = wibox { visible = true, width = 200, height = 100, screen = screen.primary }
w.opacity = 0.5  -- BEFORE fix: no visual change. AFTER fix: 50% transparent.
```

Same issue with notification popups:
```lua
naughty.connect_signal("request::display", function(n)
    local popup = naughty.layout.box { notification = n }
    popup.opacity = 0.5  -- no visual effect without this fix
end)
```

## Test plan

- [x] Verified `wibox.opacity` propagates to `drawin._opacity` (C property)
- [x] Verified `wlr_scene_buffer_set_opacity()` is called with correct value
- [x] Tested on live DRM session (NVIDIA RTX 5070 Ti)
- [x] Tested in nested sandbox (WLR_BACKENDS=wayland)
- [x] No regressions on border_width or border_color
- [x] SceneFX effects (rounded corners, blur) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)