### PR TITLE
fix: Broken exclude mechanism for some_is_idle_inhibited() #446

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -2158,7 +2158,7 @@ luaA_awesome_index(lua_State *L)
 	}
 
 	if (A_STREQ(key, "idle_inhibited")) {
-		lua_pushboolean(L, some_is_idle_inhibited(NULL) || lua_idle_inhibited);
+		lua_pushboolean(L, some_is_idle_inhibited() || lua_idle_inhibited);
 		return 1;
 	}
 
@@ -2230,7 +2230,7 @@ luaA_awesome_newindex(lua_State *L)
 
 	if (A_STREQ(key, "idle_inhibit")) {
 		lua_idle_inhibited = lua_toboolean(L, 3);
-		some_recompute_idle_inhibit(NULL);
+		some_recompute_idle_inhibit();
 		return 0;
 	}
 
@@ -5490,7 +5490,7 @@ luaA_cleanup(void)
 		/* Clean up lock/idle state before closing Lua */
 		luaA_awesome_clear_all_idle_timeouts(globalconf_L);
 		lua_idle_inhibited = false;
-		some_recompute_idle_inhibit(NULL);
+		some_recompute_idle_inhibit();
 		luaA_awesome_clear_lock_surface(globalconf_L);
 		luaA_awesome_clear_lock_covers(globalconf_L);
 

--- a/protocols.c
+++ b/protocols.c
@@ -329,7 +329,7 @@ unmaplayersurfacenotify(struct wl_listener *listener, void *data)
 
 /** Check if idle is effectively inhibited (for Lua API and idle timers). */
 bool
-some_is_idle_inhibited(struct wlr_surface *exclude)
+some_is_idle_inhibited(void)
 {
 	int unused_lx, unused_ly;
 	struct wlr_idle_inhibitor_v1 *inhibitor;
@@ -338,11 +338,19 @@ some_is_idle_inhibited(struct wlr_surface *exclude)
 		return false;
 
 	wl_list_for_each(inhibitor, &idle_inhibit_mgr->inhibitors, link) {
+		// Attention: When some_is_idle_inhibited() is called during
+		// destroyidleinhibitor() signal handler then
+		// idle_inhibit_mgr->inhibitors still contains the respective
+		// inhibitor, however, the below scene tree is already torn down and
+		// wlr_scene_node_coords() cannot be called.
+		if (!inhibitor->surface->mapped)
+			continue;
+
 		struct wlr_surface *surface = wlr_surface_get_root_surface(inhibitor->surface);
 		struct wlr_scene_tree *tree = surface->data;
 
-		if (exclude != surface && (globalconf.appearance.bypass_surface_visibility || (!tree
-				|| wlr_scene_node_coords(&tree->node, &unused_lx, &unused_ly)))) {
+		if (globalconf.appearance.bypass_surface_visibility || (!tree
+				|| wlr_scene_node_coords(&tree->node, &unused_lx, &unused_ly))) {
 			return true;
 		}
 	}
@@ -408,15 +416,14 @@ createidleinhibitor(struct wl_listener *listener, void *data)
 	struct wlr_idle_inhibitor_v1 *idle_inhibitor = data;
 	LISTEN_STATIC(&idle_inhibitor->events.destroy, destroyidleinhibitor);
 
-	some_recompute_idle_inhibit(NULL);
+	some_recompute_idle_inhibit();
 }
 
 static void
 destroyidleinhibitor(struct wl_listener *listener, void *data)
 {
-	/* `data` is the wlr_surface of the idle inhibitor being destroyed,
-	 * at this point the idle inhibitor is still in the list of the manager */
-	some_recompute_idle_inhibit(wlr_surface_get_root_surface(data));
+	some_recompute_idle_inhibit();
+
 	wl_list_remove(&listener->link);
 	free(listener);
 }

--- a/protocols.h
+++ b/protocols.h
@@ -25,7 +25,7 @@ void destroylayersurfacenotify(struct wl_listener *listener, void *data);
 void unmaplayersurfacenotify(struct wl_listener *listener, void *data);
 
 /* Idle inhibit */
-bool some_is_idle_inhibited(struct wlr_surface *exclude);
+bool some_is_idle_inhibited(void);
 int some_idle_inhibitor_count(void);
 int some_push_idle_inhibitors(lua_State *L);
 void createidleinhibitor(struct wl_listener *listener, void *data);

--- a/somewm.c
+++ b/somewm.c
@@ -243,14 +243,15 @@ sync_client_remove_from_arrays(Client *c)
 }
 
 void
-some_recompute_idle_inhibit(struct wlr_surface *exclude)
+some_recompute_idle_inhibit(void)
 {
-	bool inhibited = some_is_idle_inhibited(exclude) || some_is_lua_idle_inhibited();
+	bool inhibited = some_is_idle_inhibited() || some_is_lua_idle_inhibited();
 	wlr_idle_notifier_v1_set_inhibited(idle_notifier, inhibited);
 	some_idle_timers_set_inhibit(inhibited);
 
 	if (inhibited != last_idle_inhibited) {
 		last_idle_inhibited = inhibited;
+		// Note that this will cause a call to some_is_idle_inhibited() in luaa.
 		luaA_emit_signal_global("property::idle_inhibited");
 	}
 }

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -253,14 +253,14 @@ void some_deactivate_lua_lock(void);
 void some_promote_lock_cover(drawin_t *d);
 void some_clear_pre_lock_client(client_t *c);
 
-/* Idle/activity - defined in luaa.c, called from somewm.c */
+/* Idle/activity - defined in somewm.c */
 void some_idle_timers_set_inhibit(bool inhibit);
 void some_notify_activity(void);
-void some_recompute_idle_inhibit(struct wlr_surface *exclude);
+void some_recompute_idle_inhibit(void);
 bool some_is_lua_idle_inhibited(void);
 
-/* Idle inhibitor query - defined in somewm.c, called from luaa.c */
-bool some_is_idle_inhibited(struct wlr_surface *exclude);
+/* Idle inhibitor query - defined in protocols.c, called from luaa.c */
+bool some_is_idle_inhibited(void);
 int some_idle_inhibitor_count(void);
 
 typedef struct lua_State lua_State;

--- a/somewm_internal.h
+++ b/somewm_internal.h
@@ -21,7 +21,7 @@ void printstatus(void);
 void spawn(const Arg *arg);
 
 /* Idle inhibition coordinator (checks wlroots + Lua inhibitors, emits signals) */
-void some_recompute_idle_inhibit(struct wlr_surface *exclude);
+void some_recompute_idle_inhibit(void);
 
 /* Convert cursor position to client-relative coordinates */
 void cursor_to_client_coordinates(Client *client, double *sx, double *sy);

--- a/window.c
+++ b/window.c
@@ -253,7 +253,7 @@ fallback:
 		c && c->fullscreen);
 
 	motionnotify(0, NULL, 0, 0, 0, 0);
-	some_recompute_idle_inhibit(NULL);
+	some_recompute_idle_inhibit();
 }
 
 /* Handle initial XDG commit - sets scale, capabilities, size.


### PR DESCRIPTION
In destroyidleinhibitor() we call some_is_idle_inhibited() via some_recompute_idle_inhibit(), while the being destroyed inhibitor is still in the list. In this case the scene tree of the tearing down inhibitor surface is already invalid. This is handled by an exclude surface argument.

However, when emitting the signal "property::idle_inhibited", again some_is_idle_inhibited() is called, but this call is ignorant of this exclusion. So we need a different mechanism.

Fix this by using inhibitor->surface->mapped to decide whether we check this inhibitor in some_is_idle_inhibited() instead of the exclude argument. Remove the exclude argument for some_is_idle_inhibited() and some_recompute_idle_inhibit().

Forward-ported from release/1.4 commit 1abe77fe.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)
