### PR TITLE
fix: floating layout set_bounds + layer surface send_leave

### DIFF
--- a/protocols.c
+++ b/protocols.c
@@ -301,6 +301,9 @@ unmaplayersurfacenotify(struct wl_listener *listener, void *data)
 	if (l == exclusive_focus)
 		exclusive_focus = NULL;
 
+	if (l->layer_surface->output)
+		wlr_surface_send_leave(l->layer_surface->surface, l->layer_surface->output);
+
 	if (l->layer_surface->output && (l->mon = l->layer_surface->output->data))
 		arrangelayers(l->mon);
 

--- a/window.c
+++ b/window.c
@@ -266,12 +266,15 @@ initialcommitnotify(struct wl_listener *listener, void *data)
 			WLR_XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN);
 	if (c->decoration)
 		requestdecorationmode(&c->set_decoration_mode, c->decoration);
-	if (m && !client_is_unmanaged(c) && !client_is_float_type(c)) {
-		wlr_xdg_toplevel_set_size(c->surface.xdg->toplevel,
-			m->w.width - 2 * c->bw, m->w.height - 2 * c->bw);
-	} else {
-		wlr_xdg_toplevel_set_size(c->surface.xdg->toplevel, 0, 0);
+	/* Send the workarea as a bounds hint and let the client pick its own
+	 * initial size. Forcing set_size to the workarea here would make
+	 * clients opened under awful.layout.suit.floating fill the screen,
+	 * because floating.arrange() is a no-op and never resizes them. */
+	if (m && !client_is_unmanaged(c)) {
+		wlr_xdg_toplevel_set_bounds(c->surface.xdg->toplevel,
+			m->w.width, m->w.height);
 	}
+	wlr_xdg_toplevel_set_size(c->surface.xdg->toplevel, 0, 0);
 }
 
 /* Handle subsequent XDG commits - resizing and opacity.


### PR DESCRIPTION
## Description

Two unrelated C fixes bundled because the first was blocking `main`'s
test suite and I found it while porting the second.

**1. `fix(xdg)`: restore `set_bounds` hint for initial configure.**
The fix from #382 for issue #371 was dropped when `initialcommitnotify`
was extracted into `window.c` in `02528d340`. `tests/test-floating-layout.lua`
was failing on main as a result. This commit restores the
`set_bounds` + `set_size(0, 0)` pattern in its new home.

**2. `fix`: pair `send_leave` with `send_enter` for layer surfaces.**
Forward-port of #450 from `release/1.4` to `main`. On `main` the layer
surface handlers were moved from `somewm.c` to `protocols.c`, so a
straight cherry-pick doesn't apply. Credit for the original diagnosis
and fix to @shuber2. Without this, unplugging a monitor while a
layer-shell client (waybar, fuzzel, tofi, swaync, ...) is running trips
the \`wl_list_empty(&output->events.bind.listener_list)\` assert in
\`wlr_output_finish\`.

## Test Plan

- \`make test-unit\` - 740 passes.
- \`make test-integration\` - 112 passes (floating layout test now green).
- Manual: on a multi-output setup, unplug the secondary monitor with a
  panel running; no assert.

## Checklist

- [x] Lua libraries (\`lua/awful/\`, \`lua/gears/\`, \`lua/wibox/\`, \`lua/naughty/\`) are **not modified** - if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (\`make test-unit && make test-integration\`)