### PR TITLE
protocols: Simplify code of unmaplayersurfacenotify()

### DIFF
--- a/protocols.c
+++ b/protocols.c
@@ -301,11 +301,15 @@ unmaplayersurfacenotify(struct wl_listener *listener, void *data)
 	if (l == exclusive_focus)
 		exclusive_focus = NULL;
 
-	if (l->layer_surface->output)
-		wlr_surface_send_leave(l->layer_surface->surface, l->layer_surface->output);
+	if (l->layer_surface && l->layer_surface->output) {
+		/* Pair send_enter() with send_leave(). */
+		if (l->layer_surface->surface)
+			wlr_surface_send_leave(l->layer_surface->surface, l->layer_surface->output);
 
-	if (l->layer_surface->output && (l->mon = l->layer_surface->output->data))
-		arrangelayers(l->mon);
+		l->mon = l->layer_surface->output->data;
+		if (l->mon)
+			arrangelayers(l->mon);
+	}
 
 	/* Emit request::unmanage signal if we have a Lua object */
 	if (l->lua_object && globalconf_L) {


### PR DESCRIPTION
Reduce duplication of conditions of control flow branches and factor out variable assignment from if-conditions.