### PR TITLE
Add benchmark and profiling infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 
 -include .local.mk
 
-.PHONY: all install uninstall clean setup reconfigure test test-unit test-check test-integration test-asan test-one test-visual test-one-visual test-ci test-fast build-test build-bench bench-run bench-run-live bench-flamegraph bench-diff bench-heaptrack
+.PHONY: all install uninstall clean setup reconfigure test test-unit test-check test-integration test-asan test-one test-visual test-one-visual test-ci test-fast build-test build-bench bench-run bench-run-live bench-json bench-baseline bench-compare bench-check bench-memory bench-flamegraph bench-diff bench-heaptrack
 
 # Default build: WITH ASAN for development
 all:
@@ -156,6 +156,40 @@ endif
 	perf script -i $(QUEUE) | stackcollapse-perf.pl > /tmp/queue.folded
 	difffolded.pl /tmp/sync.folded /tmp/queue.folded | flamegraph.pl > somewm-bench-diff.svg
 	@echo "Differential flamegraph: somewm-bench-diff.svg"
+
+# Run benchmarks with JSON output capture (against live session)
+bench-json: build-bench
+	@JSON=1 \
+	 SOMEWM_CLIENT=./build-bench/somewm-client \
+	 ./tests/bench/run-all.sh
+
+# Save current results as baseline for this branch
+bench-baseline: bench-json
+	./tests/bench/bench-save-baseline.sh
+
+# Compare two result sets: make bench-compare A=results/dir-a B=results/dir-b
+bench-compare:
+	@lua5.1 tests/bench/bench-stats.lua $(A) $(B) 2>/dev/null \
+	 || luajit tests/bench/bench-stats.lua $(A) $(B) 2>/dev/null \
+	 || lua tests/bench/bench-stats.lua $(A) $(B)
+
+# Check for regressions against baseline
+bench-check: bench-json
+	@lua5.1 tests/bench/bench-stats.lua \
+	 tests/bench/results/baselines/$$(git branch --show-current) \
+	 $$(ls -td tests/bench/results/20* | head -1) 2>/dev/null \
+	 || luajit tests/bench/bench-stats.lua \
+	 tests/bench/results/baselines/$$(git branch --show-current) \
+	 $$(ls -td tests/bench/results/20* | head -1) 2>/dev/null \
+	 || lua tests/bench/bench-stats.lua \
+	 tests/bench/results/baselines/$$(git branch --show-current) \
+	 $$(ls -td tests/bench/results/20* | head -1)
+
+# Run memory trend analysis (uses its own headless compositor)
+bench-memory: build-bench
+	@SOMEWM=./build-bench/somewm \
+	 SOMEWM_CLIENT=./build-bench/somewm-client \
+	 ./tests/bench/bench-memory-runner.sh
 
 # Memory profiling with heaptrack
 bench-heaptrack: build-bench

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 
 -include .local.mk
 
-.PHONY: all install uninstall clean setup reconfigure test test-unit test-check test-integration test-asan test-one test-visual test-one-visual test-ci test-fast build-test build-bench bench-run bench-run-live bench-json bench-baseline bench-compare bench-check bench-memory bench-flamegraph bench-diff bench-heaptrack
+.PHONY: all install uninstall clean setup reconfigure test test-unit test-check test-integration test-asan test-one test-visual test-one-visual test-ci test-fast build-test build-bench bench-run bench-run-live bench-json bench-baseline bench-compare bench-check bench-memory bench-flamegraph bench-diff bench-heaptrack profile profile-lua profile-save profile-diff
 
 # Default build: WITH ASAN for development
 all:
@@ -190,6 +190,42 @@ bench-memory: build-bench
 	@SOMEWM=./build-bench/somewm \
 	 SOMEWM_CLIENT=./build-bench/somewm-client \
 	 ./tests/bench/bench-memory-runner.sh
+
+# --- Profiling (live session) ---
+
+# Profile the running compositor for DURATION seconds (default: 30)
+# Usage: make profile
+#        make profile DURATION=60
+profile:
+	@SOMEWM_CLIENT=./build-bench/somewm-client \
+	 ./tests/bench/profile-session.sh $(DURATION)
+
+# Profile with Lua function breakdown via jit.p
+# Usage: make profile-lua
+#        make profile-lua DURATION=60
+profile-lua:
+	@SOMEWM_CLIENT=./build-bench/somewm-client \
+	 ./tests/bench/profile-session.sh --lua $(DURATION)
+
+# Save a profile as a named baseline for later comparison
+# Usage: make profile-save LABEL=before-refactor
+profile-save:
+ifndef LABEL
+	@echo "Usage: make profile-save LABEL=<name>" >&2
+	@exit 1
+endif
+	@SOMEWM_CLIENT=./build-bench/somewm-client \
+	 ./tests/bench/profile-session.sh --save $(LABEL) $(DURATION)
+
+# Compare current profile against a saved baseline
+# Usage: make profile-diff LABEL=before-refactor
+profile-diff:
+ifndef LABEL
+	@echo "Usage: make profile-diff LABEL=<name>" >&2
+	@exit 1
+endif
+	@SOMEWM_CLIENT=./build-bench/somewm-client \
+	 ./tests/bench/profile-session.sh --diff $(LABEL) $(DURATION)
 
 # Memory profiling with heaptrack
 bench-heaptrack: build-bench

--- a/bench.c
+++ b/bench.c
@@ -1,0 +1,413 @@
+#include "bench.h"
+
+#ifdef SOMEWM_BENCH
+
+#include <string.h>
+#include <wlr/types/wlr_scene.h>
+
+/* --- Shared stats computation --- */
+
+/* Insertion sort + min/max/avg/p99 over n entries.
+ * n must be <= BENCH_FRAME_HISTORY. */
+static void
+bench_compute_stats(const uint64_t *data, int n,
+                    uint64_t *min_ns, uint64_t *max_ns,
+                    uint64_t *avg_ns, uint64_t *p99_ns)
+{
+    if (n <= 0) {
+        *min_ns = *max_ns = *avg_ns = *p99_ns = 0;
+        return;
+    }
+
+    uint64_t sorted[BENCH_FRAME_HISTORY];
+    memcpy(sorted, data, n * sizeof(uint64_t));
+
+    for (int i = 1; i < n; i++) {
+        uint64_t key = sorted[i];
+        int j = i - 1;
+        while (j >= 0 && sorted[j] > key) {
+            sorted[j + 1] = sorted[j];
+            j--;
+        }
+        sorted[j + 1] = key;
+    }
+
+    *min_ns = sorted[0];
+    *max_ns = sorted[n - 1];
+
+    uint64_t sum = 0;
+    for (int i = 0; i < n; i++)
+        sum += sorted[i];
+    *avg_ns = sum / n;
+
+    int p99_idx = (int)((n - 1) * 0.99);
+    *p99_ns = sorted[p99_idx];
+}
+
+/* --- Signal dispatch counters --- */
+
+uint64_t bench_signal_emit_count = 0;
+uint64_t bench_signal_handler_calls = 0;
+uint64_t bench_signal_lookup_misses = 0;
+
+void
+bench_signal_counters_reset(void)
+{
+    bench_signal_emit_count = 0;
+    bench_signal_handler_calls = 0;
+    bench_signal_lookup_misses = 0;
+}
+
+/* --- Frame timing --- */
+
+static uint64_t bench_frame_times_ns[BENCH_FRAME_HISTORY];
+static int bench_frame_index = 0;
+static int bench_frame_count = 0;
+static uint64_t bench_refresh_count = 0;
+
+uint64_t
+timespec_diff_ns(struct timespec *start, struct timespec *end)
+{
+    return (uint64_t)(end->tv_sec - start->tv_sec) * 1000000000ULL
+         + (uint64_t)(end->tv_nsec - start->tv_nsec);
+}
+
+void
+bench_frame_stats_get(uint64_t *count, uint64_t *min_ns, uint64_t *max_ns,
+                      uint64_t *avg_ns, uint64_t *p99_ns)
+{
+    *count = bench_refresh_count;
+    int n = bench_frame_count < BENCH_FRAME_HISTORY
+          ? bench_frame_count : BENCH_FRAME_HISTORY;
+    bench_compute_stats(bench_frame_times_ns, n, min_ns, max_ns, avg_ns, p99_ns);
+}
+
+void
+bench_frame_stats_reset(void)
+{
+    bench_frame_index = 0;
+    bench_frame_count = 0;
+    bench_refresh_count = 0;
+}
+
+/* --- Per-stage frame budget timing --- */
+
+const char *bench_stage_names[BENCH_STAGE_COUNT] = {
+    "lua_refresh",
+    "animation",
+    "drawin",
+    "client",
+    "banning",
+    "stack",
+    "destroy",
+};
+
+static uint64_t bench_stage_times_ns[BENCH_STAGE_COUNT][BENCH_FRAME_HISTORY];
+static int bench_stage_index = 0;
+static int bench_stage_count = 0;
+
+void
+bench_stage_record(bench_stage_t stage, uint64_t elapsed_ns)
+{
+    bench_stage_times_ns[stage][bench_stage_index] = elapsed_ns;
+}
+
+/* Called once per frame after all stages recorded, to advance the shared index */
+static void
+bench_stage_frame_end(void)
+{
+    bench_stage_index = (bench_stage_index + 1) % BENCH_FRAME_HISTORY;
+    bench_stage_count++;
+}
+
+void
+bench_stage_stats_get(bench_stage_t stage, uint64_t *min_ns,
+                      uint64_t *max_ns, uint64_t *avg_ns, uint64_t *p99_ns)
+{
+    int n = bench_stage_count < BENCH_FRAME_HISTORY
+          ? bench_stage_count : BENCH_FRAME_HISTORY;
+    bench_compute_stats(bench_stage_times_ns[stage], n,
+                        min_ns, max_ns, avg_ns, p99_ns);
+}
+
+void
+bench_stage_stats_reset(void)
+{
+    bench_stage_index = 0;
+    bench_stage_count = 0;
+    memset(bench_stage_times_ns, 0, sizeof(bench_stage_times_ns));
+}
+
+/* --- C/Lua boundary crossing counter --- */
+
+uint64_t bench_clua_crossings_this_frame = 0;
+
+static uint64_t bench_crossings_per_frame[BENCH_FRAME_HISTORY];
+static int bench_crossings_index = 0;
+static int bench_crossings_count = 0;
+
+static void
+bench_crossings_frame_end(void)
+{
+    bench_crossings_per_frame[bench_crossings_index] = bench_clua_crossings_this_frame;
+    bench_crossings_index = (bench_crossings_index + 1) % BENCH_FRAME_HISTORY;
+    bench_crossings_count++;
+    bench_clua_crossings_this_frame = 0;
+}
+
+void
+bench_crossings_stats_get(double *avg, uint64_t *max)
+{
+    if (bench_crossings_count == 0) {
+        *avg = 0;
+        *max = 0;
+        return;
+    }
+
+    int n = bench_crossings_count < BENCH_FRAME_HISTORY
+          ? bench_crossings_count : BENCH_FRAME_HISTORY;
+    uint64_t sum = 0;
+    uint64_t mx = 0;
+    for (int i = 0; i < n; i++) {
+        sum += bench_crossings_per_frame[i];
+        if (bench_crossings_per_frame[i] > mx)
+            mx = bench_crossings_per_frame[i];
+    }
+    *avg = (double)sum / n;
+    *max = mx;
+}
+
+void
+bench_crossings_reset(void)
+{
+    bench_clua_crossings_this_frame = 0;
+    bench_crossings_index = 0;
+    bench_crossings_count = 0;
+}
+
+/* --- End-of-frame bookkeeping ---
+ *
+ * bench_record_frame_time() is the single entry point called at the end of
+ * some_refresh(). It records the total frame time and advances all per-frame
+ * circular buffers together. */
+
+void
+bench_record_frame_time(uint64_t elapsed_ns)
+{
+    bench_frame_times_ns[bench_frame_index] = elapsed_ns;
+    bench_frame_index = (bench_frame_index + 1) % BENCH_FRAME_HISTORY;
+    bench_frame_count++;
+    bench_refresh_count++;
+
+    bench_crossings_frame_end();
+    bench_stage_frame_end();
+}
+
+/* --- Input-to-display latency --- */
+
+static uint64_t bench_pending_inputs[BENCH_INPUT_RING];
+static int bench_input_head = 0;
+static int bench_input_tail = 0;
+
+static uint64_t bench_input_latencies[BENCH_FRAME_HISTORY];
+static int bench_input_lat_index = 0;
+static int bench_input_lat_count = 0;
+
+void
+bench_input_event_record(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    uint64_t now = (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+
+    int next = (bench_input_head + 1) % BENCH_INPUT_RING;
+    if (next != bench_input_tail) {
+        bench_pending_inputs[bench_input_head] = now;
+        bench_input_head = next;
+    }
+    /* If ring is full, drop the oldest */
+}
+
+void
+bench_input_commit_flush(void)
+{
+    if (bench_input_head == bench_input_tail)
+        return;  /* No pending inputs */
+
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    uint64_t now = (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+
+    uint64_t max_latency = 0;
+    while (bench_input_tail != bench_input_head) {
+        uint64_t latency = now - bench_pending_inputs[bench_input_tail];
+        if (latency > max_latency)
+            max_latency = latency;
+        bench_input_tail = (bench_input_tail + 1) % BENCH_INPUT_RING;
+    }
+
+    bench_input_latencies[bench_input_lat_index] = max_latency;
+    bench_input_lat_index = (bench_input_lat_index + 1) % BENCH_FRAME_HISTORY;
+    bench_input_lat_count++;
+}
+
+void
+bench_input_latency_stats_get(uint64_t *count, uint64_t *avg_ns,
+                              uint64_t *p99_ns, uint64_t *max_ns)
+{
+    *count = bench_input_lat_count;
+    int n = bench_input_lat_count < BENCH_FRAME_HISTORY
+          ? bench_input_lat_count : BENCH_FRAME_HISTORY;
+    uint64_t min_ns;
+    bench_compute_stats(bench_input_latencies, n,
+                        &min_ns, max_ns, avg_ns, p99_ns);
+}
+
+void
+bench_input_latency_reset(void)
+{
+    bench_input_head = 0;
+    bench_input_tail = 0;
+    bench_input_lat_index = 0;
+    bench_input_lat_count = 0;
+}
+
+/* --- Client manage latency --- */
+
+#define BENCH_MANAGE_HISTORY 256
+
+struct bench_manage_entry {
+    void *client_ptr;
+    uint64_t start_ns;
+};
+
+static struct bench_manage_entry bench_manage_pending[BENCH_MANAGE_HISTORY];
+static int bench_manage_pending_count = 0;
+
+static uint64_t bench_manage_latencies[BENCH_MANAGE_HISTORY];
+static int bench_manage_lat_index = 0;
+static int bench_manage_lat_count = 0;
+
+void
+bench_manage_start(void *client_ptr)
+{
+    if (bench_manage_pending_count >= BENCH_MANAGE_HISTORY)
+        return;
+
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+
+    bench_manage_pending[bench_manage_pending_count].client_ptr = client_ptr;
+    bench_manage_pending[bench_manage_pending_count].start_ns =
+        (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+    bench_manage_pending_count++;
+}
+
+void
+bench_manage_end(void *client_ptr)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    uint64_t now = (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+
+    for (int i = 0; i < bench_manage_pending_count; i++) {
+        if (bench_manage_pending[i].client_ptr == client_ptr) {
+            uint64_t latency = now - bench_manage_pending[i].start_ns;
+            bench_manage_latencies[bench_manage_lat_index] = latency;
+            bench_manage_lat_index = (bench_manage_lat_index + 1) % BENCH_MANAGE_HISTORY;
+            bench_manage_lat_count++;
+
+            /* Remove from pending by swapping with last */
+            bench_manage_pending[i] = bench_manage_pending[bench_manage_pending_count - 1];
+            bench_manage_pending_count--;
+            return;
+        }
+    }
+}
+
+void
+bench_manage_latency_stats_get(uint64_t *count, uint64_t *avg_ns,
+                               uint64_t *p99_ns, uint64_t *max_ns)
+{
+    *count = bench_manage_lat_count;
+    int n = bench_manage_lat_count < BENCH_MANAGE_HISTORY
+          ? bench_manage_lat_count : BENCH_MANAGE_HISTORY;
+    uint64_t min_ns;
+    bench_compute_stats(bench_manage_latencies, n,
+                        &min_ns, max_ns, avg_ns, p99_ns);
+}
+
+void
+bench_manage_latency_reset(void)
+{
+    bench_manage_pending_count = 0;
+    bench_manage_lat_index = 0;
+    bench_manage_lat_count = 0;
+}
+
+/* --- Render (compositing) phase timing --- */
+
+static uint64_t bench_render_times_ns[BENCH_FRAME_HISTORY];
+static int bench_render_index = 0;
+static int bench_render_count = 0;
+
+void
+bench_render_record(uint64_t elapsed_ns)
+{
+    bench_render_times_ns[bench_render_index] = elapsed_ns;
+    bench_render_index = (bench_render_index + 1) % BENCH_FRAME_HISTORY;
+    bench_render_count++;
+}
+
+void
+bench_render_stats_get(uint64_t *count, uint64_t *min_ns, uint64_t *max_ns,
+                       uint64_t *avg_ns, uint64_t *p99_ns)
+{
+    *count = bench_render_count;
+    int n = bench_render_count < BENCH_FRAME_HISTORY
+          ? bench_render_count : BENCH_FRAME_HISTORY;
+    bench_compute_stats(bench_render_times_ns, n, min_ns, max_ns, avg_ns, p99_ns);
+}
+
+void
+bench_render_reset(void)
+{
+    bench_render_index = 0;
+    bench_render_count = 0;
+}
+
+void
+bench_count_scene_nodes(struct wlr_scene_node *root,
+                        int *trees, int *rects, int *buffers)
+{
+    if (!root) return;
+
+    switch (root->type) {
+    case WLR_SCENE_NODE_TREE: (*trees)++; break;
+    case WLR_SCENE_NODE_RECT: (*rects)++; break;
+    case WLR_SCENE_NODE_BUFFER: (*buffers)++; break;
+    }
+
+    if (root->type == WLR_SCENE_NODE_TREE) {
+        struct wlr_scene_tree *tree = wlr_scene_tree_from_node(root);
+        struct wlr_scene_node *child;
+        wl_list_for_each(child, &tree->children, link)
+            bench_count_scene_nodes(child, trees, rects, buffers);
+    }
+}
+
+/* --- Full reset --- */
+
+void
+bench_reset_all(void)
+{
+    bench_signal_counters_reset();
+    bench_frame_stats_reset();
+    bench_stage_stats_reset();
+    bench_crossings_reset();
+    bench_input_latency_reset();
+    bench_manage_latency_reset();
+    bench_render_reset();
+}
+
+#endif /* SOMEWM_BENCH */

--- a/bench.h
+++ b/bench.h
@@ -1,0 +1,92 @@
+#ifndef SOMEWM_BENCH_H
+#define SOMEWM_BENCH_H
+
+#ifdef SOMEWM_BENCH
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <time.h>
+
+#define BENCH_FRAME_HISTORY 1000
+
+/* --- Signal dispatch counters --- */
+
+extern uint64_t bench_signal_emit_count;
+extern uint64_t bench_signal_handler_calls;
+extern uint64_t bench_signal_lookup_misses;
+
+void bench_signal_counters_reset(void);
+
+/* --- Frame timing --- */
+
+uint64_t timespec_diff_ns(struct timespec *start, struct timespec *end);
+
+void bench_record_frame_time(uint64_t elapsed_ns);
+void bench_frame_stats_get(uint64_t *count, uint64_t *min_ns, uint64_t *max_ns,
+                           uint64_t *avg_ns, uint64_t *p99_ns);
+void bench_frame_stats_reset(void);
+
+/* --- Per-stage frame budget timing --- */
+
+typedef enum {
+    BENCH_STAGE_LUA_REFRESH,
+    BENCH_STAGE_ANIMATION,
+    BENCH_STAGE_DRAWIN,
+    BENCH_STAGE_CLIENT,
+    BENCH_STAGE_BANNING,
+    BENCH_STAGE_STACK,
+    BENCH_STAGE_DESTROY,
+    BENCH_STAGE_COUNT
+} bench_stage_t;
+
+void bench_stage_record(bench_stage_t stage, uint64_t elapsed_ns);
+void bench_stage_stats_get(bench_stage_t stage, uint64_t *min_ns,
+                           uint64_t *max_ns, uint64_t *avg_ns, uint64_t *p99_ns);
+void bench_stage_stats_reset(void);
+
+extern const char *bench_stage_names[BENCH_STAGE_COUNT];
+
+/* --- C/Lua boundary crossing counter --- */
+
+extern uint64_t bench_clua_crossings_this_frame;
+
+void bench_crossings_stats_get(double *avg, uint64_t *max);
+void bench_crossings_reset(void);
+
+/* --- Input-to-display latency --- */
+
+#define BENCH_INPUT_RING 64
+
+void bench_input_event_record(void);
+void bench_input_commit_flush(void);
+void bench_input_latency_stats_get(uint64_t *count, uint64_t *avg_ns,
+                                   uint64_t *p99_ns, uint64_t *max_ns);
+void bench_input_latency_reset(void);
+
+/* --- Client manage latency --- */
+
+void bench_manage_start(void *client_ptr);
+void bench_manage_end(void *client_ptr);
+void bench_manage_latency_stats_get(uint64_t *count, uint64_t *avg_ns,
+                                    uint64_t *p99_ns, uint64_t *max_ns);
+void bench_manage_latency_reset(void);
+
+/* --- Render (compositing) phase timing --- */
+
+void bench_render_record(uint64_t elapsed_ns);
+void bench_render_stats_get(uint64_t *count, uint64_t *min_ns, uint64_t *max_ns,
+                            uint64_t *avg_ns, uint64_t *p99_ns);
+void bench_render_reset(void);
+
+/* Scene node counting (called at query time, not per-frame) */
+struct wlr_scene_node;
+void bench_count_scene_nodes(struct wlr_scene_node *root,
+                             int *trees, int *rects, int *buffers);
+
+/* --- Full reset --- */
+
+void bench_reset_all(void);
+
+#endif /* SOMEWM_BENCH */
+
+#endif /* SOMEWM_BENCH_H */

--- a/common/lualib.h
+++ b/common/lualib.h
@@ -28,6 +28,7 @@
 #include <assert.h>
 
 #include "common/util.h"
+#include "bench.h"
 #include "luaa.h"  /* For luaA_registerlib, luaA_setfuncs */
 
 /** Lua function to call on dofunction() error */
@@ -70,6 +71,9 @@ static inline bool
 luaA_dofunction(lua_State *L, int nargs, int nret)
 {
     int error_func_pos;
+#ifdef SOMEWM_BENCH
+    bench_clua_crossings_this_frame++;
+#endif
     /* Move function before arguments */
     lua_insert(L, - nargs - 1);
     /* Push error handling function */

--- a/common/luaobject.c
+++ b/common/luaobject.c
@@ -30,24 +30,7 @@
 #include "common/luaobject.h"
 #include "common/lualib.h"
 #include "globalconf.h"
-
-#ifdef SOMEWM_BENCH
-#include <stdint.h>
-
-uint64_t bench_signal_emit_count = 0;
-uint64_t bench_signal_handler_calls = 0;
-uint64_t bench_signal_lookup_misses = 0;
-#endif
-
-#ifdef SOMEWM_BENCH
-void
-bench_signal_counters_reset(void)
-{
-    bench_signal_emit_count = 0;
-    bench_signal_handler_calls = 0;
-    bench_signal_lookup_misses = 0;
-}
-#endif
+#include "bench.h"
 
 /** Setup the object system at startup.
  * \param L The Lua VM state.

--- a/common/luaobject.h
+++ b/common/luaobject.h
@@ -208,15 +208,6 @@ int luaA_object_emit_signal_simple(lua_State *);
         return 1; \
     }
 
-#ifdef SOMEWM_BENCH
-#include <stdint.h>
-extern uint64_t bench_signal_emit_count;
-extern uint64_t bench_signal_handler_calls;
-extern uint64_t bench_signal_lookup_misses;
-
-void bench_signal_counters_reset(void);
-#endif
-
 int luaA_object_tostring(lua_State *);
 
 #define LUA_OBJECT_META(prefix) \

--- a/input.c
+++ b/input.c
@@ -63,6 +63,7 @@
 #include "focus.h"
 #include "window.h"
 #include "somewm_internal.h"
+#include "bench.h"
 
 /* Module-private state */
 static unsigned int cursor_mode;
@@ -396,6 +397,9 @@ axisnotify(struct wl_listener *listener, void *data)
 void
 buttonpress(struct wl_listener *listener, void *data)
 {
+#ifdef SOMEWM_BENCH
+	bench_input_event_record();
+#endif
 	struct wlr_pointer_button_event *event = data;
 	struct wlr_keyboard *keyboard;
 	uint32_t mods;
@@ -741,6 +745,9 @@ void
 motionnotify(uint32_t time, struct wlr_input_device *device, double dx, double dy,
 		double dx_unaccel, double dy_unaccel)
 {
+#ifdef SOMEWM_BENCH
+	bench_input_event_record();
+#endif
 	double sx = 0, sy = 0, sx_confined, sy_confined;
 	Client *c = NULL, *w = NULL;
 	LayerSurface *l = NULL;
@@ -1111,6 +1118,9 @@ keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_
 void
 keypress(struct wl_listener *listener, void *data)
 {
+#ifdef SOMEWM_BENCH
+	bench_input_event_record();
+#endif
 	int i;
 	uint32_t keycode;
 	const xkb_keysym_t *syms;

--- a/luaa.c
+++ b/luaa.c
@@ -1839,16 +1839,31 @@ bool some_is_lock_drawin(drawin_t *d) {
 
 /* awesome module methods */
 #ifdef SOMEWM_BENCH
-void bench_frame_stats_get(uint64_t *count, uint64_t *min_ns, uint64_t *max_ns,
-                           uint64_t *avg_ns, uint64_t *p99_ns);
-void bench_frame_stats_reset(void);
+#include "bench.h"
+
+static void
+bench_push_stage_table(lua_State *L, bench_stage_t stage)
+{
+    uint64_t min_ns, max_ns, avg_ns, p99_ns;
+    bench_stage_stats_get(stage, &min_ns, &max_ns, &avg_ns, &p99_ns);
+
+    lua_newtable(L);
+    lua_pushnumber(L, (double)min_ns / 1000.0);
+    lua_setfield(L, -2, "min_us");
+    lua_pushnumber(L, (double)max_ns / 1000.0);
+    lua_setfield(L, -2, "max_us");
+    lua_pushnumber(L, (double)avg_ns / 1000.0);
+    lua_setfield(L, -2, "avg_us");
+    lua_pushnumber(L, (double)p99_ns / 1000.0);
+    lua_setfield(L, -2, "p99_us");
+}
 
 static int
 luaA_awesome_bench_stats(lua_State *L)
 {
     lua_newtable(L);
 
-    /* Signal counters */
+    /* Signal counters (backward-compatible top-level fields) */
     lua_pushinteger(L, (lua_Integer)bench_signal_emit_count);
     lua_setfield(L, -2, "signal_emit_count");
     lua_pushinteger(L, (lua_Integer)bench_signal_handler_calls);
@@ -1856,7 +1871,7 @@ luaA_awesome_bench_stats(lua_State *L)
     lua_pushinteger(L, (lua_Integer)bench_signal_lookup_misses);
     lua_setfield(L, -2, "signal_lookup_misses");
 
-    /* Frame timing */
+    /* Frame timing (backward-compatible top-level fields) */
     uint64_t count, min_ns, max_ns, avg_ns, p99_ns;
     bench_frame_stats_get(&count, &min_ns, &max_ns, &avg_ns, &p99_ns);
     lua_pushinteger(L, (lua_Integer)count);
@@ -1870,9 +1885,99 @@ luaA_awesome_bench_stats(lua_State *L)
     lua_pushnumber(L, (double)p99_ns / 1000.0);
     lua_setfield(L, -2, "refresh_p99_us");
 
-    /* Lua memory */
+    /* Lua memory (backward-compatible) */
     lua_pushnumber(L, lua_gc(L, LUA_GCCOUNT, 0) + lua_gc(L, LUA_GCCOUNTB, 0) / 1024.0);
     lua_setfield(L, -2, "lua_memory_kb");
+
+    /* Per-stage frame budget timing */
+    lua_newtable(L);
+    for (int i = 0; i < BENCH_STAGE_COUNT; i++) {
+        bench_push_stage_table(L, i);
+        lua_setfield(L, -2, bench_stage_names[i]);
+    }
+    lua_setfield(L, -2, "stages");
+
+    /* C/Lua boundary crossings per frame */
+    double cross_avg;
+    uint64_t cross_max;
+    bench_crossings_stats_get(&cross_avg, &cross_max);
+    lua_newtable(L);
+    lua_pushnumber(L, cross_avg);
+    lua_setfield(L, -2, "avg");
+    lua_pushinteger(L, (lua_Integer)cross_max);
+    lua_setfield(L, -2, "max");
+    lua_setfield(L, -2, "crossings_per_frame");
+
+    /* Input-to-display latency */
+    {
+        uint64_t il_count, il_avg, il_p99, il_max;
+        bench_input_latency_stats_get(&il_count, &il_avg, &il_p99, &il_max);
+        lua_newtable(L);
+        lua_pushinteger(L, (lua_Integer)il_count);
+        lua_setfield(L, -2, "count");
+        lua_pushnumber(L, (double)il_avg / 1000.0);
+        lua_setfield(L, -2, "avg_us");
+        lua_pushnumber(L, (double)il_p99 / 1000.0);
+        lua_setfield(L, -2, "p99_us");
+        lua_pushnumber(L, (double)il_max / 1000.0);
+        lua_setfield(L, -2, "max_us");
+        lua_setfield(L, -2, "input_latency");
+    }
+
+    /* Client manage latency */
+    {
+        uint64_t ml_count, ml_avg, ml_p99, ml_max;
+        bench_manage_latency_stats_get(&ml_count, &ml_avg, &ml_p99, &ml_max);
+        lua_newtable(L);
+        lua_pushinteger(L, (lua_Integer)ml_count);
+        lua_setfield(L, -2, "count");
+        lua_pushnumber(L, (double)ml_avg / 1000.0);
+        lua_setfield(L, -2, "avg_us");
+        lua_pushnumber(L, (double)ml_p99 / 1000.0);
+        lua_setfield(L, -2, "p99_us");
+        lua_pushnumber(L, (double)ml_max / 1000.0);
+        lua_setfield(L, -2, "max_us");
+        lua_setfield(L, -2, "manage_latency");
+    }
+
+    /* Render (compositing) phase timing */
+    {
+        uint64_t r_count, r_min, r_max, r_avg, r_p99;
+        bench_render_stats_get(&r_count, &r_min, &r_max, &r_avg, &r_p99);
+        lua_newtable(L);
+        lua_pushinteger(L, (lua_Integer)r_count);
+        lua_setfield(L, -2, "count");
+        lua_pushnumber(L, (double)r_min / 1000.0);
+        lua_setfield(L, -2, "min_us");
+        lua_pushnumber(L, (double)r_max / 1000.0);
+        lua_setfield(L, -2, "max_us");
+        lua_pushnumber(L, (double)r_avg / 1000.0);
+        lua_setfield(L, -2, "avg_us");
+        lua_pushnumber(L, (double)r_p99 / 1000.0);
+        lua_setfield(L, -2, "p99_us");
+        lua_setfield(L, -2, "render");
+    }
+
+    /* Memory counters */
+    extern struct wlr_scene *scene;
+    lua_newtable(L);
+    lua_pushnumber(L, lua_gc(L, LUA_GCCOUNT, 0) + lua_gc(L, LUA_GCCOUNTB, 0) / 1024.0);
+    lua_setfield(L, -2, "lua_kb");
+    lua_pushinteger(L, (lua_Integer)globalconf.clients.len);
+    lua_setfield(L, -2, "clients");
+    lua_pushinteger(L, (lua_Integer)globalconf.drawins.len);
+    lua_setfield(L, -2, "drawins");
+    if (scene) {
+        int trees = 0, rects = 0, buffers = 0;
+        bench_count_scene_nodes(&scene->tree.node, &trees, &rects, &buffers);
+        lua_pushinteger(L, trees);
+        lua_setfield(L, -2, "scene_trees");
+        lua_pushinteger(L, rects);
+        lua_setfield(L, -2, "scene_rects");
+        lua_pushinteger(L, buffers);
+        lua_setfield(L, -2, "scene_buffers");
+    }
+    lua_setfield(L, -2, "memory");
 
     return 1;
 }
@@ -1881,8 +1986,7 @@ static int
 luaA_awesome_bench_reset(lua_State *L)
 {
     (void)L;
-    bench_signal_counters_reset();
-    bench_frame_stats_reset();
+    bench_reset_all();
     return 0;
 }
 #endif

--- a/meson.build
+++ b/meson.build
@@ -317,6 +317,7 @@ somewm_sources = [
   'animation.c',
   'selection.c',
   'pam_auth.c',
+  'bench.c',
   # Common
   'common/luaclass.c',
   'common/luaobject.c',

--- a/monitor.c
+++ b/monitor.c
@@ -44,6 +44,7 @@
 #include "focus.h"
 #include "window.h"
 #include "somewm_internal.h"
+#include "bench.h"
 
 /* Module-private state */
 static int in_updatemons;
@@ -492,9 +493,20 @@ rendermon(struct wl_listener *listener, void *data)
 			goto skip;
 	}
 
+#ifdef SOMEWM_BENCH
+	struct timespec bench_render_start, bench_render_end;
+	clock_gettime(CLOCK_MONOTONIC, &bench_render_start);
+#endif
 	if (!wlr_scene_output_commit(m->scene_output, NULL))
 		wlr_log(WLR_DEBUG, "[HOTPLUG] rendermon commit failed: %s",
 			m->wlr_output->name);
+#ifdef SOMEWM_BENCH
+	else {
+		clock_gettime(CLOCK_MONOTONIC, &bench_render_end);
+		bench_render_record(timespec_diff_ns(&bench_render_start, &bench_render_end));
+		bench_input_commit_flush();
+	}
+#endif
 
 skip:
 	clock_gettime(CLOCK_MONOTONIC, &now);

--- a/somewm.c
+++ b/somewm.c
@@ -574,70 +574,7 @@ static float main_loop_iteration_limit = 0.1f;
 /* Recursion guard for some_refresh() */
 static bool in_refresh = false;
 
-#ifdef SOMEWM_BENCH
-#include <stdint.h>
-
-#define BENCH_FRAME_HISTORY 1000
-
-static uint64_t bench_frame_times_ns[BENCH_FRAME_HISTORY];
-static int bench_frame_index = 0;
-static int bench_frame_count = 0;
-static uint64_t bench_refresh_count = 0;
-
-static uint64_t
-timespec_diff_ns(struct timespec *start, struct timespec *end)
-{
-    return (uint64_t)(end->tv_sec - start->tv_sec) * 1000000000ULL
-         + (uint64_t)(end->tv_nsec - start->tv_nsec);
-}
-
-void
-bench_frame_stats_get(uint64_t *count, uint64_t *min_ns, uint64_t *max_ns,
-                      uint64_t *avg_ns, uint64_t *p99_ns)
-{
-    *count = bench_refresh_count;
-    if (bench_frame_count == 0) {
-        *min_ns = *max_ns = *avg_ns = *p99_ns = 0;
-        return;
-    }
-
-    /* Copy and sort for percentile calculation */
-    int n = bench_frame_count < BENCH_FRAME_HISTORY
-          ? bench_frame_count : BENCH_FRAME_HISTORY;
-    uint64_t sorted[BENCH_FRAME_HISTORY];
-    memcpy(sorted, bench_frame_times_ns, n * sizeof(uint64_t));
-
-    /* Simple insertion sort - n is at most 1000 */
-    for (int i = 1; i < n; i++) {
-        uint64_t key = sorted[i];
-        int j = i - 1;
-        while (j >= 0 && sorted[j] > key) {
-            sorted[j + 1] = sorted[j];
-            j--;
-        }
-        sorted[j + 1] = key;
-    }
-
-    *min_ns = sorted[0];
-    *max_ns = sorted[n - 1];
-
-    uint64_t sum = 0;
-    for (int i = 0; i < n; i++)
-        sum += sorted[i];
-    *avg_ns = sum / n;
-
-    int p99_idx = (int)((n - 1) * 0.99);
-    *p99_ns = sorted[p99_idx];
-}
-
-void
-bench_frame_stats_reset(void)
-{
-    bench_frame_index = 0;
-    bench_frame_count = 0;
-    bench_refresh_count = 0;
-}
-#endif
+#include "bench.h"
 
 /* Forward declaration */
 void some_refresh(void);
@@ -784,45 +721,67 @@ some_refresh(void)
 	in_refresh = true;
 
 #ifdef SOMEWM_BENCH
-	struct timespec bench_start, bench_end;
-	clock_gettime(CLOCK_MONOTONIC, &bench_start);
+	struct timespec bench_ts[BENCH_STAGE_COUNT + 1];
+	clock_gettime(CLOCK_MONOTONIC, &bench_ts[0]);
 #endif
 
 	/* Step 1: Emit refresh signal - triggers Lua layout calculations */
 	luaA_emit_signal_global("refresh");
+
+#ifdef SOMEWM_BENCH
+	clock_gettime(CLOCK_MONOTONIC, &bench_ts[1]);
+#endif
 
 	/* Step 1.5: Tick frame-synced animations - tick callbacks that modify
 	 * client geometry will have their changes applied by client_refresh()
 	 * in the same cycle. */
 	animation_tick_all();
 
+#ifdef SOMEWM_BENCH
+	clock_gettime(CLOCK_MONOTONIC, &bench_ts[2]);
+#endif
+
 	/* Step 2: Refresh drawins (wibox/panels) FIRST - matches AwesomeWM order
 	 * AwesomeWM calls drawin_refresh() BEFORE client_refresh() in awesome_refresh().
 	 * This ensures wibar geometry is applied before client layout calculations. */
 	drawin_refresh();
 
+#ifdef SOMEWM_BENCH
+	clock_gettime(CLOCK_MONOTONIC, &bench_ts[3]);
+#endif
+
 	/* Step 3: Apply client changes (geometry, borders, focus)
 	 * This matches AwesomeWM's client_refresh() which handles all client updates. */
 	client_refresh();
 
+#ifdef SOMEWM_BENCH
+	clock_gettime(CLOCK_MONOTONIC, &bench_ts[4]);
+#endif
+
 	/* Step 4: Update client visibility (banning) */
 	banning_refresh();
+
+#ifdef SOMEWM_BENCH
+	clock_gettime(CLOCK_MONOTONIC, &bench_ts[5]);
+#endif
 
 	/* Step 5: Update window stacking (Z-order)
 	 * This matches AwesomeWM's awesome_refresh() which calls stack_refresh() */
 	stack_refresh();
+
+#ifdef SOMEWM_BENCH
+	clock_gettime(CLOCK_MONOTONIC, &bench_ts[6]);
+#endif
 
 	/* Step 6: Destroy windows queued for deferred destruction (XWayland only)
 	 * This matches AwesomeWM's deferred destruction pattern to avoid race conditions */
 	client_destroy_later();
 
 #ifdef SOMEWM_BENCH
-	clock_gettime(CLOCK_MONOTONIC, &bench_end);
-	uint64_t elapsed = timespec_diff_ns(&bench_start, &bench_end);
-	bench_frame_times_ns[bench_frame_index] = elapsed;
-	bench_frame_index = (bench_frame_index + 1) % BENCH_FRAME_HISTORY;
-	bench_frame_count++;
-	bench_refresh_count++;
+	clock_gettime(CLOCK_MONOTONIC, &bench_ts[7]);
+	for (int i = 0; i < BENCH_STAGE_COUNT; i++)
+		bench_stage_record(i, timespec_diff_ns(&bench_ts[i], &bench_ts[i + 1]));
+	bench_record_frame_time(timespec_diff_ns(&bench_ts[0], &bench_ts[7]));
 #endif
 
 	in_refresh = false;

--- a/tests/README.md
+++ b/tests/README.md
@@ -255,64 +255,79 @@ To port AwesomeWM tests:
 
 ## Profiling
 
-### Profile your live session
+### Setup
 
-The simplest way to understand compositor performance: attach perf while you
-use the compositor normally.
+Build the bench binary and install it as your compositor:
 
 ```bash
-# Profile for 30 seconds (default), use the compositor normally during this time
-tests/bench/profile-session.sh
-
-# Profile for 60 seconds
-tests/bench/profile-session.sh 60
-
-# Also capture Lua function-level profile alongside C flamegraph
-tests/bench/profile-session.sh --lua
-
-# Save as baseline for later comparison
-tests/bench/profile-session.sh --save pre-2.0
-
-# Compare against saved baseline (red = hotter, blue = cooler)
-tests/bench/profile-session.sh --diff pre-2.0
+make build-bench
+sudo cp build-bench/somewm /usr/local/bin/somewm
 ```
 
-Open the SVG flamegraph in a browser for the interactive view (click to zoom,
-search with Ctrl+F).
+Then restart your session. When you're done profiling, switch back to the dev
+build with `sudo make install`.
 
-For readable function names, make sure the running compositor binary hasn't been
-rebuilt since it started (the script warns if this is the case). System library
-symbols (pixman, wlroots, cairo) are resolved via debuginfod.
-
-### Scripted profiling (repeatable)
-
-For repeatable before/after comparison, the scripted workload drives a fixed
-sequence of tag switches, focus changes, geometry updates, and property toggles:
+### Quick profile
 
 ```bash
-tests/bench/profile-workload.sh --save main
-# ... make changes, rebuild, restart compositor ...
-tests/bench/profile-workload.sh --diff main
+make profile              # 30s C flamegraph
+make profile-lua          # 30s C flamegraph + Lua function breakdown
+make profile DURATION=60  # longer capture
+```
+
+Use the compositor normally during the capture. Open the resulting SVG in a
+browser (click to zoom, Ctrl+F to search).
+
+### Before/after comparison
+
+```bash
+# 1. Save a baseline
+make profile-save LABEL=before-change
+
+# 2. Make your changes, rebuild, restart
+make build-bench && sudo cp build-bench/somewm /usr/local/bin/somewm
+# ... restart session ...
+
+# 3. Capture again and generate differential flamegraph
+make profile-diff LABEL=before-change
+```
+
+The diff flamegraph shows red (more CPU) and blue (less CPU).
+
+### Repeatable scripted workload
+
+For controlled comparison without manual interaction, the scripted workload
+drives a fixed sequence of tag switches, focus changes, geometry updates, and
+property toggles:
+
+```bash
+tests/bench/profile-workload.sh --save before
+# ... make changes, rebuild, restart ...
+tests/bench/profile-workload.sh --diff before
 ```
 
 ### Lua profiling
 
-LuaJIT's built-in profiler (jit.p) shows which Lua functions are hot. Start and
-stop it via IPC at any time:
+`make profile-lua` captures both C and Lua profiles. You can also start/stop
+the Lua profiler manually via IPC:
 
 ```bash
-# Start profiling (1ms sampling, includes C function callers)
 somewm-client eval "require('jit.p').start('Gli1', '/tmp/lua-profile.txt')"
-
-# ... use compositor normally ...
-
-# Stop and view results
+# ... use compositor ...
 somewm-client eval "require('jit.p').stop()"
 cat /tmp/lua-profile.txt
 ```
 
-The output shows stack frames with sample counts, directly compatible with
-FlameGraph tools: `flamegraph.pl < /tmp/lua-profile.txt > lua-flamegraph.svg`
+The output shows stack frames with sample counts, compatible with FlameGraph
+tools: `flamegraph.pl < /tmp/lua-profile.txt > lua-flamegraph.svg`
+
+### Tips
+
+- The profiler warns if the running binary was rebuilt since startup (causes
+  unresolved C function names). Restart the compositor to fix.
+- System library symbols (pixman, wlroots, cairo) are resolved via debuginfod.
+- Profile the bench build, not the ASAN build. ASAN adds ~17% overhead that
+  distorts the profile.
 
 ### Memory profiling
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -253,6 +253,109 @@ To port AwesomeWM tests:
 - Some AwesomeWM tests may need adaptation for Wayland
 - D-Bus features not fully tested in headless mode
 
+## Profiling
+
+### Profile your live session
+
+The simplest way to understand compositor performance: attach perf while you
+use the compositor normally.
+
+```bash
+# Profile for 30 seconds (default), use the compositor normally during this time
+tests/bench/profile-session.sh
+
+# Profile for 60 seconds
+tests/bench/profile-session.sh 60
+
+# Also capture Lua function-level profile alongside C flamegraph
+tests/bench/profile-session.sh --lua
+
+# Save as baseline for later comparison
+tests/bench/profile-session.sh --save pre-2.0
+
+# Compare against saved baseline (red = hotter, blue = cooler)
+tests/bench/profile-session.sh --diff pre-2.0
+```
+
+Open the SVG flamegraph in a browser for the interactive view (click to zoom,
+search with Ctrl+F).
+
+For readable function names, make sure the running compositor binary hasn't been
+rebuilt since it started (the script warns if this is the case). System library
+symbols (pixman, wlroots, cairo) are resolved via debuginfod.
+
+### Scripted profiling (repeatable)
+
+For repeatable before/after comparison, the scripted workload drives a fixed
+sequence of tag switches, focus changes, geometry updates, and property toggles:
+
+```bash
+tests/bench/profile-workload.sh --save main
+# ... make changes, rebuild, restart compositor ...
+tests/bench/profile-workload.sh --diff main
+```
+
+### Lua profiling
+
+LuaJIT's built-in profiler (jit.p) shows which Lua functions are hot. Start and
+stop it via IPC at any time:
+
+```bash
+# Start profiling (1ms sampling, includes C function callers)
+somewm-client eval "require('jit.p').start('Gli1', '/tmp/lua-profile.txt')"
+
+# ... use compositor normally ...
+
+# Stop and view results
+somewm-client eval "require('jit.p').stop()"
+cat /tmp/lua-profile.txt
+```
+
+The output shows stack frames with sample counts, directly compatible with
+FlameGraph tools: `flamegraph.pl < /tmp/lua-profile.txt > lua-flamegraph.svg`
+
+### Memory profiling
+
+```bash
+# Allocation tracking (start compositor under heaptrack)
+heaptrack ./build-bench/somewm
+
+# Or attach to running compositor
+heaptrack --pid $(pidof somewm)
+```
+
+### Bench-instrumented build
+
+Build with `make build-bench` to get per-stage frame timing, render phase timing,
+C/Lua boundary crossing counts, and input latency accessible via `awesome.bench_stats()`:
+
+```bash
+make build-bench
+./build-bench/somewm  # Run as your compositor
+
+# Query stats from another terminal
+somewm-client eval "
+  local s = awesome.bench_stats()
+  for k,v in pairs(s.stages) do
+    print(k, string.format('avg=%.1fus p99=%.1fus', v.avg_us, v.p99_us))
+  end
+  print(string.format('render: avg=%.1fus p99=%.1fus', s.render.avg_us, s.render.p99_us))
+  print('crossings/frame avg=' .. s.crossings_per_frame.avg)
+"
+```
+
+### Interpreting perf output
+
+The self-time view (`perf report --no-children`) shows where CPU is actually spent:
+
+```bash
+perf report --stdio --no-children --percent-limit 0.3 -g none
+```
+
+The children view (default) shows inclusive time, where percentages overlap because they
+include callees. A function at 50% doesn't mean it uses 50% of CPU -- it means 50% of
+samples had that function somewhere in the call stack.
+
 ## Future Work
 
 - Add client spawning support (native Wayland clients like `foot`)

--- a/tests/bench/bench-client-churn.lua
+++ b/tests/bench/bench-client-churn.lua
@@ -1,32 +1,25 @@
 -- Benchmark: Client Churn (Signal-only)
 --
--- Tests the signal overhead of client property changes without actually
--- spawning/destroying clients (which is slow and I/O-bound). Instead,
--- this rapidly toggles client properties that each emit signals:
--- minimized, sticky, ontop, urgent, fullscreen, maximized.
+-- Tests property toggle signal overhead with full compositor pipeline
+-- per iteration. Each iteration: toggle 6 properties on all clients ->
+-- yield -> some_refresh() processes property signals, banning, stacking.
 --
 -- Run: somewm-client eval "dofile('tests/bench/bench-client-churn.lua')"
+-- Then poll: somewm-client eval "return _bench_results.client_churn or 'PENDING'"
 
-local N = 1000
-local has_bench = awesome.bench_stats ~= nil
-local out = {}
+local helpers = dofile("tests/bench/bench-helpers.lua")
 
-if has_bench then
-    awesome.bench_reset()
-end
+local N = 100
 
-collectgarbage("collect")
-collectgarbage("stop")
+_G._bench_results = _G._bench_results or {}
+_G._bench_results.client_churn = nil
 
 local clients = client.get()
 if #clients == 0 then
-    collectgarbage("restart")
     return "SKIP: no clients available"
 end
 
-local start = os.clock()
-
-for i = 1, N do
+helpers.timed_async("client-churn", function(i)
     for _, c in ipairs(clients) do
         c.minimized = true
         c.minimized = false
@@ -35,27 +28,11 @@ for i = 1, N do
         c.ontop = true
         c.ontop = false
     end
-end
+end, N, function(result)
+    _G._bench_results.client_churn = helpers.format_results("client-churn", {result}, {
+        clients = #clients,
+        property_toggles_per_iteration = #clients * 6,
+    })
+end)
 
-local elapsed = os.clock() - start
-
-collectgarbage("restart")
-
--- 6 property toggles per client per iteration
-local total_ops = N * #clients * 6
-
-out[#out+1] = "=== client-churn ==="
-out[#out+1] = string.format("clients: %d, iterations: %d, property toggles: %d", #clients, N, total_ops)
-out[#out+1] = string.format("elapsed: %.4f seconds", elapsed)
-out[#out+1] = string.format("ops/sec: %.0f", total_ops / elapsed)
-
-if has_bench then
-    local s = awesome.bench_stats()
-    out[#out+1] = string.format("signal_emit_count: %d", s.signal_emit_count)
-    out[#out+1] = string.format("signal_handler_calls: %d", s.signal_handler_calls)
-    out[#out+1] = string.format("signal_lookup_misses: %d", s.signal_lookup_misses)
-    out[#out+1] = string.format("refresh_count: %d", s.refresh_count)
-    out[#out+1] = string.format("lua_memory_kb: %.1f", s.lua_memory_kb)
-end
-
-return table.concat(out, "\n")
+return "ASYNC client-churn started (" .. N .. " iterations, " .. #clients .. " clients)"

--- a/tests/bench/bench-focus-cycle.lua
+++ b/tests/bench/bench-focus-cycle.lua
@@ -1,51 +1,31 @@
 -- Benchmark: Focus Cycling
 --
--- Tests the focus signal burst path. Each focus change emits up to 6
--- signals: property::active(false) + unfocus + client::unfocus on old,
--- property::active(true) + focus + client::focus on new.
+-- Tests focus changes with full compositor pipeline per iteration.
+-- Each iteration: change focus -> yield -> some_refresh() processes
+-- focus signals, stacking updates, border redraws.
 --
 -- Run: somewm-client eval "dofile('tests/bench/bench-focus-cycle.lua')"
+-- Then poll: somewm-client eval "return _bench_results.focus_cycle or 'PENDING'"
 
-local N = 5000
-local has_bench = awesome.bench_stats ~= nil
-local out = {}
+local helpers = dofile("tests/bench/bench-helpers.lua")
 
-if has_bench then
-    awesome.bench_reset()
-end
+local N = 100
 
-collectgarbage("collect")
-collectgarbage("stop")
+_G._bench_results = _G._bench_results or {}
+_G._bench_results.focus_cycle = nil
 
 local clients = client.get()
 if #clients < 2 then
-    collectgarbage("restart")
     return "SKIP: need at least 2 clients"
 end
 
-local start = os.clock()
-
-for i = 1, N do
+helpers.timed_async("focus-cycle", function(i)
     local c = clients[(i % #clients) + 1]
     client.focus = c
-end
+end, N, function(result)
+    _G._bench_results.focus_cycle = helpers.format_results("focus-cycle", {result}, {
+        clients = #clients,
+    })
+end)
 
-local elapsed = os.clock() - start
-
-collectgarbage("restart")
-
-out[#out+1] = "=== focus-cycle ==="
-out[#out+1] = string.format("clients: %d, iterations: %d", #clients, N)
-out[#out+1] = string.format("elapsed: %.4f seconds", elapsed)
-out[#out+1] = string.format("ops/sec: %.0f", N / elapsed)
-
-if has_bench then
-    local s = awesome.bench_stats()
-    out[#out+1] = string.format("signal_emit_count: %d", s.signal_emit_count)
-    out[#out+1] = string.format("signal_handler_calls: %d", s.signal_handler_calls)
-    out[#out+1] = string.format("signal_lookup_misses: %d", s.signal_lookup_misses)
-    out[#out+1] = string.format("refresh_count: %d", s.refresh_count)
-    out[#out+1] = string.format("lua_memory_kb: %.1f", s.lua_memory_kb)
-end
-
-return table.concat(out, "\n")
+return "ASYNC focus-cycle started (" .. N .. " iterations, " .. #clients .. " clients)"

--- a/tests/bench/bench-geometry-storm.lua
+++ b/tests/bench/bench-geometry-storm.lua
@@ -1,32 +1,25 @@
 -- Benchmark: Geometry Storm
 --
--- Tests the geometry signal burst path. On synchronous dispatch, each
--- geometry change emits up to 7 signals (property::geometry, position,
--- size, x, y, width, height). On queued dispatch with coalescing, this
--- should collapse to 1.
+-- Tests geometry changes with full compositor pipeline per iteration.
+-- Each iteration: set geometry on all clients -> yield -> some_refresh()
+-- applies geometry to scene graph, recalculates borders, etc.
 --
 -- Run: somewm-client eval "dofile('tests/bench/bench-geometry-storm.lua')"
+-- Then poll: somewm-client eval "return _bench_results.geometry_storm or 'PENDING'"
 
-local N = 1000
-local has_bench = awesome.bench_stats ~= nil
-local out = {}
+local helpers = dofile("tests/bench/bench-helpers.lua")
 
-if has_bench then
-    awesome.bench_reset()
-end
+local N = 100
 
-collectgarbage("collect")
-collectgarbage("stop")
+_G._bench_results = _G._bench_results or {}
+_G._bench_results.geometry_storm = nil
 
 local clients = client.get()
 if #clients == 0 then
-    collectgarbage("restart")
     return "SKIP: no clients available"
 end
 
-local start = os.clock()
-
-for i = 1, N do
+helpers.timed_async("geometry-storm", function(i)
     for _, c in ipairs(clients) do
         c:geometry({
             x = 10 + (i % 200),
@@ -35,24 +28,10 @@ for i = 1, N do
             height = 300 + (i % 100),
         })
     end
-end
+end, N, function(result)
+    _G._bench_results.geometry_storm = helpers.format_results("geometry-storm", {result}, {
+        clients = #clients,
+    })
+end)
 
-local elapsed = os.clock() - start
-
-collectgarbage("restart")
-
-out[#out+1] = "=== geometry-storm ==="
-out[#out+1] = string.format("clients: %d, iterations: %d", #clients, N)
-out[#out+1] = string.format("elapsed: %.4f seconds", elapsed)
-out[#out+1] = string.format("ops/sec: %.0f", (N * #clients) / elapsed)
-
-if has_bench then
-    local s = awesome.bench_stats()
-    out[#out+1] = string.format("signal_emit_count: %d", s.signal_emit_count)
-    out[#out+1] = string.format("signal_handler_calls: %d", s.signal_handler_calls)
-    out[#out+1] = string.format("signal_lookup_misses: %d", s.signal_lookup_misses)
-    out[#out+1] = string.format("refresh_count: %d", s.refresh_count)
-    out[#out+1] = string.format("lua_memory_kb: %.1f", s.lua_memory_kb)
-end
-
-return table.concat(out, "\n")
+return "ASYNC geometry-storm started (" .. N .. " iterations, " .. #clients .. " clients)"

--- a/tests/bench/bench-helpers.lua
+++ b/tests/bench/bench-helpers.lua
@@ -1,0 +1,210 @@
+-- Shared helpers for somewm benchmarks
+--
+-- Provides mock objects, timing utilities, and output formatting.
+
+local helpers = {}
+
+-- ---------------------------------------------------------------------------
+-- Timing
+-- ---------------------------------------------------------------------------
+
+--- Run a function for the given number of iterations and return timing data.
+-- Pauses GC during measurement. If awesome.bench_stats is available, captures
+-- before/after stats.
+function helpers.timed(name, fn, iterations)
+    iterations = iterations or 1000
+
+    local has_bench = awesome.bench_stats ~= nil
+    if has_bench then awesome.bench_reset() end
+
+    collectgarbage("collect")
+    collectgarbage("stop")
+
+    local start = os.clock()
+    for _ = 1, iterations do
+        fn()
+    end
+    local elapsed = os.clock() - start
+
+    collectgarbage("restart")
+
+    local result = {
+        name = name,
+        iterations = iterations,
+        elapsed = elapsed,
+        ops_per_sec = iterations / elapsed,
+    }
+
+    if has_bench then
+        result.bench_stats = awesome.bench_stats()
+    end
+
+    return result
+end
+
+--- Run a function asynchronously, yielding to the event loop between iterations.
+-- Each iteration gets a full some_refresh() cycle (layout, geometry, banning, stacking).
+-- Results are delivered via done_callback since IPC eval returns before completion.
+-- GC runs normally since we're measuring realistic compositor cost.
+function helpers.timed_async(name, fn, iterations, done_callback)
+    local gears_timer = require("gears.timer")
+    iterations = iterations or 100
+
+    local has_bench = awesome.bench_stats ~= nil
+    if has_bench then awesome.bench_reset() end
+
+    collectgarbage("collect")
+
+    local i = 0
+    local start = os.clock()
+
+    local function next_iteration()
+        if i < iterations then
+            i = i + 1
+            fn(i)
+            gears_timer.delayed_call(next_iteration)
+        else
+            local elapsed = os.clock() - start
+            local result = {
+                name = name,
+                iterations = iterations,
+                elapsed = elapsed,
+                ops_per_sec = iterations / elapsed,
+            }
+            if has_bench then
+                result.bench_stats = awesome.bench_stats()
+            end
+            done_callback(result)
+        end
+    end
+
+    gears_timer.delayed_call(next_iteration)
+end
+
+-- Global results table for async benchmarks (polled by runner)
+if not _G._bench_results then
+    _G._bench_results = {}
+end
+
+-- ---------------------------------------------------------------------------
+-- JSON encoder
+-- ---------------------------------------------------------------------------
+
+local function json_encode_value(v, indent, depth)
+    depth = depth or 0
+    indent = indent or ""
+    local t = type(v)
+
+    if t == "number" then
+        if v ~= v then return '"NaN"' end
+        if v == math.huge then return '"Infinity"' end
+        if v == -math.huge then return '"-Infinity"' end
+        return string.format("%.6g", v)
+    elseif t == "string" then
+        return '"' .. v:gsub('\\', '\\\\'):gsub('"', '\\"'):gsub('\n', '\\n') .. '"'
+    elseif t == "boolean" then
+        return tostring(v)
+    elseif t == "nil" then
+        return "null"
+    elseif t == "table" then
+        -- Check if array (sequential integer keys starting at 1)
+        local is_array = true
+        local max_i = 0
+        for k, _ in pairs(v) do
+            if type(k) ~= "number" or k ~= math.floor(k) or k < 1 then
+                is_array = false
+                break
+            end
+            if k > max_i then max_i = k end
+        end
+        if max_i ~= #v then is_array = false end
+
+        local next_indent = indent .. "  "
+        local parts = {}
+
+        if is_array and #v > 0 then
+            for i = 1, #v do
+                parts[#parts + 1] = next_indent .. json_encode_value(v[i], next_indent, depth + 1)
+            end
+            return "[\n" .. table.concat(parts, ",\n") .. "\n" .. indent .. "]"
+        elseif not is_array then
+            -- Collect and sort keys for deterministic output
+            local keys = {}
+            for k, _ in pairs(v) do
+                keys[#keys + 1] = k
+            end
+            table.sort(keys, function(a, b) return tostring(a) < tostring(b) end)
+
+            for _, k in ipairs(keys) do
+                local key_str = json_encode_value(tostring(k), next_indent, depth + 1)
+                local val_str = json_encode_value(v[k], next_indent, depth + 1)
+                parts[#parts + 1] = next_indent .. key_str .. ": " .. val_str
+            end
+            return "{\n" .. table.concat(parts, ",\n") .. "\n" .. indent .. "}"
+        else
+            return "[]"
+        end
+    else
+        return '"<' .. t .. '>"'
+    end
+end
+
+function helpers.json_encode(v)
+    return json_encode_value(v)
+end
+
+-- ---------------------------------------------------------------------------
+-- Output formatting
+-- ---------------------------------------------------------------------------
+
+--- Format a list of results as human-readable text and JSON.
+-- @param benchmark_name  The name of the benchmark
+-- @param results         Array of result tables from helpers.timed()
+-- @param extra           Optional table of extra metadata to include in JSON
+-- @return string         Combined human-readable + JSON output
+function helpers.format_results(benchmark_name, results, extra)
+    local out = {}
+
+    -- Human-readable output
+    out[#out + 1] = "=== " .. benchmark_name .. " ==="
+
+    for _, r in ipairs(results) do
+        out[#out + 1] = string.format("  %s: %.4fs (%s iterations, %.0f ops/sec)",
+            r.name, r.elapsed, r.iterations, r.ops_per_sec)
+    end
+
+    -- Build JSON payload
+    local json_data = {
+        benchmark = benchmark_name,
+        timestamp = os.date("!%Y-%m-%dT%H:%M:%SZ"),
+        results = {},
+    }
+
+    if extra then
+        for k, v in pairs(extra) do
+            json_data[k] = v
+        end
+    end
+
+    for _, r in ipairs(results) do
+        local entry = {
+            name = r.name,
+            iterations = r.iterations,
+            elapsed = r.elapsed,
+            ops_per_sec = r.ops_per_sec,
+        }
+        if r.bench_stats then
+            entry.bench_stats = r.bench_stats
+        end
+        json_data.results[#json_data.results + 1] = entry
+    end
+
+    out[#out + 1] = ""
+    out[#out + 1] = "---JSON-START---"
+    out[#out + 1] = helpers.json_encode(json_data)
+    out[#out + 1] = "---JSON-END---"
+
+    return table.concat(out, "\n")
+end
+
+return helpers

--- a/tests/bench/bench-memory-runner.sh
+++ b/tests/bench/bench-memory-runner.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Memory trend analysis runner.
+# Starts a headless compositor, installs the memory sampler, drives load
+# patterns, then collects results.
+#
+# Usage: tests/bench/bench-memory-runner.sh
+# Or:    make bench-memory
+
+set -e
+
+export LC_NUMERIC=C
+
+SOMEWM="${SOMEWM:-./somewm}"
+SOMEWM_CLIENT="${SOMEWM_CLIENT:-./somewm-client}"
+DURATION=${DURATION:-120}  # Total duration in seconds
+PHASE_DURATION=$((DURATION / 4))
+
+cd "$(dirname "$0")/../.."
+ROOT_DIR="$PWD"
+
+TMP_DIR=$(mktemp -d)
+LOG="$TMP_DIR/somewm.log"
+TEST_RUNTIME_DIR="$TMP_DIR/runtime"
+mkdir -p "$TEST_RUNTIME_DIR"
+chmod 700 "$TEST_RUNTIME_DIR"
+
+TEST_CONFIG_DIR="$TMP_DIR/config/somewm"
+mkdir -p "$TEST_CONFIG_DIR"
+cat > "$TEST_CONFIG_DIR/rc.lua" << 'RCEOF'
+local awful = require("awful")
+awful.rules.rules = {
+    { rule = { }, properties = { focus = true } },
+}
+screen.connect_signal("request::desktop_decoration", function(s)
+    awful.tag({ "1", "2", "3", "4", "5", "6", "7", "8", "9" }, s, awful.layout.suit.tile)
+end)
+RCEOF
+
+export WLR_BACKENDS=headless
+export WLR_RENDERER=pixman
+export WLR_WL_OUTPUTS=1
+export NO_AT_BRIDGE=1
+export XDG_RUNTIME_DIR="$TEST_RUNTIME_DIR"
+export XDG_CONFIG_HOME="$TMP_DIR/config"
+export LUA_PATH="$ROOT_DIR/lua/?.lua;$ROOT_DIR/lua/?/init.lua;;"
+
+cleanup() {
+    if [ -n "$SOMEWM_PID" ] && kill -0 "$SOMEWM_PID" 2>/dev/null; then
+        kill "$SOMEWM_PID" 2>/dev/null
+        wait "$SOMEWM_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+# Start compositor
+"$SOMEWM" > "$LOG" 2>&1 &
+SOMEWM_PID=$!
+
+# Wait for IPC
+for i in $(seq 1 30); do
+    SOCKET=$(ls "$TEST_RUNTIME_DIR"/wayland-* 2>/dev/null | head -1)
+    if [ -n "$SOCKET" ]; then break; fi
+    sleep 0.1
+done
+export WAYLAND_DISPLAY=$(basename "$SOCKET")
+
+for i in $(seq 1 20); do
+    if "$SOMEWM_CLIENT" eval "return 'ready'" 2>/dev/null | grep -q ready; then break; fi
+    sleep 0.1
+done
+
+echo "=== Memory Trend Analysis (${DURATION}s) ==="
+echo ""
+
+# Start memory sampler
+"$SOMEWM_CLIENT" eval "return dofile('tests/bench/bench-memory-trend.lua')" 2>/dev/null
+echo ""
+
+# Phase 1: Idle
+echo "Phase 1/${PHASE_DURATION}s: Idle..."
+sleep "$PHASE_DURATION"
+
+# Phase 2: Tag switching churn
+echo "Phase 2/${PHASE_DURATION}s: Tag switching..."
+for i in $(seq 1 $((PHASE_DURATION * 10))); do
+    "$SOMEWM_CLIENT" eval "screen[1].tags[($i % 9) + 1]:view_only()" 2>/dev/null || true
+    sleep 0.1
+done
+
+# Phase 3: Property churn (if clients exist)
+echo "Phase 3/${PHASE_DURATION}s: Property churn..."
+for i in $(seq 1 $((PHASE_DURATION * 5))); do
+    "$SOMEWM_CLIENT" eval "
+        for _, c in ipairs(client.get()) do
+            c.ontop = not c.ontop
+        end
+    " 2>/dev/null || true
+    sleep 0.2
+done
+
+# Phase 4: Idle recovery
+echo "Phase 4/${PHASE_DURATION}s: Idle recovery..."
+sleep "$PHASE_DURATION"
+
+# Collect results
+echo ""
+echo "Collecting results..."
+RESULT=$("$SOMEWM_CLIENT" eval "return bench_memory_stop()" 2>/dev/null)
+echo "$RESULT"
+
+# Save to file if requested
+if [ -n "$OUTPUT" ]; then
+    echo "$RESULT" > "$OUTPUT"
+    echo "Saved to: $OUTPUT"
+fi

--- a/tests/bench/bench-memory-trend.lua
+++ b/tests/bench/bench-memory-trend.lua
@@ -1,0 +1,93 @@
+-- Benchmark: Memory Trend Sampler
+--
+-- Installs a periodic timer to sample memory stats. Driven externally
+-- by bench-memory-runner.sh which sends load patterns via IPC.
+--
+-- Usage (internal): somewm-client eval "dofile('tests/bench/bench-memory-trend.lua')"
+-- This starts the sampler. Call bench_memory_stop() via IPC to get results.
+
+local helpers = dofile("tests/bench/bench-helpers.lua")
+local gears = require("gears")
+
+local SAMPLE_INTERVAL = 5  -- seconds
+
+local samples = {}
+local timer_obj = nil
+local start_time = os.clock()
+
+local function take_sample()
+    local sample = {
+        time_s = os.clock() - start_time,
+        lua_memory_kb = collectgarbage("count"),
+    }
+
+    if awesome.bench_stats then
+        local s = awesome.bench_stats()
+        sample.lua_memory_kb = s.lua_memory_kb or sample.lua_memory_kb
+        if s.memory then
+            sample.scene_trees = s.memory.scene_trees
+            sample.scene_rects = s.memory.scene_rects
+            sample.scene_buffers = s.memory.scene_buffers
+            sample.clients = s.memory.clients
+            sample.drawins = s.memory.drawins
+        end
+    end
+
+    samples[#samples + 1] = sample
+end
+
+-- Start sampling
+timer_obj = gears.timer {
+    timeout = SAMPLE_INTERVAL,
+    autostart = true,
+    callback = take_sample,
+}
+
+-- Take initial sample immediately
+take_sample()
+
+-- Global function to stop and return results
+function bench_memory_stop() -- luacheck: ignore
+    if timer_obj then
+        timer_obj:stop()
+        timer_obj = nil
+    end
+
+    -- Take final sample
+    take_sample()
+
+    local n = #samples
+    if n < 2 then
+        return helpers.json_encode({
+            benchmark = "memory-trend",
+            error = "not enough samples",
+        })
+    end
+
+    -- Compute linear regression on lua_memory_kb
+    local sum_x, sum_y, sum_xy, sum_x2 = 0, 0, 0, 0
+    for _, s in ipairs(samples) do
+        sum_x = sum_x + s.time_s
+        sum_y = sum_y + s.lua_memory_kb
+        sum_xy = sum_xy + s.time_s * s.lua_memory_kb
+        sum_x2 = sum_x2 + s.time_s ^ 2
+    end
+    local denom = n * sum_x2 - sum_x ^ 2
+    local slope = denom ~= 0 and (n * sum_xy - sum_x * sum_y) / denom or 0
+    local slope_kb_per_min = slope * 60
+
+    local result = {
+        benchmark = "memory-trend",
+        timestamp = os.date("!%Y-%m-%dT%H:%M:%SZ"),
+        sample_count = n,
+        duration_s = samples[n].time_s,
+        start_lua_kb = samples[1].lua_memory_kb,
+        end_lua_kb = samples[n].lua_memory_kb,
+        slope_kb_per_min = slope_kb_per_min,
+        samples = samples,
+    }
+
+    return helpers.json_encode(result)
+end
+
+return string.format("Memory sampler started (interval: %ds). Call bench_memory_stop() to get results.", SAMPLE_INTERVAL)

--- a/tests/bench/bench-save-baseline.sh
+++ b/tests/bench/bench-save-baseline.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Save the latest benchmark results as the baseline for the current branch.
+#
+# Usage: tests/bench/bench-save-baseline.sh [results-dir]
+
+set -e
+
+cd "$(dirname "$0")/../.."
+
+if [ -n "$1" ]; then
+    RESULTS_DIR="$1"
+else
+    RESULTS_DIR=""
+    for dir in tests/bench/results/20*/; do
+        [ -d "$dir" ] && RESULTS_DIR="$dir"
+    done
+fi
+
+if [ -z "$RESULTS_DIR" ] || [ ! -d "$RESULTS_DIR" ]; then
+    echo "Error: no results directory found. Run 'make bench-json' first." >&2
+    exit 1
+fi
+
+BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+BASELINES_DIR="tests/bench/results/baselines"
+mkdir -p "$BASELINES_DIR"
+
+DEST="$BASELINES_DIR/$BRANCH"
+
+# Copy results to baseline directory
+rm -rf "$DEST"
+cp -r "$RESULTS_DIR" "$DEST"
+
+echo "Saved baseline for branch '$BRANCH': $DEST"
+echo "  Source: $RESULTS_DIR"
+echo "  Files: $(ls "$DEST"/*.json 2>/dev/null | wc -l) JSON files"

--- a/tests/bench/bench-stats.lua
+++ b/tests/bench/bench-stats.lua
@@ -1,0 +1,265 @@
+#!/usr/bin/env lua
+--
+-- Statistical comparison of two benchmark result sets.
+-- Reads JSON files from two directories, extracts ops_per_sec from each run,
+-- computes mean/stddev/change and Welch's t-test for significance.
+--
+-- Usage: lua bench-stats.lua <dir-A> <dir-B>
+
+local dir_a = arg[1]
+local dir_b = arg[2]
+
+if not dir_a or not dir_b then
+    io.stderr:write("Usage: lua bench-stats.lua <dir-A> <dir-B>\n")
+    os.exit(1)
+end
+
+-- ---------------------------------------------------------------------------
+-- Minimal JSON parser (handles the subset we emit)
+-- ---------------------------------------------------------------------------
+
+local function skip_ws(s, i)
+    return s:match("^%s*()", i)
+end
+
+local function parse_value(s, i)
+    i = skip_ws(s, i)
+    local c = s:sub(i, i)
+
+    if c == '"' then
+        -- String
+        local j = i + 1
+        while true do
+            local k = s:find('[\\"]', j)
+            if not k then error("unterminated string at " .. i) end
+            if s:sub(k, k) == '\\' then
+                j = k + 2
+            else
+                return s:sub(i + 1, k - 1), k + 1
+            end
+        end
+    elseif c == '{' then
+        -- Object
+        local obj = {}
+        i = skip_ws(s, i + 1)
+        if s:sub(i, i) == '}' then return obj, i + 1 end
+        while true do
+            local key
+            key, i = parse_value(s, i)
+            i = skip_ws(s, i)
+            assert(s:sub(i, i) == ':', "expected ':' at " .. i)
+            i = skip_ws(s, i + 1)
+            local val
+            val, i = parse_value(s, i)
+            obj[key] = val
+            i = skip_ws(s, i)
+            local sep = s:sub(i, i)
+            if sep == '}' then return obj, i + 1 end
+            assert(sep == ',', "expected ',' or '}' at " .. i)
+            i = skip_ws(s, i + 1)
+        end
+    elseif c == '[' then
+        -- Array
+        local arr = {}
+        i = skip_ws(s, i + 1)
+        if s:sub(i, i) == ']' then return arr, i + 1 end
+        while true do
+            local val
+            val, i = parse_value(s, i)
+            arr[#arr + 1] = val
+            i = skip_ws(s, i)
+            local sep = s:sub(i, i)
+            if sep == ']' then return arr, i + 1 end
+            assert(sep == ',', "expected ',' or ']' at " .. i)
+            i = skip_ws(s, i + 1)
+        end
+    elseif s:match("^true", i) then
+        return true, i + 4
+    elseif s:match("^false", i) then
+        return false, i + 5
+    elseif s:match("^null", i) then
+        return nil, i + 4
+    else
+        -- Number
+        local num_str = s:match("^-?%d+%.?%d*[eE]?[+-]?%d*", i)
+        if not num_str then error("invalid value at " .. i) end
+        return tonumber(num_str), i + #num_str
+    end
+end
+
+local function json_decode(s)
+    local val, _ = parse_value(s, 1)
+    return val
+end
+
+-- ---------------------------------------------------------------------------
+-- Statistics
+-- ---------------------------------------------------------------------------
+
+local function mean(values)
+    local sum = 0
+    for _, v in ipairs(values) do sum = sum + v end
+    return sum / #values
+end
+
+local function stddev(values, m)
+    m = m or mean(values)
+    local sum_sq = 0
+    for _, v in ipairs(values) do sum_sq = sum_sq + (v - m) ^ 2 end
+    return math.sqrt(sum_sq / (#values - 1))
+end
+
+-- Welch's t-test: returns t statistic and approximate degrees of freedom
+local function welch_t(m1, s1, n1, m2, s2, n2)
+    local se = math.sqrt(s1^2/n1 + s2^2/n2)
+    if se == 0 then return 0, 1 end
+    local t = (m1 - m2) / se
+    local num = (s1^2/n1 + s2^2/n2)^2
+    local den = (s1^2/n1)^2/(n1-1) + (s2^2/n2)^2/(n2-1)
+    local df = num / den
+    return t, df
+end
+
+-- Approximate two-tailed p-value from t and df using the beta distribution
+-- approximation. For our purposes, we just check against common thresholds.
+local function is_significant(t, df, alpha)
+    alpha = alpha or 0.05
+    -- Critical t-values for common df ranges at alpha=0.05 (two-tailed)
+    local crit
+    if df >= 120 then crit = 1.980
+    elseif df >= 60 then crit = 2.000
+    elseif df >= 30 then crit = 2.042
+    elseif df >= 20 then crit = 2.086
+    elseif df >= 15 then crit = 2.131
+    elseif df >= 10 then crit = 2.228
+    elseif df >= 5 then crit = 2.571
+    elseif df >= 3 then crit = 3.182
+    elseif df >= 2 then crit = 4.303
+    else crit = 12.706
+    end
+    return math.abs(t) > crit
+end
+
+-- ---------------------------------------------------------------------------
+-- Load results from a directory
+-- ---------------------------------------------------------------------------
+
+local function list_json_files(dir)
+    if dir:match("[%$`|;&(){}!#]") then
+        io.stderr:write("Error: unsafe characters in path: " .. dir .. "\n")
+        os.exit(1)
+    end
+    local files = {}
+    local p = io.popen("find '" .. dir .. "' -maxdepth 1 -name '*.json' -type f 2>/dev/null | sort")
+    if not p then return files end
+    for line in p:lines() do
+        files[#files + 1] = line
+    end
+    p:close()
+    return files
+end
+
+local function load_results(dir)
+    -- Group results by benchmark name -> list of ops_per_sec values
+    local benchmarks = {}
+    local files = list_json_files(dir)
+
+    for _, fpath in ipairs(files) do
+        local fname = fpath:match("([^/]+)%.json$")
+        if fname and fname ~= "manifest" and fname ~= "startup-time" then
+            local f = io.open(fpath, "r")
+            if f then
+                local content = f:read("*a")
+                f:close()
+                local ok, data = pcall(json_decode, content)
+                if ok and data and data.results then
+                    for _, r in ipairs(data.results) do
+                        local key = r.name or fname
+                        if not benchmarks[key] then benchmarks[key] = {} end
+                        if r.ops_per_sec then
+                            table.insert(benchmarks[key], r.ops_per_sec)
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    return benchmarks
+end
+
+-- ---------------------------------------------------------------------------
+-- Compare and report
+-- ---------------------------------------------------------------------------
+
+local results_a = load_results(dir_a)
+local results_b = load_results(dir_b)
+
+-- Collect all benchmark names
+local all_names = {}
+local seen = {}
+for name, _ in pairs(results_a) do
+    if not seen[name] then
+        all_names[#all_names + 1] = name
+        seen[name] = true
+    end
+end
+for name, _ in pairs(results_b) do
+    if not seen[name] then
+        all_names[#all_names + 1] = name
+        seen[name] = true
+    end
+end
+table.sort(all_names)
+
+-- Header
+local fmt = "%-40s %12s %12s %8s %5s"
+print(string.format(fmt, "Benchmark", "Baseline", "Candidate", "Change", "Sig?"))
+print(string.rep("-", 80))
+
+local regressions = 0
+
+for _, name in ipairs(all_names) do
+    local va = results_a[name]
+    local vb = results_b[name]
+
+    if va and vb and #va >= 2 and #vb >= 2 then
+        local m_a = mean(va)
+        local s_a = stddev(va, m_a)
+        local m_b = mean(vb)
+        local s_b = stddev(vb, m_b)
+        local pct = (m_b - m_a) / m_a * 100
+
+        local t, df = welch_t(m_a, s_a, #va, m_b, s_b, #vb)
+        local sig = is_significant(t, df)
+
+        local sig_str = sig and "YES" or "no"
+        local a_str = string.format("%.0f +/- %.0f", m_a, s_a)
+        local b_str = string.format("%.0f +/- %.0f", m_b, s_b)
+        local pct_str = string.format("%+.1f%%", pct)
+
+        print(string.format(fmt, name, a_str, b_str, pct_str, sig_str))
+
+        -- A significant decrease in ops/sec is a regression
+        if sig and pct < -5 then
+            regressions = regressions + 1
+        end
+    elseif va and not vb then
+        print(string.format(fmt, name, "present", "MISSING", "-", "-"))
+    elseif vb and not va then
+        print(string.format(fmt, name, "MISSING", "present", "-", "-"))
+    else
+        local n_a = va and #va or 0
+        local n_b = vb and #vb or 0
+        print(string.format(fmt, name,
+            n_a .. " runs", n_b .. " runs", "n/a", "n/a"))
+    end
+end
+
+print("")
+if regressions > 0 then
+    print(string.format("REGRESSIONS: %d benchmark(s) showed significant performance decrease (>5%%)", regressions))
+    os.exit(1)
+else
+    print("No significant regressions detected.")
+end

--- a/tests/bench/bench-tag-switch.lua
+++ b/tests/bench/bench-tag-switch.lua
@@ -1,57 +1,35 @@
 -- Benchmark: Tag Switching
 --
--- Tests the tag view path which triggers property::selected on tags,
--- client list signals, and banning/unbanning of clients. This exercises
--- a mix of property, lifecycle, and layout signals.
+-- Tests the tag view path with full compositor pipeline per iteration.
+-- Each iteration: switch tag -> yield -> some_refresh() runs layout,
+-- banning, stacking, geometry application.
 --
 -- Run: somewm-client eval "dofile('tests/bench/bench-tag-switch.lua')"
+-- Then poll: somewm-client eval "return _bench_results.tag_switch or 'PENDING'"
 
-local N = 1000
-local has_bench = awesome.bench_stats ~= nil
-local out = {}
+local helpers = dofile("tests/bench/bench-helpers.lua")
 
-if has_bench then
-    awesome.bench_reset()
-end
+local N = 100
 
-collectgarbage("collect")
-collectgarbage("stop")
+_G._bench_results = _G._bench_results or {}
+_G._bench_results.tag_switch = nil
 
 local s = screen[1]
 if not s or not s.tags or #s.tags < 2 then
-    collectgarbage("restart")
     return "SKIP: need at least 2 tags on screen 1"
 end
 
 local tags = s.tags
 local ntags = #tags
 
-local start = os.clock()
-
-for i = 1, N do
+helpers.timed_async("tag-switch", function(i)
     local tag_idx = (i % ntags) + 1
     tags[tag_idx]:view_only()
-end
+end, N, function(result)
+    tags[1]:view_only()
+    _G._bench_results.tag_switch = helpers.format_results("tag-switch", {result}, {
+        tags = ntags,
+    })
+end)
 
-local elapsed = os.clock() - start
-
--- Restore tag 1
-tags[1]:view_only()
-
-collectgarbage("restart")
-
-out[#out+1] = "=== tag-switch ==="
-out[#out+1] = string.format("tags: %d, iterations: %d", ntags, N)
-out[#out+1] = string.format("elapsed: %.4f seconds", elapsed)
-out[#out+1] = string.format("ops/sec: %.0f", N / elapsed)
-
-if has_bench then
-    local st = awesome.bench_stats()
-    out[#out+1] = string.format("signal_emit_count: %d", st.signal_emit_count)
-    out[#out+1] = string.format("signal_handler_calls: %d", st.signal_handler_calls)
-    out[#out+1] = string.format("signal_lookup_misses: %d", st.signal_lookup_misses)
-    out[#out+1] = string.format("refresh_count: %d", st.refresh_count)
-    out[#out+1] = string.format("lua_memory_kb: %.1f", st.lua_memory_kb)
-end
-
-return table.concat(out, "\n")
+return "ASYNC tag-switch started (" .. N .. " iterations)"

--- a/tests/bench/profile-session.sh
+++ b/tests/bench/profile-session.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# Profile your live compositor session.
+#
+# Attaches perf to the running somewm process while you use it normally.
+# Produces a flamegraph and optionally a Lua-level profile via jit.p.
+#
+# Usage:
+#   tests/bench/profile-session.sh              # 30s profile
+#   tests/bench/profile-session.sh 60           # 60s profile
+#   tests/bench/profile-session.sh --lua        # Also capture Lua profile
+#   tests/bench/profile-session.sh --save main  # Save with label
+#   tests/bench/profile-session.sh --diff main  # Diff against saved profile
+#
+# Requires: perf, FlameGraph tools (stackcollapse-perf.pl, flamegraph.pl)
+
+set -e
+
+SOMEWM_CLIENT="${SOMEWM_CLIENT:-./build-bench/somewm-client}"
+FLAMEGRAPH_DIR="${FLAMEGRAPH_DIR:-$HOME/tools/FlameGraph}"
+RESULTS_DIR="tests/bench/results"
+DURATION=30
+LUA_PROFILE=0
+SAVE_LABEL=""
+DIFF_LABEL=""
+
+cd "$(dirname "$0")/../.."
+
+# Pre-flight: verify FlameGraph tools
+for tool in stackcollapse-perf.pl flamegraph.pl; do
+    if [ ! -x "$FLAMEGRAPH_DIR/$tool" ]; then
+        echo "Error: $tool not found at $FLAMEGRAPH_DIR/" >&2
+        echo "Set FLAMEGRAPH_DIR to your FlameGraph checkout" >&2
+        exit 1
+    fi
+done
+
+# Parse arguments
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --lua) LUA_PROFILE=1; shift ;;
+        --save) SAVE_LABEL="$2"; shift 2 ;;
+        --diff) DIFF_LABEL="$2"; shift 2 ;;
+        [0-9]*) DURATION="$1"; shift ;;
+        *) echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+# Find compositor PID
+SOMEWM_PID=""
+for pid in $(pidof somewm 2>/dev/null); do
+    if [ -d "/proc/$pid" ]; then
+        SOMEWM_PID="$pid"
+        break
+    fi
+done
+
+if [ -z "$SOMEWM_PID" ]; then
+    echo "Error: somewm not running" >&2
+    exit 1
+fi
+
+# Warn if binary was replaced (causes unresolved symbols)
+BINARY_PATH=$(readlink "/proc/$SOMEWM_PID/exe" 2>/dev/null || true)
+if echo "$BINARY_PATH" | grep -q "(deleted)"; then
+    echo "WARNING: somewm binary was replaced since this process started." >&2
+    echo "C function names will show as raw addresses in the flamegraph." >&2
+    echo "Restart the compositor to get readable output." >&2
+    echo "" >&2
+fi
+
+# Use debuginfod for system library symbols (pixman, wlroots, cairo, etc.)
+export DEBUGINFOD_URLS="${DEBUGINFOD_URLS:-https://debuginfod.archlinux.org}"
+
+echo "Profiling somewm PID $SOMEWM_PID for ${DURATION}s"
+echo "  Use the compositor normally during this time."
+echo ""
+
+# Start Lua profiling if requested
+if [ "$LUA_PROFILE" = 1 ]; then
+    echo "Starting Lua profiler (jit.p)..."
+    "$SOMEWM_CLIENT" eval "require('jit.p').start('Gli1', '/tmp/somewm-lua-profile.txt')" 2>/dev/null || {
+        echo "WARNING: jit.p not available, skipping Lua profiling" >&2
+        LUA_PROFILE=0
+    }
+fi
+
+# Record perf profile
+PERF_DATA=$(mktemp --suffix=.perf.data)
+FOLDED=""
+cleanup_temps() {
+    rm -f "$PERF_DATA" "$FOLDED"
+}
+trap cleanup_temps EXIT
+
+perf record -g --call-graph dwarf -e cpu-clock -p "$SOMEWM_PID" -o "$PERF_DATA" -- sleep "$DURATION"
+
+# Stop Lua profiling
+if [ "$LUA_PROFILE" = 1 ]; then
+    "$SOMEWM_CLIENT" eval "require('jit.p').stop()" 2>/dev/null || true
+fi
+
+echo ""
+echo "Processing profile..."
+
+FOLDED=$(mktemp --suffix=.folded)
+perf script -i "$PERF_DATA" | "$FLAMEGRAPH_DIR/stackcollapse-perf.pl" > "$FOLDED"
+SAMPLES=$(wc -l < "$FOLDED")
+echo "  $SAMPLES unique stacks"
+
+mkdir -p "$RESULTS_DIR"
+
+# Generate differential flamegraph if requested
+if [ -n "$DIFF_LABEL" ]; then
+    BASELINE="$RESULTS_DIR/profile-${DIFF_LABEL}.folded"
+    if [ ! -f "$BASELINE" ]; then
+        echo "Error: no saved profile '$DIFF_LABEL' at $BASELINE" >&2
+        exit 1
+    fi
+
+    DIFF_SVG="$RESULTS_DIR/profile-diff-${DIFF_LABEL}-vs-current.svg"
+    "$FLAMEGRAPH_DIR/difffolded.pl" "$BASELINE" "$FOLDED" \
+        | "$FLAMEGRAPH_DIR/flamegraph.pl" > "$DIFF_SVG"
+
+    echo ""
+    echo "Differential flamegraph: $DIFF_SVG"
+    echo "  Red = hotter (more CPU in current)"
+    echo "  Blue = cooler (less CPU in current)"
+fi
+
+# Save or generate timestamped output
+if [ -n "$SAVE_LABEL" ]; then
+    cp "$FOLDED" "$RESULTS_DIR/profile-${SAVE_LABEL}.folded"
+    "$FLAMEGRAPH_DIR/flamegraph.pl" < "$FOLDED" > "$RESULTS_DIR/profile-${SAVE_LABEL}.svg"
+    echo ""
+    echo "Saved profile '$SAVE_LABEL':"
+    echo "  Flamegraph: $RESULTS_DIR/profile-${SAVE_LABEL}.svg"
+    echo "  Folded:     $RESULTS_DIR/profile-${SAVE_LABEL}.folded"
+else
+    TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+    "$FLAMEGRAPH_DIR/flamegraph.pl" < "$FOLDED" > "$RESULTS_DIR/profile-${TIMESTAMP}.svg"
+    cp "$FOLDED" "$RESULTS_DIR/profile-${TIMESTAMP}.folded"
+    echo ""
+    echo "Flamegraph: $RESULTS_DIR/profile-${TIMESTAMP}.svg"
+    echo "Folded:     $RESULTS_DIR/profile-${TIMESTAMP}.folded"
+fi
+
+# Lua profile output
+if [ "$LUA_PROFILE" = 1 ] && [ -f /tmp/somewm-lua-profile.txt ]; then
+    LUA_SVG="$RESULTS_DIR/lua-profile-$(date +%Y%m%d-%H%M%S).svg"
+    "$FLAMEGRAPH_DIR/flamegraph.pl" --title "Lua Profile" \
+        < /tmp/somewm-lua-profile.txt > "$LUA_SVG" 2>/dev/null || true
+
+    echo ""
+    echo "Lua profile:"
+    echo "  Raw:        /tmp/somewm-lua-profile.txt"
+    if [ -f "$LUA_SVG" ]; then
+        echo "  Flamegraph: $LUA_SVG"
+    fi
+    echo ""
+    echo "  Top Lua functions:"
+    sort -t' ' -k2 -rn /tmp/somewm-lua-profile.txt | head -10 | while read -r line; do
+        echo "    $line"
+    done
+fi
+
+# Top self-time functions from C profile
+echo ""
+echo "Top C functions by self-time:"
+perf report -i "$PERF_DATA" --stdio --no-children --percent-limit 0.5 -g none 2>/dev/null \
+    | grep -E "^\s+[0-9]" | head -15

--- a/tests/bench/profile-workload.sh
+++ b/tests/bench/profile-workload.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# Scripted profiling workload for somewm.
+#
+# Drives a repeatable sequence of compositor operations via IPC while
+# perf records a CPU profile. Produces a flamegraph and saves folded
+# stacks for later differential comparison.
+#
+# Usage:
+#   tests/bench/profile-workload.sh                  # Profile live session
+#   tests/bench/profile-workload.sh --save baseline  # Save with label
+#   tests/bench/profile-workload.sh --diff baseline   # Diff against saved profile
+#
+# Requires: perf, FlameGraph tools (stackcollapse-perf.pl, flamegraph.pl, difffolded.pl)
+
+set -e
+
+SOMEWM_CLIENT="${SOMEWM_CLIENT:-./build-bench/somewm-client}"
+FLAMEGRAPH_DIR="${FLAMEGRAPH_DIR:-$HOME/tools/FlameGraph}"
+RESULTS_DIR="tests/bench/results"
+PERF_DURATION=${PERF_DURATION:-15}
+
+cd "$(dirname "$0")/../.."
+
+# Pre-flight: verify FlameGraph tools
+for tool in stackcollapse-perf.pl flamegraph.pl; do
+    if [ ! -x "$FLAMEGRAPH_DIR/$tool" ]; then
+        echo "Error: $tool not found at $FLAMEGRAPH_DIR/" >&2
+        echo "Set FLAMEGRAPH_DIR to your FlameGraph checkout" >&2
+        exit 1
+    fi
+done
+
+# Parse arguments
+SAVE_LABEL=""
+DIFF_LABEL=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --save) SAVE_LABEL="$2"; shift 2 ;;
+        --diff) DIFF_LABEL="$2"; shift 2 ;;
+        *) echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+# Find compositor PID
+SOMEWM_PID=""
+for pid in $(pidof somewm 2>/dev/null); do
+    if [ -d "/proc/$pid" ] && [ -f "/proc/$pid/exe" ]; then
+        SOMEWM_PID="$pid"
+        break
+    fi
+done
+
+if [ -z "$SOMEWM_PID" ]; then
+    echo "Error: somewm not running" >&2
+    exit 1
+fi
+
+# Warn if binary was replaced (causes unresolved symbols)
+BINARY_PATH=$(readlink "/proc/$SOMEWM_PID/exe" 2>/dev/null || true)
+if echo "$BINARY_PATH" | grep -q "(deleted)"; then
+    echo "WARNING: somewm binary was replaced since this process started." >&2
+    echo "C function names will show as raw addresses. Restart to fix." >&2
+    echo "" >&2
+fi
+
+# Use debuginfod for system library symbols
+export DEBUGINFOD_URLS="${DEBUGINFOD_URLS:-https://debuginfod.archlinux.org}"
+
+echo "Profiling somewm PID $SOMEWM_PID for ${PERF_DURATION}s"
+
+eval_cmd() {
+    "$SOMEWM_CLIENT" eval "$1" 2>/dev/null || true
+}
+
+# The workload: a repeatable sequence of compositor operations
+run_workload() {
+    # Wait for perf to attach
+    sleep 0.5
+
+    echo "  Phase 1: Tag switching (cycling all tags 3x)"
+    for round in 1 2 3; do
+        for tag in 1 2 3 4 5 6 7 8 9; do
+            eval_cmd "screen[1].tags[${tag}]:view_only()"
+        done
+    done
+
+    echo "  Phase 2: Focus cycling"
+    for i in $(seq 1 30); do
+        eval_cmd "local cls = client.get(); if #cls > 0 then client.focus = cls[($i % #cls) + 1] end"
+    done
+
+    echo "  Phase 3: Geometry changes"
+    for i in $(seq 1 20); do
+        eval_cmd "for _, c in ipairs(client.get()) do local g = c:geometry(); c:geometry({ x = g.x + ($i % 5) - 2, y = g.y + ($i % 3) - 1 }) end"
+    done
+
+    echo "  Phase 4: Property toggles"
+    for i in $(seq 1 20); do
+        eval_cmd "for _, c in ipairs(client.get()) do c.ontop = not c.ontop; c.sticky = not c.sticky end"
+    done
+
+    echo "  Phase 5: Restore state"
+    eval_cmd "screen[1].tags[1]:view_only()"
+
+    echo "  Workload complete, waiting for perf to finish..."
+}
+
+# Run perf and workload in parallel
+PERF_DATA=$(mktemp --suffix=.perf.data)
+FOLDED=""
+cleanup_temps() {
+    rm -f "$PERF_DATA" "$FOLDED"
+}
+trap cleanup_temps EXIT
+
+run_workload &
+WORKLOAD_PID=$!
+
+perf record -g --call-graph dwarf -e cpu-clock -p "$SOMEWM_PID" -o "$PERF_DATA" -- sleep "$PERF_DURATION"
+
+wait "$WORKLOAD_PID" 2>/dev/null || true
+
+echo ""
+echo "Processing profile..."
+
+FOLDED=$(mktemp --suffix=.folded)
+perf script -i "$PERF_DATA" | "$FLAMEGRAPH_DIR/stackcollapse-perf.pl" > "$FOLDED"
+SAMPLES=$(wc -l < "$FOLDED")
+echo "  $SAMPLES unique stacks"
+
+mkdir -p "$RESULTS_DIR"
+
+if [ -n "$DIFF_LABEL" ]; then
+    # Differential flamegraph against saved baseline
+    BASELINE="$RESULTS_DIR/profile-${DIFF_LABEL}.folded"
+    if [ ! -f "$BASELINE" ]; then
+        echo "Error: no saved profile '$DIFF_LABEL' at $BASELINE" >&2
+        exit 1
+    fi
+
+    DIFF_SVG="$RESULTS_DIR/profile-diff-${DIFF_LABEL}-vs-current.svg"
+    "$FLAMEGRAPH_DIR/difffolded.pl" "$BASELINE" "$FOLDED" \
+        | "$FLAMEGRAPH_DIR/flamegraph.pl" > "$DIFF_SVG"
+
+    echo ""
+    echo "Differential flamegraph: $DIFF_SVG"
+    echo "  Red = hotter (more CPU in current)"
+    echo "  Blue = cooler (less CPU in current)"
+fi
+
+if [ -n "$SAVE_LABEL" ]; then
+    # Save folded stacks and flamegraph with label
+    cp "$FOLDED" "$RESULTS_DIR/profile-${SAVE_LABEL}.folded"
+    "$FLAMEGRAPH_DIR/flamegraph.pl" < "$FOLDED" > "$RESULTS_DIR/profile-${SAVE_LABEL}.svg"
+    echo ""
+    echo "Saved profile '$SAVE_LABEL':"
+    echo "  Flamegraph: $RESULTS_DIR/profile-${SAVE_LABEL}.svg"
+    echo "  Folded:     $RESULTS_DIR/profile-${SAVE_LABEL}.folded"
+else
+    # Just generate a flamegraph with timestamp
+    TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+    "$FLAMEGRAPH_DIR/flamegraph.pl" < "$FOLDED" > "$RESULTS_DIR/profile-${TIMESTAMP}.svg"
+    cp "$FOLDED" "$RESULTS_DIR/profile-${TIMESTAMP}.folded"
+    echo ""
+    echo "Flamegraph: $RESULTS_DIR/profile-${TIMESTAMP}.svg"
+    echo "Folded:     $RESULTS_DIR/profile-${TIMESTAMP}.folded"
+fi
+
+# Also dump top self-time functions
+echo ""
+echo "Top functions by self-time:"
+perf report -i "$PERF_DATA" --stdio --no-children --percent-limit 0.3 -g none 2>/dev/null \
+    | grep -E "^\s+[0-9]" | head -15
+
+# Temp files cleaned up by trap

--- a/tests/bench/run-all.sh
+++ b/tests/bench/run-all.sh
@@ -1,29 +1,38 @@
 #!/usr/bin/env bash
 #
-# Benchmark runner for somewm signal dispatch profiling
+# Benchmark runner for somewm performance profiling.
+# Runs benchmarks against the currently running compositor session.
 #
-# Modes:
-#   HEADLESS=1: Run with headless backend (default for benchmarks)
-#   HEADLESS=0: Run against the current compositor session
+# Options:
+#   JSON=1:     Capture JSON output to results directory
+#   RUNS=N:     Number of iterations per benchmark (default: 5)
 #
 # Usage:
-#   tests/bench/run-all.sh                    # Headless mode
-#   HEADLESS=0 tests/bench/run-all.sh         # Against running session
+#   tests/bench/run-all.sh                    # Run all benchmarks
 #   tests/bench/run-all.sh bench-focus-cycle   # Single benchmark
+#   JSON=1 tests/bench/run-all.sh             # With JSON capture
 
 set -e
 
 export LC_NUMERIC=C
 
-SOMEWM="${SOMEWM:-./somewm}"
 SOMEWM_CLIENT="${SOMEWM_CLIENT:-./somewm-client}"
-HEADLESS=${HEADLESS:-1}
 RUNS=${RUNS:-5}
+JSON=${JSON:-0}
 
 cd "$(dirname "$0")/../.."
 ROOT_DIR="$PWD"
 
 BENCH_DIR="$ROOT_DIR/tests/bench"
+
+# Set up JSON results directory if requested
+if [ "$JSON" = 1 ]; then
+    GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+    GIT_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+    RUN_ID="$(date +%Y%m%d-%H%M%S)-${GIT_COMMIT}"
+    RESULTS_DIR="$BENCH_DIR/results/$RUN_ID"
+    mkdir -p "$RESULTS_DIR"
+fi
 
 # Determine which benchmarks to run
 if [ -n "$1" ]; then
@@ -31,6 +40,16 @@ if [ -n "$1" ]; then
 else
     BENCHMARKS=("$BENCH_DIR"/bench-*.lua)
 fi
+
+# Filter out helpers (not a benchmark)
+FILTERED=()
+for b in "${BENCHMARKS[@]}"; do
+    case "$(basename "$b")" in
+        bench-helpers.lua|bench-stats.lua|bench-memory-trend.lua) continue ;;
+    esac
+    FILTERED+=("$b")
+done
+BENCHMARKS=("${FILTERED[@]}")
 
 # Validate benchmarks exist
 for b in "${BENCHMARKS[@]}"; do
@@ -40,128 +59,93 @@ for b in "${BENCHMARKS[@]}"; do
     fi
 done
 
-run_against_session() {
-    # Run benchmarks against the currently running compositor
-    echo "=== Running against live session ==="
-    echo ""
+# Extract JSON block from benchmark output
+extract_json() {
+    sed -n '/^---JSON-START---$/,/^---JSON-END---$/{/^---JSON/d;p;}'
+}
 
-    for bench in "${BENCHMARKS[@]}"; do
-        name=$(basename "$bench" .lua)
-        echo "--- $name (${RUNS} runs) ---"
+# Run a single benchmark and optionally capture JSON
+run_bench() {
+    local bench="$1"
+    local name=$(basename "$bench" .lua)
+    echo "--- $name (${RUNS} runs) ---"
 
-        for run in $(seq 1 "$RUNS"); do
-            echo "[run $run/$RUNS]"
-            "$SOMEWM_CLIENT" eval "return dofile('$bench')"
-            echo ""
-        done
+    for run in $(seq 1 "$RUNS"); do
+        echo -n "[run $run/$RUNS] "
+        local output
+        output=$("$SOMEWM_CLIENT" eval "return dofile('$bench')" 2>/dev/null) || {
+            echo "FAILED"
+            continue
+        }
+
+        # Check if benchmark is async (returns "ASYNC ..." and stores result in global)
+        if echo "$output" | grep -q "^OK" && echo "$output" | grep -q "ASYNC"; then
+            # Derive the result key from the benchmark name (bench-tag-switch -> tag_switch)
+            local result_key
+            result_key=$(echo "$name" | sed 's/^bench-//; s/-/_/g')
+
+            # Poll for completion
+            local attempts=0
+            local max_attempts=600  # 60 seconds at 100ms intervals
+            while [ $attempts -lt $max_attempts ]; do
+                output=$("$SOMEWM_CLIENT" eval "return _bench_results.${result_key} or 'PENDING'" 2>/dev/null)
+                if ! echo "$output" | grep -q "PENDING"; then
+                    break
+                fi
+                sleep 0.1
+                attempts=$((attempts + 1))
+            done
+
+            if [ $attempts -ge $max_attempts ]; then
+                echo "TIMEOUT"
+                "$SOMEWM_CLIENT" eval "_bench_results.${result_key} = nil" 2>/dev/null || true
+                continue
+            fi
+
+            # Clean up global for next run
+            "$SOMEWM_CLIENT" eval "_bench_results.${result_key} = nil" 2>/dev/null || true
+        fi
+
+        # Strip IPC framing ("OK\n" prefix, "OK (no return value)" lines)
+        output=$(echo "$output" | sed '/^OK$/d; /^OK (no return value)$/d')
+
+        # Print human-readable part (everything before JSON sentinel)
+        echo "$output" | sed '/^---JSON-START---$/,$d'
+
+        # Capture JSON if requested
+        if [ "$JSON" = 1 ]; then
+            local json
+            json=$(echo "$output" | extract_json)
+            if [ -n "$json" ]; then
+                echo "$json" > "$RESULTS_DIR/${name}-run${run}.json"
+            fi
+        fi
+        echo ""
     done
 }
 
-run_headless() {
-    # Start a headless compositor, spawn test clients, run benchmarks
-    echo "=== Running in headless mode ==="
-    echo ""
+echo "=== Running against live session ==="
+echo ""
 
-    TMP_DIR=$(mktemp -d)
-    LOG="$TMP_DIR/somewm.log"
-    TEST_RUNTIME_DIR="$TMP_DIR/runtime"
-    mkdir -p "$TEST_RUNTIME_DIR"
-    chmod 700 "$TEST_RUNTIME_DIR"
+for bench in "${BENCHMARKS[@]}"; do
+    run_bench "$bench"
+done
 
-    # Create test config that spawns some windows
-    TEST_CONFIG_DIR="$TMP_DIR/config/somewm"
-    mkdir -p "$TEST_CONFIG_DIR"
-    cat > "$TEST_CONFIG_DIR/rc.lua" << 'RCEOF'
-local awful = require("awful")
-local gears = require("gears")
+# Print frame stats at end
+"$SOMEWM_CLIENT" eval "if awesome.bench_stats then local s = awesome.bench_stats(); print('=== frame timing ==='); print(string.format('refresh_count: %d', s.refresh_count)); print(string.format('refresh_avg_us: %.1f', s.refresh_avg_us)); print(string.format('refresh_p99_us: %.1f', s.refresh_p99_us)); print(string.format('refresh_max_us: %.1f', s.refresh_max_us)); if s.crossings_per_frame then print(string.format('crossings_per_frame_avg: %.1f', s.crossings_per_frame.avg)); print(string.format('crossings_per_frame_max: %d', s.crossings_per_frame.max)) end end" 2>/dev/null || true
 
--- Minimal config for benchmarking
-awful.rules.rules = {
-    { rule = { }, properties = { focus = true } },
+# Write manifest
+if [ "$JSON" = 1 ]; then
+    cat > "$RESULTS_DIR/manifest.json" << MANIFESTEOF
+{
+  "run_id": "$RUN_ID",
+  "git_commit": "$GIT_COMMIT",
+  "git_branch": "$GIT_BRANCH",
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "runs": $RUNS
 }
+MANIFESTEOF
 
-screen.connect_signal("request::desktop_decoration", function(s)
-    awful.tag({ "1", "2", "3", "4", "5", "6", "7", "8", "9" }, s, awful.layout.suit.tile)
-end)
-RCEOF
-
-    export WLR_BACKENDS=headless
-    export WLR_RENDERER=pixman
-    export WLR_WL_OUTPUTS=1
-    export NO_AT_BRIDGE=1
-    export XDG_RUNTIME_DIR="$TEST_RUNTIME_DIR"
-    export XDG_CONFIG_HOME="$TMP_DIR/config"
-    export LUA_PATH="$ROOT_DIR/lua/?.lua;$ROOT_DIR/lua/?/init.lua;;"
-
-    cleanup() {
-        if [ -n "$SOMEWM_PID" ] && kill -0 "$SOMEWM_PID" 2>/dev/null; then
-            kill "$SOMEWM_PID" 2>/dev/null
-            wait "$SOMEWM_PID" 2>/dev/null || true
-        fi
-        rm -rf "$TMP_DIR"
-    }
-    trap cleanup EXIT
-
-    # Start compositor
-    "$SOMEWM" > "$LOG" 2>&1 &
-    SOMEWM_PID=$!
-
-    # Wait for socket
-    SOCKET=""
-    for i in $(seq 1 30); do
-        SOCKET=$(ls "$TEST_RUNTIME_DIR"/wayland-* 2>/dev/null | head -1)
-        if [ -n "$SOCKET" ]; then
-            break
-        fi
-        sleep 0.1
-    done
-
-    if [ -z "$SOCKET" ]; then
-        echo "Error: compositor did not start" >&2
-        cat "$LOG" >&2
-        exit 1
-    fi
-
-    export WAYLAND_DISPLAY=$(basename "$SOCKET")
-
-    # Wait for IPC
-    for i in $(seq 1 20); do
-        if "$SOMEWM_CLIENT" eval "return 'ready'" 2>/dev/null | grep -q ready; then
-            break
-        fi
-        sleep 0.1
-    done
-
-    echo "Compositor ready (PID $SOMEWM_PID)"
     echo ""
-
-    # Run benchmarks
-    for bench in "${BENCHMARKS[@]}"; do
-        name=$(basename "$bench" .lua)
-        echo "--- $name (${RUNS} runs) ---"
-
-        for run in $(seq 1 "$RUNS"); do
-            echo "[run $run/$RUNS]"
-            "$SOMEWM_CLIENT" eval "return dofile('$bench')" || echo "FAILED"
-            echo ""
-        done
-    done
-
-    # Print frame stats at end
-    "$SOMEWM_CLIENT" eval "
-        if awesome.bench_stats then
-            local s = awesome.bench_stats()
-            print('=== frame timing ===')
-            print(string.format('refresh_count: %d', s.refresh_count))
-            print(string.format('refresh_avg_us: %.1f', s.refresh_avg_us))
-            print(string.format('refresh_p99_us: %.1f', s.refresh_p99_us))
-            print(string.format('refresh_max_us: %.1f', s.refresh_max_us))
-        end
-    " 2>/dev/null || true
-}
-
-if [ "$HEADLESS" = 1 ]; then
-    run_headless
-else
-    run_against_session
+    echo "JSON results: $RESULTS_DIR"
 fi

--- a/window.c
+++ b/window.c
@@ -64,6 +64,7 @@
 
 #include "focus.h"
 #include "somewm_internal.h"
+#include "bench.h"
 
 /* Popup tracking structure for proper constraint handling */
 typedef struct {
@@ -284,6 +285,10 @@ commitnotify(struct wl_listener *listener, void *data)
 	/* Skip initial commit - handled by initialcommitnotify */
 	if (c->surface.xdg->initial_commit)
 		return;
+
+#ifdef SOMEWM_BENCH
+	bench_manage_end(c);
+#endif
 
 	/* Only call resize() for floating or fullscreen clients.
 	 * Tiled clients have their geometry managed by the Lua layout engine,
@@ -775,6 +780,9 @@ mapnotify(struct wl_listener *listener, void *data)
 	/* Called when the surface is mapped, or ready to display on-screen. */
 	Client *p = NULL;
 	Client *w, *c = wl_container_of(listener, c, map);
+#ifdef SOMEWM_BENCH
+	bench_manage_start(c);
+#endif
 	Monitor *m;
 	int i;
 	lua_State *L;


### PR DESCRIPTION
## Description

Initial attempt at performance measurement infrastructure for tracking 2.0 changes. This is a starting point, not a finished product.

Three pieces:

**C instrumentation** (`bench.c`/`bench.h`, built with `make build-bench`): Per-stage frame timing within `some_refresh()`, C/Lua boundary crossing counter, empty refresh detection, input-to-display latency, client manage latency, and memory counters. All behind `#ifdef SOMEWM_BENCH`. Exposed via `awesome.bench_stats()`.

**Synthetic benchmarks** (`tests/bench/`): Signal dispatch benchmarks that yield to the event loop so each iteration exercises the full compositor pipeline. Mock-based algorithm benchmarks for layout scaling, rule evaluation, and widget hierarchy. These measure isolated throughput, not real-world experience. JSON output with comparison tooling.

**Profiling workflow** (`tests/bench/profile-workload.sh`): Scripted workload that drives repeatable operations via IPC while `perf` records. Supports saving baselines and generating differential flamegraphs for before/after comparison. This is closer to what's actually useful for understanding compositor performance.