### PR TITLE
refactor(headers): deduplicate function declarations across module headers

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -65,6 +65,10 @@ static lua_State *luaA_create_fresh_state(void);
 /* Includes merged from objects/awesome.c */
 #include "systray.h"
 #include "somewm_api.h"
+#include "somewm_internal.h"
+#include "protocols.h"
+#include "input.h"
+#include "window.h"
 #include "color.h"
 #include <xkbcommon/xkbcommon.h>
 #include <wayland-server-core.h>

--- a/objects/spawn.h
+++ b/objects/spawn.h
@@ -9,10 +9,6 @@
 /* XDG Activation protocol for startup notification */
 extern struct wlr_xdg_activation_v1 *activation;
 
-/* Token management functions */
-char *activation_token_create(const char *app_id);
-void activation_token_cleanup(const char *token);
-
 void spawn_init(void);
 void spawn_start_notify(client_t*, const char*);
 int luaA_spawn(lua_State*);

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -218,12 +218,6 @@ void some_apply_keyboard_repeat_info(void);
 void some_set_numlock(int enabled);
 
 /*
- * Input Device Configuration API
- * Re-apply libinput settings to all connected pointer devices
- */
-void apply_input_settings_to_all_devices(void);
-
-/*
  * Layer Surface Focus API
  * Called from objects/layer_surface.c when Lua sets has_keyboard_focus property
  */
@@ -256,15 +250,7 @@ void some_clear_pre_lock_client(client_t *c);
 /* Idle/activity - defined in somewm.c */
 void some_idle_timers_set_inhibit(bool inhibit);
 void some_notify_activity(void);
-void some_recompute_idle_inhibit(void);
 bool some_is_lua_idle_inhibited(void);
-
-/* Idle inhibitor query - defined in protocols.c, called from luaa.c */
-bool some_is_idle_inhibited(void);
-int some_idle_inhibitor_count(void);
-
-typedef struct lua_State lua_State;
-int some_push_idle_inhibitors(lua_State *L);
 
 /** Check if the session is locked by any mechanism (ext-session-lock or Lua lock).
  * Use this instead of repeating `locked || some_is_lua_locked()` everywhere. */
@@ -273,10 +259,8 @@ static inline bool session_is_locked(void) {
 }
 
 /*
- * Hot-reload support - listener management for in-process Lua state rebuild
+ * Hot-reload support
  */
-void client_remove_all_listeners(client_t *c);
-void client_reregister_listeners(client_t *c);
 void some_refresh(void);
 
 /*

--- a/spawn.c
+++ b/spawn.c
@@ -12,6 +12,7 @@
  */
 
 #include "objects/spawn.h"
+#include "protocols.h"
 #include "globalconf.h"
 #include "luaa.h"
 #include "objects/signal.h"

--- a/window.c
+++ b/window.c
@@ -77,40 +77,14 @@ typedef struct {
 } Popup;
 
 /* forward declarations */
-void applybounds(Client *c, struct wlr_box *bbox);
-void arrange(Monitor *m);
-unsigned int get_border_width(void);
-const float *get_focuscolor(void);
-const float *get_bordercolor(void);
-const float *get_urgentcolor(void);
-void initialcommitnotify(struct wl_listener *listener, void *data);
-void commitnotify(struct wl_listener *listener, void *data);
 void commitpopup(struct wl_listener *listener, void *data);
 void createdecoration(struct wl_listener *listener, void *data);
-void createnotify(struct wl_listener *listener, void *data);
 void createpopup(struct wl_listener *listener, void *data);
 void destroydecoration(struct wl_listener *listener, void *data);
-void destroynotify(struct wl_listener *listener, void *data);
 void destroypopup(struct wl_listener *listener, void *data);
-void fullscreennotify(struct wl_listener *listener, void *data);
-void killclient(const Arg *arg);
-void mapnotify(struct wl_listener *listener, void *data);
-void maximizenotify(struct wl_listener *listener, void *data);
 void popup_unconstrain(Popup *p);
 void repositionpopup(struct wl_listener *listener, void *data);
 void requestdecorationmode(struct wl_listener *listener, void *data);
-void resize(Client *c, struct wlr_box geo, int interact);
-void apply_geometry_to_wlroots(Client *c);
-void client_remove_all_listeners(client_t *c);
-void client_reregister_listeners(client_t *c);
-void setfullscreen(Client *c, int fullscreen);
-void setmon(Client *c, Monitor *m, uint32_t newtags);
-void swapstack(const Arg *arg);
-void tagmon(const Arg *arg);
-void togglefloating(const Arg *arg);
-void unmapnotify(struct wl_listener *listener, void *data);
-void updatetitle(struct wl_listener *listener, void *data);
-void zoom(const Arg *arg);
 void sync_tiling_reorder(Client *c);
 
 /* listener structs */

--- a/x11_compat.h
+++ b/x11_compat.h
@@ -26,10 +26,6 @@
 typedef struct wlr_box area_t;
 /* lua_object_t is typedef'd in common/luaclass.h - don't redeclare it here */
 
-/* Forward declarations for screen functions (defined in objects/screen.h and objects/luaa.h) */
-typedef struct screen_t screen_t;
-screen_t *luaA_screen_getbycoord(lua_State *L, int x, int y);
-
 /* Include real XCB headers if available (wlroots includes them) */
 #ifdef XWAYLAND
 #include <xcb/xcb.h>
@@ -301,10 +297,6 @@ static inline double xwindow_get_opacity_from_cookie(xcb_get_property_cookie_t c
 /* Systray stubs moved to systray.c */
 
 /* draw_find_visual moved to draw.c where it belongs (AwesomeWM parity) */
-
-/* screen_getbycoord - forward to luaA_screen_getbycoord
- * Implementation in screen.c to avoid header ordering issues */
-screen_t *screen_getbycoord(int x, int y);
 
 /* Shape extension stub - always use stub even with XWAYLAND */
 static inline void xcb_shape_select_input(void *conn, xcb_window_t w, uint8_t enable) {


### PR DESCRIPTION
## Description

Dedupe function declarations so every function has exactly one declaration header. Also deletes 26 stale forward decls in `window.c` that mirrored `window.h`, and two unnecessary forward decls in `x11_compat.h`. Adds the now-explicit module-header includes in `luaa.c` and `spawn.c`.

No behavior change.

## Test Plan
- [x] `make build-test` clean
- [x] `make test-unit` passes
- [x] `make test-integration` passes

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)