### PR TITLE
fix: Assert upon monitor unplug due to missing surface cleanup #442

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -5870,6 +5870,9 @@ unmaplayersurfacenotify(struct wl_listener *listener, void *data)
 	if (l == exclusive_focus)
 		exclusive_focus = NULL;
 
+	if (l->layer_surface && l->layer_surface->surface && l->layer_surface->output)
+		wlr_surface_send_leave(l->layer_surface->surface, l->layer_surface->output);
+
 	if (l->layer_surface->output && (l->mon = l->layer_surface->output->data))
 		arrangelayers(l->mon);
 


### PR DESCRIPTION
When a zwlr_layer_surface_v1 is created in createsurfacelayer() then a wlr_surface_send_enter() is unconditionally fired for the created surface.

Consequently, wlr_surface_send_leave() need also be sent prior destroying them. Not doing so (apparently) leaves listeners registered, e.g., for output->events.bind or others, eventually causing an assert() in wlr_output_finish().

This leads to crashes during updatemon() when a screen is removed, e.g., when unplugging external monitors, see issue #442.

Add wlr_surface_send_leave() in unmaplayersurfacenotify() to fix #442.

## Test Plan

Manual plug-unplug sequences that would reproduce the crash before.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)
