### PR TITLE
fix(lgi): clean up stale GLib sources on config timeout

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -4155,6 +4155,57 @@ luaA_enhance_lua_compat_error(const char *err, char *buf, size_t bufsize)
 	return false;
 }
 
+/** Remove all GLib sources registered by Lua code and bump the Lgi closure
+ * guard generation. This prevents stale FFI closures from dispatching against
+ * a dead Lua state (either closed after config timeout or leaked after
+ * hot-reload).
+ *
+ * \param label Caller label for the log message (e.g. "config-timeout" or "hot-reload").
+ */
+static void
+luaA_cleanup_stale_glib_sources(const char *label)
+{
+	/* Remove all GLib sources registered by Lua code (Lgi, awful.spawn,
+	 * dbus watchers, timers, etc.). These sources hold FFI closures with
+	 * lua_State* pointers to the old Lua VM. If GLib dispatches them after
+	 * state teardown, lua_rawgeti(freed_L, ...) -> SEGV.
+	 *
+	 * Probe first to get the exact upper bound - all Lua-registered sources
+	 * have IDs in [baseline+1, probe_id-1]. No guesswork needed. */
+	{
+		GMainContext *ctx = g_main_context_default();
+		guint baseline = globalconf.glib_source_baseline;
+		GSource *probe = g_idle_source_new();
+		guint upper = g_source_attach(probe, ctx);
+		g_source_destroy(probe);
+		g_source_unref(probe);
+
+		guint removed = 0;
+		for (guint id = baseline + 1; id < upper; id++) {
+			GSource *src = g_main_context_find_source_by_id(ctx, id);
+			if (src) {
+				g_source_destroy(src);
+				removed++;
+			}
+		}
+		globalconf.glib_source_baseline = upper;
+		fprintf(stderr, "somewm: %s: removed %u stale GLib sources "
+			"(baseline=%u, new_baseline=%u)\n", label, removed, baseline, upper);
+	}
+
+	/* Bump Lgi closure generation - all old closures become no-ops.
+	 * lgi_closure_guard.so must be LD_PRELOADed for this to work. */
+	{
+		void (*bump)(void) = dlsym(RTLD_DEFAULT, "lgi_guard_bump_generation");
+		if (bump) {
+			bump();
+		} else {
+			fprintf(stderr, "somewm: %s: WARNING: lgi_closure_guard.so "
+				"not preloaded, stale closures may crash\n", label);
+		}
+	}
+}
+
 void
 luaA_loadrc(void)
 {
@@ -4386,7 +4437,14 @@ luaA_loadrc(void)
 			        config_paths[i]);
 
 			/* CRITICAL: Lua state is corrupted after siglongjmp.
-			 * We must recreate it before trying the next config. */
+			 * We must recreate it before trying the next config.
+			 *
+			 * Clean up GLib sources FIRST - they hold FFI closures
+			 * with lua_State* pointers. Without this, g_main_loop_run()
+			 * dispatches stale closures against freed memory -> SEGV.
+			 * Skip GDBus close here (it calls g_bus_get_sync which
+			 * could itself block if D-Bus was what caused the timeout). */
+			luaA_cleanup_stale_glib_sources("config-timeout");
 			luaA_signal_cleanup();
 			luaA_keybinding_cleanup();
 			lua_close(globalconf_L);
@@ -5005,45 +5063,8 @@ luaA_hot_reload(void)
 		}
 	}
 
-	/* Remove all GLib sources registered by Lua code (Lgi, awful.spawn,
-	 * dbus watchers, timers, etc.). These sources hold FFI closures with
-	 * lua_State* pointers to the old Lua VM. If GLib dispatches them after
-	 * reload, lua_status(NULL) -> SEGV.
-	 *
-	 * Probe first to get the exact upper bound - all Lua-registered sources
-	 * have IDs in [baseline+1, probe_id-1]. No guesswork needed. */
-	{
-		GMainContext *ctx = g_main_context_default();
-		guint baseline = globalconf.glib_source_baseline;
-		GSource *probe = g_idle_source_new();
-		guint upper = g_source_attach(probe, ctx);
-		g_source_destroy(probe);
-		g_source_unref(probe);
-
-		guint removed = 0;
-		for (guint id = baseline + 1; id < upper; id++) {
-			GSource *src = g_main_context_find_source_by_id(ctx, id);
-			if (src) {
-				g_source_destroy(src);
-				removed++;
-			}
-		}
-		globalconf.glib_source_baseline = upper;
-		fprintf(stderr, "somewm: hot-reload: removed %u stale GLib sources "
-			"(baseline=%u, new_baseline=%u)\n", removed, baseline, upper);
-	}
-
-	/* Bump Lgi closure generation - all old closures become no-ops.
-	 * lgi_closure_guard.so must be LD_PRELOADed for this to work. */
-	{
-		void (*bump)(void) = dlsym(RTLD_DEFAULT, "lgi_guard_bump_generation");
-		if (bump) {
-			bump();
-		} else {
-			fprintf(stderr, "somewm: hot-reload: WARNING: lgi_closure_guard.so "
-				"not preloaded, second reload may crash\n");
-		}
-	}
+	/* Remove stale GLib sources and bump Lgi closure generation. */
+	luaA_cleanup_stale_glib_sources("hot-reload");
 
 	/* Leak the old Lua state. lua_close() is unsafe because client
 	 * snapshots, screens, and other C objects still reference Lua

--- a/tests/test-floating-layout.lua
+++ b/tests/test-floating-layout.lua
@@ -15,15 +15,9 @@ local awful = require("awful")
 local runner = require("_runner")
 local test_client = require("_client")
 
--- Capture initial geometry of newly managed clients
-local managed_geos = {}
-client.connect_signal("request::manage", function(c)
-    managed_geos[c] = { width = c.width, height = c.height }
-end)
-
 runner.run_steps({
     -- =================================================================
-    -- SCENARIO 1: Switch tiling → floating, windows must keep tiled size
+    -- SCENARIO 1: Switch tiling -> floating, windows must keep tiled size
     -- =================================================================
     function()
         -- Start in tiling layout, spawn 3 clients
@@ -38,9 +32,8 @@ runner.run_steps({
         if #client.get() < 3 then return end
 
         -- Record tiled geometries before switch
-        local wa = awful.screen.focused().workarea
         local pre_geos = {}
-        for i, c in ipairs(client.get()) do
+        for _, c in ipairs(client.get()) do
             local g = c:geometry()
             pre_geos[c] = { width = g.width, height = g.height }
         end
@@ -56,41 +49,48 @@ runner.run_steps({
                 "BUG: client '" .. (c.class or "?") ..
                 "' grew from " .. pre.width .. "x" .. pre.height ..
                 " to " .. g.width .. "x" .. g.height ..
-                " after tiling→floating switch")
+                " after tiling->floating switch")
         end
         return true
     end,
 
     -- =================================================================
-    -- SCENARIO 2: New window in floating layout — initial size check
+    -- SCENARIO 2: New window in floating layout must not be forced to
+    -- workarea size. We record geometry at manage time (before the
+    -- client can resize itself) and verify the compositor did not set
+    -- it to the full workarea.
     -- =================================================================
     function()
-        -- Still in floating layout — spawn a new client
-        _G._pre_spawn_count = #client.get()
+        -- Still in floating layout. Capture manage-time geometry via
+        -- a one-shot signal so we observe what the compositor chose,
+        -- not what the terminal later resized to.
+        _G._float_manage_geo = nil
+        _G._float_manage_conn = function(c)
+            _G._float_manage_geo = { width = c.width, height = c.height }
+            client.disconnect_signal("request::manage", _G._float_manage_conn)
+        end
+        client.connect_signal("request::manage", _G._float_manage_conn)
         test_client(nil, "float_new")
         return true
     end,
     function()
-        -- Wait for the new client
-        local cls = client.get()
-        if #cls <= _G._pre_spawn_count then return end
+        -- Wait for the manage signal to fire
+        if not _G._float_manage_geo then return end
 
         local wa = awful.screen.focused().workarea
-        local new_client = cls[#cls]
-        local g = new_client:geometry()
+        local g = _G._float_manage_geo
 
-        -- Retry until the client settles to its preferred size.
-        -- Under load, the initial geometry may briefly be workarea-sized
-        -- before the client commits its preferred dimensions.
-        if g.width >= wa.width - 10 and g.height >= wa.height - 10 then
-            return
-        end
-
+        -- The compositor must not have forced the client to fill
+        -- the workarea. Allow a small tolerance for borders.
+        assert(g.width < wa.width - 10 or g.height < wa.height - 10,
+            "BUG: new client in floating layout was forced to workarea size " ..
+            g.width .. "x" .. g.height ..
+            " (workarea " .. wa.width .. "x" .. wa.height .. ")")
         return true
     end,
 
     -- =================================================================
-    -- SCENARIO 3: Tile → float → tile → float cycle
+    -- SCENARIO 3: Tile -> float -> tile -> float cycle
     -- =================================================================
     function()
         awful.layout.set(awful.layout.suit.tile)
@@ -115,7 +115,7 @@ runner.run_steps({
                 "BUG: client '" .. (c.class or "?") ..
                 "' grew from " .. tg.width .. "x" .. tg.height ..
                 " to " .. g.width .. "x" .. g.height ..
-                " after tile→float→tile→float cycle")
+                " after tile->float->tile->float cycle")
         end
         return true
     end,


### PR DESCRIPTION
## Description

When rc.lua loading times out, the timeout handler closes the Lua state but does not clean up GLib sources or bump the lgi closure guard generation. After the fallback config loads, `g_main_loop_run()` dispatches stale lgi closures that dereference freed Lua state memory, causing a SEGV in `lua_rawgeti`.

Extracts the GLib source sweep and closure guard bump from the hot-reload path into `luaA_cleanup_stale_glib_sources()` and calls it from both the timeout handler and hot-reload. Skips the GDBus close in the timeout path since `g_bus_get_sync` could itself block if D-Bus was what caused the timeout.

Also fixes flaky `test-floating-layout`: scenario 2 polled geometry in a retry loop waiting for the terminal to settle, which timed out under full-suite load. Replaced with a one-shot `request::manage` signal capture that observes manage-time geometry directly.

Related: #434

## Test Plan

- `make test-unit` (758/758 pass)
- `make test-integration` (111/111 pass, 2 consecutive runs)
- `test-floating-layout` passes 5/5 in isolation and 2/2 in full suite (was flaky before)

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified**
- [x] Tests pass (`make test-unit && make test-integration`)