### PR TITLE
release: prepare 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to somewm will be documented in this file.
 
+## [1.4.1] - 2026-04-24
+
+Patch release. 19 commits since 1.4.0, all bug fixes and one additive
+signal change. No public API breaks; existing rc.lua configs run unchanged.
+
+### Fixed
+
+- Use-after-free of `wlr_scene_tree` via `wlr_surface->data`
+- SEGV on monitor unplug from missing surface cleanup (#442)
+- `createmon()` hardening for partial monitor init failures (#477)
+- Carousel: clients render across monitors when outside the carousel layout
+- Borders stay visible when a client is partially offscreen
+- Pointer enter delivered to newly mapped layer-shell surfaces
+- Pointer focus re-evaluated after the banning refresh
+- `LyrOverlay` placement preserved for override-redirect clients (XWayland stacking)
+- wibox: opacity and border properties propagate to the underlying C drawin
+- wibox: A1 surface format restored for shape masks
+- Idle-inhibit exclude mechanism honored again (#446)
+- Icon resolution falls back to `.desktop` entries when class isn't a theme icon
+- Keygrabber stops key repeat when starting mid-press
+- Keyboard layout `next_layout()` off-by-one in wrap-around
+- README links point at the 1.4 docs site
+
+### Changed
+
+- The `exit` signal now carries a `restart` boolean argument: `true` on
+  hot-reload, `false` on shutdown. Matches AwesomeWM behavior. Existing
+  handlers that ignore arguments are unaffected.
+
+### Notes
+
+- AwesomeWM baseline unchanged from 1.4.0.
+- See [`DEVIATIONS.md`](DEVIATIONS.md) for Wayland vs X11 differences.
+
 ## [1.4.0] - 2026-04-07
 
 First stable release. SomeWM 1.4 = AwesomeWM 4.4 on Wayland.
@@ -109,8 +143,9 @@ First stable release. SomeWM 1.4 = AwesomeWM 4.4 on Wayland.
 
 Initial public release with core AwesomeWM compatibility.
 
-[Unreleased]: https://github.com/trip-zip/somewm/compare/1.4.0...HEAD
-[1.4.0]: https://github.com/trip-zip/somewm/compare/0.5.0...1.4.0
+[Unreleased]: https://github.com/trip-zip/somewm/compare/v1.4.1...HEAD
+[1.4.1]: https://github.com/trip-zip/somewm/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/trip-zip/somewm/compare/0.5.0...v1.4.0
 [0.5.0]: https://github.com/trip-zip/somewm/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/trip-zip/somewm/compare/0.3.0...0.4.0
 [0.3.0]: https://github.com/trip-zip/somewm/releases/tag/0.3.0

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ See the [full docs](https://somewm.org) for details.
 
 **Arch Linux (AUR):**
 ```bash
-yay -S somewm-git
+yay -S somewm        # stable release
+yay -S somewm-git    # tracks main (2.x development)
 ```
 
 **From source:**

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'somewm',
   'c',
-  version: '1.4.0',
+  version: '1.4.1',
   license: 'MIT',
   default_options: [
     'c_std=gnu11',


### PR DESCRIPTION
## Description

Release prep for 1.4.1. shuber2 raised this in discussion #496: 19
commits have landed on `release/1.4` since `v1.4.0` was tagged on
2026-04-09, all bug fixes (plus one additive `restart` arg on the
`exit` signal), no public API breaks. Cutting 1.4.1 now gets the
stability fixes to non-git users.

Changes:
- `meson.build`: 1.4.0 -> 1.4.1
- `CHANGELOG.md`: new [1.4.1] section grouping the 19 commits;
  fixes the pre-existing broken [Unreleased] and [1.4.0] compare
  links (they used bare numbers; tags are v-prefixed)
- `README.md`: recommend `yay -S somewm` for stable users, keep
  `somewm-git` listed for 2.x development tracking

Once this merges, the v1.4.1 tag goes on the merged tip, GitHub
Release follows, then the somewm AUR PKGBUILD bump.

## Test Plan

- `make test-unit` clean (758/758, 1 pending GDK skip, expected)
- Integration tests not re-run; release/1.4 has been driver-tested
  extensively. No code changes in this PR, only meson version
  string + docs.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** (if a bug surfaces in Lua, the fix belongs in C)
- [x] Tests pass (`make test-unit && make test-integration`)