### PR TITLE
fix: deliver pointer enter to newly mapped layer surfaces

### DIFF
--- a/protocols.c
+++ b/protocols.c
@@ -218,6 +218,16 @@ commitlayersurfacenotify(struct wl_listener *listener, void *data)
 
 	arrangelayers(l->mon);
 
+	/* When a layer surface maps, re-evaluate pointer focus so that
+	 * wl_pointer.enter is delivered if the cursor is already over it.
+	 * Without this, hover doesn't work until the user moves the mouse.
+	 * Similar to sway's cursor_rebase_all() in handle_map(), but uses
+	 * motionnotify(0,...) which re-runs xytonode() + pointerfocus()
+	 * without emitting Lua mouse signals (those are gated on time != 0).
+	 * Skip when exclusive_focus is active to avoid disrupting grabs. */
+	if (!was_mapped && l->mapped && !exclusive_focus)
+		motionnotify(0, NULL, 0, 0, 0, 0);
+
 	/* Emit property change signals for Lua (matches AwesomeWM pattern) */
 	if (l->lua_object && globalconf_L && layer_surface->current.committed) {
 		lua_State *L = globalconf_get_lua_State();


### PR DESCRIPTION
## Summary

When a layer-shell surface maps under a stationary cursor, it does not receive `wl_pointer.enter` until the user physically moves the mouse. This breaks hover interactions on panels/overlays that appear under the cursor (e.g. wlr-layer-shell panels triggered by screen edge hover).

## Root cause

`commitlayersurfacenotify()` detects layer surface map transitions (`was_mapped=0 → l->mapped=1`) but does not re-evaluate pointer focus afterward. The cursor remains focused on whatever was under it before the surface appeared.

Sway handles this via `cursor_rebase_all()` in `handle_map()` (`sway/desktop/layer_shell.c`). somewm's own `unmaplayersurfacenotify()` already calls `motionnotify(0, NULL, 0, 0, 0, 0)` for the reverse case (unmap).

## Fix

Add `motionnotify(0, NULL, 0, 0, 0, 0)` after `arrangelayers()` when a layer surface transitions from unmapped to mapped.

```c
if (!was_mapped && l->mapped && !exclusive_focus)
    motionnotify(0, NULL, 0, 0, 0, 0);
```

## Design decisions

- **After `arrangelayers()`**: scene node geometry must be updated before `xytonode()` hit-test
- **`!exclusive_focus` guard**: prevents disrupting keyboard grabs (e.g. session lock)
- **`time=0`**: only runs `xytonode()` + `pointerfocus()` for `wl_pointer` delivery, skips Lua mouse signals
- **`CurPressed` safe**: `motionnotify()` keeps focus on drag target when button is held

Regular clients (XDG/XWayland) are not affected — `mapnotify()` already has a cursor-in-geometry check with direct `pointerfocus()` call.

## Test plan

- [ ] Layer surface maps under stationary cursor → receives `wl_pointer.enter` immediately
- [ ] Layer surface maps while `exclusive_focus` is active → no disruption
- [ ] Layer surface maps while mouse button held → no focus steal mid-drag
- [ ] Layer surface unmaps under cursor → focus returns to surface below (existing behavior, unchanged)
- [ ] Multi-output: layer surface maps on non-focused output → no spurious pointer events