### PR TITLE
fix(focus): preserve focus during cross-monitor mouse-drag

### DIFF
--- a/input.c
+++ b/input.c
@@ -870,6 +870,15 @@ motionnotify(uint32_t time, struct wlr_input_device *device, double dx, double d
 			if (!continue_grab) {
 				/* Callback returned false, stop grabbing */
 				luaA_mousegrabber_stop(L);
+				/* Re-evaluate pointer/keyboard focus now that the
+				 * grab is over and (for cross-monitor moves)
+				 * tag/monitor state is consistent. Without this
+				 * rebase the pointer-focused surface stays at
+				 * whatever it was when the grab started, so the
+				 * just-dropped client doesn't get button events
+				 * until the next pointer motion. Mirrors Sway's
+				 * seatop_default re-entry. */
+				motionnotify(0, NULL, 0, 0, 0, 0);
 			}
 		} else {
 			/* Error in callback */

--- a/objects/client.c
+++ b/objects/client.c
@@ -92,6 +92,7 @@
 #include "objects/drawable.h"
 #include "objects/button.h"
 #include "objects/key.h"
+#include "objects/mousegrabber.h"
 #include "luaa.h"
 #include "common/lualib.h"
 #include "signal.h"
@@ -1953,6 +1954,16 @@ void client_ban_unfocus(client_t *c)
 {
     /* Wait until the last moment to take away the focus from the window. */
     if(globalconf.focus.client == c) {
+        /* During a Lua mousegrabber-driven move, screen_client_moveto()
+         * updates c->mon/c->screen ahead of the tag retag. The banning
+         * pass then briefly sees the actively-dragged client as
+         * "invisible" (tags still on the source screen) and would
+         * clear focus mid-drag, stealing focus to another client on
+         * the source monitor. Skip the unfocus while the grab is
+         * active; the post-grab motionnotify(0) re-evaluates
+         * pointer/keyboard focus once tag/monitor state is consistent. */
+        if (mousegrabber_isrunning())
+            return;
         client_unfocus(c);
     }
 }

--- a/protocols.c
+++ b/protocols.c
@@ -310,10 +310,11 @@ void
 unmaplayersurfacenotify(struct wl_listener *listener, void *data)
 {
 	LayerSurface *l = wl_container_of(listener, l, unmap);
+	bool had_exclusive_focus = (l == exclusive_focus);
 
 	l->mapped = 0;
 	wlr_scene_node_set_enabled(&l->scene->node, 0);
-	if (l == exclusive_focus)
+	if (had_exclusive_focus)
 		exclusive_focus = NULL;
 
 	if (l->layer_surface && l->layer_surface->output) {
@@ -331,8 +332,18 @@ unmaplayersurfacenotify(struct wl_listener *listener, void *data)
 		layer_surface_emit_unmanage(l->lua_object);
 	}
 
-	/* Restore focus via Lua history on the layer surface's monitor */
-	focus_restore(l->mon ? l->mon : selmon);
+	/* Restore focus only if this layer surface actually held keyboard focus
+	 * (exclusive_focus). Layer surfaces without keyboard interactivity
+	 * (notifications, tooltips, transient popups) never owned focus, so
+	 * triggering Lua focus history on their unmap would steal focus from
+	 * the currently focused client.
+	 *
+	 * Also skip while a mousegrabber is active: the user is dragging a
+	 * client and focus_restore() would pick a candidate from focus
+	 * history, stealing focus from the dragged window. The drag operation
+	 * owns focus until it completes. */
+	if (had_exclusive_focus && !mousegrabber_isrunning())
+		focus_restore(l->mon ? l->mon : selmon);
 
 	motionnotify(0, NULL, 0, 0, 0, 0);
 }


### PR DESCRIPTION
## Description

Cross-monitor floating-client drag (Lua `mousegrabber`-driven move from one screen to another) clears keyboard focus and the active border mid-drag, even though the user is still holding the mouse button. Pointer focus also goes stale on the destination monitor, so the just-dropped client doesn't receive button events until the next pointer motion.

Easy to reproduce on a 2+ monitor setup: hold `Mod+LMB` on a floating client and drag it across the monitor boundary. Expected: client stays focused until the button is released, and immediately receives input events at the drop location. Actual: focus is lost mid-drag (border colour flips to inactive); after release, the dropped client doesn't get button/keyboard events until the pointer moves.

### Root cause

Three independent code paths conspire to drop focus on the moving client:

1. `screen_client_moveto` flips `c->mon`/`c->screen` ahead of the tag retag. During that brief window the banning pass in `client_ban_unfocus()` sees the actively-dragged client as "invisible" (its tags are still on the source screen) and calls `client_unfocus()` on the very client the user is still holding.
2. `unmaplayersurfacenotify` calls `focus_restore()` unconditionally on every layer-surface unmap. Layer surfaces without keyboard interactivity (notifications, tooltips, transient popups) never owned focus, so triggering Lua focus history on their unmap steals focus from the currently focused client. During a drag this can fire repeatedly as transient surfaces appear/disappear.
3. After `luaA_mousegrabber_stop()` returns, `motionnotify()` doesn't rebase pointer focus. The pointer-focused surface stays at whatever it was when the grab started, so the dropped client doesn't receive button events until the next motion. Mirrors a known seatop transition pattern in Sway (`seatop_default` re-entry).

### Fix

- `objects/client.c::client_ban_unfocus`: early-return while a mousegrabber is active. The drag operation owns focus until the user releases the button.
- `protocols.c::unmaplayersurfacenotify`: only call `focus_restore()` when the unmapping layer surface actually held keyboard focus (`exclusive_focus`). Also skip while a mousegrabber is active.
- `input.c::motionnotify`: after the mousegrabber callback returns false (drag complete), call `motionnotify(0, NULL, 0, 0, 0, 0)` to rebase pointer/keyboard focus once tag/monitor state is consistent. Only the motion path needs this; the two button-path call sites don't terminate a drag the same way.

3 files, 34 insertions, 3 deletions. Each change is guarded so it cannot affect single-monitor users or non-mousegrabber focus paths.

### Test plan

- [x] Build clean against `trip-zip/somewm:main` (`meson setup build && ninja -C build`)
- [x] Live test on 3-monitor setup: cross-monitor `Mod+LMB` drag preserves focus throughout the drag and dropped client receives input immediately
- [x] Single-monitor floating drag: no behavior change
- [x] Layer surfaces with `keyboard-interactivity: exclusive` (Quickshell launcher, lockscreen): still receive focus on map and restore focus on unmap
- [x] Notification popups (`keyboard-interactivity: none`): unmap no longer steals focus
