### PR TITLE
fix(client): keep borders visible when client partially offscreen (cherry-pick of #491)

### DIFF
--- a/window.c
+++ b/window.c
@@ -1311,8 +1311,10 @@ apply_geometry_to_wlroots(Client *c)
 			if (c->shadow.tree)
 				wlr_scene_node_set_enabled(&c->shadow.tree->node, true);
 		} else {
-			/* Client extends past monitor: clip surface, hide everything
-			 * else (wlr_scene_rect/buffer have no clip API). */
+			/* Client extends past monitor. Clip the surface to the
+			 * visible rectangle; decorations only hide when fully
+			 * offscreen (carousel scrolling) because wlr_scene_rect/
+			 * buffer have no clip API. */
 			int cx = c->geometry.x + c->bw + titlebar_left;
 			int cy = c->geometry.y + c->bw + titlebar_top;
 			int vl = cx > mon.x ? cx : mon.x;
@@ -1322,28 +1324,31 @@ apply_geometry_to_wlroots(Client *c)
 			int vb = (cy + clip.height) < (mon.y + mon.height)
 				? (cy + clip.height) : (mon.y + mon.height);
 
-			if (vr > vl && vb > vt) {
-				/* Partially visible: narrow the clip */
+			bool partially_visible = vr > vl && vb > vt;
+
+			if (partially_visible) {
 				clip.x += vl - cx;
 				clip.y += vt - cy;
 				clip.width = vr - vl;
 				clip.height = vb - vt;
-				wlr_scene_node_set_enabled(&c->scene_surface->node, true);
-			} else {
-				/* Fully offscreen */
-				wlr_scene_node_set_enabled(&c->scene_surface->node, false);
 			}
 
-			/* Hide borders, shadow, and titlebars */
+			wlr_scene_node_set_enabled(&c->scene_surface->node, partially_visible);
 			for (int i = 0; i < 4; i++)
-				wlr_scene_node_set_enabled(&c->border[i]->node, false);
+				wlr_scene_node_set_enabled(&c->border[i]->node, partially_visible);
 			if (c->shadow.tree)
-				wlr_scene_node_set_enabled(&c->shadow.tree->node, false);
-			for (client_titlebar_t bar = CLIENT_TITLEBAR_TOP;
-					bar < CLIENT_TITLEBAR_COUNT; bar++) {
-				if (c->titlebar[bar].scene_buffer)
-					wlr_scene_node_set_enabled(
-						&c->titlebar[bar].scene_buffer->node, false);
+				wlr_scene_node_set_enabled(&c->shadow.tree->node, partially_visible);
+
+			/* Titlebar buffers: client_update_titlebar_positions()
+			 * already enables them based on size/fullscreen. Only
+			 * forcibly disable when fully offscreen. */
+			if (!partially_visible) {
+				for (client_titlebar_t bar = CLIENT_TITLEBAR_TOP;
+						bar < CLIENT_TITLEBAR_COUNT; bar++) {
+					if (c->titlebar[bar].scene_buffer)
+						wlr_scene_node_set_enabled(
+							&c->titlebar[bar].scene_buffer->node, false);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Cherry-picks the fix for #474 from #491 (merged into `release/1.4`) to `main`. On `main` the target code lives in `window.c:1296-1349` instead of `somewm.c` due to the 2.0 refactor, so `git cherry-pick` couldn't auto-apply; the patch was applied to `window.c` manually. The diff is byte-for-byte identical to the release/1.4 version (21 additions / 16 deletions).

For reference: `apply_geometry_to_wlroots()` previously hid border, shadow, and titlebar scene nodes whenever a client's geometry extended past its assigned monitor. The "hide chrome" block sat outside the partially-visible / fully-offscreen split, so any floating client dragged slightly past the screen edge lost its chrome while most of it was still visible. This PR splits the `!fully_inside` branch so that `scene_surface`, `border[0..3]`, and `shadow.tree` are all enabled iff the visible rectangle is non-empty, and only the fully-offscreen path forcibly disables the titlebar buffers. Carousel behavior preserved.

Diagnosis and original fix shape by @raven2cz on the issue thread; credited via `Co-authored-by:` trailer.

## Test Plan

- `make test-unit`: 740/740 pass
- `make test-integration`: the suite has pre-existing flakiness on `main` independent of this change. Evidence across three runs:
  - Run 1 (with this fix): `test-carousel-column-widths` + `test-carousel-vertical-animation` fail
  - Run 2 (with this fix): `test-carousel-vertical-focus` + `test-floating-layout` fail
  - Run 3 (clean `origin/main`, no fix): `test-carousel-stacking` + `test-floating-layout` fail
  - Each failing test passes in isolation; different tests fail each run. The instability is not introduced by this change and will be addressed in a separate PR.
- Manual (on the identical release/1.4 build): dragging a floating client past the viewport edge keeps borders/shadow/titlebar visible on the on-screen portion; fully-offscreen moves via `client.focus:geometry({x=-9999,y=-9999,...})` hide all chrome as expected (carousel path preserved).

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified**
- [ ] Tests pass (`make test-unit && make test-integration`) — unit pass; integration has pre-existing flakiness documented above