### PR TITLE
fix(client): keep borders visible when client partially offscreen

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -4737,8 +4737,10 @@ apply_geometry_to_wlroots(Client *c)
 			if (c->shadow.tree)
 				wlr_scene_node_set_enabled(&c->shadow.tree->node, true);
 		} else {
-			/* Client extends past monitor: clip surface, hide everything
-			 * else (wlr_scene_rect/buffer have no clip API). */
+			/* Client extends past monitor. Clip the surface to the
+			 * visible rectangle; decorations only hide when fully
+			 * offscreen (carousel scrolling) because wlr_scene_rect/
+			 * buffer have no clip API. */
 			int cx = c->geometry.x + c->bw + titlebar_left;
 			int cy = c->geometry.y + c->bw + titlebar_top;
 			int vl = cx > mon.x ? cx : mon.x;
@@ -4748,28 +4750,31 @@ apply_geometry_to_wlroots(Client *c)
 			int vb = (cy + clip.height) < (mon.y + mon.height)
 				? (cy + clip.height) : (mon.y + mon.height);
 
-			if (vr > vl && vb > vt) {
-				/* Partially visible: narrow the clip */
+			bool partially_visible = vr > vl && vb > vt;
+
+			if (partially_visible) {
 				clip.x += vl - cx;
 				clip.y += vt - cy;
 				clip.width = vr - vl;
 				clip.height = vb - vt;
-				wlr_scene_node_set_enabled(&c->scene_surface->node, true);
-			} else {
-				/* Fully offscreen */
-				wlr_scene_node_set_enabled(&c->scene_surface->node, false);
 			}
 
-			/* Hide borders, shadow, and titlebars */
+			wlr_scene_node_set_enabled(&c->scene_surface->node, partially_visible);
 			for (int i = 0; i < 4; i++)
-				wlr_scene_node_set_enabled(&c->border[i]->node, false);
+				wlr_scene_node_set_enabled(&c->border[i]->node, partially_visible);
 			if (c->shadow.tree)
-				wlr_scene_node_set_enabled(&c->shadow.tree->node, false);
-			for (client_titlebar_t bar = CLIENT_TITLEBAR_TOP;
-					bar < CLIENT_TITLEBAR_COUNT; bar++) {
-				if (c->titlebar[bar].scene_buffer)
-					wlr_scene_node_set_enabled(
-						&c->titlebar[bar].scene_buffer->node, false);
+				wlr_scene_node_set_enabled(&c->shadow.tree->node, partially_visible);
+
+			/* Titlebar buffers: client_update_titlebar_positions()
+			 * already enables them based on size/fullscreen. Only
+			 * forcibly disable when fully offscreen. */
+			if (!partially_visible) {
+				for (client_titlebar_t bar = CLIENT_TITLEBAR_TOP;
+						bar < CLIENT_TITLEBAR_COUNT; bar++) {
+					if (c->titlebar[bar].scene_buffer)
+						wlr_scene_node_set_enabled(
+							&c->titlebar[bar].scene_buffer->node, false);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Fixes #474. `apply_geometry_to_wlroots()` hid border, shadow, and titlebar scene nodes whenever a client's geometry extended past its assigned monitor. The intent was to let carousel-scrolled clients hide cleanly when fully offscreen, but the "hide chrome" block sat outside the partially-visible / fully-offscreen split, so any floating client dragged slightly past the screen edge lost its chrome while most of it was still visible.

Split the `!fully_inside` branch so that `scene_surface`, `border[0..3]`, and `shadow.tree` are all enabled iff the visible rectangle is non-empty (partially visible), and only the fully-offscreen path forcibly disables the titlebar buffers. Titlebar enabled state in the partially-visible case is already managed by `client_update_titlebar_positions()`. Carousel behavior is preserved: fully-offscreen clients still have all chrome hidden.

Diagnosis and original fix shape by @raven2cz on the issue thread; re-implemented here with a single `partially_visible` boolean for clarity, matching the boolean-as-arg idiom used elsewhere in `somewm.c` for dynamic scene visibility (e.g. the arrange loop and fullscreen_bg update). Credited via `Co-authored-by:` trailer.

A separate, unrelated bug exists where clients dragged toward an adjacent physical monitor don't render on that monitor, caused by the same block's `vl/vt/vr/vb` clamping to the source monitor. Out of scope for this PR; will file a follow-up.

## Test Plan

- `make test-unit`: 758/758 pass
- `make test-integration`: 113/113 pass
- Manual: installed fixed build as host session, dragged a floating client past the viewport edge; borders/shadow/titlebar stay visible on the on-screen portion, reappear cleanly when dragged fully back inside.
- Manual: `somewm-client 'client.focus:geometry({x=-9999,y=-9999,width=400,height=300})'` moves a client fully outside the monitor; all chrome disappears (carousel path preserved).

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified**
- [x] Tests pass (`make test-unit && make test-integration`)