### PR TITLE
build: actually propagate werror=false to nested subprojects + clean two GCC 15/16 -Werror hits

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -4212,7 +4212,7 @@ luaA_loadrc(void)
 	char xdg_config_path[512];
 	const char *xdg_config_home;
 	const char *home;
-	const char *config_paths[8];
+	const char *config_paths[8] = {NULL};
 	int path_count = 0;
 	volatile int loaded = 0;  /* volatile: may be modified across siglongjmp */
 	int load_result;

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,9 @@ project(
     'c_std=gnu11',
     'warning_level=2',
     'werror=true',
+    'wlroots:werror=false',
+    'libdisplay-info:werror=false',
+    'v4l-utils:werror=false',
   ],
 )
 
@@ -130,7 +133,6 @@ if not wlroots.found()
   wlroots_options = [
     'examples=false',
     'default_library=static',
-    'werror=false',
   ]
   if have_xwayland
     wlroots_options += 'xwayland=enabled'

--- a/objects/button.c
+++ b/objects/button.c
@@ -150,8 +150,6 @@ luaA_button_array_set(lua_State *L, int oidx, int idx, button_array_t *buttons)
 {
 	int i;
 	int abs_idx;
-	int count = 0;
-	int nested_count;
 
 	luaL_checktype(L, idx, LUA_TTABLE);
 
@@ -168,7 +166,6 @@ luaA_button_array_set(lua_State *L, int oidx, int idx, button_array_t *buttons)
 	/* Iterate table and collect button objects */
 	lua_pushnil(L);
 	while (lua_next(L, abs_idx)) {
-		count++;
 		/* Check if value is a button object or awful.button wrapper */
 		if (lua_istable(L, -1)) {
 			/* Try to get _c_button field (awful.button wrapper) */
@@ -181,18 +178,14 @@ luaA_button_array_set(lua_State *L, int oidx, int idx, button_array_t *buttons)
 			} else {
 				lua_pop(L, 1); /* Pop nil _c_button */
 				/* Maybe it's an array of capi.button objects - iterate it */
-				nested_count = 0;
 				lua_pushnil(L);
 				while (lua_next(L, -2)) {
 					if (luaA_toudata(L, -1, &button_class)) {
-						nested_count++;
 						/* luaA_object_ref_item removes the item from stack */
 						button_array_append(buttons, luaA_object_ref_item(L, oidx, -1));
 					} else {
 						lua_pop(L, 1); /* Pop non-button value */
 					}
-				}
-				if (nested_count == 0) {
 				}
 				/* Pop the table after iteration */
 				lua_pop(L, 1);


### PR DESCRIPTION
## Description
PR #528's `werror=false` in `wlroots_options` was a no-op: `default_options` to `subproject()` doesn't override meson's `werror` builtin and doesn't cascade to nested subprojects. The right form is `<subproj>:werror=false` in top-level project default_options.

Plus two -Werror hits in our own code:
- `luaa.c`: zero-init `config_paths` (GCC 15+ `-Wmaybe-uninitialized`)
- `objects/button.c`: drop dead `count`/`nested_count` locals (GCC 16 `-Wunused-but-set-variable`)

Closes #525, #526.

## Test Plan
Built green on Arch (gcc 15.2.1, force-fallback), Ubuntu 26.04 (gcc 15, docker), Fedora 44 (gcc 16, docker). `make test-unit && make test-integration`: 758 + 116 pass.

## Checklist
- [x] Lua libraries not modified
- [x] Tests pass