### PR TITLE
build: don't propagate -Werror into wlroots subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -130,6 +130,7 @@ if not wlroots.found()
   wlroots_options = [
     'examples=false',
     'default_library=static',
+    'werror=false',
   ]
   if have_xwayland
     wlroots_options += 'xwayland=enabled'


### PR DESCRIPTION
## Description

When system wlroots-0.19 is absent, somewm builds it from the bundled subproject. wlroots 0.19's meson then falls back through `libdisplay-info` to `v4l-utils 1.29.0`, and the project-level `werror=true` propagates into all of that vendored code. Newer GCC (15 on Ubuntu 26.04 / 16 on Fedora 44) flags warnings in v4l-utils that 1.29.0 was never updated for, and `-Werror` turns them into hard build failures.

Adding `werror=false` to `wlroots_options` stops `-Werror` at the somewm/wlroots boundary. somewm's own C code stays under the project default `werror=true`, so PR #246's intent is preserved.

Should address #525 and #526.

## Test Plan

- `make build-test` succeeds (system wlroots-0.19 path, unchanged behavior)
- `make test-unit` passes (758 successes, 0 failures)
- `make test-integration` passes (116/116)
- End-to-end build on Ubuntu 26.04 / Fedora 44 needs `@johannesk` / `@hsekitir` to verify; this box ships GCC 14.2 and doesn't reproduce the failure

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)