### PR TITLE
fix(icons): consult .desktop entries when class isn't a theme icon

### DIFF
--- a/lua/awful/client.lua
+++ b/lua/awful/client.lua
@@ -1626,11 +1626,60 @@ function client.object.is_transient_for(self, c2)
     return nil
 end
 
+-- Lazily-built cache mapping `StartupWMClass` or `.desktop` filename stem
+-- to an icon path resolved via `menubar.utils.parse_desktop_file`.
+local desktop_cache
+
+local function build_desktop_cache()
+    local cache = {}
+    local mutils = require("menubar.utils")
+    local lgi = require("lgi")
+    local glib = lgi.GLib
+    local Gio = lgi.Gio
+
+    local dirs = { glib.build_filenamev({ glib.get_user_data_dir(), "applications" }) }
+    for _, d in ipairs(glib.get_system_data_dirs()) do
+        table.insert(dirs, glib.build_filenamev({ d, "applications" }))
+    end
+
+    for _, dir in ipairs(dirs) do
+        local gdir = Gio.File.new_for_path(dir)
+        if gdir:query_exists() then
+            local enum = gdir:enumerate_children(
+                "standard::name,standard::type",
+                Gio.FileQueryInfoFlags.NONE, nil)
+            if enum then
+                while true do
+                    local info = enum:next_file(nil)
+                    if not info then break end
+                    local name = info:get_name()
+                    if name and name:sub(-8) == ".desktop" then
+                        local path = glib.build_filenamev({ dir, name })
+                        local ok, entry = pcall(mutils.parse_desktop_file, path)
+                        if ok and entry and entry.icon_path then
+                            local stem = name:sub(1, -9)
+                            if cache[stem] == nil then cache[stem] = entry.icon_path end
+                            if entry.StartupWMClass and cache[entry.StartupWMClass] == nil then
+                                cache[entry.StartupWMClass] = entry.icon_path
+                            end
+                        end
+                    end
+                end
+                enum:close(nil)
+            end
+        end
+    end
+
+    return cache
+end
+
 --- Resolve a client's icon file path from desktop entry / icon theme.
 --
--- Looks up the client's `class` (app_id) in FDO icon theme directories.
--- Results are cached on the client object. Returns a file path string
--- suitable for passing to `imagebox:set_image()`.
+-- Tries `menubar.utils.lookup_icon(c.class)` first (with a lowercase
+-- fallback), then falls back to a lazily-built `.desktop` index keyed by
+-- filename stem and `StartupWMClass`. Results are cached on the client
+-- object. Returns a file path string suitable for passing to
+-- `imagebox:set_image()`.
 --
 -- @tparam client c The client.
 -- @treturn string|nil Icon file path, or nil if not found.
@@ -1643,10 +1692,10 @@ function client.get_icon_path(c)
         return nil
     end
     local lookup = require("menubar.utils").lookup_icon
-    local path = lookup(app_id)
-    -- Try lowercase (e.g., "Slack" -> "slack")
+    local path = lookup(app_id) or lookup(app_id:lower())
     if not path then
-        path = lookup(app_id:lower())
+        desktop_cache = desktop_cache or build_desktop_cache()
+        path = desktop_cache[app_id] or desktop_cache[app_id:lower()]
     end
     c._icon_path = path or false
     return path


### PR DESCRIPTION
## Description

Backport of #509 to `release/1.4`, scope-reduced.

`awful.client.get_icon_path` looked up `c.class` as a theme icon filename. That works for Kitty (`kitty.png` exists) but not for apps whose WM class doesn't literally match a theme icon (Helium `class="Helium"`, Claude `class="Claude"`, JetBrains apps), even when their `.desktop` file specifies an `Icon=` value that does resolve.

This PR adds a third resolution step inside `get_icon_path`: on miss, consult a lazily-built index of `.desktop` entries keyed by filename stem and `StartupWMClass`, with each entry's resolved `icon_path` as the value.

Deliberately minimal vs. the `main` PR (#509):
- Function signature unchanged — still returns `string|nil`, still uses the `_icon_path` cache field.
- No `clienticon.lua` / `tasklist.lua` changes. The existing `(c.icon or aclient.get_icon_path(c))` fallback in `tasklist.lua:575` and `get_fallback_surface` in `clienticon.lua` already call `get_icon_path`, so they pick up the fix transparently.
- No new `awful.client.resolve_icon`, no `request::manage` changes, no `c.icon` mutation from Lua. The architectural rewrite stays on `main`.

## Test Plan

- `make test-unit` — 758 pass.
- `make test-integration` — `tests/test-tasklist-client-icons.lua` passes (it asserts an unknown class still resolves to `nil`, which still holds).
- Live: launch Helium / Claude / JetBrains on a 1.4 build, confirm tasklist icons appear.

## Checklist

- [ ] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)