### PR TITLE
fix(stack): call ewmh_update_net_client_list_stacking() in stack_refresh()

### DIFF
--- a/stack.c
+++ b/stack.c
@@ -6,10 +6,10 @@
  *
  * Key differences from AwesomeWM:
  * - Uses wlroots scene graph layers instead of XCB stacking
- * - No EWMH updates (TODO)
  */
 
 #include "stack.h"
+#include "ewmh.h"
 #include "somewm_types.h"
 #include "objects/client.h"  /* For complete client_t definition */
 #include "objects/drawin.h"  /* For drawin stacking */
@@ -37,7 +37,6 @@ stack_client_remove(Client *c)
 			client_array_remove(&globalconf.stack, client);
 			break;
 		}
-	/* TODO: ewmh_update_net_client_list_stacking(); */
 	stack_windows();
 }
 
@@ -49,7 +48,6 @@ stack_client_push(Client *c)
 {
 	stack_client_remove(c);
 	client_array_push(&globalconf.stack, c);
-	/* TODO: ewmh_update_net_client_list_stacking(); */
 	stack_windows();
 }
 
@@ -61,7 +59,6 @@ stack_client_append(Client *c)
 {
 	stack_client_remove(c);
 	client_array_append(&globalconf.stack, c);
-	/* TODO: ewmh_update_net_client_list_stacking(); */
 	stack_windows();
 }
 
@@ -288,7 +285,7 @@ stack_refresh(void)
 		wlr_scene_node_raise_to_top(&(*drawin)->scene_tree->node);
 	}
 
-	/* TODO: Call ewmh_update_net_client_list_stacking() */
+	ewmh_update_net_client_list_stacking();
 
 	need_stack_refresh = false;
 }


### PR DESCRIPTION
## Description

Call `ewmh_update_net_client_list_stacking()` in `stack_refresh()` so somewm explicitly sets `_NET_CLIENT_LIST_STACKING` on the X11 root window after each stack refresh. Previously the four call sites were commented out as TODOs. The call is placed only in `stack_refresh()` since that is the single point where stacking is finalized, avoiding redundant updates from the individual `stack_client_remove/push/append` functions. The three stale TODO comments in those functions are removed.

Closes #406

## Test Plan

- Launched two XWayland clients (xterm), verified `xprop -root _NET_CLIENT_LIST_STACKING` updates correctly on raise/lower
- `make test-integration` passes (106 tests, pre-existing `test-floating-layout.lua` timeout unrelated)

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** -- if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)