### PR TITLE
test: pin kitty initial size to fix test-floating-layout flake

### DIFF
--- a/tests/_client.lua
+++ b/tests/_client.lua
@@ -74,10 +74,16 @@ local function spawn_client(_, class, title, sn_rules, callback)
 
     local exe, class_flag, exec_flag = terminal_cmd[1], terminal_cmd[2], terminal_cmd[3]
 
+    -- Pin kitty initial size so cold-cache kitty doesn't size itself to the bounds hint.
+    local extra = (exe == "kitty")
+        and " -o initial_window_width=400 -o initial_window_height=300"
+        or ""
+
     -- Build command
     local cmd = string.format(
-        "%s %s %s sleep infinity",
+        "%s%s %s %s sleep infinity",
         exe,
+        extra,
         string.format(class_flag, class),
         exec_flag
     )

--- a/tests/test-floating-layout.lua
+++ b/tests/test-floating-layout.lua
@@ -20,11 +20,11 @@ runner.run_steps({
     -- SCENARIO 1: Switch tiling -> floating, windows must keep tiled size
     -- =================================================================
     function()
-        -- Start in tiling layout, spawn 3 clients
+        -- Start in tiling layout, spawn 3 clients with distinct classes
         awful.layout.set(awful.layout.suit.tile)
-        test_client(nil, "tile_a")
-        test_client(nil, "tile_b")
-        test_client(nil, "tile_c")
+        test_client("tile_a")
+        test_client("tile_b")
+        test_client("tile_c")
         return true
     end,
     function()
@@ -66,11 +66,16 @@ runner.run_steps({
         -- not what the terminal later resized to.
         _G._float_manage_geo = nil
         _G._float_manage_conn = function(c)
+            -- Filter by class: tile_a/b/c manage signals can fire late
+            -- (after this handler is connected) and would otherwise be
+            -- captured here, since signal dispatch is not synchronous
+            -- with client.get() membership.
+            if c.class ~= "float_new" then return end
             _G._float_manage_geo = { width = c.width, height = c.height }
             client.disconnect_signal("request::manage", _G._float_manage_conn)
         end
         client.connect_signal("request::manage", _G._float_manage_conn)
-        test_client(nil, "float_new")
+        test_client("float_new")
         return true
     end,
     function()


### PR DESCRIPTION
## Description

test-floating-layout was failing about half the time. Every failure looked the same: a freshly-spawned floating client coming in at workarea size (1280x720) when the request::manage handler reads its width/height. Failures clustered in the first 10-11 runs of a 20-run series and disappeared after that.

The compositor turned out to be fine. initialcommitnotify sends the workarea as a bounds *hint* and configure size = 0,0 ("pick your own"). That's the right thing to do, and #321 set it up that way for the Firefox tiling case.

The flake was kitty. With a cold font cache, kitty doesn't know its preferred size yet, so it falls back to filling the bounds hint and commits at workarea size. After a few runs the cache warms up and kitty starts picking ~80 cols x 24 rows like normal. Hence the warm-up pattern in the failures.

Fix: in tests/_client.lua, when we spawn kitty (the preferred terminal), pass `-o initial_window_width=400 -o initial_window_height=300`. Now kitty's commit size is 400x300 regardless of cache state. The other terminals (foot, alacritty, ghostty) are fallbacks and unchanged.

While I was in there I also fixed two existing bugs in test-floating-layout.lua:
- `test_client(nil, "tile_a")` was passing the class as the title. Every "tile_a/b/c" client was actually using the default "test_client" class.
- The request::manage handler in scenario 2 had no class filter. A late-arriving manage signal from one of the tile clients could capture the wrong geometry. Filtered to "float_new".

The carousel flakes I noticed in the same run (test-carousel-vertical-focus, test-carousel-vertical-operations) have separate root causes. Follow-up PR.

## Test Plan

- Ran `make test-one TEST=tests/test-floating-layout.lua` 20 times in a row: 20/20 PASS (was 10/20 PASS before).
- `make test-integration`: 116/116 PASS.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** -- if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)