### PR TITLE
fix: stop key repeat when a keygrabber starts mid-press

### DIFF
--- a/input.c
+++ b/input.c
@@ -1252,6 +1252,17 @@ keyrepeat(void *data)
 		return 0;
 	}
 
+	/* If a keygrabber started after the initial press (e.g. a keybinding
+	 * handler opened a launcher and installed an awful.keygrabber), stop
+	 * repeating the compositor binding. The grabber now owns the keyboard
+	 * and re-firing the binding that started it causes flicker for
+	 * toggle-style keybindings that alternate state at the repeat rate.
+	 * Mirrors the guard in keypress() above. */
+	if (!locked && some_keygrabber_is_running()) {
+		group->nsyms = 0;
+		return 0;
+	}
+
 	wl_event_source_timer_update(group->key_repeat_source,
 			1000 / group->wlr_group->keyboard.repeat_info.rate);
 


### PR DESCRIPTION
## Description

Forward-port of #455 from `release/1.4`. Same 11-line fix, applied in
`input.c` instead of `somewm.c` (2.x split the input path into its own
translation unit). Cherry-picked with `-x` so the commit carries the
provenance trailer.

`keypress()` already disarms the key repeat timer when an `awful.keygrabber`
is running. `keyrepeat()` had no matching guard, so a compositor binding
whose handler installs a grabber mid-press (e.g. a launcher on `Mod+p`)
would re-enter itself at the repeat rate and flicker. This adds the
symmetric check.

## Test Plan

- `make test-unit`: 740/740.
- `make test-integration`: 112/112 on re-run. First run flaked on
  `test-floating-layout.lua`; verified not caused by this change by
  running the full suite on plain `main` (112/112 pass). The same
  intermittent flake was also observed on the 1.4 PR branch.
- Manual repro carried over from the 1.4 branch: `Mod+p` launcher, one
  `show()` call instead of ~11.

## Checklist

- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)