### PR TITLE
fix: set screen.primary in c not in userspace

### DIFF
--- a/objects/screen.c
+++ b/objects/screen.c
@@ -1850,6 +1850,29 @@ luaA_screen_module_index(lua_State *L)
 	return 1;
 }
 
+/** __newindex metamethod for screen class table
+ */
+static int
+luaA_screen_module_newindex(lua_State *L)
+{
+	const char *key = luaL_checkstring(L, 2);
+
+	/* The .primary property is tracked separately */
+	if (strcmp(key, "primary") == 0) {
+		screen_t *new_primary_screen = luaA_checkscreen(L, 3);
+
+		if ((new_primary_screen) && (new_primary_screen != primary_screen)) {
+			primary_screen = new_primary_screen;
+			luaA_screen_emit_primary_changed(L, primary_screen);
+		}
+		return 0;
+	}
+
+	/* Fallback: Allow arbitrary properties. */
+	lua_rawset(L, 1);
+	return 0;
+}
+
 /** __call metamethod for screen class
  * This function serves as both:
  * 1. The iterator function for "for s in screen do" loops
@@ -2355,6 +2378,7 @@ const luaL_Reg screen_methods[] = {
 	{ "fake_add", luaA_screen_fake_add },
 	/* Module-level metamethods */
 	{ "__index", luaA_screen_module_index },
+	{ "__newindex", luaA_screen_module_newindex },
 	{ "__call", luaA_screen_call },
 	{ NULL, NULL }
 };


### PR DESCRIPTION
## Description
See #460, although I now think this is more of a bug fix than a new feature.


## Test Plan
```lua
screen.test = 'Dynamic properties work'
print(screen.test)

screen.connect_signal("primary_changed", function()
    print("primary screen signal")
end)

print("primary screen: " .. (screen.primary.output and screen.primary.output.name or 'nil'))

for i = screen.count(), 1, -1 do
    local s = screen[i]
    if s ~= screen.primary then
        screen.primary = s
        break
    end
end
print("new primary screen: " .. (screen.primary.output and screen.primary.output.name or 'nil'))
```

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`) They are very flaky for me with or without this patch. 


I now think this should be applied to 1.4 as well. I can make a PR if you agree.