### PR TITLE
fix(fullscreen): emit per-client property::geometry in setfullscreen

### DIFF
--- a/window.c
+++ b/window.c
@@ -1424,10 +1424,22 @@ setfullscreen(Client *c, int fullscreen)
 		resize(c, c->prev, 0);
 	}
 	/* Emit per-client property::fullscreen so Lua handlers run
-	 * (update_implicitly_floating, arrange_prop_nf) before arrange */
+	 * (update_implicitly_floating, arrange_prop_nf) before arrange.
+	 *
+	 * Also emit per-client property::geometry after resize() so the
+	 * xdg-protocol fullscreen path fires the same Lua signal surface
+	 * as the Lua path. client_set_fullscreen() in objects/client.c
+	 * already emits property::geometry via client_resize_do, so
+	 * clients toggled through the Lua API notify geometry listeners
+	 * correctly. A client that requests fullscreen via xdg-shell
+	 * (request_fullscreen -> fullscreennotify -> setfullscreen) used
+	 * to change geometry silently from Lua's perspective, breaking
+	 * any handler that tracks geometry changes through this signal
+	 * (rules, placement reapplication, user animations, etc.). */
 	lua_State *L = globalconf_get_lua_State();
 	if (L) {
 		luaA_object_push(L, c);
+		luaA_object_emit_signal(L, -1, "property::geometry", 0);
 		luaA_object_emit_signal(L, -1, "property::fullscreen", 0);
 		lua_pop(L, 1);
 	}


### PR DESCRIPTION
## Description

`setfullscreen()` in `window.c` (the C protocol path for xdg-shell `request_fullscreen`) resizes the client but emits only `property::fullscreen` to Lua, never `property::geometry`. The Lua path (`client_set_fullscreen` -> `client_resize_do`) emits both.

This means Lua code that subscribes to `property::geometry` silently misses all client-initiated fullscreen transitions, breaking:

- rules that re-apply placement on geometry change
- handlers that snapshot `c:geometry()` for later comparison or animation
- any ad-hoc subscriber expecting Lua to observe every geometry mutation the compositor performs

```lua
client.connect_signal("property::geometry", function(c)
    -- never fires when a client enters/exits fullscreen via xdg protocol,
    -- only when toggled from the Lua side
end)
```

### Fix

Emit `property::geometry` alongside `property::fullscreen` in `setfullscreen()` after the `resize()` call, mirroring what `client_resize_do` does in the Lua path. Both code paths now notify Lua geometry listeners consistently.

`window.c` diff (13 lines added, 1 replaced; 2 LOC of signal emit + comment):

```c
 /* Emit per-client property::fullscreen so Lua handlers run
- * (update_implicitly_floating, arrange_prop_nf) before arrange */
+ * (update_implicitly_floating, arrange_prop_nf) before arrange.
+ * Also emit per-client property::geometry ... */
 lua_State *L = globalconf_get_lua_State();
 if (L) {
     luaA_object_push(L, c);
+    luaA_object_emit_signal(L, -1, "property::geometry", 0);
     luaA_object_emit_signal(L, -1, "property::fullscreen", 0);
     lua_pop(L, 1);
 }
```

### How this was found

We maintain a downstream geometry-tweening animation module that snapshots `c:geometry()` on every `property::geometry` into `normal_geo` / `max_geo` slots, then animates between them on `property::fullscreen`. MPV's `F` key (xdg-shell `set_fullscreen` request) would enter fullscreen fine but exit without the shrink animation, because `max_geo` was never populated: `property::geometry` never fired while `c.fullscreen = true`. The telling symptom: toggling the same client once via the Lua API (which does fire the signal) "unlocked" the exit animation for subsequent `F`-key presses, because `max_geo` was now cached. That pointed straight at the asymmetric signal emission.

### Test plan

- [x] Build passes with this patch applied.
- [x] Live-tested: MPV `F` toggles now fire `property::geometry` on both enter and exit. Geometry-tracking Lua handlers observe the transition. No regressions in Super-F (Lua path) since the Lua path already emitted both signals and this does not duplicate them: `client_set_fullscreen` does not call `setfullscreen`.
- [ ] No new tests added; this is a Lua signal surface fix and the existing Lua signal infrastructure is not covered by the C test suite.

One file, one signal emit, one comment paragraph. No behavior change for Lua code that subscribes only to `property::fullscreen`.
