### PR TITLE
refactor(focus): consolidate focus restoration into single focus_restore()

### DIFF
--- a/lua/awful/permissions/init.lua
+++ b/lua/awful/permissions/init.lua
@@ -867,10 +867,11 @@ if layer_surface then
     layer_surface.connect_signal("request::keyboard", permissions.layer_surface_keyboard)
 end
 
---- Default handler for layer surface unmanage (focus restoration).
+--- Default handler for layer surface unmanage.
 --
--- When a layer surface with keyboard focus closes, this handler restores
--- focus to the previously focused client using the focus history.
+-- Placeholder for user customization. Focus restoration after layer surface
+-- close is handled by the C-level focus_restore() which emits
+-- request::focus_restore on the screen.
 --
 -- @signalhandler awful.permissions.layer_surface_unmanage
 -- @tparam layer_surface l The layer surface being unmanaged.
@@ -879,32 +880,33 @@ end
 -- @sourcesignal layer_surface request::unmanage
 function permissions.layer_surface_unmanage(l, context, hints)
     if not pcommon.check(l, "layer_surface", "unmanage", context) then return end
-
-    -- Restore focus when a keyboard-interactive layer surface closes
-    -- Check both has_keyboard_focus AND keyboard_interactive as the flag may
-    -- be cleared before this handler runs in some edge cases
-    local had_focus = l.has_keyboard_focus
-    local was_keyboard_interactive = l.keyboard_interactive and l.keyboard_interactive ~= "none"
-
-    if had_focus or was_keyboard_interactive then
-        -- Use l.screen if valid, otherwise fall back to focused screen
-        -- NOTE: Use ascreen.focused() not screen.focused() - screen is capi.screen
-        local s = (l.screen and l.screen.valid) and l.screen or ascreen.focused()
-        if s and s.valid then
-            -- Try to find a client to focus using focus history
-            local aclient = require("awful.client")
-            local c = aclient.focus.history.get(s, 0, aclient.focus.filter)
-            if c and c.valid then
-                c:emit_signal("request::activate", "layer_surface_closed", {raise = false})
-            end
-        end
-    end
 end
 
 -- Connect default handler for layer surface unmanage (somewm-specific)
 if layer_surface then
     layer_surface.connect_signal("request::unmanage", permissions.layer_surface_unmanage)
 end
+
+--- Default handler for focus restoration (somewm-specific).
+--
+-- When something closes, unlocks, or disconnects, the C compositor emits
+-- `request::focus_restore` on the relevant screen. This handler picks the
+-- best client from focus history and activates it.
+--
+-- @signalhandler awful.permissions.focus_restore
+-- @tparam screen s The screen that needs focus restored.
+-- @sourcesignal screen request::focus_restore
+function permissions.focus_restore(s)
+    if not s or not s.valid then return end
+
+    -- Find the most recent focusable client on this screen
+    local c = aclient.focus.history.get(s, 0, aclient.focus.filter)
+    if c and c.valid then
+        c:emit_signal("request::activate", "focus_restore", {raise = false})
+    end
+end
+
+screen.connect_signal("request::focus_restore", permissions.focus_restore)
 
 --- Saved tag metadata from disconnected screens, keyed by output connector name.
 --

--- a/somewm.c
+++ b/somewm.c
@@ -198,6 +198,7 @@ Monitor *dirtomon(enum wlr_direction dir);
 static void apply_input_settings_to_device(struct libinput_device *device);
 void focusclient(Client *c, int lift);
 void focusmon(const Arg *arg);
+void focus_restore(Monitor *m);
 Client *focustop(Monitor *m);
 static void fullscreennotify(struct wl_listener *listener, void *data);
 static void foreign_toplevel_request_activate(struct wl_listener *listener, void *data);
@@ -1426,7 +1427,7 @@ closemon(Monitor *m)
 		selmon ? selmon->wlr_output->name : "NULL",
 		nclients);
 
-	focusclient(focustop(selmon), 1);
+	focus_restore(selmon);
 	printstatus();
 }
 
@@ -2272,6 +2273,11 @@ destroylayersurfacenotify(struct wl_listener *listener, void *data)
 {
 	LayerSurface *l = wl_container_of(listener, l, destroy);
 
+	/* Defensive: clear exclusive_focus if the destroyed surface held it
+	 * (shouldn't happen per Wayland spec - unmap fires before destroy) */
+	if (l == exclusive_focus)
+		exclusive_focus = NULL;
+
 	wl_list_remove(&l->link);
 	wl_list_remove(&l->destroy.link);
 	wl_list_remove(&l->unmap.link);
@@ -2290,7 +2296,7 @@ destroylock(SessionLock *lock, int unlock)
 
 	wlr_scene_node_set_enabled(&locked_bg->node, 0);
 
-	focusclient(focustop(selmon), 0);
+	focus_restore(selmon);
 	motionnotify(0, NULL, 0, 0, 0, 0);
 
 destroy:
@@ -2319,7 +2325,7 @@ destroylocksurface(struct wl_listener *listener, void *data)
 		surface = wl_container_of(cur_lock->surfaces.next, surface, link);
 		client_notify_enter(surface->surface, wlr_seat_get_keyboard(seat));
 	} else if (!locked) {
-		focusclient(focustop(selmon), 1);
+		focus_restore(selmon);
 	} else {
 		wlr_seat_keyboard_clear_focus(seat);
 	}
@@ -2407,7 +2413,7 @@ some_deactivate_lua_lock(void)
 	if (pre_lock_focused_client && pre_lock_focused_client->scene) {
 		focusclient(pre_lock_focused_client, 1);
 	} else {
-		focusclient(focustop(selmon), 1);
+		focus_restore(selmon);
 	}
 	pre_lock_focused_client = NULL;
 	motionnotify(0, NULL, 0, 0, 0, 0);
@@ -2902,7 +2908,7 @@ focusmon(const Arg *arg)
 			selmon = dirtomon(arg->i);
 		while (!selmon->wlr_output->enabled && i++ < nmons);
 	}
-	focusclient(focustop(selmon), 1);
+	focus_restore(selmon);
 }
 
 /* We probably should change the name of this: it sounds like it
@@ -2916,6 +2922,36 @@ focustop(Monitor *m)
 			return *c;
 	}
 	return NULL;
+}
+
+/* Single entry point for restoring focus after something closed, unlocked,
+ * or disconnected. Emits request::focus_restore on the screen so Lua can
+ * pick the right client from focus history. Falls back to focustop() when
+ * Lua is unavailable or doesn't handle it. */
+void
+focus_restore(Monitor *m)
+{
+	if (session_is_locked())
+		return;
+
+	if (!m)
+		m = selmon;
+
+	if (globalconf_L) {
+		lua_State *L = globalconf_get_lua_State();
+		screen_t *screen = luaA_screen_get_by_monitor(L, m);
+		if (screen) {
+			luaA_object_push(L, screen);
+			luaA_object_emit_signal(L, -1, "request::focus_restore", 0);
+			lua_pop(L, 1);
+			/* If Lua set a focused client, we're done */
+			if (globalconf.focus.client)
+				return;
+		}
+	}
+
+	/* Fallback: focus topmost client on the monitor */
+	focusclient(focustop(m), 1);
 }
 
 void
@@ -5651,7 +5687,7 @@ tagmon(const Arg *arg)
 	Client *sel = focustop(selmon);
 	if (sel) {
 		setmon(sel, dirtomon(arg->i), 0);
-		focusclient(focustop(selmon), 1);
+		focus_restore(selmon);
 	}
 }
 
@@ -5701,10 +5737,9 @@ unmaplayersurfacenotify(struct wl_listener *listener, void *data)
 
 	l->mapped = 0;
 	wlr_scene_node_set_enabled(&l->scene->node, 0);
-	if (l == exclusive_focus) {
+	if (l == exclusive_focus)
 		exclusive_focus = NULL;
-		focusclient(focustop(selmon), 1);
-	}
+
 	if (l->layer_surface->output && (l->mon = l->layer_surface->output->data))
 		arrangelayers(l->mon);
 
@@ -5712,6 +5747,9 @@ unmaplayersurfacenotify(struct wl_listener *listener, void *data)
 	if (l->lua_object && globalconf_L) {
 		layer_surface_emit_unmanage(l->lua_object);
 	}
+
+	/* Restore focus via Lua history on the layer surface's monitor */
+	focus_restore(l->mon ? l->mon : selmon);
 
 	motionnotify(0, NULL, 0, 0, 0, 0);
 }
@@ -5755,7 +5793,7 @@ unmapnotify(struct wl_listener *listener, void *data)
 	if (client_is_unmanaged(c)) {
 		if (c == exclusive_focus) {
 			exclusive_focus = NULL;
-			focusclient(focustop(selmon), 1);
+			focus_restore(c->mon ? c->mon : selmon);
 		}
 	} else {
 		/* AwesomeWM pattern: call client_unmanage() from unmapnotify.
@@ -6008,7 +6046,7 @@ updatemons(struct wl_listener *listener, void *data)
 				setmon(c, selmon, 0);
 			}
 		}
-		focusclient(focustop(selmon), 1);
+		focus_restore(selmon);
 		if (selmon->lock_surface) {
 			client_notify_enter(selmon->lock_surface->surface,
 					wlr_seat_get_keyboard(seat));

--- a/tests/test-focus-history.lua
+++ b/tests/test-focus-history.lua
@@ -129,7 +129,9 @@ local steps = {
             count, client.focus and client.focus.class or "nil"))
 
         if client.focus == client_b then
-            io.stderr:write("[TEST] PASS: focus moved to client B (correct focus history)\n")
+            assert(client_b:has_keyboard_focus(),
+                "Client B regained visual focus but NOT keyboard focus (seat desync)")
+            io.stderr:write("[TEST] PASS: focus moved to client B (correct focus history + keyboard)\n")
             return true
         end
 

--- a/tests/test-layer-shell-focus-sloppy.lua
+++ b/tests/test-layer-shell-focus-sloppy.lua
@@ -1,0 +1,265 @@
+---------------------------------------------------------------------------
+--- Test: layer-shell focus restoration with sloppy focus enabled
+--
+-- Verifies that when a layer-shell surface closes, focus returns to the
+-- correct client even when sloppy focus (mouse::enter) is enabled and the
+-- mouse cursor is positioned over a different client.
+--
+-- This is the exact scenario from issue #414: two windows, rofi opens and
+-- closes, focus should return to the previously focused window, not the one
+-- under the cursor.
+--
+-- Uses test-layer-client for deterministic, instant layer surface creation.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local test_client = require("_client")
+local utils = require("_utils")
+local awful = require("awful")
+
+-- Path to test-layer-client (built by meson)
+local TEST_LAYER_CLIENT = "./build-test/test-layer-client"
+
+-- Check if test-layer-client exists
+local function is_test_layer_client_available()
+    local f = io.open(TEST_LAYER_CLIENT, "r")
+    if f then
+        f:close()
+        return true
+    end
+    return false
+end
+
+-- Skip test if requirements not met
+if not is_test_layer_client_available() then
+    io.stderr:write("SKIP: test-layer-client not found (run meson compile first)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+if not test_client.is_available() then
+    io.stderr:write("SKIP: no terminal available for test clients\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local client_a, client_b
+local layer_pid
+local layer_surf
+
+-- Enable sloppy focus (mouse::enter activates client) to match default rc.lua
+local sloppy_handler = function(c)
+    c:activate { context = "mouse_enter", raise = false }
+end
+client.connect_signal("mouse::enter", sloppy_handler)
+
+-- Use tiled layout so clients are side-by-side with predictable geometry
+awful.screen.focused().selected_tag.layout = awful.layout.suit.tile
+
+local steps = {
+    -- Step 1: Spawn client A
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning client A...\n")
+            test_client("sloppy_test_a")
+        end
+        client_a = utils.find_client_by_class("sloppy_test_a")
+        if client_a then
+            io.stderr:write("[TEST] Client A spawned\n")
+            return true
+        end
+        return nil
+    end,
+
+    -- Step 2: Wait for client A to have focus
+    function(count)
+        if client.focus == client_a then
+            io.stderr:write("[TEST] Client A has focus\n")
+            return true
+        end
+        if count > 10 then
+            error(string.format("Expected client A to have focus, got %s",
+                client.focus and client.focus.class or "nil"))
+        end
+        return nil
+    end,
+
+    -- Step 3: Spawn client B
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning client B...\n")
+            test_client("sloppy_test_b")
+        end
+        client_b = utils.find_client_by_class("sloppy_test_b")
+        if client_b then
+            io.stderr:write("[TEST] Client B spawned\n")
+            return true
+        end
+        return nil
+    end,
+
+    -- Step 4: Wait for client B to have focus
+    function(count)
+        if client.focus == client_b then
+            io.stderr:write("[TEST] Client B has focus\n")
+            return true
+        end
+        if count > 10 then
+            error(string.format("Expected client B to have focus, got %s",
+                client.focus and client.focus.class or "nil"))
+        end
+        return nil
+    end,
+
+    -- Step 5: Move mouse over client A (but keep keyboard focus on B)
+    function(count)
+        if count == 1 then
+            -- Position cursor in the center of client A's geometry
+            local geo = client_a:geometry()
+            local cx = geo.x + geo.width / 2
+            local cy = geo.y + geo.height / 2
+            io.stderr:write(string.format("[TEST] Moving mouse to client A at (%d, %d)...\n", cx, cy))
+            -- Use ignore_enter_notify=true to suppress the sloppy focus effect
+            mouse.coords({x = cx, y = cy}, true)
+        end
+        -- Ensure B still has focus after mouse move (ignore_enter_notify=true
+        -- should have suppressed the sloppy focus effect)
+        if client.focus == client_b then
+            io.stderr:write("[TEST] Mouse over A, B still has focus\n")
+            return true
+        end
+        if count > 10 then
+            error(string.format("Expected client B to have focus, got %s",
+                client.focus and client.focus.class or "nil"))
+        end
+        return nil
+    end,
+
+    -- Step 6: Spawn test-layer-client (layer-shell surface with exclusive keyboard)
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning test-layer-client...\n")
+            layer_pid = awful.spawn(TEST_LAYER_CLIENT .. " --namespace test-sloppy --keyboard exclusive")
+        end
+
+        -- Wait for layer surface to appear
+        if layer_surface then
+            for _, ls in ipairs(layer_surface.get()) do
+                if ls.namespace and ls.namespace:match("test%-sloppy") then
+                    layer_surf = ls
+                    io.stderr:write("[TEST] Layer surface appeared\n")
+                    return true
+                end
+            end
+        end
+
+        if count > 20 then
+            io.stderr:write("[TEST] ERROR: layer surface did not appear\n")
+            return true
+        end
+        return nil
+    end,
+
+    -- Step 7: Verify layer surface has keyboard focus
+    function(count)
+        if not layer_surf then
+            io.stderr:write("[TEST] SKIP: layer surface not found\n")
+            return true
+        end
+
+        if layer_surf.has_keyboard_focus then
+            io.stderr:write("[TEST] Layer surface has keyboard focus\n")
+            return true
+        end
+
+        if count > 20 then
+            io.stderr:write("[TEST] ERROR: layer surface did not get keyboard focus\n")
+            return true
+        end
+        return nil
+    end,
+
+    -- Step 8: Close layer surface (kill the test-layer-client process)
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Closing layer surface...\n")
+            if layer_pid then
+                os.execute("kill -9 " .. layer_pid .. " 2>/dev/null")
+            end
+        end
+
+        -- Wait for layer surface to be gone
+        if layer_surface then
+            local still_exists = false
+            for _, ls in ipairs(layer_surface.get()) do
+                if ls.namespace and ls.namespace:match("test%-sloppy") then
+                    still_exists = true
+                    break
+                end
+            end
+            if not still_exists then
+                io.stderr:write("[TEST] Layer surface closed\n")
+                return true
+            end
+        else
+            if count > 10 then return true end
+        end
+        return nil
+    end,
+
+    -- Step 9: Verify focus returns to client B (not A which is under the cursor)
+    function(count)
+        if count < 3 then return nil end
+
+        io.stderr:write(string.format(
+            "[TEST] Checking focus (attempt %d): client.focus=%s\n",
+            count, client.focus and client.focus.class or "nil"))
+
+        if client.focus == client_b then
+            assert(client_b:has_keyboard_focus(),
+                "Client B regained visual focus but NOT keyboard focus (seat desync)")
+            io.stderr:write("[TEST] PASS: focus returned to client B (correct, not sloppy-focused A)\n")
+            return true
+        end
+
+        if count > 10 then
+            local got = client.focus and client.focus.class or "nil"
+            local kb_a = client_a and client_a.valid and client_a:has_keyboard_focus()
+            local kb_b = client_b and client_b.valid and client_b:has_keyboard_focus()
+            error(string.format(
+                "Expected focus to return to client B, got %s "..
+                "(A has_keyboard_focus=%s, B has_keyboard_focus=%s)",
+                got, tostring(kb_a), tostring(kb_b)))
+        end
+        return nil
+    end,
+
+    -- Step 10: Cleanup
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Cleanup\n")
+            client.disconnect_signal("mouse::enter", sloppy_handler)
+            if client_a and client_a.valid then client_a:kill() end
+            if client_b and client_b.valid then client_b:kill() end
+            os.execute("pkill -9 test-layer-client 2>/dev/null")
+        end
+
+        if #client.get() == 0 then
+            return true
+        end
+
+        if count >= 10 then
+            local pids = test_client.get_spawned_pids()
+            for _, pid in ipairs(pids) do
+                os.execute("kill -9 " .. pid .. " 2>/dev/null")
+            end
+            return true
+        end
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-lock-focus-management.lua
+++ b/tests/test-lock-focus-management.lua
@@ -45,11 +45,13 @@ runner.run_steps({
         return true
     end,
 
-    -- Verify focus restored to same client
+    -- Verify focus restored to same client (both Lua bookkeeping and keyboard)
     function(count)
         if count < 2 then return end
         assert(client.focus == focused_before_lock,
             "BEH-6: focus should be restored to pre-lock client")
+        assert(focused_before_lock:has_keyboard_focus(),
+            "BEH-6: pre-lock client should have Wayland keyboard focus after unlock")
         return true
     end,
 
@@ -64,6 +66,8 @@ runner.run_steps({
     function(count)
         if count < 2 then return end
         assert(client.focus ~= nil, "focus should exist after second lock/unlock cycle")
+        assert(client.focus:has_keyboard_focus(),
+            "focused client should have Wayland keyboard focus after second unlock")
         return true
     end,
 


### PR DESCRIPTION
## Description

Consolidate 8 scattered `focusclient(focustop(selmon), N)` call sites into a single `focus_restore(Monitor *m)` function. The new function emits `request::focus_restore` on the relevant screen so Lua can pick the correct client from focus history, falling back to `focustop()` when Lua is unavailable.

Previously, multiple independent focus restoration paths could disagree or use the wrong monitor:
- C path always used `selmon` (wrong for layer surfaces on a different monitor)
- Lua `layer_surface_unmanage` handler used `l.screen` + focus history
- Both ran sequentially in `unmaplayersurfacenotify`, potentially conflicting

Now `focus_restore()` is the single authority. Other changes:
- `unmaplayersurfacenotify` passes `l->mon` instead of `selmon`
- `destroylayersurfacenotify` defensively clears `exclusive_focus`
- Layer surface unmanage handler no longer duplicates focus restoration
- Tests strengthened with `has_keyboard_focus()` assertions
- New test for sloppy focus + layer surface close scenario

Relates to #414.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)