### PR TITLE
fix: Hardening createmon() #477

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -1810,6 +1810,18 @@ createmon(struct wl_listener *listener, void *data)
 	struct wlr_output_state state;
 	Monitor *m;
 
+	if (wlr_output->data) {
+		wlr_log(WLR_ERROR, "[HOTPLUG] createmon duplicate ignored: %s already has monitor data",
+			wlr_output->name);
+		return;
+	}
+
+	if (wlr_output_layout_get(output_layout, wlr_output)) {
+		wlr_log(WLR_ERROR, "[HOTPLUG] createmon duplicate ignored: %s already in layout",
+			wlr_output->name);
+		return;
+	}
+
 	if (!wlr_output_init_render(wlr_output, alloc, drw))
 		return;
 


### PR DESCRIPTION
In issue #477 we have a segfault in the function call sequence createmon() -> wlr_output_layout_add_auto() -> wl_signal_add() -> wl_list_insert().

This issue motivates this commit to harden createmon() in the sense to make it idempotent through these additional two checks:

  1. Whether wlr_output->data is already set up.

  2. Whether output is already in layout. This can only be true if cleanupmon() set data to NULL already but has not removed output from layout yet.

In case, log an error and return, instead of continuing with setting up (an already set up) monitor.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)
