### PR TITLE
Fix/somewm firefoxtab close crash

### DIFF
--- a/client.h
+++ b/client.h
@@ -23,16 +23,24 @@ client_is_x11(Client *c)
 	return 0;
 }
 
+static inline bool
+client_has_surface(Client *c)
+{
+#ifdef XWAYLAND
+	if (client_is_x11(c))
+		return c->surface.xwayland != NULL;
+#endif
+	return c->surface.xdg != NULL;
+}
+
 static inline struct wlr_surface *
 client_surface(Client *c)
 {
+	assert(client_has_surface(c));
 #ifdef XWAYLAND
-	if (client_is_x11(c)) {
-		assert(c->surface.xwayland != NULL);
+	if (client_is_x11(c))
 		return c->surface.xwayland->surface;
-	}
 #endif
-	assert(c->surface.xdg != NULL);
 	return c->surface.xdg->surface;
 }
 

--- a/client.h
+++ b/client.h
@@ -269,24 +269,6 @@ client_is_float_type(Client *c)
 }
 
 static inline int
-client_is_rendered_on_mon(Client *c, Monitor *m)
-{
-	/* This is needed for when you don't want to check formal assignment,
-	 * but rather actual displaying of the pixels.
-	 * Usually VISIBLEON suffices and is also faster. */
-	struct wlr_surface_output *s;
-	int unused_lx, unused_ly;
-	if (!c->scene)
-		return 0;
-	if (!wlr_scene_node_coords(&c->scene->node, &unused_lx, &unused_ly))
-		return 0;
-	wl_list_for_each(s, &client_surface(c)->current_outputs, link)
-		if (s->output == m->wlr_output)
-			return 1;
-	return 0;
-}
-
-static inline int
 client_is_stopped(Client *c)
 {
 	int pid;

--- a/client.h
+++ b/client.h
@@ -276,6 +276,8 @@ client_is_rendered_on_mon(Client *c, Monitor *m)
 	 * Usually VISIBLEON suffices and is also faster. */
 	struct wlr_surface_output *s;
 	int unused_lx, unused_ly;
+	if (!c->scene)
+		return 0;
 	if (!wlr_scene_node_coords(&c->scene->node, &unused_lx, &unused_ly))
 		return 0;
 	wl_list_for_each(s, &client_surface(c)->current_outputs, link)

--- a/somewm.c
+++ b/somewm.c
@@ -2505,6 +2505,31 @@ some_is_ext_session_locked(void)
 	return locked;
 }
 
+static struct wlr_scene_tree *
+surface_scene_tree_from_data(struct wlr_surface *surface)
+{
+	return surface ? surface->data : NULL;
+}
+
+static void
+surface_clear_scene_data(struct wlr_surface *surface, struct wlr_scene_tree *st)
+{
+	if (!surface || surface->data != st)
+		return;
+
+	surface->data = NULL;
+}
+
+static void
+client_scene_node_destroy(Client* c) {
+	if (client_has_surface(c)) {
+		struct wlr_surface *surface = client_surface(c);
+		surface_clear_scene_data(surface, c->scene);
+	}
+	wlr_scene_node_destroy(&c->scene->node);
+	c->scene = NULL;
+}
+
 /** Check if idle is effectively inhibited (for Lua API and idle timers). */
 bool
 some_is_idle_inhibited(struct wlr_surface *exclude)
@@ -2517,7 +2542,7 @@ some_is_idle_inhibited(struct wlr_surface *exclude)
 
 	wl_list_for_each(inhibitor, &idle_inhibit_mgr->inhibitors, link) {
 		struct wlr_surface *surface = wlr_surface_get_root_surface(inhibitor->surface);
-		struct wlr_scene_tree *tree = surface->data;
+		struct wlr_scene_tree *tree = surface_scene_tree_from_data(surface);
 
 		if (exclude != surface && (globalconf.appearance.bypass_surface_visibility || (!tree
 				|| wlr_scene_node_coords(&tree->node, &unused_lx, &unused_ly)))) {
@@ -2558,7 +2583,8 @@ some_push_idle_inhibitors(lua_State *L)
 	lua_newtable(L);
 	wl_list_for_each(inhibitor, &idle_inhibit_mgr->inhibitors, link) {
 		struct wlr_surface *surface = wlr_surface_get_root_surface(inhibitor->surface);
-		struct wlr_scene_tree *tree = surface->data;
+		struct wlr_scene_tree *tree = surface_scene_tree_from_data(surface);
+
 		bool visible = globalconf.appearance.bypass_surface_visibility
 			|| (!tree || wlr_scene_node_coords(&tree->node, &lx, &ly));
 
@@ -3579,9 +3605,8 @@ mapnotify(struct wl_listener *listener, void *data)
 	/* Handle scene surface creation failure (can happen with XWayland/Electron apps) */
 	if (!c->scene_surface) {
 		warn("Failed to create scene surface for client (type=%d)", c->client_type);
-		wlr_scene_node_destroy(&c->scene->node);
-		c->scene = NULL;
-		client_surface(c)->data = NULL;
+		client_scene_node_destroy(c);
+		assert(client_surface(c)->data == NULL);
 		return;
 	}
 
@@ -5911,7 +5936,7 @@ unmapnotify(struct wl_listener *listener, void *data)
 
 	/* Safety: If Lua destroyed during cleanup, skip Lua-dependent operations */
 	if (!globalconf_L) {
-		wlr_scene_node_destroy(&c->scene->node);
+		client_scene_node_destroy(c);
 		return;
 	}
 
@@ -5959,8 +5984,7 @@ unmapnotify(struct wl_listener *listener, void *data)
 		wl_list_remove(&c->commit.link);
 	}
 
-	wlr_scene_node_destroy(&c->scene->node);
-	c->scene = NULL;  /* Mark as cleaned up so destroynotify won't double-remove */
+	client_scene_node_destroy(c);
 
 	/* Clear titlebar scene buffer pointers - they were children of c->scene
 	 * and are now freed. Prevents use-after-free in refresh callbacks. */
@@ -6076,7 +6100,7 @@ updatemons(struct wl_listener *listener, void *data)
 		wlr_scene_rect_set_size(m->fullscreen_bg, m->m.width, m->m.height);
 
 		if (m->lock_surface) {
-			struct wlr_scene_tree *scene_tree = m->lock_surface->surface->data;
+			struct wlr_scene_tree *scene_tree = surface_scene_tree_from_data(m->lock_surface->surface);
 			wlr_scene_node_set_position(&scene_tree->node, m->m.x, m->m.y);
 			wlr_session_lock_surface_v1_configure(m->lock_surface, m->m.width, m->m.height);
 		}


### PR DESCRIPTION
## Description

Fixe a use-after-free of scene node accessed via surface->data, but was already destroyed, due to inconsistent and missing cleanup.

## Test Plan

Very difficult. Found in an attempt to tackle issue #446. The reasoning with a canary pointer value is explained in the last commit.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)