### PR TITLE
Kill trailing whitespace

### DIFF
--- a/spawn.c
+++ b/spawn.c
@@ -229,9 +229,9 @@ static void
 spawn_child_setup(gpointer user_data)
 {
 	char *token;
-	
+
 	setsid();
-	
+
 	/* Set XDG_ACTIVATION_TOKEN for Wayland startup notification
 	 * (matches AwesomeWM's DESKTOP_STARTUP_ID pattern for X11) */
 	token = (char *)user_data;


### PR DESCRIPTION
The current editorconfig file has trim_trailing_whitespace set, which is reasonable. However, it makes editors respecting this setting to actually do this, causing git diff output to show whitespace changes.

Fix this by making source code adhere to current editorconfig.

Those files were identified by

  git ls-files -z | xargs -0 grep -n '[[:blank:]]$'

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)
