### PR TITLE
fix(mouse): defer aerosnap placeholder by dwell to kill cross-monitor flicker

### DIFF
--- a/lua/awful/mouse/snap.lua
+++ b/lua/awful/mouse/snap.lua
@@ -14,6 +14,7 @@ local beautiful = require("beautiful")
 local color     = require("gears.color")
 local shape     = require("gears.shape")
 local cairo     = require("lgi").cairo
+local GLib      = require("lgi").GLib
 local alayout   = require("awful.layout")
 
 local capi = {
@@ -26,7 +27,13 @@ local capi = {
 
 local module = {
     default_distance  = 8,
-    aerosnap_distance = 16
+    aerosnap_distance = 16,
+    -- Minimum time the cursor must dwell inside an aerosnap edge zone
+    -- before the placeholder is shown.  Flying past an edge during a
+    -- cross-monitor drag (typical: <50 ms in the edge band) never
+    -- lights up the placeholder and never damages the second output.
+    -- Set to 0 to restore the legacy behaviour (show on first tick).
+    snap_dwell_ms     = 150,
 }
 
 local placeholder_w = nil
@@ -105,6 +112,34 @@ local function detect_screen_edges(c, snap)
 end
 
 local current_snap, current_axis = nil
+-- Monotonic timestamp (µs) at which the cursor first entered the
+-- current snap zone.  Used to enforce `module.snap_dwell_ms`: the
+-- placeholder is only shown once the cursor has been in the same
+-- edge zone for at least that long.  0 means "not currently in any
+-- snap zone".
+local current_snap_entered_us = 0
+-- Whether `show_placeholder` has been called with a non-nil geometry
+-- for the current snap zone.  Used to gate `apply_areasnap`: a
+-- release without prior visual confirmation is treated as a no-op.
+local current_snap_visible = false
+
+local function reset_snap_state()
+    current_snap = nil
+    current_axis = nil
+    current_snap_entered_us = 0
+    current_snap_visible = false
+end
+
+local function show_snap_for(c)
+    show_placeholder(build_placement(current_snap, current_axis)(c, {
+        to_percent     = 0.5,
+        honor_workarea = true,
+        honor_padding  = true,
+        pretend        = true,
+        margins        = beautiful.snapper_gap
+    }))
+    current_snap_visible = true
+end
 
 local function detect_areasnap(c, distance)
     if (not c.floating) and alayout.get(c.screen) ~= alayout.suit.floating then
@@ -120,34 +155,68 @@ local function detect_areasnap(c, distance)
         current_snap = v or h or nil
     end
 
-    if old_snap == current_snap then return end
+    local dwell_ms = module.snap_dwell_ms or 0
 
-    current_axis = ((v and not h) and "horizontally")
-        or ((h and not v) and "vertically")
-        or nil
+    -- Snap zone changed: refresh axis + dwell timestamp, hide any
+    -- previously visible placeholder.  In dwell mode we re-show only
+    -- after the dwell threshold below, never on the first tick of
+    -- entering a new zone — that's what eliminates the flicker when
+    -- the cursor briefly grazes an edge while flying between monitors.
+    -- With dwell disabled (snap_dwell_ms <= 0) we restore legacy
+    -- behaviour and show immediately on entry.
+    if old_snap ~= current_snap then
+        current_axis = ((v and not h) and "horizontally")
+            or ((h and not v) and "vertically")
+            or nil
+        current_snap_entered_us = current_snap and GLib.get_monotonic_time() or 0
+        current_snap_visible = false
+        show_placeholder(nil)
+        if current_snap and dwell_ms <= 0 then
+            show_snap_for(c)
+        end
+        return
+    end
 
-    -- Show the expected geometry outline
-    show_placeholder(
-        current_snap and build_placement(current_snap, current_axis)(c, {
-            to_percent     = 0.5,
-            honor_workarea = true,
-            honor_padding  = true,
-            pretend        = true,
-            margins         = beautiful.snapper_gap
-        }) or nil
-    )
+    -- Same zone as last tick: defer placeholder until the cursor has
+    -- dwelled long enough.  Fast cross-monitor flights graze the
+    -- edge band for <50 ms and never satisfy the dwell, so the
+    -- destination output is never damaged with a placeholder.
+    if not current_snap or current_snap_visible or current_snap_entered_us == 0 then
+        return
+    end
 
+    if dwell_ms > 0 then
+        local elapsed_us = GLib.get_monotonic_time() - current_snap_entered_us
+        if elapsed_us < dwell_ms * 1000 then return end
+    end
+
+    show_snap_for(c)
 end
 
 local function apply_areasnap(c, args)
     if not current_snap then return end
 
+    -- If the placeholder was never shown for this zone, the user got
+    -- no visual confirmation that a snap was about to happen.  Treat
+    -- release as a no-op rather than surprising them with a layout
+    -- change.
+    if not current_snap_visible then
+        reset_snap_state()
+        return
+    end
+
     -- Remove the move offset
     args.offset = {}
 
-    placeholder_w.visible = false
+    if placeholder_w then placeholder_w.visible = false end
 
-    return build_placement(current_snap, current_axis)(c,{
+    -- Snapshot the placement choice before clearing state so the
+    -- next drag — even one that immediately re-enters the same edge
+    -- zone — starts with a clean slate.
+    local snap, axis = current_snap, current_axis
+    reset_snap_state()
+
+    return build_placement(snap, axis)(c, {
         to_percent     = 0.5,
         honor_workarea = true,
         honor_padding  = true,


### PR DESCRIPTION
## Description

Dragging a floating client across the seam between two outputs on a Wayland scene-graph compositor produces a visible single-frame placeholder flicker on the destination monitor. `detect_areasnap()` shows the aerosnap placeholder on the very first tick the cursor enters an edge band, even when the cursor is just transiting and parks somewhere far from the edge.

This patch debounces the placeholder by `awful.mouse.snap.snap_dwell_ms` (default 150 ms): the placeholder is only shown once the cursor has dwelled in the same edge zone for that long. Fast cross-monitor crossings graze the edge band for under 50 ms and so never trigger the placeholder; the destination output is never damaged.

### Behaviour

| Scenario | Before | After |
|----------|--------|-------|
| Cross-monitor drag (cursor flies past edge) | Placeholder flashes on destination output for one frame | No placeholder, no damage |
| Park cursor near edge for >150 ms | Placeholder appears on first edge-detect tick | Placeholder appears after 150 ms |
| Release inside edge zone with no prior placeholder | Snap applies | No-op (no visual confirmation, no commit) |
| `module.snap_dwell_ms = 0` | n/a | Legacy first-tick behaviour preserved |

### State changes

The dwell mechanism required tightening surrounding state: a `current_snap_visible` flag tracks whether `show_placeholder` was ever called for the current zone (gates the release decision on actual visual feedback rather than just elapsed time), and after a successful apply the snap/axis are snapshotted to locals before `reset_snap_state()` clears all globals so an immediate same-edge follow-up isn't blocked by stale state. A small `show_snap_for(c)` helper deduplicates the `awful.placement` call between the two code paths.

### Test plan

- [x] Drag floating windows between all three pairs of monitors at varying speeds: placeholder no longer flashes on transit
- [x] Park cursor at left edge for ~200 ms: placeholder appears, snap commits on release
- [x] Park cursor at left edge briefly (<100 ms), release: no surprise snap
- [x] Drag, snap left, drag again, snap left: second snap works (regression check)
- [x] `awful.mouse.snap.snap_dwell_ms = 0` at runtime: legacy behaviour restored
- [x] `luac -p lua/awful/mouse/snap.lua` clean

Originally hit on a multi-monitor NVIDIA setup where per-frame placeholder + cross-output damage was particularly visible, but the fix is platform-agnostic.
