### PR TITLE
docs: point README links at 2.0-dev docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ make
 sudo make install
 ```
 
-For Debian, Fedora, NixOS, and detailed instructions, see the [Installation Guide](https://somewm.org/docs/getting-started/installation).
+For Debian, Fedora, NixOS, and detailed instructions, see the [Installation Guide](https://somewm.org/docs/next/getting-started/installation).
 
 ## Run
 
@@ -50,16 +50,16 @@ Validate your config before switching:
 somewm --check
 ```
 
-See [First Launch](https://somewm.org/docs/getting-started/first-launch) for configuration and migrating from AwesomeWM.
+See [First Launch](https://somewm.org/docs/next/getting-started/first-launch) for configuration and migrating from AwesomeWM.
 
 ## Documentation
 
 Full documentation at **[somewm.org](https://somewm.org)**:
 
-- [Getting Started](https://somewm.org/docs/getting-started/installation) - Installation, first launch, migration
-- [Tutorials](https://somewm.org/docs/tutorials/basics) - Keybindings, widgets, themes
-- [Wayland Protocols](https://somewm.org/docs/reference/wayland-protocols) - Protocols somewm advertises to clients
-- [Troubleshooting](https://somewm.org/docs/troubleshooting) - Common issues and solutions
+- [Getting Started](https://somewm.org/docs/next/getting-started/installation) - Installation, first launch, migration
+- [Tutorials](https://somewm.org/docs/next/tutorials/basics) - Keybindings, widgets, themes
+- [Wayland Protocols](https://somewm.org/docs/next/reference/wayland-protocols) - Protocols somewm advertises to clients
+- [Troubleshooting](https://somewm.org/docs/next/troubleshooting) - Common issues and solutions
 
 ## Contributing
 


### PR DESCRIPTION
## Description
The README's docs links used /docs/<path>, which resolves to the 1.4
version on somewm.org (Docusaurus `lastVersion: '1.4'`). This branch is
2.0-dev, so the links were silently sending readers to the wrong docs.
Repointed them at /docs/next/... (the current/unreleased version URL).

## Test Plan
- Rendered each updated link and confirmed it lands on the "2.0 (dev)"
  version in the Docusaurus version switcher.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`) — n/a, README-only