### PR TITLE
send exit signal parameter

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -4842,7 +4842,8 @@ luaA_hot_reload(void)
 	}
 
 	/* Emit "exit" signal so Lua code can clean up */
-	luaA_signal_emit(L, "exit", 0);
+	lua_pushboolean(L, true);
+	luaA_signal_emit(L, "exit", 1);
 
 	/* Cancel in-flight animations */
 	animation_cleanup();

--- a/somewm.c
+++ b/somewm.c
@@ -1202,7 +1202,9 @@ cleanup(void)
 {
 	/* Emit exit signal while Lua alive (matches AwesomeWM pattern) */
 	if (globalconf_L) {
-		luaA_emit_signal_global("exit");
+		lua_State *L = globalconf_get_lua_State();
+		lua_pushboolean(L, false);
+		luaA_signal_emit(L, "exit", 1);
 	}
 
 	a_dbus_cleanup();


### PR DESCRIPTION
## Description
Fixes #457


## Test Plan
Manually


## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)
