### PR TITLE
fix(hot-reload): recreate output objects in new Lua state

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -5223,6 +5223,10 @@ luaA_hot_reload(void)
 		lua_pop(L, 1);  /* luaA_screen_new leaves screen on stack */
 	}
 
+	/* Outputs are independent of screens (disabled monitors still have
+	 * outputs). Must exist before rc.lua so added::connected works. */
+	luaA_output_hot_reload(L);
+
 	/* Load and execute rc.lua.
 	 * Screens already exist (created above). When rc.lua registers handlers
 	 * for request::desktop_decoration etc., the ::connected pattern

--- a/objects/output.c
+++ b/objects/output.c
@@ -187,6 +187,22 @@ luaA_output_invalidate(lua_State *L, output_t *o)
 	luaA_object_unref(L, o);
 }
 
+void
+luaA_output_hot_reload(lua_State *L)
+{
+	Monitor *m;
+
+	/* Discard stale registry refs from the old Lua state */
+	output_count = 0;
+
+	/* Recreate output objects for all physical monitors */
+	wl_list_for_each(m, &mons, link) {
+		m->output = luaA_output_new(L, m);
+		if (m->output)
+			lua_pop(L, 1);
+	}
+}
+
 /* ========================================================================
  * Instance property getters (read-only)
  * ======================================================================== */

--- a/objects/output.h
+++ b/objects/output.h
@@ -29,6 +29,7 @@ output_t *luaA_output_new(lua_State *L, Monitor *m);
 output_t *luaA_output_new_virtual(lua_State *L, const char *name);
 void luaA_output_push(lua_State *L, output_t *output);
 void luaA_output_invalidate(lua_State *L, output_t *output);
+void luaA_output_hot_reload(lua_State *L);
 
 /* Set output scale from C (used by screen.scale delegation).
  * Expects the output userdata at stack position `ud_idx` and scale value at top of stack. */


### PR DESCRIPTION
## Description

Fixes #435.

Output objects were never recreated during hot-reload. The `output_refs` array retained stale Lua registry indices from the old state, causing:
- SEGV in `output.get_by_name()` (strcmp on garbage pointer)
- All output metadata (description, make, model, serial) returning nil
- UB when reading `valid` field from stale userdata

Adds `luaA_output_hot_reload()` which resets stale refs and recreates output objects for all physical monitors before rc.lua loads. This mirrors the existing screen recreation pattern (screens had the same two-step reset+recreate, outputs were missed).

## Test Plan

- `make test-unit` (758/758 pass) and `make test-integration` (112/112 pass)

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)