### PR TITLE
fix: revert bug report template to somewm --version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,10 +24,10 @@ assignees: ''
 
 
 ## Version Info
-<!-- Run `somewm version` and paste the output below -->
+<!-- Run `somewm --version` and paste the output below -->
 
 ```
-<paste somewm version output here>
+<paste somewm --version output here>
 ```
 
 ## Configuration


### PR DESCRIPTION
Restores somewm --version in the bug report template (the correct flag syntax for the daemon)