### PR TITLE
fix(awful/permissions): handle nil screen on transient_for tag fallback

### DIFF
--- a/lua/awful/permissions/init.lua
+++ b/lua/awful/permissions/init.lua
@@ -319,7 +319,14 @@ function permissions.tag(c, t, hints) --luacheck: no unused
             c.screen = c.transient_for.screen
             if not c.sticky then
                 local tags = c.transient_for:tags()
-                c:tags(#tags > 0 and tags or c.transient_for.screen.selected_tags)
+                local fallback_screen = c.transient_for.screen or c.screen
+                if #tags > 0 then
+                    c:tags(tags)
+                elseif fallback_screen then
+                    c:tags(fallback_screen.selected_tags)
+                else
+                    c:to_selected_tags()
+                end
             end
         else
             c:to_selected_tags()


### PR DESCRIPTION
## Summary

Avoid an "attempt to index field 'screen' (a nil value)" crash in
`awful.permissions.tag()` when a transient client requests a tag while
its parent's `.screen` is transiently `nil`.

## The bug

`lua/awful/permissions/init.lua:322` does:

```lua
c:tags(#tags > 0 and tags or c.transient_for.screen.selected_tags)
```

If `c.transient_for.screen == nil`, the `.selected_tags` deref crashes
the request. The same code one line up assigns `c.screen = c.transient_for.screen`,
so the parent's nil screen also propagates to the transient — but the
crash happens first, before that has a chance to matter.

## When it surfaces

Most reliably during `awesome.restart()` while the screen state is
mid-rebuild. Timing-sensitive transient emitters (notification
applets, tray menus) can fire `request::tag` for a transient whose
parent's `.screen` is briefly `nil`. Outside of hot-reload it is rare
but reproducible under load.

## Fix

Compute `fallback_screen` once (parent's screen, then the client's own
as a last resort) and route through `c:to_selected_tags()` when neither
is available, instead of dereferencing nil:

```lua
local fallback_screen = c.transient_for.screen or c.screen
if #tags > 0 then
    c:tags(tags)
elseif fallback_screen then
    c:tags(fallback_screen.selected_tags)
else
    c:to_selected_tags()
end
```

Behavior on the happy path (parent has a screen, transient has tags or
the parent's screen has selected tags) is unchanged.

## Test plan

- [x] No crash when forcing `c.transient_for.screen = nil` in a repro
- [x] Tag inheritance still works for normal transients (verified live
      with nm-applet/blueman-applet menus and notification popups)
- [x] No regression in `awesome.restart()` flow on our fork
