### PR TITLE
fix(stack): preserve LyrOverlay placement for override_redirect clients

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -132,6 +132,7 @@ void apply_geometry_to_wlroots(client_t *c);
 
 /* External references to somewm.c globals */
 extern struct wlr_renderer *drw;
+extern struct wlr_scene_tree *layers[NUM_LAYERS];
 
 /* X11-specific includes commented out - not needed for Wayland
 #include "common/atoms.h"
@@ -3683,6 +3684,39 @@ luaA_client_get_first_tag(lua_State *L, client_t *c)
     return 0;
 }
 
+/** Get the wlroots scene-graph layer the client currently lives in.
+ * Returns the layer name as a string, or nil if the client has no scene
+ * node or its parent is not one of the known top-level layers. Intended
+ * for integration tests that verify stacking behavior.
+ */
+static int
+luaA_client_get__scene_layer(lua_State *L, client_t *c)
+{
+    static const char *const layer_names[NUM_LAYERS] = {
+        [LyrBg]      = "background",
+        [LyrBottom]  = "bottom",
+        [LyrTile]    = "tile",
+        [LyrFloat]   = "float",
+        [LyrWibox]   = "wibox",
+        [LyrTop]     = "top",
+        [LyrFS]      = "fullscreen",
+        [LyrOverlay] = "overlay",
+        [LyrBlock]   = "block",
+    };
+
+    if (!c->scene || !c->scene->node.parent)
+        return 0;
+
+    for (int i = 0; i < NUM_LAYERS; i++) {
+        if ((void *)c->scene->node.parent == (void *)layers[i]) {
+            lua_pushstring(L, layer_names[i]);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
 /** Raise a client on top of others which are on the same layer.
  *
  * @method raise
@@ -5376,6 +5410,7 @@ client_class_setup(lua_State *L)
         { "opacity", (lua_class_propfunc_t) luaA_client_set_opacity, (lua_class_propfunc_t) luaA_client_get_opacity, (lua_class_propfunc_t) luaA_client_set_opacity },
         { "pid", NULL, (lua_class_propfunc_t) luaA_client_get_pid, NULL },
         { "role", NULL, (lua_class_propfunc_t) luaA_client_get_role, NULL },
+        { "_scene_layer", NULL, (lua_class_propfunc_t) luaA_client_get__scene_layer, NULL },
         { "screen", NULL, (lua_class_propfunc_t) luaA_client_get_screen, (lua_class_propfunc_t) luaA_client_set_screen },
         { "shadow", (lua_class_propfunc_t) luaA_client_set_shadow, (lua_class_propfunc_t) luaA_client_get_shadow, (lua_class_propfunc_t) luaA_client_set_shadow },
         { "shape_bounding", (lua_class_propfunc_t) luaA_client_set_shape_bounding, (lua_class_propfunc_t) luaA_client_get_shape_bounding, (lua_class_propfunc_t) luaA_client_set_shape_bounding },

--- a/stack.c
+++ b/stack.c
@@ -17,6 +17,9 @@
 #include "somewm_api.h"
 #include <stdbool.h>
 #include <wlr/types/wlr_scene.h>
+#ifdef XWAYLAND
+#include <wlr/xwayland.h>
+#endif
 
 /* Flag to mark stack as needing refresh */
 static bool need_stack_refresh = false;
@@ -226,6 +229,18 @@ stack_refresh(void)
 	foreach(node, globalconf.stack) {
 		if (!(*node) || !(*node)->scene)
 			continue;
+
+		/* Unmanaged (override_redirect) X11 clients bypass the window
+		 * manager; they have no stacking attributes, so running them
+		 * through client_layer_translator() returns LyrTile and drops
+		 * Wine/Qt popups below their floating parents. mapnotify()
+		 * placed them in LyrOverlay; skip them here so the placement
+		 * survives. */
+#ifdef XWAYLAND
+		if ((*node)->client_type == X11 &&
+		    (*node)->surface.xwayland->override_redirect)
+			continue;
+#endif
 
 		layer = client_layer_translator(*node);
 

--- a/tests/helpers/x11_override_redirect.py
+++ b/tests/helpers/x11_override_redirect.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""X11 test helper: create an override_redirect window (simulates popup/menu).
+
+Usage: python3 x11_override_redirect.py <WM_CLASS> [x y width height]
+
+Creates an override_redirect=True window, which bypasses the window manager.
+This is what Wine, Steam, and other X11 apps use for popup menus and tooltips.
+
+The window stays mapped until SIGTERM is received.
+"""
+
+import ctypes
+import ctypes.util
+import signal
+import sys
+
+# --- Load libX11 via ctypes ---
+
+_x11_path = ctypes.util.find_library("X11")
+if not _x11_path:
+    print("ERROR: libX11 not found", file=sys.stderr)
+    sys.exit(1)
+
+x11 = ctypes.cdll.LoadLibrary(_x11_path)
+
+# Type aliases
+Display_p = ctypes.c_void_p
+Window = ctypes.c_ulong
+Atom = ctypes.c_ulong
+
+# XSetWindowAttributes structure (partial, only fields we need)
+class XSetWindowAttributes(ctypes.Structure):
+    _fields_ = [
+        ("background_pixmap", ctypes.c_ulong),
+        ("background_pixel", ctypes.c_ulong),
+        ("border_pixmap", ctypes.c_ulong),
+        ("border_pixel", ctypes.c_ulong),
+        ("bit_gravity", ctypes.c_int),
+        ("win_gravity", ctypes.c_int),
+        ("backing_store", ctypes.c_int),
+        ("backing_planes", ctypes.c_ulong),
+        ("backing_pixel", ctypes.c_ulong),
+        ("save_under", ctypes.c_int),
+        ("event_mask", ctypes.c_long),
+        ("do_not_propagate_mask", ctypes.c_long),
+        ("override_redirect", ctypes.c_int),
+    ]
+
+# XClassHint structure
+class XClassHint(ctypes.Structure):
+    _fields_ = [
+        ("res_name", ctypes.c_char_p),
+        ("res_class", ctypes.c_char_p),
+    ]
+
+# Function prototypes
+x11.XOpenDisplay.argtypes = [ctypes.c_char_p]
+x11.XOpenDisplay.restype = Display_p
+
+x11.XDefaultScreen.argtypes = [Display_p]
+x11.XDefaultScreen.restype = ctypes.c_int
+
+x11.XRootWindow.argtypes = [Display_p, ctypes.c_int]
+x11.XRootWindow.restype = Window
+
+x11.XCreateWindow.argtypes = [
+    Display_p, Window,
+    ctypes.c_int, ctypes.c_int,     # x, y
+    ctypes.c_uint, ctypes.c_uint,   # width, height
+    ctypes.c_uint,                   # border_width
+    ctypes.c_int,                    # depth (CopyFromParent=0)
+    ctypes.c_uint,                   # class (InputOutput=1)
+    ctypes.c_void_p,                 # visual (CopyFromParent=NULL)
+    ctypes.c_ulong,                  # valuemask
+    ctypes.POINTER(XSetWindowAttributes),
+]
+x11.XCreateWindow.restype = Window
+
+x11.XSetClassHint.argtypes = [Display_p, Window, ctypes.POINTER(XClassHint)]
+x11.XSetClassHint.restype = ctypes.c_int
+
+x11.XStoreName.argtypes = [Display_p, Window, ctypes.c_char_p]
+x11.XStoreName.restype = ctypes.c_int
+
+x11.XMapWindow.argtypes = [Display_p, Window]
+x11.XMapWindow.restype = ctypes.c_int
+
+x11.XFlush.argtypes = [Display_p]
+x11.XFlush.restype = ctypes.c_int
+
+x11.XDestroyWindow.argtypes = [Display_p, Window]
+x11.XDestroyWindow.restype = ctypes.c_int
+
+x11.XCloseDisplay.argtypes = [Display_p]
+x11.XCloseDisplay.restype = ctypes.c_int
+
+# --- Constants ---
+
+CWOverrideRedirect = (1 << 9)   # valuemask bit for override_redirect
+CWBackPixel = (1 << 1)          # valuemask bit for background_pixel
+InputOutput = 1
+CopyFromParent = 0
+
+# --- Globals ---
+
+dpy = None
+win = None
+
+def handle_term(signum, frame):
+    """SIGTERM: Clean exit."""
+    if dpy and win:
+        x11.XDestroyWindow(dpy, win)
+        x11.XCloseDisplay(dpy)
+    sys.exit(0)
+
+def main():
+    global dpy, win
+
+    if len(sys.argv) < 2:
+        print("Usage: %s <WM_CLASS> [x y width height]" % sys.argv[0], file=sys.stderr)
+        sys.exit(1)
+
+    wm_class = sys.argv[1]
+    wx = int(sys.argv[2]) if len(sys.argv) > 2 else 100
+    wy = int(sys.argv[3]) if len(sys.argv) > 3 else 100
+    ww = int(sys.argv[4]) if len(sys.argv) > 4 else 200
+    wh = int(sys.argv[5]) if len(sys.argv) > 5 else 150
+
+    # Open display
+    dpy = x11.XOpenDisplay(None)
+    if not dpy:
+        print("ERROR: Cannot open X display", file=sys.stderr)
+        sys.exit(1)
+
+    screen = x11.XDefaultScreen(dpy)
+    root = x11.XRootWindow(dpy, screen)
+
+    # Set up attributes with override_redirect = True
+    attrs = XSetWindowAttributes()
+    attrs.override_redirect = 1
+    attrs.background_pixel = 0xFF0000  # Red background for visibility
+
+    # Create override_redirect window
+    win = x11.XCreateWindow(
+        dpy, root,
+        wx, wy, ww, wh,
+        0,                          # border_width
+        CopyFromParent,             # depth
+        InputOutput,                # class
+        None,                       # visual (CopyFromParent)
+        CWOverrideRedirect | CWBackPixel,
+        ctypes.byref(attrs),
+    )
+
+    # Set WM_CLASS
+    hint = XClassHint()
+    hint.res_name = wm_class.lower().encode()
+    hint.res_class = wm_class.encode()
+    x11.XSetClassHint(dpy, win, ctypes.byref(hint))
+
+    # Set title
+    x11.XStoreName(dpy, win, wm_class.encode())
+
+    # Map window
+    x11.XMapWindow(dpy, win)
+    x11.XFlush(dpy)
+
+    print("[x11_override_redirect] mapped: class=%s override_redirect=1 geom=%dx%d+%d+%d"
+          % (wm_class, ww, wh, wx, wy), file=sys.stderr)
+
+    # Install signal handlers
+    signal.signal(signal.SIGTERM, handle_term)
+
+    # Block until killed
+    while True:
+        signal.pause()
+
+if __name__ == "__main__":
+    main()

--- a/tests/test-xwayland-override-redirect-stacking.lua
+++ b/tests/test-xwayland-override-redirect-stacking.lua
@@ -1,0 +1,230 @@
+---------------------------------------------------------------------------
+--- Test: XWayland override_redirect popup stacking (issue #415)
+--
+-- Bug: Override_redirect X11 surfaces (Wine menus, Steam popups, Qt
+-- tooltips) appeared BELOW their parent window instead of above it.
+--
+-- Root cause: stack_refresh() ran unmanaged clients through
+-- client_layer_translator(), which returned WINDOW_LAYER_NORMAL (LyrTile)
+-- by default because override_redirect clients have no stacking
+-- attributes. That reparenting dropped popups below floating parents.
+--
+-- Fix: mapnotify() places override_redirect clients in LyrOverlay;
+-- stack_refresh() skips unmanaged clients entirely so the placement
+-- survives.
+--
+-- This test:
+--  1. Spawns a managed X11 client and makes it floating.
+--  2. Spawns an override_redirect X11 window via a ctypes helper.
+--  3. Asserts the popup's scene-graph parent is LyrOverlay right after map.
+--  4. Toggles parent properties (ontop/above/floating/fullscreen), forcing
+--     stack_refresh() cycles.
+--  5. Asserts the popup is STILL in LyrOverlay after each cycle. Without
+--     the fix the popup would read as "tile" after the first cycle.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local x11_client = require("_x11_client")
+local utils = require("_utils")
+
+if utils.is_headless() then
+    io.stderr:write("SKIP: override_redirect test requires visual mode (HEADLESS=0)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+if not x11_client.is_available() then
+    io.stderr:write("SKIP: no X11 application available (install xterm)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local python3_check = os.execute("which python3 >/dev/null 2>&1")
+if not python3_check then
+    io.stderr:write("SKIP: python3 not available for X11 helper\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local awful = require("awful")
+
+local PARENT_CLASS = "or_stacking_parent"
+local POPUP_CLASS  = "or_stacking_popup"
+
+-- Resolve helper script path (same pattern as test-xwayland-remap.lua)
+local script_dir = debug.getinfo(1, "S").source:match("@(.*/)")
+local helper_path = script_dir .. "helpers/x11_override_redirect.py"
+
+local parent_client     = nil
+local popup_pid         = nil
+local popup_client      = nil
+local pre_spawn_windows = {}
+
+-- Track parent via request::manage (managed clients emit it).
+client.connect_signal("request::manage", function(c)
+    if x11_client.is_xwayland(c) and
+       (c.class == PARENT_CLASS or c.class == PARENT_CLASS:lower()) then
+        parent_client = c
+        io.stderr:write(string.format(
+            "[TEST] Managed parent client appeared: class=%s\n", tostring(c.class)
+        ))
+    end
+end)
+
+-- Override_redirect clients do NOT fire request::manage and
+-- property_update_xwayland_properties() is skipped for them in
+-- mapnotify(), so c.class is never populated. Identify the popup
+-- instead by diffing client.get() against a snapshot of pre-existing
+-- X11 window IDs taken just before spawning the helper.
+local function snapshot_x11_windows()
+    local set = {}
+    for _, c in ipairs(client.get()) do
+        if x11_client.is_xwayland(c) and c.window and c.window > 0 then
+            set[c.window] = true
+        end
+    end
+    return set
+end
+
+local function find_popup()
+    for _, c in ipairs(client.get()) do
+        if x11_client.is_xwayland(c) and
+           c.window and c.window > 0 and
+           not pre_spawn_windows[c.window] then
+            return c
+        end
+    end
+    return nil
+end
+
+local function assert_popup_in_overlay(popup, context)
+    assert(popup.valid, context .. ": popup should be valid")
+    local layer = popup._scene_layer
+    assert(layer == "overlay", string.format(
+        "%s: expected popup in LyrOverlay, got %q (bug #415 regression)",
+        context, tostring(layer)
+    ))
+    io.stderr:write(string.format(
+        "[TEST] PASS %s: popup is in %s layer\n", context, layer
+    ))
+end
+
+local steps = {
+    -- Step 1: Spawn managed X11 parent client
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning managed X11 parent client...\n")
+            x11_client(PARENT_CLASS)
+        end
+
+        if parent_client then return true end
+
+        if count > 80 then
+            error("Managed X11 parent client did not appear within timeout")
+        end
+        return nil
+    end,
+
+    -- Step 2: Make parent floating (so it lives in LyrFloat, the buggy
+    -- regression point would surface popups below it).
+    function()
+        parent_client.floating = true
+        assert(parent_client.floating, "Parent should be floating")
+        io.stderr:write("[TEST] Parent set floating\n")
+        return true
+    end,
+
+    -- Step 3: Spawn the override_redirect popup. Snapshot existing X11
+    -- window IDs first so we can diff for the new one.
+    function(count)
+        if count == 1 then
+            pre_spawn_windows = snapshot_x11_windows()
+            io.stderr:write("[TEST] Spawning override_redirect popup helper...\n")
+            popup_pid = awful.spawn("python3 " .. helper_path ..
+                " " .. POPUP_CLASS .. " 50 50 200 150")
+            io.stderr:write(string.format("[TEST] Popup helper PID: %s\n",
+                tostring(popup_pid)))
+
+            if not popup_pid or type(popup_pid) ~= "number" or popup_pid <= 0 then
+                error("Failed to spawn override_redirect helper: " ..
+                    tostring(popup_pid))
+            end
+        end
+
+        popup_client = find_popup()
+        if popup_client then
+            io.stderr:write(string.format(
+                "[TEST] Override_redirect popup appeared: window=%d type=%s\n",
+                popup_client.window, tostring(popup_client.type)
+            ))
+            return true
+        end
+        return nil
+    end,
+
+    -- Step 4: Immediately after map, popup must be in LyrOverlay.
+    -- This catches the mapnotify placement bug (LyrFloat in the old code).
+    function()
+        assert(popup_client, "Popup should be findable after map")
+        assert_popup_in_overlay(popup_client, "after-map")
+        return true
+    end,
+
+    -- Step 5: Trigger stack_refresh() cycles via parent property toggles.
+    -- Pre-fix: the first toggle would reparent the popup to LyrTile.
+    function()
+        assert(popup_client and popup_client.valid, "Popup must still be valid")
+
+        -- floating starts true (set in step 2), so toggle false->true; the
+        -- others start false so toggle true->false. Every pair crosses a
+        -- stack_refresh() boundary, which is what we want to stress.
+        local toggles = {
+            { prop = "ontop",      sequence = { true, false } },
+            { prop = "above",      sequence = { true, false } },
+            { prop = "floating",   sequence = { false, true } },
+            { prop = "fullscreen", sequence = { true, false } },
+        }
+        for _, t in ipairs(toggles) do
+            io.stderr:write("[TEST] Toggling parent " .. t.prop .. "...\n")
+            for _, value in ipairs(t.sequence) do
+                parent_client[t.prop] = value
+                assert_popup_in_overlay(popup_client,
+                    string.format("after-%s-%s", t.prop, tostring(value)))
+            end
+        end
+
+        return true
+    end,
+
+    -- Step 6: Cleanup. Kill popup helper first (unmanaged, no close path),
+    -- then let the parent's kill proceed.
+    function(count)
+        if count == 1 then
+            if popup_pid then
+                os.execute("kill " .. popup_pid .. " 2>/dev/null")
+            end
+            os.execute("pkill -f x11_override_redirect.py 2>/dev/null")
+
+            if parent_client and parent_client.valid then
+                parent_client:kill()
+            end
+        end
+
+        if count > 10 then
+            io.stderr:write("[TEST] All override_redirect stacking assertions PASSED\n")
+            io.stderr:write("Test finished successfully.\n")
+            awesome.quit()
+            return true
+        end
+        return nil
+    end,
+}
+
+-- Spawning python3 and waiting for the popup to show up in client.get()
+-- can take longer than the default 2 seconds per step under load.
+runner.run_steps(steps, { kill_clients = false, wait_per_step = 10 })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/window.c
+++ b/window.c
@@ -849,8 +849,12 @@ mapnotify(struct wl_listener *listener, void *data)
 
 	/* Handle unmanaged clients first so we can return prior create borders */
 	if (client_is_unmanaged(c)) {
-		/* Unmanaged clients always are floating */
-		wlr_scene_node_reparent(&c->scene->node, layers[LyrFloat]);
+		/* Unmanaged (override_redirect) X11 surfaces bypass the window
+		 * manager and must display above all managed windows. Place
+		 * them in LyrOverlay to match X11 semantics; LyrBlock (session
+		 * lock) still covers them. stack_refresh() skips unmanaged
+		 * clients so this placement is preserved. */
+		wlr_scene_node_reparent(&c->scene->node, layers[LyrOverlay]);
 		wlr_scene_node_set_position(&c->scene->node, c->geometry.x, c->geometry.y);
 		client_set_size(c, c->geometry.width, c->geometry.height);
 		if (client_wants_focus(c)) {


### PR DESCRIPTION
## Description

Cherry-pick of #503 to `main`.

- `stack.c`, `objects/client.c`, `tests/` applied cleanly from #503.
- `window.c`: `mapnotify()` LyrFloat→LyrOverlay re-applied by hand (mapnotify was extracted from `somewm.c` to `window.c` on main).
- Test listener uses `request::manage` since `manage` was removed on main.

Fixes #415.

## Test Plan

- `make test-unit`: 740/740
- `make test-integration`: 119/119, including `test-xwayland-override-redirect-stacking.lua`

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)