### PR TITLE
docs: point README links at 1.4 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ make
 sudo make install
 ```
 
-For Debian, Fedora, NixOS, and detailed instructions, see the [Installation Guide](https://somewm.org/getting-started/installation).
+For Debian, Fedora, NixOS, and detailed instructions, see the [Installation Guide](https://somewm.org/docs/getting-started/installation).
 
 ## Run
 
@@ -51,15 +51,15 @@ Or from a TTY:
 dbus-run-session somewm
 ```
 
-See [First Launch](https://somewm.org/getting-started/first-launch) for configuration and migrating from AwesomeWM.
+See [First Launch](https://somewm.org/docs/getting-started/first-launch) for configuration and migrating from AwesomeWM.
 
 ## Documentation
 
 Full documentation at **[somewm.org](https://somewm.org)**:
 
-- [Getting Started](https://somewm.org/getting-started/installation) - Installation, first launch, migration
-- [Tutorials](https://somewm.org/tutorials/basics) - Keybindings, widgets, themes
-- [Troubleshooting](https://somewm.org/troubleshooting) - Common issues and solutions
+- [Getting Started](https://somewm.org/docs/getting-started/installation) - Installation, first launch, migration
+- [Tutorials](https://somewm.org/docs/tutorials/basics) - Keybindings, widgets, themes
+- [Troubleshooting](https://somewm.org/docs/troubleshooting) - Common issues and solutions
 
 ## Contributing
 


### PR DESCRIPTION
## Description
The README's docs links omitted the /docs/ routeBasePath and 404'd on
somewm.org. Repointed them at /docs/1.4/... with the explicit version
segment so they stay on 1.4 docs even after 2.0 becomes the default
Docusaurus `lastVersion`.

## Test Plan
- Rendered each updated link and confirmed it lands on the "1.4" version
  in the Docusaurus version switcher.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`) — n/a, README-only