### PR TITLE
fix(screenshot): render snipping wibox at logical resolution

### DIFF
--- a/lua/awful/screenshot.lua
+++ b/lua/awful/screenshot.lua
@@ -229,6 +229,11 @@ local function show_frame(self, surface, geo)
         widget  = self._private.canvas_widget,
         visible = true,
     }
+
+    -- Render at logical resolution; let the GPU upscale for display. Without
+    -- this, the snipping overlay repaints at physical resolution on every
+    -- mouse move and drops to ~1 FPS at HiDPI scales (issue #541).
+    self._private.frame.surface_scale = 1.0
 end
 
 --- Emitted when the interactive snipping starts.

--- a/tests/test-screenshot-snipping-surface-scale.lua
+++ b/tests/test-screenshot-snipping-surface-scale.lua
@@ -1,0 +1,31 @@
+-- Test: awful.screenshot{interactive=true} sets surface_scale=1.0 on its
+-- snipping wibox. Without this, the overlay repaints at physical resolution
+-- on every mousemove and drops to ~1 FPS at HiDPI.
+
+local awful  = require("awful")
+local runner = require("_runner")
+
+local steps = {
+    function()
+        screen[1].scale = 1.5
+        return true
+    end,
+
+    function()
+        local ss = awful.screenshot {
+            interactive = true,
+            screen      = screen[1],
+        }
+        ss:refresh()
+
+        local frame = ss._private.frame
+        assert(frame, "snipping frame wibox was not created")
+        assert(frame.surface_scale == 1.0,
+            "expected frame.surface_scale=1.0, got " .. tostring(frame.surface_scale))
+
+        ss:reject("test_done")
+        return true
+    end,
+}
+
+runner.run_steps(steps)


### PR DESCRIPTION
## Description
Sets `surface_scale = 1.0` on the snipping wibox in `awful.screenshot` so the overlay repaints at logical pixels. Without this, dragging the selection rectangle at HiDPI scales (e.g. `screen.scale = 1.5`) drops to ~1 FPS as cairo upscales every frame on the CPU. With `surface_scale` pinned, the GPU upscales for display and tracking stays smooth.

The `drawin.surface_scale` property already exists in C (commit `34ac3a348`, for #167); this just wires it into the snipping wibox.

Forward-port of #542 (release/1.4). Closes #541.

## Test Plan
- New `tests/test-screenshot-snipping-surface-scale.lua` asserts the property is set after `awful.screenshot{interactive=true}:refresh()` at `screen.scale = 1.5`.
- `make test-unit` and `make test-integration` (121 tests) pass on main.
- Manual: at `screen.scale = 1.5`, drag-to-select tracks smoothly (was 1 FPS).

## Checklist
- [ ] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — accepted deviation; one-line wiring of a somewm-only property (AwesomeWM ignores `surface_scale`)
- [x] Tests pass (`make test-unit && make test-integration`)