### PR TITLE
fix: Use static inline for scene-tree surface helpers

### DIFF
--- a/window.c
+++ b/window.c
@@ -117,17 +117,15 @@ struct wl_listener new_xdg_toplevel = {.notify = createnotify};
 struct wl_listener new_xdg_popup = {.notify = createpopup};
 struct wl_listener new_xdg_decoration = {.notify = createdecoration};
 
-extern inline struct wlr_scene_tree * client_surface_get_scene_tree(struct wlr_surface *surface);
-extern inline void client_surface_clear_scene_data(struct wlr_surface *surface, struct wlr_scene_tree *st);
-
 void
-client_scene_node_destroy(Client* c) {
-       if (client_has_surface(c)) {
-               struct wlr_surface *surface = client_surface(c);
-               client_surface_clear_scene_data(surface, c->scene);
-       }
-       wlr_scene_node_destroy(&c->scene->node);
-       c->scene = NULL;
+client_scene_node_destroy(Client *c)
+{
+	if (client_has_surface(c)) {
+		struct wlr_surface *surface = client_surface(c);
+		client_surface_clear_scene_data(surface, c->scene);
+	}
+	wlr_scene_node_destroy(&c->scene->node);
+	c->scene = NULL;
 }
 
 void

--- a/window.h
+++ b/window.h
@@ -55,13 +55,13 @@ extern struct wl_listener new_xdg_toplevel;
 extern struct wl_listener new_xdg_popup;
 extern struct wl_listener new_xdg_decoration;
 
-inline struct wlr_scene_tree *
+static inline struct wlr_scene_tree *
 client_surface_get_scene_tree(struct wlr_surface *surface)
 {
 	return surface ? surface->data : NULL;
 }
 
-inline void
+static inline void
 client_surface_clear_scene_data(struct wlr_surface *surface, struct wlr_scene_tree *st)
 {
 	if (surface && surface->data == st)


### PR DESCRIPTION
## Description

Tightening up the scene-tree helpers in `window.h`.

- Mark `client_surface_get_scene_tree()` and `client_surface_clear_scene_data()` as `static inline` (matches the pattern in `client.h`). Plain `inline` in a header is fragile under C11 semantics.
- Drop the now-unnecessary `extern inline` forward decls in `window.c`.
- Small style pass on `client_scene_node_destroy()` for Allman braces + tabs.

No behavior change; `nm` confirms both helpers fully inline out.

## Test Plan

- `make build-test` and `make` both link clean.
- `make test-unit` (740) and `make test-integration` (112) green.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)