### PR TITLE
fix(keygrabber): route key release events to keygrabber callbacks

### DIFF
--- a/keygrabber.c
+++ b/keygrabber.c
@@ -34,6 +34,7 @@
 #include "luaa.h"
 #include "common/lualib.h"
 #include "somewm_types.h"
+#include "somewm_api.h"
 
 /** Grab the keyboard.
  * \return True if keyboard was grabbed.
@@ -179,25 +180,17 @@ some_keygrabber_is_running(void)
     return globalconf.keygrabber != LUA_REFNIL;
 }
 
-/* somewm-specific: Handle a key event when keygrabber is running
- * Used by somewm.c keyboard event handling
+/* somewm-specific: Handle a key event when keygrabber is running.
+ * Delegates to keygrabber_handlekpress() for argument pushing, then
+ * invokes the Lua callback via pcall.
  */
 bool
-some_keygrabber_handle_key(uint32_t modifiers, xkb_keycode_t keycode, struct xkb_state *state)
+some_keygrabber_handle_key(xkb_keycode_t keycode, struct xkb_state *state, bool is_press)
 {
-    lua_State *L;
-    char keyname[64] = {0};
-
-    if (!state)
+    if (!state || globalconf.keygrabber == LUA_REFNIL)
         return false;
 
-    /* Convert key event to human-readable string. */
-    key_to_text(state, keycode, keyname, sizeof(keyname));
-
-    if (globalconf.keygrabber == LUA_REFNIL)
-        return false;
-
-    L = globalconf_get_lua_State();
+    lua_State *L = globalconf_get_lua_State();
 
     /* Get the callback function from registry */
     lua_rawgeti(L, LUA_REGISTRYINDEX, globalconf.keygrabber);
@@ -207,14 +200,8 @@ some_keygrabber_handle_key(uint32_t modifiers, xkb_keycode_t keycode, struct xkb
         return false;
     }
 
-    /* Push modifiers table using AwesomeWM helper */
-    luaA_pushmodifiers(L, modifiers);
-
-    /* Push key name */
-    lua_pushstring(L, keyname);
-
-    /* Push event type (always "press" for now) */
-    lua_pushstring(L, "press");
+    /* Push modifiers, key name, event type */
+    keygrabber_handlekpress(L, keycode, state, is_press);
 
     /* Call the callback: callback(modifiers, key, event) */
     if (lua_pcall(L, 3, 0, 0) != 0) {
@@ -235,6 +222,70 @@ luaA_keygrabber_setup(lua_State *L)
 {
     /* Register the methods on the table at the top of the stack */
     luaA_setfuncs(L, awesome_keygrabber_lib);
+}
+
+/* ---- _keygrabber test helper module (somewm-specific) ---- */
+
+/** Inject a key event into the keygrabber for testing.
+ * Called from Lua: _keygrabber.inject(keyname, is_press)
+ * Returns: boolean (consumed by keygrabber)
+ *
+ * Unlike root.fake_input(), this routes through the keygrabber callback,
+ * following the same pattern as _gesture.inject().
+ */
+static int
+luaA_keygrabber_inject(lua_State *L)
+{
+    const char *key_str = luaL_checkstring(L, 1);
+    if (lua_gettop(L) < 2)
+        return luaL_error(L, "_keygrabber.inject requires 2 arguments: keyname, is_press");
+    bool is_press = lua_toboolean(L, 2);
+
+    struct xkb_keymap *keymap = some_xkb_get_keymap();
+    struct xkb_state *state = some_xkb_get_state();
+    if (!keymap || !state) {
+        lua_pushboolean(L, 0);
+        return 1;
+    }
+
+    /* Resolve keysym name to keycode */
+    xkb_keysym_t keysym = xkb_keysym_from_name(key_str, XKB_KEYSYM_CASE_INSENSITIVE);
+    if (keysym == XKB_KEY_NoSymbol)
+        return luaL_error(L, "Unknown keysym: %s", key_str);
+
+    xkb_keycode_t keycode = 0;
+    xkb_keycode_t min_kc = xkb_keymap_min_keycode(keymap);
+    xkb_keycode_t max_kc = xkb_keymap_max_keycode(keymap);
+    for (xkb_keycode_t kc = min_kc; kc <= max_kc; kc++) {
+        const xkb_keysym_t *syms;
+        int nsyms = xkb_keymap_key_get_syms_by_level(keymap, kc, 0, 0, &syms);
+        for (int i = 0; i < nsyms; i++) {
+            if (syms[i] == keysym) {
+                keycode = kc;
+                break;
+            }
+        }
+        if (keycode != 0)
+            break;
+    }
+    if (keycode == 0)
+        return luaL_error(L, "Keysym '%s' not in current keymap", key_str);
+
+    bool consumed = some_keygrabber_handle_key(keycode, state, is_press);
+    lua_pushboolean(L, consumed);
+    return 1;
+}
+
+static const struct luaL_Reg awesome_keygrabber_test_lib[] =
+{
+    { "inject", luaA_keygrabber_inject },
+    { NULL, NULL }
+};
+
+void
+luaA_keygrabber_test_setup(lua_State *L)
+{
+    luaA_setfuncs(L, awesome_keygrabber_test_lib);
 }
 
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/luaa.c
+++ b/luaa.c
@@ -2558,6 +2558,11 @@ luaA_init(void)
 	luaA_gesture_setup(globalconf_L);
 	lua_setglobal(globalconf_L, "_gesture");
 
+	/* Setup keygrabber test helper (somewm-specific: inject for tests) */
+	lua_newtable(globalconf_L);
+	luaA_keygrabber_test_setup(globalconf_L);
+	lua_setglobal(globalconf_L, "_keygrabber");
+
 	/* NOTE: The C-based key class is now set up by key_class_setup() above (line 88).
 	 * The old Lua-based implementation below has been disabled to let the C implementation work.
 	 * The C key class provides full AwesomeWM compatibility with proper signal emission
@@ -4460,6 +4465,11 @@ luaA_create_fresh_state(void)
 	lua_newtable(L);
 	luaA_gesture_setup(L);
 	lua_setglobal(L, "_gesture");
+
+	/* Keygrabber test helper */
+	lua_newtable(L);
+	luaA_keygrabber_test_setup(L);
+	lua_setglobal(L, "_keygrabber");
 
 	return L;
 }

--- a/objects/keygrabber.h
+++ b/objects/keygrabber.h
@@ -32,8 +32,9 @@ bool keygrabber_handlekpress(lua_State *, xkb_keycode_t, struct xkb_state *, boo
 
 /* somewm-specific */
 bool some_keygrabber_is_running(void);
-bool some_keygrabber_handle_key(uint32_t modifiers, xkb_keycode_t keycode, struct xkb_state *state);
+bool some_keygrabber_handle_key(xkb_keycode_t keycode, struct xkb_state *state, bool is_press);
 void luaA_keygrabber_setup(lua_State *L);
+void luaA_keygrabber_test_setup(lua_State *L);
 
 #endif
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/somewm.c
+++ b/somewm.c
@@ -3261,12 +3261,15 @@ keypress(struct wl_listener *listener, void *data)
 	/* Check if keygrabber is active - if so, route event to Lua callback.
 	 * Note: Keygrabber is allowed when Lua-locked (for lock screen password input)
 	 * but NOT when externally locked (session-lock-v1 protocol handles that). */
-	if (!locked && event->state == WL_KEYBOARD_KEY_STATE_PRESSED && some_keygrabber_is_running()) {
+	if (!locked && some_keygrabber_is_running()) {
+		bool is_press = event->state == WL_KEYBOARD_KEY_STATE_PRESSED;
 		/* Route to keygrabber callback */
-		if (some_keygrabber_handle_key(mods, keycode, group->wlr_group->keyboard.xkb_state)) {
-			/* Keygrabber handled the event, disable key repeat and return */
-			group->nsyms = 0;
-			wl_event_source_timer_update(group->key_repeat_source, 0);
+		if (some_keygrabber_handle_key(keycode, group->wlr_group->keyboard.xkb_state, is_press)) {
+			/* Only disable key repeat for press events */
+			if (is_press) {
+				group->nsyms = 0;
+				wl_event_source_timer_update(group->key_repeat_source, 0);
+			}
 			return;
 		}
 	}

--- a/spec/awful/keygrabber_release_spec.lua
+++ b/spec/awful/keygrabber_release_spec.lua
@@ -1,0 +1,173 @@
+-- Unit tests for keygrabber key release event handling (issue #409).
+--
+-- Tests that the Lua-level runner() logic correctly handles "release" events:
+-- stop_event, keyreleased_callback, keybinding on_release, signal emission.
+
+local gtable = require "gears.table"
+
+describe("awful.keygrabber release events", function()
+   -- Mock the C-level keygrabber before loading the module, so capi captures it.
+   local captured_grabber = nil
+   local grabber_running = false
+
+   _G.keygrabber = {
+      run = function(cb)
+         captured_grabber = cb
+         grabber_running = true
+      end,
+      stop = function()
+         captured_grabber = nil
+         grabber_running = false
+      end,
+      isrunning = function()
+         return grabber_running
+      end,
+   }
+
+   package.loaded["gears.timer"] = {}
+   package.loaded["awful.keyboard"] = {
+      append_global_keybinding = function() end,
+   }
+   _G.awesome = gtable.join(_G.awesome, { connect_signal = function() end })
+   _G.key = {
+      set_index_miss_handler = function() end,
+      set_newindex_miss_handler = function() end,
+   }
+
+   local akeygrabber = require "awful.keygrabber"
+
+   -- Helper: invoke the captured C-level grabber callback directly.
+   local function send_key(mods, key, event)
+      assert(captured_grabber, "No keygrabber is running")
+      captured_grabber(mods, key, event)
+   end
+
+   after_each(function()
+      -- Stop any lingering keygrabber
+      if grabber_running then
+         _G.keygrabber.stop()
+      end
+   end)
+
+   it("stop_event='release' stops on release, not press", function()
+      local stop_fired = false
+
+      local kg = akeygrabber {
+         stop_key = "Escape",
+         stop_event = "release",
+         stop_callback = function() stop_fired = true end,
+         autostart = true,
+      }
+
+      -- Press should not stop
+      send_key({}, "Escape", "press")
+      assert.is_true(grabber_running)
+      assert.is_false(stop_fired)
+
+      -- Release should stop
+      send_key({}, "Escape", "release")
+      assert.is_true(stop_fired)
+   end)
+
+   it("keyreleased_callback fires on release events", function()
+      local released_key = nil
+
+      local kg = akeygrabber {
+         stop_key = "Escape",
+         keyreleased_callback = function(self, mods, key, event)
+            released_key = key
+         end,
+         autostart = true,
+      }
+
+      send_key({}, "x", "release")
+      assert.are.equal("x", released_key)
+
+      -- Clean up
+      send_key({}, "Escape", "press")
+   end)
+
+   it("keypressed_callback does not fire on release events", function()
+      local pressed_count = 0
+
+      local kg = akeygrabber {
+         stop_key = "Escape",
+         keypressed_callback = function()
+            pressed_count = pressed_count + 1
+         end,
+         autostart = true,
+      }
+
+      send_key({}, "a", "release")
+      assert.are.equal(0, pressed_count)
+
+      send_key({}, "a", "press")
+      assert.are.equal(1, pressed_count)
+
+      -- Clean up
+      send_key({}, "Escape", "press")
+   end)
+
+   it("keybinding on_release handler fires on release", function()
+      local release_called = false
+
+      local fake_binding = {
+         _is_awful_key = true,
+         key = "r",
+         modifiers = {},
+         on_release = function() release_called = true end,
+      }
+
+      local kg = akeygrabber {
+         stop_key = "Escape",
+         keybindings = { fake_binding },
+         autostart = true,
+      }
+
+      send_key({}, "r", "release")
+      assert.is_true(release_called)
+
+      -- Clean up
+      send_key({}, "Escape", "press")
+   end)
+
+   it("emits key::release signal on release event", function()
+      local signal_fired = false
+
+      local kg = akeygrabber {
+         stop_key = "Escape",
+         autostart = true,
+      }
+
+      kg:connect_signal("a::release", function()
+         signal_fired = true
+      end)
+
+      send_key({}, "a", "release")
+      assert.is_true(signal_fired)
+
+      -- Clean up
+      send_key({}, "Escape", "press")
+   end)
+
+   it("key sequence accumulates on release, not press", function()
+      local seq_press = nil
+      local seq_release = nil
+
+      local kg = akeygrabber {
+         stop_key = "Escape",
+         keypressed_callback = function(self) seq_press = self.sequence end,
+         keyreleased_callback = function(self) seq_release = self.sequence end,
+         autostart = true,
+      }
+
+      send_key({}, "h", "press")
+      send_key({}, "h", "release")
+
+      assert.are.equal("", seq_press)
+      assert.are.equal("h", seq_release)
+
+      -- Clean up
+      send_key({}, "Escape", "press")
+   end)
+end)

--- a/tests/test-keygrabber-release.lua
+++ b/tests/test-keygrabber-release.lua
@@ -1,0 +1,152 @@
+-- Test: keygrabber key release events (issue #409).
+--
+-- Verifies that key release events reach keygrabber callbacks via the
+-- _keygrabber.inject() C test helper. Before the fix, the C layer only
+-- forwarded WL_KEYBOARD_KEY_STATE_PRESSED events and hardcoded "press"
+-- as the event type, making stop_event="release" permanently lock the
+-- keyboard and keyreleased_callback dead code.
+
+local runner = require("_runner")
+local awful = require("awful")
+
+local steps = {
+    -- Test 1: Release events reach the raw keygrabber callback
+    function()
+        local events = {}
+
+        keygrabber.run(function(mods, key, event)
+            table.insert(events, {key = key, event = event})
+        end)
+
+        _keygrabber.inject("a", true)
+        _keygrabber.inject("a", false)
+        keygrabber.stop()
+
+        assert(#events == 2, "Expected 2 events, got " .. #events)
+        assert(events[1].event == "press",
+            "First event should be 'press', got '" .. events[1].event .. "'")
+        assert(events[2].event == "release",
+            "Second event should be 'release', got '" .. events[2].event .. "'")
+        assert(events[1].key == "a", "Key should be 'a', got '" .. events[1].key .. "'")
+
+        return true
+    end,
+
+    -- Test 2: stop_event="release" stops on key release, not press
+    function()
+        local stop_fired = false
+        local press_seen = false
+
+        local kg = awful.keygrabber {
+            stop_key = "Escape",
+            stop_event = "release",
+            keypressed_callback = function()
+                press_seen = true
+            end,
+            stop_callback = function()
+                stop_fired = true
+            end,
+            autostart = true,
+        }
+
+        assert(keygrabber.isrunning(), "Keygrabber should be running")
+
+        -- Press Escape: should NOT stop (stop_event is "release")
+        _keygrabber.inject("Escape", true)
+        assert(keygrabber.isrunning(),
+            "Keygrabber should still be running after Escape press")
+        assert(not stop_fired, "stop_callback should not fire on press")
+
+        -- Release Escape: should stop
+        _keygrabber.inject("Escape", false)
+        assert(not keygrabber.isrunning(),
+            "Keygrabber should have stopped after Escape release")
+        assert(stop_fired, "stop_callback should fire on release")
+
+        return true
+    end,
+
+    -- Test 3: keyreleased_callback fires on release events
+    function()
+        local pressed = {}
+        local released = {}
+
+        local kg = awful.keygrabber {
+            keypressed_callback = function(self, mods, key, event)
+                table.insert(pressed, key)
+            end,
+            keyreleased_callback = function(self, mods, key, event)
+                table.insert(released, key)
+            end,
+            stop_key = "Escape",
+            autostart = true,
+        }
+
+        _keygrabber.inject("x", true)
+        _keygrabber.inject("x", false)
+
+        assert(#pressed == 1, "keypressed_callback should fire once, got " .. #pressed)
+        assert(#released == 1, "keyreleased_callback should fire once, got " .. #released)
+        assert(pressed[1] == "x", "Pressed key should be 'x'")
+        assert(released[1] == "x", "Released key should be 'x'")
+
+        -- Clean up
+        _keygrabber.inject("Escape", true)
+
+        return true
+    end,
+
+    -- Test 4: Key sequence accumulates on release, not press
+    function()
+        local seq_after_press = nil
+        local seq_after_release = nil
+
+        local kg = awful.keygrabber {
+            keypressed_callback = function(self)
+                seq_after_press = self.sequence
+            end,
+            keyreleased_callback = function(self)
+                seq_after_release = self.sequence
+            end,
+            stop_key = "Escape",
+            autostart = true,
+        }
+
+        _keygrabber.inject("h", true)
+        _keygrabber.inject("h", false)
+
+        assert(seq_after_press == "",
+            "Sequence should be empty after press, got '" .. tostring(seq_after_press) .. "'")
+        assert(seq_after_release == "h",
+            "Sequence should be 'h' after release, got '" .. tostring(seq_after_release) .. "'")
+
+        -- Clean up
+        _keygrabber.inject("Escape", true)
+
+        return true
+    end,
+
+    -- Test 5: Standalone release event is delivered (regression guard for
+    -- the old WL_KEYBOARD_KEY_STATE_PRESSED-only filter)
+    function()
+        local events = {}
+
+        keygrabber.run(function(mods, key, event)
+            table.insert(events, {key = key, event = event})
+        end)
+
+        -- Only inject a release, no prior press
+        _keygrabber.inject("Return", false)
+        keygrabber.stop()
+
+        assert(#events == 1, "Expected 1 event, got " .. #events)
+        assert(events[1].event == "release",
+            "Event should be 'release', got '" .. events[1].event .. "'")
+        assert(events[1].key == "Return",
+            "Key should be 'Return', got '" .. events[1].key .. "'")
+
+        return true
+    end,
+}
+
+runner.run_steps(steps)


### PR DESCRIPTION
## Description

Key release events never reached keygrabber callbacks. `somewm.c:keypress()` guarded keygrabber dispatch with `WL_KEYBOARD_KEY_STATE_PRESSED`, and `some_keygrabber_handle_key()` hardcoded `"press"` as the event type. This made `stop_event = "release"` permanently lock the keyboard (only recovery was switching to a TTY), and left `keyreleased_callback` as dead code.

This broadens the guard to route both press and release events, refactors `some_keygrabber_handle_key()` to delegate to the existing `keygrabber_handlekpress()` (dropping the redundant `modifiers` parameter), and adds a `_keygrabber.inject()` test helper following the `_gesture.inject()` pattern.

Closes #409

## Test Plan

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)