### PR TITLE
fix(wibox): propagate opacity/border to underlying C drawin

### DIFF
--- a/lua/wibox/init.lua
+++ b/lua/wibox/init.lua
@@ -295,6 +295,10 @@ for _, prop in ipairs { "border_width", "border_color", "opacity" } do
     wibox["set_"..prop] = function(self, value)
         self._private["_user_"..prop] = true
         self["_"..prop] = value
+        -- Propagate to underlying C drawin (Wayland compositing)
+        if self.drawin then
+            self.drawin["_"..prop] = value
+        end
     end
 end
 

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -2487,6 +2487,7 @@ drawin_class_setup(lua_State *L)
 		{ "border_width", (lua_class_propfunc_t) luaA_drawin_set_border_width, (lua_class_propfunc_t) luaA_drawin_get_border_width, (lua_class_propfunc_t) luaA_drawin_set_border_width },
 		{ "_border_width", (lua_class_propfunc_t) luaA_drawin_set_border_width, (lua_class_propfunc_t) luaA_drawin_get_border_width, (lua_class_propfunc_t) luaA_drawin_set_border_width },
 		{ "border_color", (lua_class_propfunc_t) luaA_drawin_set_border_color, (lua_class_propfunc_t) luaA_drawin_get_border_color, (lua_class_propfunc_t) luaA_drawin_set_border_color },
+		{ "_border_color", (lua_class_propfunc_t) luaA_drawin_set_border_color, (lua_class_propfunc_t) luaA_drawin_get_border_color, (lua_class_propfunc_t) luaA_drawin_set_border_color },
 		{ "shape_bounding", (lua_class_propfunc_t) luaA_drawin_set_shape_bounding, (lua_class_propfunc_t) luaA_drawin_get_shape_bounding, (lua_class_propfunc_t) luaA_drawin_set_shape_bounding },
 		{ "shape_clip", (lua_class_propfunc_t) luaA_drawin_set_shape_clip, (lua_class_propfunc_t) luaA_drawin_get_shape_clip, (lua_class_propfunc_t) luaA_drawin_set_shape_clip },
 		{ "shape_input", (lua_class_propfunc_t) luaA_drawin_set_shape_input, (lua_class_propfunc_t) luaA_drawin_get_shape_input, (lua_class_propfunc_t) luaA_drawin_set_shape_input },

--- a/tests/test-wibox-property-propagation.lua
+++ b/tests/test-wibox-property-propagation.lua
@@ -1,0 +1,80 @@
+---------------------------------------------------------------------------
+-- Test: wibox property setters (opacity, border_width, border_color)
+-- propagate to the underlying C drawin so Wayland compositing sees them.
+--
+-- Before the fix, wibox["set_opacity"](self, v) stored v only on the Lua
+-- wrapper; it never reached drawin->opacity, so wlr_scene_buffer_set_opacity
+-- was never called. border_width and border_color had the same problem.
+--
+-- The fix propagates the value to self.drawin["_"..prop]. That relies on
+-- every prop having an underscore-prefixed alias registered on the C side;
+-- _opacity and _border_width had aliases, _border_color did not, so writes
+-- to drawin._border_color fell through to the Lua miss-handler in
+-- gears.object.properties which stashes them in _private - the value reads
+-- back but never reaches drawin->border_color_parsed.
+--
+-- Each assertion below reads through a path that hits the C getter only
+-- (plain names for border_*, _opacity for opacity since plain opacity is
+-- not registered on the drawin class). The Lua miss-handler fallback path
+-- would silently pass the old version of this test if we read the same
+-- underscore name we wrote.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local awful  = require("awful")
+local wibox  = require("wibox")
+
+local test_wibox
+
+local steps = {
+    function()
+        test_wibox = wibox {
+            x = 10, y = 10,
+            width = 100, height = 50,
+            bg = "#224466",
+            visible = true,
+            screen = awful.screen.focused(),
+        }
+        return true
+    end,
+
+    function()
+        test_wibox.opacity = 0.5
+        assert(test_wibox.drawin._opacity == 0.5,
+            "opacity should reach drawin->opacity: got "
+            .. tostring(test_wibox.drawin._opacity))
+        io.stderr:write("[PASS] opacity propagates to drawin\n")
+        return true
+    end,
+
+    function()
+        test_wibox.border_width = 3
+        assert(test_wibox.drawin.border_width == 3,
+            "border_width should reach drawin->border_width: got "
+            .. tostring(test_wibox.drawin.border_width))
+        io.stderr:write("[PASS] border_width propagates to drawin\n")
+        return true
+    end,
+
+    function()
+        test_wibox.border_color = "#ff0000"
+        local got = test_wibox.drawin.border_color
+        assert(got and tostring(got):find("ff0000"),
+            "border_color should reach drawin->border_color_parsed: got "
+            .. tostring(got))
+        io.stderr:write("[PASS] border_color propagates to drawin\n")
+        return true
+    end,
+
+    function()
+        if test_wibox then
+            test_wibox.visible = false
+            test_wibox = nil
+        end
+        return true
+    end,
+}
+
+runner.run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
## Description

Fixes wibox `opacity`, `border_width`, and `border_color` propagation to the underlying C drawin so Wayland compositing actually sees user changes. Before this, the wibox setters stored values only on the Lua wrapper: `wlr_scene_buffer_set_opacity()` never fired, and `drawin->border_color_parsed` stayed uninitialized, so `wibox.opacity`, `awful.popup.opacity`, `naughty.layout.box.opacity`, and `border_color` on any wibox had no visual effect.

Two parts:
- **Lua** (`lua/wibox/init.lua`): propagate each of opacity/border_width/border_color to `self.drawin["_"..prop]` in the wibox setter. Equivalent to raven2cz's patch in #407; credited via `Co-authored-by`.
- **C** (`objects/drawin.c`): register `_border_color` as an alias for `luaA_drawin_set_border_color`, matching the existing `_opacity` and `_border_width` aliases. Without this, writes to `drawin._border_color` fall through `luaA_class_newindex` to the miss handler installed by `gears.object.properties`, which stashes the value in `_private` (readable from Lua but never applied to the C struct). This completes the fix for the third property.

Lua modification: release/1.4 predates the "Lua libraries unmodified" policy (CLAUDE.md scopes that rule to `main` and 2.0 branches).

## Test Plan

- `make test-unit`: 758/758 pass.
- `make test-one TEST=tests/test-wibox-property-propagation.lua`: passes with the full fix, fails at the border_color assertion if the C alias is reverted (verified).
- `make test-integration`: same two pre-existing flakes (`test-floating-layout.lua` plus a rotating carousel test) that reproduce on clean `release/1.4`; both pass in isolation.
- ASAN build clean.
- Manual live-session verification: setting opacity / border_width / border_color post-construction on a panel or popup should now take visible effect.

## Checklist
- [ ] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** - if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)