### PR TITLE
fix: Sync meson license with actual LICENSE file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'somewm',
   'c',
   version: '2.0.0-dev',
-  license: 'MIT',
+  license: 'GPL-3.0',
   default_options: [
     'c_std=gnu11',
     'warning_level=2',


### PR DESCRIPTION
## Description
Meson build file had MIT license set, where the LICENSE file is GPL-3. Applies to main and release/1.4.