### PR TITLE
docs: link to Wayland protocols reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Full documentation at **[somewm.org](https://somewm.org)**:
 
 - [Getting Started](https://somewm.org/docs/getting-started/installation) - Installation, first launch, migration
 - [Tutorials](https://somewm.org/docs/tutorials/basics) - Keybindings, widgets, themes
+- [Wayland Protocols](https://somewm.org/docs/reference/wayland-protocols) - Protocols somewm advertises to clients
 - [Troubleshooting](https://somewm.org/docs/troubleshooting) - Common issues and solutions
 
 ## Contributing


### PR DESCRIPTION
## Description
Adds a Wayland Protocols bullet to the README's Documentation section, pointing at the new docs-site page. Refs #398.

## Test Plan
README-only change. No code paths touched, no tests affected.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)