### PR TITLE
chore: prepare main for 2.0 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to somewm will be documented in this file.
 
+## [2.0.0-dev] - Unreleased
+
+### Added
+
+### Fixed
+
+### Changed
+
 ## [1.4.0] - 2026-04-07
 
 First stable release. SomeWM 1.4 = AwesomeWM 4.4 on Wayland.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,15 @@
 # Contributing to somewm
 
-## The North Star
+**The public Lua API should be preserved where possible.** Function signatures, signal names, and property names should stay compatible so existing `rc.lua` configs work, but some changes are inevitable as 2.0 evolves.
 
-**Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) must stay identical to AwesomeWM's.**
+Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) were originally copied from [AwesomeWM](https://github.com/awesomeWM/awesome/tree/master/lib). When in doubt, check AwesomeWM's source for how things are supposed to work.
 
-These are copied directly from [AwesomeWM](https://github.com/awesomeWM/awesome/tree/master/lib) and must not diverge. If something crashes or misbehaves in Lua, the fix belongs in C — the bug is almost always a missing API, wrong signal timing, or incomplete object lifecycle in the compositor layer.
+## Branches
 
-When in doubt, check [AwesomeWM's source](https://github.com/awesomeWM/awesome) for how things are supposed to work.
+- **`release/1.4`**: AwesomeWM compatibility branch. Tracks AwesomeWM master, ports upstream PRs, and maintains strict(ish) API parity. Bugfixes and upstream ports go here.
+- **`main`**: SomeWM 2.0. New architecture, new features, Wayland-native direction. The public Lua API stays compatible, but internals and new capabilities diverge from AwesomeWM.
+
+If your PR is a bugfix that applies to both, target `release/1.4` and it will be cherry-picked to `main`.
 
 ## Building
 
@@ -32,8 +35,16 @@ make test-one TEST=tests/test-foo.lua  # Single test (handy for TDD)
 | Wayland deviations | `DEVIATIONS.md` |
 | Integration test examples | `tests/` |
 
+## AI Usage
+
+AI tools are welcome, but:
+
+- **Disclose it.** State what tool you used and the extent of the assistance.
+- **Understand it.** If you can't explain what your changes do and how they interact with the rest of the codebase without AI, don't submit them.
+
 ## Submitting a PR
 
+- Discuss your approach in an [issue](https://github.com/trip-zip/somewm/issues) or [discussion](https://github.com/trip-zip/somewm/discussions) before opening a PR
 - Fix bugs in C, not by patching Lua libraries
 - Include a test when possible (`tests/test-*.lua`)
 - Run `make test-unit && make test-integration` before pushing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-# somewm - AwesomeWM for Wayland
+# somewm
 
-**somewm** is AwesomeWM ported to Wayland, built on [wlroots](https://gitlab.freedesktop.org/wlroots/wlroots) 0.19. It implements AwesomeWM's full Lua API - your `rc.lua`, widgets, and themes carry over with no changes. somewm supports LuaJIT as well as Lua 5.4, 5.3, 5.2, and 5.1.
+A Lua framework for building your Wayland desktop. Layouts, widgets, keybindings, window rules, notifications, status bars, etc.
+
+SomeWM has a complete widget system, a signal-driven object model, and a compositor runtime, all wired together so every piece can talk to every other piece. Write a widget that reacts to window focus changes. Build a layout that adapts to screen geometry. Script your entire workflow from `rc.lua` or from the command line.
+
+Built on [wlroots](https://gitlab.freedesktop.org/wlroots/wlroots) 0.19. Compatible with [AwesomeWM's](https://github.com/awesomeWM/awesome) Lua API - existing configs, widgets, and themes carry over.
+
+> **This branch (`main`) is 2.0-dev.** If you want 100% AwesomeWM parity, use the [`release/1.4`](https://github.com/trip-zip/somewm/tree/release/1.4) branch or install `somewm` from the [AUR](https://aur.archlinux.org/packages/somewm).
 
 <p align="center">
   <img src="screenshots/default.png" alt="Default configuration" width="45%">
@@ -10,26 +16,12 @@
   <em>Default config (left) and a styled config (right)</em>
 </p>
 
-## Highlights
-
-What somewm brings to the table:
-
-- **Built-in lockscreen** - PAM-based session locking with theme integration (`Mod4 + Shift + Escape`)
-- **`somewm-client`** - IPC CLI for controlling the compositor from scripts and the command line
-- **Fractional scaling** - Per-output `screen.scale` for HiDPI displays
-- **Input device configuration** - `awful.input` for pointer speed, tap-to-click, keyboard layout, etc.
-- **Tag persistence** - Tags and client assignments survive monitor hotplug
-- **Shadows** - Configurable window shadows via `beautiful`
-- **Wallpaper caching** - Automatic GPU-side caching for wallpaper rendering
-- **Idle and DPMS** - `awesome.set_idle_timeout()` and `awesome.dpms_off()`/`dpms_on()`
-
-See the [full docs](https://somewm.org) for details.
-
 ## Install
 
 **Arch Linux (AUR):**
 ```bash
-yay -S somewm-git
+yay -S somewm      # Stable 1.4
+yay -S somewm-git  # Development (this branch)
 ```
 
 **From source:**
@@ -40,26 +32,33 @@ make
 sudo make install
 ```
 
-For Debian, Fedora, NixOS, and detailed instructions, see the [Installation Guide](https://somewm.org/getting-started/installation).
+For Debian, Fedora, NixOS, and detailed instructions, see the [Installation Guide](https://somewm.org/docs/getting-started/installation).
 
 ## Run
 
-From your display manager, select "somewm" as your session.
-
-Or from a TTY:
+From a TTY:
 ```bash
 dbus-run-session somewm
 ```
 
-See [First Launch](https://somewm.org/getting-started/first-launch) for configuration and migrating from AwesomeWM.
+From a display manager, select "somewm" as your session.
+
+Systemd units are also included for session management.
+
+Validate your config before switching:
+```bash
+somewm --check
+```
+
+See [First Launch](https://somewm.org/docs/getting-started/first-launch) for configuration and migrating from AwesomeWM.
 
 ## Documentation
 
 Full documentation at **[somewm.org](https://somewm.org)**:
 
-- [Getting Started](https://somewm.org/getting-started/installation) - Installation, first launch, migration
-- [Tutorials](https://somewm.org/tutorials/basics) - Keybindings, widgets, themes
-- [Troubleshooting](https://somewm.org/troubleshooting) - Common issues and solutions
+- [Getting Started](https://somewm.org/docs/getting-started/installation) - Installation, first launch, migration
+- [Tutorials](https://somewm.org/docs/tutorials/basics) - Keybindings, widgets, themes
+- [Troubleshooting](https://somewm.org/docs/troubleshooting) - Common issues and solutions
 
 ## Contributing
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'somewm',
   'c',
-  version: '1.4.0',
+  version: '2.0.0-dev',
   license: 'MIT',
   default_options: [
     'c_std=gnu11',


### PR DESCRIPTION
## Description

Prepare main for 2.0 development after the 1.4.0 stable release.

- Bump version to 2.0.0-dev in meson.build
- Add empty 2.0.0-dev unreleased section to CHANGELOG.md
- Update CONTRIBUTING.md: soften Lua API rule for 2.0, add branch strategy (release/1.4 vs main), add AI usage policy, require issue/discussion before PRs
- Rewrite README.md: position SomeWM as a Lua framework rather than an AwesomeWM port, add 2.0-dev banner pointing to release/1.4 for stable, update install/run sections

## Test Plan

Documentation and metadata only, no code changes.

## Checklist
- [x] Lua libraries are not modified
- [x] Tests pass (no code changes)