### PR TITLE
test: wait for spawn autofocus in carousel tests

### DIFF
--- a/tests/test-carousel-vertical-focus.lua
+++ b/tests/test-carousel-vertical-focus.lua
@@ -35,23 +35,26 @@ local steps = {
         return true
     end,
 
-    -- Spawn three clients
+    -- Spawn three clients. Wait for the newly-spawned client to be the
+    -- focused one before advancing: kitty's xdg_activation autofocus is
+    -- deferred, and if a later step sets focus explicitly before the
+    -- activation lands, the activation will stomp it (race).
     function(count)
         if count == 1 then test_client("vfocus_a") end
         c1 = utils.find_client_by_class("vfocus_a")
-        if c1 then return true end
+        if c1 and client.focus == c1 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("vfocus_b") end
         c2 = utils.find_client_by_class("vfocus_b")
-        if c2 then return true end
+        if c2 and client.focus == c2 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("vfocus_c") end
         c3 = utils.find_client_by_class("vfocus_c")
-        if c3 then return true end
+        if c3 and client.focus == c3 then return true end
     end,
 
     -- Focus c1 and verify it is visible

--- a/tests/test-carousel-vertical-operations.lua
+++ b/tests/test-carousel-vertical-operations.lua
@@ -34,23 +34,26 @@ local steps = {
         return true
     end,
 
-    -- Spawn three clients
+    -- Spawn three clients. Wait for the newly-spawned client to be the
+    -- focused one before advancing: kitty's xdg_activation autofocus is
+    -- deferred, and if a later step sets focus explicitly before the
+    -- activation lands, the activation will stomp it (race).
     function(count)
         if count == 1 then test_client("vops_a") end
         c1 = utils.find_client_by_class("vops_a")
-        if c1 then return true end
+        if c1 and client.focus == c1 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("vops_b") end
         c2 = utils.find_client_by_class("vops_b")
-        if c2 then return true end
+        if c2 and client.focus == c2 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("vops_c") end
         c3 = utils.find_client_by_class("vops_c")
-        if c3 then return true end
+        if c3 and client.focus == c3 then return true end
     end,
 
     -- Let layout settle with focus on c1


### PR DESCRIPTION
## Description

`test-carousel-vertical-focus` and `test-carousel-vertical-operations` flaked at ~5% each.

Both spawn kitty via `test_client(class)`, then advance to the next step as soon as the client appears in `client.get()`. Kitty's xdg_activation autofocus is deferred: kitty calls `xdg_activation_v1.activate(token)` some time after it maps; somewm's `urgent` handler (somewm.c:6514) emits `request::activate` with context `"startup"`; `permissions.activate` sets `client.focus = c`. If the next step has already set focus explicitly before that activation arrives, the activation stomps it.

- vertical-focus: focus jumped back to c3, arrange re-centered there, c1.y stuck at -1440.
- vertical-operations: `consume_window(1)` ran with focus on c3, found no column at index 4, no-op'd; c1 and c2 stayed in separate columns; the `g1.y == g2.y` wait timed out.

Fix: in the spawn steps, wait until the spawned client is the focused client, not just that it exists.

## Test Plan

- 100-run loop on each carousel test, before: ~5/100 FAIL. After: 0/100 FAIL.
- `make test-integration`: 116/116 PASS.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** -- if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)