### PR TITLE
fix: deliver pointer enter to newly mapped layer surfaces

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -1484,6 +1484,16 @@ commitlayersurfacenotify(struct wl_listener *listener, void *data)
 
 	arrangelayers(l->mon);
 
+	/* When a layer surface maps, re-evaluate pointer focus so that
+	 * wl_pointer.enter is delivered if the cursor is already over it.
+	 * Without this, hover doesn't work until the user moves the mouse.
+	 * Similar to sway's cursor_rebase_all() in handle_map(), but uses
+	 * motionnotify(0,...) which re-runs xytonode() + pointerfocus()
+	 * without emitting Lua mouse signals (those are gated on time != 0).
+	 * Skip when exclusive_focus is active to avoid disrupting grabs. */
+	if (!was_mapped && l->mapped && !exclusive_focus)
+		motionnotify(0, NULL, 0, 0, 0, 0);
+
 	/* Emit property change signals for Lua (matches AwesomeWM pattern) */
 	if (l->lua_object && globalconf_L && layer_surface->current.committed) {
 		lua_State *L = globalconf_get_lua_State();
@@ -1766,13 +1776,17 @@ createlayersurface(struct wl_listener *listener, void *data)
 
 	l = layer_surface->data = ecalloc(1, sizeof(*l));
 	l->type = LayerShell;
-	LISTEN(&surface->events.commit, &l->surface_commit, commitlayersurfacenotify);
 	LISTEN(&surface->events.unmap, &l->unmap, unmaplayersurfacenotify);
 	LISTEN(&layer_surface->events.destroy, &l->destroy, destroylayersurfacenotify);
 
 	l->layer_surface = layer_surface;
 	l->mon = layer_surface->output->data;
 	l->scene_layer = wlr_scene_layer_surface_v1_create(scene_layer, layer_surface);
+	/* Register commit listener AFTER wlr_scene_layer_surface_v1_create() so our
+	 * listener fires AFTER wlroots' internal scene commit handler. This lets
+	 * the scene graph reflect the new buffer before the commit handler calls
+	 * motionnotify(0, ...) to re-evaluate pointer focus on map. */
+	LISTEN(&surface->events.commit, &l->surface_commit, commitlayersurfacenotify);
 	l->scene = l->scene_layer->tree;
 	l->popups = surface->data = wlr_scene_tree_create(layer_surface->current.layer
 			< ZWLR_LAYER_SHELL_V1_LAYER_TOP ? layers[LyrTop] : scene_layer);

--- a/tests/test-layer-client.c
+++ b/tests/test-layer-client.c
@@ -24,6 +24,7 @@ static struct wl_compositor *g_compositor;
 static struct wl_shm *g_shm;
 static struct wl_seat *g_seat;
 static struct wl_keyboard *g_keyboard;
+static struct wl_pointer *g_pointer;
 static struct zwlr_layer_shell_v1 *g_layer_shell;
 static struct wl_surface *g_surface;
 static struct zwlr_layer_surface_v1 *g_layer_surface;
@@ -34,6 +35,8 @@ static uint32_t g_width = 100, g_height = 100;
 /* Config from args */
 static const char *g_namespace = "test-layer";
 static uint32_t g_keyboard_mode = 1; /* EXCLUSIVE */
+static const char *g_pointer_marker = NULL;
+static uint32_t g_anchor = 0;
 
 /* Signal handler for clean shutdown */
 static void handle_signal(int sig) {
@@ -159,6 +162,73 @@ static const struct wl_keyboard_listener keyboard_listener = {
     .repeat_info = keyboard_repeat_info,
 };
 
+/* Pointer callbacks */
+static void pointer_enter(void *data, struct wl_pointer *ptr,
+        uint32_t serial, struct wl_surface *surf,
+        wl_fixed_t sx, wl_fixed_t sy) {
+    (void)data; (void)ptr; (void)serial; (void)surf; (void)sx; (void)sy;
+    fprintf(stderr, "[test-layer-client] pointer enter\n");
+    if (g_pointer_marker) {
+        FILE *f = fopen(g_pointer_marker, "w");
+        if (f) {
+            fputs("entered\n", f);
+            fclose(f);
+        }
+    }
+}
+
+static void pointer_leave(void *data, struct wl_pointer *ptr,
+        uint32_t serial, struct wl_surface *surf) {
+    (void)data; (void)ptr; (void)serial; (void)surf;
+    fprintf(stderr, "[test-layer-client] pointer leave\n");
+}
+
+static void pointer_motion(void *data, struct wl_pointer *ptr,
+        uint32_t time, wl_fixed_t sx, wl_fixed_t sy) {
+    (void)data; (void)ptr; (void)time; (void)sx; (void)sy;
+}
+
+static void pointer_button(void *data, struct wl_pointer *ptr,
+        uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
+    (void)data; (void)ptr; (void)serial; (void)time; (void)button; (void)state;
+}
+
+static void pointer_axis(void *data, struct wl_pointer *ptr,
+        uint32_t time, uint32_t axis, wl_fixed_t value) {
+    (void)data; (void)ptr; (void)time; (void)axis; (void)value;
+}
+
+static void pointer_frame(void *data, struct wl_pointer *ptr) {
+    (void)data; (void)ptr;
+}
+
+static void pointer_axis_source(void *data, struct wl_pointer *ptr,
+        uint32_t axis_source) {
+    (void)data; (void)ptr; (void)axis_source;
+}
+
+static void pointer_axis_stop(void *data, struct wl_pointer *ptr,
+        uint32_t time, uint32_t axis) {
+    (void)data; (void)ptr; (void)time; (void)axis;
+}
+
+static void pointer_axis_discrete(void *data, struct wl_pointer *ptr,
+        uint32_t axis, int32_t discrete) {
+    (void)data; (void)ptr; (void)axis; (void)discrete;
+}
+
+static const struct wl_pointer_listener pointer_listener = {
+    .enter = pointer_enter,
+    .leave = pointer_leave,
+    .motion = pointer_motion,
+    .button = pointer_button,
+    .axis = pointer_axis,
+    .frame = pointer_frame,
+    .axis_source = pointer_axis_source,
+    .axis_stop = pointer_axis_stop,
+    .axis_discrete = pointer_axis_discrete,
+};
+
 /* Seat callbacks */
 static void seat_capabilities(void *data, struct wl_seat *st,
         uint32_t caps) {
@@ -166,6 +236,10 @@ static void seat_capabilities(void *data, struct wl_seat *st,
     if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && !g_keyboard) {
         g_keyboard = wl_seat_get_keyboard(st);
         wl_keyboard_add_listener(g_keyboard, &keyboard_listener, NULL);
+    }
+    if ((caps & WL_SEAT_CAPABILITY_POINTER) && !g_pointer) {
+        g_pointer = wl_seat_get_pointer(st);
+        wl_pointer_add_listener(g_pointer, &pointer_listener, NULL);
     }
 }
 
@@ -214,6 +288,9 @@ static void print_usage(const char *prog) {
     fprintf(stderr, "  --namespace NAME      Layer surface namespace (default: test-layer)\n");
     fprintf(stderr, "  --keyboard MODE       Keyboard interactivity: exclusive|on_demand|none\n");
     fprintf(stderr, "                        (default: exclusive)\n");
+    fprintf(stderr, "  --pointer-marker PATH Write \"entered\\n\" to PATH on wl_pointer.enter\n");
+    fprintf(stderr, "  --anchor EDGES        Comma-separated anchor edges: top,bottom,left,right\n");
+    fprintf(stderr, "                        (default: unanchored; compositor chooses position)\n");
 }
 
 int main(int argc, char *argv[]) {
@@ -234,6 +311,29 @@ int main(int argc, char *argv[]) {
                 print_usage(argv[0]);
                 return 1;
             }
+        } else if (strcmp(argv[i], "--pointer-marker") == 0 && i + 1 < argc) {
+            g_pointer_marker = argv[++i];
+        } else if (strcmp(argv[i], "--anchor") == 0 && i + 1 < argc) {
+            const char *edges = argv[++i];
+            char *buf = strdup(edges);
+            char *tok = strtok(buf, ",");
+            while (tok) {
+                if (strcmp(tok, "top") == 0)
+                    g_anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
+                else if (strcmp(tok, "bottom") == 0)
+                    g_anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
+                else if (strcmp(tok, "left") == 0)
+                    g_anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
+                else if (strcmp(tok, "right") == 0)
+                    g_anchor |= ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
+                else {
+                    fprintf(stderr, "Unknown anchor edge: %s\n", tok);
+                    free(buf);
+                    return 1;
+                }
+                tok = strtok(NULL, ",");
+            }
+            free(buf);
         } else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
             print_usage(argv[0]);
             return 0;
@@ -273,6 +373,8 @@ int main(int argc, char *argv[]) {
         ZWLR_LAYER_SHELL_V1_LAYER_TOP, g_namespace);
 
     zwlr_layer_surface_v1_set_size(g_layer_surface, 100, 100);
+    if (g_anchor)
+        zwlr_layer_surface_v1_set_anchor(g_layer_surface, g_anchor);
     zwlr_layer_surface_v1_set_keyboard_interactivity(g_layer_surface, g_keyboard_mode);
     zwlr_layer_surface_v1_add_listener(g_layer_surface, &layer_surface_listener, NULL);
 
@@ -294,6 +396,7 @@ int main(int argc, char *argv[]) {
     if (g_layer_surface) zwlr_layer_surface_v1_destroy(g_layer_surface);
     if (g_surface) wl_surface_destroy(g_surface);
     if (g_keyboard) wl_keyboard_destroy(g_keyboard);
+    if (g_pointer) wl_pointer_destroy(g_pointer);
     if (g_seat) wl_seat_destroy(g_seat);
     if (g_shm) wl_shm_destroy(g_shm);
     if (g_compositor) wl_compositor_destroy(g_compositor);

--- a/tests/test-layer-shell-pointer-enter.lua
+++ b/tests/test-layer-shell-pointer-enter.lua
@@ -1,0 +1,107 @@
+---------------------------------------------------------------------------
+--- Test: wl_pointer.enter delivered when layer surface maps under stationary cursor
+--
+-- Regression test: a layer-shell surface mapping underneath a stationary
+-- cursor must receive wl_pointer.enter synchronously, without requiring the
+-- user to move the mouse. The bug (before the fix in commitlayersurfacenotify)
+-- was that motionnotify() was never re-run after the new scene node appeared,
+-- so the seat kept its old focused_surface and hover/click-through didn't work.
+--
+-- Verification: test-layer-client writes "entered\n" to a marker file on its
+-- wl_pointer.enter callback. The test positions the cursor inside the 100x100
+-- top-left-anchored surface area BEFORE the client maps, then spawns the
+-- client and asserts the marker file is written.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local async = require("_async")
+local awful = require("awful")
+
+local TEST_LAYER_CLIENT = "./build-test/test-layer-client"
+
+local function file_exists(path)
+    local f = io.open(path, "r")
+    if not f then return false end
+    f:close()
+    return true
+end
+
+local function read_file(path)
+    local f = io.open(path, "r")
+    if not f then return nil end
+    local data = f:read("*a")
+    f:close()
+    return data
+end
+
+if not file_exists(TEST_LAYER_CLIENT) then
+    io.stderr:write("SKIP: test-layer-client not found (run meson compile first)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local marker = string.format("/tmp/somewm-test-pointer-enter-%d.mark", os.time() * 1000 + math.random(0, 999))
+os.remove(marker)
+
+local namespace = "test-pointer-enter"
+local layer_pid
+
+runner.run_async(function()
+    -- 1. Park the cursor inside the future surface area BEFORE spawning.
+    --    --anchor top,left lands the 100x100 surface at (0,0)-(100,100);
+    --    (50, 50) is the centre of that box.
+    mouse.coords({ x = 50, y = 50 }, true)
+    io.stderr:write("[TEST] Cursor parked at (50, 50)\n")
+
+    -- 2. Spawn the layer client.  --keyboard=none avoids keyboard focus stealing.
+    local cmd = string.format(
+        "%s --namespace %s --keyboard none --anchor top,left --pointer-marker %s",
+        TEST_LAYER_CLIENT, namespace, marker)
+    io.stderr:write("[TEST] Spawning: " .. cmd .. "\n")
+    layer_pid = awful.spawn(cmd)
+    assert(type(layer_pid) == "number", "awful.spawn returned: " .. tostring(layer_pid))
+
+    -- 3. Wait for the layer surface to be known to Lua.
+    local layer_surf
+    local mapped = async.wait_for_condition(function()
+        if not layer_surface then return false end
+        for _, ls in ipairs(layer_surface.get()) do
+            if ls.namespace and ls.namespace == namespace then
+                layer_surf = ls
+                return ls.mapped
+            end
+        end
+        return false
+    end, 5)
+    assert(mapped, "layer surface did not map within 5s")
+    local geo = layer_surf.geometry
+    io.stderr:write(string.format("[TEST] Layer surface mapped at (%d, %d) %dx%d\n",
+        geo.x, geo.y, geo.width, geo.height))
+    io.stderr:write(string.format("[TEST] Cursor at (%d, %d)\n",
+        mouse.coords().x, mouse.coords().y))
+
+    -- 4. Wait for the round-trip: compositor sends wl_pointer.enter, client's
+    --    event loop dispatches it, callback writes the marker file.
+    local got_enter = async.wait_for_condition(function()
+        return file_exists(marker)
+    end, 3, 0.05)
+
+    if not got_enter then
+        os.execute("kill -9 " .. layer_pid .. " 2>/dev/null")
+        os.remove(marker)
+        error("wl_pointer.enter was NOT delivered to layer surface under stationary cursor")
+    end
+
+    local contents = read_file(marker) or ""
+    assert(contents:match("entered"), "marker file exists but content was: " .. contents)
+    io.stderr:write("[TEST] PASS: wl_pointer.enter delivered to layer surface\n")
+
+    -- 5. Cleanup.
+    os.execute("kill -9 " .. layer_pid .. " 2>/dev/null")
+    os.remove(marker)
+
+    runner.done()
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
Ports the fix from #421 (raven2cz) to release/1.4 with a regression test, and adds a load-bearing listener reorder the original PR didn't need because it predated changes to the commit listener order. A layer-shell surface that maps under a stationary cursor now receives wl_pointer.enter without the user having to jiggle the mouse. Fix lands on release/1.4 first per the usual backport direction; will cherry-pick to main separately.

## Description

A layer-shell surface (panel, notification, quickshell widget) that maps underneath a stationary cursor never received `wl_pointer.enter` until the user physically moved the mouse, so hover and click-through on the new surface didn't work.

`commitlayersurfacenotify` detects the unmapped -> mapped transition but doesn't re-evaluate pointer focus afterward. After `arrangelayers()`, when `!was_mapped && l->mapped && !exclusive_focus`, call `motionnotify(0, NULL, 0, 0, 0, 0)`. `time=0` re-runs `xytonode()` + `pointerfocus()` without emitting Lua mouse signals. The `!exclusive_focus` guard avoids disrupting session lock.

Also reorders the commit-listener registration so our handler fires AFTER wlroots' scene module updates the buffer tree — without this, `xytonode()` can't find the newly-mapped surface yet and the fix is a no-op.

## Test Plan

- [x] `make test-unit` — 758 passes / 0 fails
- [x] `make test-one TEST=tests/test-layer-shell-pointer-enter.lua` passes with the fix, fails without it (verified before/after)
- [x] `make test-one` on all existing `test-layer-shell-*` tests — still pass
- [ ] Live session: launch Quickshell panel or swaync under stationary cursor, hover fires immediately

## Checklist

- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)