### PR TITLE
feat(ipc): add screenshot interactive CLI subcommand

### DIFF
--- a/lua/awful/ipc.lua
+++ b/lua/awful/ipc.lua
@@ -107,6 +107,26 @@ function ipc.register(name, handler)
   commands[name] = handler
 end
 
+--- Sentinel for handlers that produce a response asynchronously.
+-- When a handler returns this value, the dispatcher does not send a response;
+-- the handler must call _ipc_send_response(fd, response) itself once its work
+-- completes. Used by interactive commands like screenshot.interactive.
+ipc.DEFERRED = setmetatable({}, { __tostring = function() return "<deferred>" end })
+
+local _current_fd = nil
+local _current_json_mode = false
+
+--- Return the client fd of the request currently being handled.
+-- Only valid while a handler is executing.
+function ipc.current_fd()
+  return _current_fd
+end
+
+--- Return the json_mode flag of the request currently being handled.
+function ipc.current_json_mode()
+  return _current_json_mode
+end
+
 --- Format userdata pointer as ID for screens (remove space after colon)
 -- Converts "screen: 0x123" to "screen:0x123" for CLI usage.
 -- Note: Clients use numeric IDs (c.id) instead.
@@ -287,7 +307,11 @@ function ipc.dispatch(command_string, client_fd)
   end
 
   -- Execute with error handling
+  _current_fd = client_fd
+  _current_json_mode = json_mode
   local success, result = pcall(handler, unpack(args))
+  _current_fd = nil
+  _current_json_mode = false
 
   if not success then
     -- Error occurred
@@ -295,6 +319,12 @@ function ipc.dispatch(command_string, client_fd)
       return json_encode({status = "error", error = tostring(result)}) .. "\n\n"
     end
     return string.format("ERROR %s\n\n", tostring(result))
+  end
+
+  -- Handler claimed the fd for an async response. Returning nil tells C to
+  -- skip ipc_send_response; the handler will call _ipc_send_response itself.
+  if result == ipc.DEFERRED then
+    return nil
   end
 
   -- Success
@@ -2043,6 +2073,52 @@ local function register_builtin_commands()
     end
 
     return string.format("Screen %d screenshot saved to %s", s.index, path)
+  end)
+
+  --- screenshot.interactive <path> - Drag-to-select snip and save
+  -- Shows the snipping overlay; user drags a region with the left mouse
+  -- button to capture, or presses Escape / right-clicks to cancel. The IPC
+  -- response is held open until the user accepts or cancels.
+  ipc.register("screenshot.interactive", function(path)
+    if not path then
+      error("Missing file path. Usage: screenshot interactive <path>")
+    end
+
+    local fd = ipc.current_fd()
+    local json = ipc.current_json_mode()
+    local awful_screenshot = require("awful.screenshot")
+
+    local function reply(ok, msg)
+      local response
+      if json then
+        response = json_encode({
+          status = ok and "ok" or "error",
+          [ok and "result" or "error"] = msg,
+        }) .. "\n\n"
+      elseif ok then
+        response = "OK\n" .. msg .. "\n\n"
+      else
+        response = "ERROR " .. msg .. "\n\n"
+      end
+      if _ipc_send_response then
+        _ipc_send_response(fd, response)
+      end
+    end
+
+    local ss = awful_screenshot {
+      interactive = true,
+      file_path   = path,
+    }
+
+    ss:connect_signal("file::saved", function(_, saved_path)
+      reply(true, "Screenshot saved to " .. saved_path)
+    end)
+    ss:connect_signal("snipping::cancelled", function(_, reason)
+      reply(false, "Screenshot cancelled: " .. tostring(reason))
+    end)
+
+    ss:refresh()
+    return ipc.DEFERRED
   end)
 
   -- =================================================================

--- a/objects/ipc.c
+++ b/objects/ipc.c
@@ -54,7 +54,13 @@ ipc_dispatch_to_lua(int client_fd, const char *command)
 		return;
 	}
 
-	/* Get result from Lua (should be a string like "OK\n\n" or "ERROR msg\n\n") */
+	/* Get result from Lua. A nil return means the handler claimed the fd and
+	 * will call _ipc_send_response itself when its async work finishes (used
+	 * by interactive commands like screenshot.interactive). */
+	if (lua_isnil(L, -1)) {
+		lua_pop(L, 1);
+		return;
+	}
 	result = lua_tostring(L, -1);
 	if (result) {
 		ipc_send_response(client_fd, result);

--- a/somewm-client.c
+++ b/somewm-client.c
@@ -131,7 +131,8 @@ print_usage(const char *progname)
 	fprintf(stderr, "  screenshot save <path> [--transparent]\n");
 	fprintf(stderr, "                                 Save full desktop screenshot\n");
 	fprintf(stderr, "  screenshot client <path> [ID]  Save client window screenshot\n");
-	fprintf(stderr, "  screenshot screen <path> [ID]  Save single screen screenshot\n\n");
+	fprintf(stderr, "  screenshot screen <path> [ID]  Save single screen screenshot\n");
+	fprintf(stderr, "  screenshot interactive <path>  Drag-to-select region and save\n\n");
 
 	fprintf(stderr, "INPUT SETTINGS:\n");
 	fprintf(stderr, "  input                          Show all input settings\n");
@@ -442,7 +443,7 @@ print_completions(const char *shell)
 		printf("      COMPREPLY=( $(compgen -W \"list show hide toggle\" -- \"${cur}\") )\n");
 		printf("      ;;\n");
 		printf("    screenshot)\n");
-		printf("      COMPREPLY=( $(compgen -W \"save client screen\" -- \"${cur}\") )\n");
+		printf("      COMPREPLY=( $(compgen -W \"save client screen interactive\" -- \"${cur}\") )\n");
 		printf("      ;;\n");
 		printf("    mouse)\n");
 		printf("      COMPREPLY=( $(compgen -W \"coords screen\" -- \"${cur}\") )\n");
@@ -525,7 +526,7 @@ print_completions(const char *shell)
 		printf("        keybind) _values 'subcommand' list add remove trigger ;;\n");
 		printf("        rule) _values 'subcommand' list add remove test ;;\n");
 		printf("        wibar) _values 'subcommand' list show hide toggle ;;\n");
-		printf("        screenshot) _values 'subcommand' save client screen ;;\n");
+		printf("        screenshot) _values 'subcommand' save client screen interactive ;;\n");
 		printf("        mouse) _values 'subcommand' coords screen ;;\n");
 		printf("        titlebar) _values 'subcommand' show hide toggle ;;\n");
 		printf("        theme) _values 'subcommand' get set ;;\n");
@@ -590,7 +591,7 @@ print_completions(const char *shell)
 		printf("# Wibar subcommands\n");
 		printf("complete -c somewm-client -n '__fish_seen_subcommand_from wibar' -a 'list show hide toggle'\n");
 		printf("# Screenshot subcommands\n");
-		printf("complete -c somewm-client -n '__fish_seen_subcommand_from screenshot' -a 'save client screen'\n");
+		printf("complete -c somewm-client -n '__fish_seen_subcommand_from screenshot' -a 'save client screen interactive'\n");
 		printf("# Mouse subcommands\n");
 		printf("complete -c somewm-client -n '__fish_seen_subcommand_from mouse' -a 'coords screen'\n");
 		printf("# Titlebar subcommands\n");

--- a/tests/test-screenshot-interactive-ipc.lua
+++ b/tests/test-screenshot-interactive-ipc.lua
@@ -1,0 +1,78 @@
+-- Test: screenshot.interactive IPC command defers its response, runs the
+-- snipping mousegrabber, and replies via _ipc_send_response when the user
+-- accepts or cancels.
+
+local awful   = require("awful")
+local ipc     = require("awful.ipc")
+local runner  = require("_runner")
+
+local awful_screenshot = require("awful.screenshot")
+
+-- Wrap awful.screenshot so the test can grab the instance the handler
+-- creates and drive it through reject() / save() to simulate user input.
+local original_meta = getmetatable(awful_screenshot) or {}
+local original_call = original_meta.__call
+local captured_ss = nil
+local new_meta = {}
+for k, v in pairs(original_meta) do new_meta[k] = v end
+new_meta.__call = function(cls, args)
+    captured_ss = original_call(cls, args)
+    return captured_ss
+end
+setmetatable(awful_screenshot, new_meta)
+
+-- Stub _ipc_send_response so the test can read the deferred reply.
+local captured_fd, captured_response = nil, nil
+local original_send = _G._ipc_send_response
+_G._ipc_send_response = function(fd, response)
+    captured_fd, captured_response = fd, response
+end
+
+local function reset()
+    captured_ss, captured_fd, captured_response = nil, nil, nil
+end
+
+local steps = {
+    -- Cancel path: dispatch starts snipping, reject() sends ERROR reply.
+    function()
+        reset()
+
+        local result = ipc.dispatch("screenshot interactive /tmp/test-interactive-cancel.png", 1234)
+        assert(result == nil,
+            "dispatch should return nil for deferred response, got: " .. tostring(result))
+        assert(captured_ss, "no awful.screenshot instance was created")
+        assert(mousegrabber.isrunning(), "mousegrabber should be active during snipping")
+        assert(captured_response == nil, "response should not be sent yet")
+
+        captured_ss:reject("test_cancel")
+
+        assert(captured_fd == 1234, "wrong fd: " .. tostring(captured_fd))
+        assert(captured_response, "no response sent on cancel")
+        assert(captured_response:match("^ERROR"),
+            "expected ERROR prefix, got: " .. tostring(captured_response))
+        assert(captured_response:match("Screenshot cancelled"),
+            "expected cancel message, got: " .. tostring(captured_response))
+        assert(not mousegrabber.isrunning(), "mousegrabber should have stopped")
+
+        return true
+    end,
+
+    -- Missing path arg: dispatch returns ERROR synchronously.
+    function()
+        reset()
+
+        local result = ipc.dispatch("screenshot interactive", 1235)
+        assert(type(result) == "string" and result:match("^ERROR"),
+            "expected synchronous ERROR for missing path, got: " .. tostring(result))
+        assert(captured_response == nil,
+            "no async response should be sent on argument error")
+        return true
+    end,
+}
+
+-- Restore original _ipc_send_response when test exits (best-effort).
+awesome.connect_signal("exit", function()
+    _G._ipc_send_response = original_send
+end)
+
+runner.run_steps(steps)


### PR DESCRIPTION
## Description
Adds `somewm-client screenshot interactive <path>` for drag-to-select region capture. The Lua side already had `awful.screenshot{interactive = true}`; this exposes it as a first-class subcommand alongside `save` / `client` / `screen`.

The handler pattern needed deferred IPC responses: `mousegrabber.run` is non-blocking, so the handler returns control to the dispatcher before the user has finished dragging. Adds an `ipc.DEFERRED` sentinel — handlers can return it and later send their reply via `_ipc_send_response(fd, response)`. `objects/ipc.c` skips its automatic reply when the dispatcher returns `nil`. The `screenshot.interactive` handler hooks `file::saved` and `snipping::cancelled` to send `OK` / `ERROR`.

Updates help text, bash/zsh/fish completions.

Closes #540.

## Test Plan
- New `tests/test-screenshot-interactive-ipc.lua` exercises both the cancel path and the missing-arg path through `ipc.dispatch`, asserting the deferred response is held until the screenshot instance fires its terminal signal.
- `make test-unit` and `make test-integration` pass.
- Manual: `somewm-client screenshot interactive /tmp/x.png` shows the snipper, drag selects a region, file is written, CLI prints `OK Screenshot saved to /tmp/x.png` and exits. ESC during snipping returns an `ERROR` message.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — `lua/awful/ipc.lua` is a somewm-only file (not from AwesomeWM)
- [x] Tests pass (`make test-unit && make test-integration`)