### PR TITLE
fix: re-evaluate pointer focus after banning refresh

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -761,7 +761,17 @@ some_refresh(void)
 #endif
 
 	/* Step 4: Update client visibility (banning) */
+	bool banning_pending = globalconf.need_lazy_banning;
 	banning_refresh();
+
+	/* Step 4.5: Re-evaluate pointer focus after visibility changes.
+	 * When scene nodes are disabled (banned) wlroots sends wl_pointer.leave,
+	 * but re-enabling them does not automatically send wl_pointer.enter.
+	 * Without this, clients (notably Chromium) that were unbanned under a
+	 * stationary cursor never regain pointer focus and stop receiving all
+	 * input until the user moves the mouse. */
+	if (banning_pending)
+		motionnotify(0, NULL, 0, 0, 0, 0);
 
 #ifdef SOMEWM_BENCH
 	clock_gettime(CLOCK_MONOTONIC, &bench_ts[5]);


### PR DESCRIPTION
## Description
Cherry-pick of the release/1.4 fix for #461.

After switching tags, Chromium-based browsers stop receiving all input
(keyboard, mouse, scroll) until the user moves the mouse. This happens
because banning_refresh() disables/enables scene nodes to hide/show
clients, and wlroots sends wl_pointer.leave when a node is disabled but
does not send wl_pointer.enter when it is re-enabled. With a stationary
cursor, the client never regains pointer focus.

Calls motionnotify(0, ...) after banning_refresh() to re-evaluate
pointer focus against the updated scene graph.

Should handle #461

## Test Plan
- `make test-unit` (740 pass) and `make test-integration` (112 pass)
- Manual: open Chromium, switch tags away and back without moving the
  mouse, verify browser accepts input immediately

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)