### PR TITLE
fix: member access within null pointer of type 'struct wlr_xdg_surface'

### DIFF
--- a/client.h
+++ b/client.h
@@ -143,6 +143,8 @@ client_get_appid(Client *c)
 	if (client_is_x11(c))
 		return c->surface.xwayland->class ? c->surface.xwayland->class : "broken";
 #endif
+	if (!c->surface.xdg)
+		return "broken";
 	return c->surface.xdg->toplevel->app_id ? c->surface.xdg->toplevel->app_id : "broken";
 }
 


### PR DESCRIPTION
## Description
Fixes #412


## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)
