### PR TITLE
fix: make createmon() idempotent to prevent post-resume segfault

### DIFF
--- a/monitor.c
+++ b/monitor.c
@@ -204,6 +204,18 @@ createmon(struct wl_listener *listener, void *data)
 	struct wlr_output_state state;
 	Monitor *m;
 
+	if (wlr_output->data) {
+		wlr_log(WLR_ERROR, "[HOTPLUG] createmon duplicate ignored: %s already has monitor data",
+			wlr_output->name);
+		return;
+	}
+
+	if (wlr_output_layout_get(output_layout, wlr_output)) {
+		wlr_log(WLR_ERROR, "[HOTPLUG] createmon duplicate ignored: %s already in layout",
+			wlr_output->name);
+		return;
+	}
+
 	if (!wlr_output_init_render(wlr_output, alloc, drw))
 		return;
 


### PR DESCRIPTION
## Description
Forward-port of #480 (which landed on release/1.4 as 93523c49f) to `main`. The same race exists here: `createmon()` can run twice for the same `wlr_output` when the wlroots DRM backend re-emits `new_output` after resume from suspend, corrupting `wl_list` via duplicate listener insertion (see #477 for the backtrace).

`createmon()` moved from `somewm.c` to `monitor.c` during the 2.0 refactor, so a straight cherry-pick doesn't apply. The 12-line guard block is byte-for-byte identical to what landed on release/1.4; only the target file differs.

Fixes #477 on `main`.

## Test Plan
- [x] `make build-test` - green
- [x] `make test-unit` - 740 passed, 0 failed, 1 display-less skip
- [x] `make test-integration` - 112/112 passed

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** - if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)