### PR TITLE
fix: Wrong SPDX identifier in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'somewm',
   'c',
   version: '2.0.0-dev',
-  license: 'GPL-3.0',
+  license: 'GPL-3.0-or-later',
   default_options: [
     'c_std=gnu11',
     'warning_level=2',


### PR DESCRIPTION
The correct GPL-3 specifiers are GPL-3.0-only or GPL-3.0-or-later. Switch to GPL-3.0-or-later.

## Description

Sorry, the AI comment was right.