### PR TITLE
fix(client): capture c.content via scene-tree walk

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -229,6 +229,21 @@ xdg_shell_client_code = custom_target(
   command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
 )
 
+# linux-dmabuf-v1 client protocol (header + code) for the DMA-BUF test client
+linux_dmabuf_client_header = custom_target(
+  'linux-dmabuf-v1-client-protocol.h',
+  input: wayland_protocols_dir / 'stable/linux-dmabuf/linux-dmabuf-v1.xml',
+  output: 'linux-dmabuf-v1-client-protocol.h',
+  command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+)
+
+linux_dmabuf_client_code = custom_target(
+  'linux-dmabuf-v1-client-protocol.c',
+  input: wayland_protocols_dir / 'stable/linux-dmabuf/linux-dmabuf-v1.xml',
+  output: 'linux-dmabuf-v1-client-protocol.c',
+  command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
+)
+
 # ==============================================================================
 # Compiler Flags
 # ==============================================================================
@@ -441,6 +456,24 @@ test_content_pattern_client = executable(
   dependencies: [wayland_client],
   install: false,
 )
+
+# DMA-BUF test client (gbm + zwp_linux_dmabuf_v1) for the GPU readback path
+# in c.content. Used by test-client-content-dmabuf.lua. Only built when gbm
+# is available; the Lua test skips itself otherwise.
+gbm_dep = dependency('gbm', required: false)
+if gbm_dep.found()
+  test_dmabuf_pattern_client = executable(
+    'test-dmabuf-pattern-client',
+    [
+      'tests/test-dmabuf-pattern-client.c',
+      xdg_shell_client_code,
+      linux_dmabuf_client_code,
+    ],
+    [xdg_shell_client_header, linux_dmabuf_client_header],
+    dependencies: [wayland_client, gbm_dep],
+    install: false,
+  )
+endif
 
 # ==============================================================================
 # Install Data

--- a/objects/client.c
+++ b/objects/client.c
@@ -110,6 +110,7 @@
 #include "../shadow.h"
 #include "objects/spawn.h"
 #include "../property.h"
+#include "../screenshot_compose.h"
 
 /* Forward declaration - applies client geometry to wlroots scene graph */
 void apply_geometry_to_wlroots(client_t *c);
@@ -4637,17 +4638,11 @@ static int
 luaA_client_get_content(lua_State *L, client_t *c)
 {
     cairo_surface_t *surface;
-    struct wlr_surface *wlr_surf;
-    struct wlr_texture *texture;
-    struct wlr_buffer *client_buffer;
+    cairo_t *cr;
     int dst_width  = c->geometry.width;
     int dst_height = c->geometry.height;
-    int src_width, src_height;
-    void *shm_data;
-    uint32_t shm_format;
-    size_t shm_stride;
-    void *pixels = NULL;
-    size_t stride;
+    int origin_x, origin_y;
+    struct screenshot_render_data rdata;
 
     /* Logical client size without decorations - what we return to Lua. */
     dst_width  -= c->titlebar[CLIENT_TITLEBAR_LEFT].size + c->titlebar[CLIENT_TITLEBAR_RIGHT].size;
@@ -4656,122 +4651,36 @@ luaA_client_get_content(lua_State *L, client_t *c)
     if (dst_width <= 0 || dst_height <= 0)
         return 0;
 
-    /* Get the client's wlr_surface based on client type */
-    if (c->client_type == XDGShell && c->surface.xdg)
-        wlr_surf = c->surface.xdg->surface;
-#ifdef XWAYLAND
-    else if (c->client_type == X11 && c->surface.xwayland)
-        wlr_surf = c->surface.xwayland->surface;
-#endif
-    else
+    if (!c->scene_surface)
         return 0;
 
-    if (!wlr_surf || !wlr_surf->buffer)
+    /* Anchor the walk at the client's surface root in scene coords so we can
+     * subtract it from each per-buffer (sx, sy) and end up at (0, 0) in the
+     * destination cairo surface. */
+    if (!wlr_scene_node_coords(&c->scene_surface->node, &origin_x, &origin_y))
         return 0;
 
-    client_buffer = &wlr_surf->buffer->base;
-
-    /* The buffer is at physical pixel resolution; on HiDPI it differs from the
-     * logical dst dimensions and we must scale on composite (see root.c). */
-    src_width  = client_buffer->width;
-    src_height = client_buffer->height;
-
-    if (src_width <= 0 || src_height <= 0)
+    surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, dst_width, dst_height);
+    if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS)
         return 0;
 
-    /* First try direct buffer access (works for SHM clients) */
-    if (wlr_buffer_begin_data_ptr_access(client_buffer, WLR_BUFFER_DATA_PTR_ACCESS_READ,
-                                         &shm_data, &shm_format, &shm_stride)) {
-        /* Direct access succeeded - create Cairo surface from SHM data */
-        if (shm_format == DRM_FORMAT_ARGB8888 || shm_format == DRM_FORMAT_XRGB8888) {
-            cairo_format_t cairo_fmt = (shm_format == DRM_FORMAT_ARGB8888) ?
-                                       CAIRO_FORMAT_ARGB32 : CAIRO_FORMAT_RGB24;
-            cairo_surface_t *tmp = cairo_image_surface_create_for_data(
-                shm_data, cairo_fmt, src_width, src_height, shm_stride);
+    cr = cairo_create(surface);
 
-            if (cairo_surface_status(tmp) == CAIRO_STATUS_SUCCESS) {
-                /* Destination at logical dimensions; outlives the SHM access. */
-                surface = cairo_image_surface_create(cairo_fmt, dst_width, dst_height);
-                if (cairo_surface_status(surface) == CAIRO_STATUS_SUCCESS) {
-                    cairo_t *cr = cairo_create(surface);
-                    if (src_width != dst_width || src_height != dst_height) {
-                        cairo_scale(cr,
-                            (double)dst_width  / src_width,
-                            (double)dst_height / src_height);
-                    }
-                    cairo_set_source_surface(cr, tmp, 0, 0);
-                    cairo_paint(cr);
-                    cairo_destroy(cr);
-                    cairo_surface_destroy(tmp);
-                    wlr_buffer_end_data_ptr_access(client_buffer);
-                    cairo_surface_mark_dirty(surface);
-                    lua_pushlightuserdata(L, surface);
-                    return 1;
-                }
-                cairo_surface_destroy(surface);
-            }
-            cairo_surface_destroy(tmp);
-        }
-        wlr_buffer_end_data_ptr_access(client_buffer);
-    }
+    /* Walk the client's scene subtree and composite each buffer. The shared
+     * helper handles SHM (terminals) and the GPU/DMA-BUF readback (Firefox,
+     * GPU-accelerated apps); reading via the scene buffer ensures wlroots'
+     * synchronization, which is what was missing in the previous
+     * direct-from-wlr_surface->buffer path that came back blank for DMA-BUF
+     * clients (issue #539). */
+    rdata.cr        = cr;
+    rdata.renderer  = drw;
+    rdata.offset_x  = -origin_x;
+    rdata.offset_y  = -origin_y;
+    wlr_scene_node_for_each_buffer(&c->scene_surface->node,
+                                   composite_scene_buffer_to_cairo, &rdata);
 
-    /* Direct access failed - try GPU texture path */
-    texture = wlr_texture_from_buffer(drw, client_buffer);
-    if (!texture)
-        return 0;
-
-    /* Read at full physical buffer resolution, not logical dimensions. */
-    stride = src_width * 4;
-    pixels = malloc(stride * src_height);
-    if (!pixels) {
-        wlr_texture_destroy(texture);
-        return 0;
-    }
-
-    if (!wlr_texture_read_pixels(texture, &(struct wlr_texture_read_pixels_options){
-        .data = pixels,
-        .format = DRM_FORMAT_ARGB8888,
-        .stride = stride,
-        .src_box = { .x = 0, .y = 0, .width = src_width, .height = src_height },
-    })) {
-        free(pixels);
-        wlr_texture_destroy(texture);
-        return 0;
-    }
-
-    wlr_texture_destroy(texture);
-
-    /* Wrap pixels at physical dims, then composite into a logical-sized surface. */
-    {
-        cairo_surface_t *tmp = cairo_image_surface_create_for_data(
-            pixels, CAIRO_FORMAT_ARGB32, src_width, src_height, stride);
-        if (cairo_surface_status(tmp) != CAIRO_STATUS_SUCCESS) {
-            cairo_surface_destroy(tmp);
-            free(pixels);
-            return 0;
-        }
-
-        surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, dst_width, dst_height);
-        if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) {
-            cairo_surface_destroy(tmp);
-            free(pixels);
-            return 0;
-        }
-
-        cairo_t *cr = cairo_create(surface);
-        if (src_width != dst_width || src_height != dst_height) {
-            cairo_scale(cr,
-                (double)dst_width  / src_width,
-                (double)dst_height / src_height);
-        }
-        cairo_set_source_surface(cr, tmp, 0, 0);
-        cairo_paint(cr);
-        cairo_destroy(cr);
-        cairo_surface_destroy(tmp);
-        cairo_surface_mark_dirty(surface);
-    }
-
-    free(pixels);
+    cairo_destroy(cr);
+    cairo_surface_mark_dirty(surface);
 
     /* lua has to make sure to free the ref or we have a leak */
     lua_pushlightuserdata(L, surface);

--- a/root.c
+++ b/root.c
@@ -22,6 +22,7 @@
 #include "objects/drawin.h"
 #include "objects/client.h"
 #include "objects/screen.h"
+#include "screenshot_compose.h"
 #include "somewm_types.h"
 #include <xkbcommon/xkbcommon.h>
 #include <wlr/types/wlr_seat.h>
@@ -1465,12 +1466,8 @@ luaA_root_set_call_handler(lua_State *L)
 
 /* ========== SCREENSHOT SUPPORT ========== */
 
-/** Callback data for scene buffer iteration during screenshot */
-struct screenshot_render_data {
-	cairo_t *cr;             /* Cairo context to draw on */
-	struct wlr_renderer *renderer;
-	int offset_x, offset_y;  /* Offset for this output in virtual screen */
-};
+/* struct screenshot_render_data is declared in screenshot_compose.h so it can
+ * be shared with objects/client.c. */
 
 /** Composite a Cairo surface onto the screenshot at the given position.
  * Used to directly composite widget content from drawable surfaces.
@@ -1601,8 +1598,10 @@ composite_widgets_directly(cairo_t *cr, bool ontop_only)
 /** Callback for wlr_scene_output_for_each_buffer
  * Reads pixels from each scene buffer and composites onto Cairo surface.
  * Handles both SHM buffers (widgets) and GPU buffers (clients).
+ *
+ * Shared with objects/client.c via screenshot_compose.h.
  */
-static void
+void
 composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
                                 int sx, int sy, void *data)
 {

--- a/screenshot_compose.h
+++ b/screenshot_compose.h
@@ -1,0 +1,26 @@
+/* Shared scene-buffer compositing helper for the screenshot capture paths in
+ * root.c (luaA_root_get_content) and objects/client.c (luaA_client_get_content).
+ *
+ * Walks an arbitrary subtree via wlr_scene_node_for_each_buffer() and reads
+ * each buffer's pixels into a cairo target. Handles SHM directly and falls
+ * back to a wlr_renderer GPU texture readback for DMA-BUF clients. Scales
+ * per-buffer when the scene_buffer's dst_width/dst_height differ from the
+ * underlying buffer's physical size, so HiDPI renders correctly.
+ */
+#ifndef SOMEWM_SCREENSHOT_COMPOSE_H
+#define SOMEWM_SCREENSHOT_COMPOSE_H
+
+#include <cairo/cairo.h>
+#include <wlr/render/wlr_renderer.h>
+#include <wlr/types/wlr_scene.h>
+
+struct screenshot_render_data {
+	cairo_t *cr;
+	struct wlr_renderer *renderer;
+	int offset_x, offset_y;
+};
+
+void composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
+                                     int sx, int sy, void *data);
+
+#endif

--- a/tests/test-client-content-dmabuf.lua
+++ b/tests/test-client-content-dmabuf.lua
@@ -1,0 +1,133 @@
+---------------------------------------------------------------------------
+-- Pixel-content test for c.content with a DMA-BUF client (issue #539).
+--
+-- The companion C client (test-dmabuf-pattern-client) allocates a linear
+-- ARGB8888 buffer via gbm, fills it with a 4-quadrant pattern (TL=red,
+-- TR=green, BL=blue, BR=yellow), and imports it through
+-- zwp_linux_dmabuf_v1. The Lua driver captures c.content and asserts each
+-- quadrant has its expected color. Without the scene-tree-walk fix, the
+-- DMA-BUF readback path returns blank pixels (Firefox-style symptom).
+--
+-- Skips when:
+--   * non-LuaJIT (no FFI for pixel sampling)
+--   * test-dmabuf-pattern-client wasn't built (gbm dependency missing)
+--   * client never appears (e.g. no /dev/dri render node in the test env)
+--
+-- Run: make test-one TEST=tests/test-client-content-dmabuf.lua
+---------------------------------------------------------------------------
+
+local awful  = require("awful")
+local gears  = require("gears")
+local runner = require("_runner")
+local async  = require("_async")
+
+local ok_ffi, ffi = pcall(require, "ffi")
+if not ok_ffi then
+    io.stderr:write("SKIP: ffi not available (non-LuaJIT build)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+ffi.cdef[[
+void cairo_surface_flush(void *surface);
+unsigned char *cairo_image_surface_get_data(void *surface);
+int cairo_image_surface_get_stride(void *surface);
+int cairo_image_surface_get_width(void *surface);
+int cairo_image_surface_get_height(void *surface);
+]]
+
+local APP_ID = "dmabuf_pattern_test"
+
+local function find_binary()
+    local somewm = os.getenv("SOMEWM") or "./build-test/somewm"
+    local build_dir = somewm:match("^(.*)/somewm$") or "./build-test"
+    for _, candidate in ipairs({
+        build_dir .. "/test-dmabuf-pattern-client",
+        "./build/test-dmabuf-pattern-client",
+        "./build-test/test-dmabuf-pattern-client",
+    }) do
+        local f = io.open(candidate, "r")
+        if f then f:close(); return candidate end
+    end
+    return nil
+end
+
+local BINARY = find_binary()
+if not BINARY then
+    io.stderr:write("SKIP: test-dmabuf-pattern-client not found (gbm dep missing or not built)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local function pixel_rgb(raw_surface, x, y)
+    ffi.C.cairo_surface_flush(raw_surface)
+    local data   = ffi.C.cairo_image_surface_get_data(raw_surface)
+    local stride = ffi.C.cairo_image_surface_get_stride(raw_surface)
+    local off = y * stride + x * 4
+    return data[off + 2], data[off + 1], data[off + 0]
+end
+
+local function dominant_color(r, g, b)
+    if r > 200 and g <  80 and b <  80 then return "red"    end
+    if g > 200 and r <  80 and b <  80 then return "green"  end
+    if b > 200 and r <  80 and g <  80 then return "blue"   end
+    if r > 200 and g > 200 and b <  80 then return "yellow" end
+    return string.format("rgb(%d,%d,%d)", r, g, b)
+end
+
+runner.run_async(function()
+    local pid = awful.spawn({BINARY})
+    assert(type(pid) == "number" and pid > 0,
+        "Failed to spawn binary: " .. tostring(pid))
+
+    local c = async.wait_for_client(APP_ID, 5)
+    if not c then
+        os.execute("kill -9 " .. pid .. " 2>/dev/null")
+        io.stderr:write("SKIP: dmabuf client never appeared (no DRM render node?)\n")
+        io.stderr:write("Test finished successfully.\n")
+        runner.done()
+        return
+    end
+
+    -- Give one event-loop tick for the buffer to actually attach.
+    async.sleep(0.1)
+
+    local raw = c.content
+    assert(raw, "c.content returned nil")
+
+    local img = gears.surface(raw)
+    local w = img:get_width()
+    local h = img:get_height()
+    assert(w > 4 and h > 4,
+        string.format("c.content surface too small (%dx%d)", w, h))
+
+    local qx1, qx2 = math.floor(w * 0.25), math.floor(w * 0.75)
+    local qy1, qy2 = math.floor(h * 0.25), math.floor(h * 0.75)
+    local tl = dominant_color(pixel_rgb(raw, qx1, qy1))
+    local tr = dominant_color(pixel_rgb(raw, qx2, qy1))
+    local bl = dominant_color(pixel_rgb(raw, qx1, qy2))
+    local br = dominant_color(pixel_rgb(raw, qx2, qy2))
+
+    io.stderr:write(string.format(
+        "[dmabuf] surface=%dx%d TL=%s TR=%s BL=%s BR=%s\n",
+        w, h, tl, tr, bl, br))
+
+    local ok, err = pcall(function()
+        assert(tl == "red"   , "TL should be red, got "    .. tl)
+        assert(tr == "green" , "TR should be green, got "  .. tr)
+        assert(bl == "blue"  , "BL should be blue, got "   .. bl)
+        assert(br == "yellow", "BR should be yellow, got " .. br)
+    end)
+
+    c:kill()
+    os.execute("kill -9 " .. pid .. " 2>/dev/null")
+    async.wait_for_no_clients(3)
+
+    if not ok then
+        runner.done("test-client-content-dmabuf: " .. tostring(err))
+    else
+        runner.done()
+    end
+end)

--- a/tests/test-dmabuf-pattern-client.c
+++ b/tests/test-dmabuf-pattern-client.c
@@ -1,0 +1,261 @@
+/* Minimal DMA-BUF Wayland client for verifying c.content's GPU readback path.
+ *
+ * Allocates a single linear ARGB8888 buffer via gbm, fills it with a
+ * 4-quadrant pattern (TL=red, TR=green, BL=blue, BR=yellow), imports it as
+ * a wl_buffer through zwp_linux_dmabuf_v1, and attaches it to an
+ * xdg_toplevel. Used by test-client-content-dmabuf.lua to assert c.content
+ * returns real pixels for DMA-BUF clients (issue #539).
+ *
+ * Buffer is intentionally a DMA-BUF (not SHM) so the compositor exercises
+ * its scene-tree walk + GPU texture readback path inside
+ * composite_scene_buffer_to_cairo().
+ *
+ * Lifecycle: SIGTERM/SIGINT for clean exit. App ID: "dmabuf_pattern_test".
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <gbm.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <wayland-client.h>
+#include "linux-dmabuf-v1-client-protocol.h"
+#include "xdg-shell-client-protocol.h"
+
+#define WIDTH  200
+#define HEIGHT 200
+
+static struct wl_display *g_display;
+static struct wl_compositor *g_compositor;
+static struct xdg_wm_base *g_xdg_wm_base;
+static struct zwp_linux_dmabuf_v1 *g_dmabuf;
+
+static struct wl_surface *g_surface;
+static struct xdg_surface *g_xdg_surface;
+static struct xdg_toplevel *g_toplevel;
+static struct wl_buffer *g_buffer;
+
+static int g_drm_fd = -1;
+static struct gbm_device *g_gbm_dev;
+static struct gbm_bo *g_bo;
+
+static volatile sig_atomic_t g_running = 1;
+static bool g_committed = false;
+
+static void on_signal(int sig) { (void)sig; g_running = 0; }
+
+/* Pattern: top-left=red, top-right=green, bottom-left=blue, bottom-right=yellow */
+static uint32_t pattern_color(int x, int y) {
+	bool right  = x >= WIDTH  / 2;
+	bool bottom = y >= HEIGHT / 2;
+	if (!right && !bottom) return 0xFFFF0000u; /* red */
+	if ( right && !bottom) return 0xFF00FF00u; /* green */
+	if (!right &&  bottom) return 0xFF0000FFu; /* blue */
+	return 0xFFFFFF00u; /* yellow */
+}
+
+static void
+xdg_wm_base_ping(void *data, struct xdg_wm_base *base, uint32_t serial) {
+	(void)data;
+	xdg_wm_base_pong(base, serial);
+}
+static const struct xdg_wm_base_listener xdg_wm_base_listener = {
+	.ping = xdg_wm_base_ping,
+};
+
+static void
+xdg_surface_configure(void *data, struct xdg_surface *s, uint32_t serial) {
+	(void)data;
+	xdg_surface_ack_configure(s, serial);
+	if (g_buffer && !g_committed) {
+		wl_surface_attach(g_surface, g_buffer, 0, 0);
+		wl_surface_damage_buffer(g_surface, 0, 0, WIDTH, HEIGHT);
+		wl_surface_commit(g_surface);
+		g_committed = true;
+	}
+}
+static const struct xdg_surface_listener xdg_surface_listener = {
+	.configure = xdg_surface_configure,
+};
+
+static void
+xdg_toplevel_configure(void *data, struct xdg_toplevel *t,
+                       int32_t w, int32_t h, struct wl_array *states) {
+	(void)data; (void)t; (void)w; (void)h; (void)states;
+}
+static void
+xdg_toplevel_close(void *data, struct xdg_toplevel *t) {
+	(void)data; (void)t;
+	g_running = 0;
+}
+static void
+xdg_toplevel_configure_bounds(void *data, struct xdg_toplevel *t, int32_t w, int32_t h) {
+	(void)data; (void)t; (void)w; (void)h;
+}
+static void
+xdg_toplevel_wm_capabilities(void *data, struct xdg_toplevel *t, struct wl_array *caps) {
+	(void)data; (void)t; (void)caps;
+}
+static const struct xdg_toplevel_listener xdg_toplevel_listener = {
+	.configure         = xdg_toplevel_configure,
+	.close             = xdg_toplevel_close,
+	.configure_bounds  = xdg_toplevel_configure_bounds,
+	.wm_capabilities   = xdg_toplevel_wm_capabilities,
+};
+
+static void
+params_created(void *data, struct zwp_linux_buffer_params_v1 *p, struct wl_buffer *buf) {
+	(void)data;
+	g_buffer = buf;
+	zwp_linux_buffer_params_v1_destroy(p);
+}
+static void
+params_failed(void *data, struct zwp_linux_buffer_params_v1 *p) {
+	(void)data; (void)p;
+	fprintf(stderr, "dmabuf params failed\n");
+	g_running = 0;
+}
+static const struct zwp_linux_buffer_params_v1_listener params_listener = {
+	.created = params_created,
+	.failed  = params_failed,
+};
+
+static void
+registry_global(void *data, struct wl_registry *reg, uint32_t name,
+                const char *interface, uint32_t version) {
+	(void)data;
+	if (strcmp(interface, wl_compositor_interface.name) == 0) {
+		g_compositor = wl_registry_bind(reg, name, &wl_compositor_interface, 4);
+	} else if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
+		g_xdg_wm_base = wl_registry_bind(reg, name, &xdg_wm_base_interface, 1);
+		xdg_wm_base_add_listener(g_xdg_wm_base, &xdg_wm_base_listener, NULL);
+	} else if (strcmp(interface, zwp_linux_dmabuf_v1_interface.name) == 0) {
+		uint32_t v = version > 3 ? 3 : version;
+		g_dmabuf = wl_registry_bind(reg, name, &zwp_linux_dmabuf_v1_interface, v);
+	}
+}
+static void
+registry_global_remove(void *data, struct wl_registry *reg, uint32_t name) {
+	(void)data; (void)reg; (void)name;
+}
+static const struct wl_registry_listener registry_listener = {
+	.global         = registry_global,
+	.global_remove  = registry_global_remove,
+};
+
+static int
+open_render_node(void) {
+	int fd = open("/dev/dri/renderD128", O_RDWR | O_CLOEXEC);
+	if (fd < 0) fd = open("/dev/dri/card0", O_RDWR | O_CLOEXEC);
+	return fd;
+}
+
+static int
+create_dmabuf(void) {
+	g_drm_fd = open_render_node();
+	if (g_drm_fd < 0) {
+		fprintf(stderr, "failed to open DRM render node: %s\n", strerror(errno));
+		return -1;
+	}
+	g_gbm_dev = gbm_create_device(g_drm_fd);
+	if (!g_gbm_dev) {
+		fprintf(stderr, "failed to create gbm device\n");
+		return -1;
+	}
+	g_bo = gbm_bo_create(g_gbm_dev, WIDTH, HEIGHT, GBM_FORMAT_ARGB8888,
+	                     GBM_BO_USE_LINEAR | GBM_BO_USE_RENDERING);
+	if (!g_bo) {
+		fprintf(stderr, "failed to create gbm bo\n");
+		return -1;
+	}
+
+	void *map_data = NULL;
+	uint32_t stride = 0;
+	void *mapped = gbm_bo_map(g_bo, 0, 0, WIDTH, HEIGHT,
+	                          GBM_BO_TRANSFER_WRITE, &stride, &map_data);
+	if (!mapped) {
+		fprintf(stderr, "failed to map gbm bo\n");
+		return -1;
+	}
+	for (int y = 0; y < HEIGHT; y++) {
+		uint32_t *row = (uint32_t *)((char *)mapped + (size_t)y * stride);
+		for (int x = 0; x < WIDTH; x++) {
+			row[x] = pattern_color(x, y);
+		}
+	}
+	gbm_bo_unmap(g_bo, map_data);
+
+	int dma_fd = gbm_bo_get_fd(g_bo);
+	if (dma_fd < 0) {
+		fprintf(stderr, "failed to get dma-buf fd\n");
+		return -1;
+	}
+	uint64_t modifier = gbm_bo_get_modifier(g_bo);
+
+	struct zwp_linux_buffer_params_v1 *params =
+		zwp_linux_dmabuf_v1_create_params(g_dmabuf);
+	zwp_linux_buffer_params_v1_add_listener(params, &params_listener, NULL);
+	zwp_linux_buffer_params_v1_add(params, dma_fd, 0, 0, stride,
+	                               (uint32_t)(modifier >> 32),
+	                               (uint32_t)(modifier & 0xffffffff));
+	zwp_linux_buffer_params_v1_create(params, WIDTH, HEIGHT,
+	                                  GBM_FORMAT_ARGB8888, 0);
+	close(dma_fd);
+
+	wl_display_roundtrip(g_display);
+	if (!g_buffer) {
+		fprintf(stderr, "buffer creation never confirmed\n");
+		return -1;
+	}
+	return 0;
+}
+
+int
+main(void) {
+	signal(SIGTERM, on_signal);
+	signal(SIGINT,  on_signal);
+
+	g_display = wl_display_connect(NULL);
+	if (!g_display) {
+		fprintf(stderr, "failed to connect to wayland display\n");
+		return 1;
+	}
+
+	struct wl_registry *reg = wl_display_get_registry(g_display);
+	wl_registry_add_listener(reg, &registry_listener, NULL);
+	wl_display_roundtrip(g_display);
+
+	if (!g_compositor || !g_xdg_wm_base || !g_dmabuf) {
+		fprintf(stderr, "missing required globals (compositor=%p wm_base=%p dmabuf=%p)\n",
+		        (void *)g_compositor, (void *)g_xdg_wm_base, (void *)g_dmabuf);
+		return 1;
+	}
+
+	if (create_dmabuf() < 0) return 1;
+
+	g_surface = wl_compositor_create_surface(g_compositor);
+	g_xdg_surface = xdg_wm_base_get_xdg_surface(g_xdg_wm_base, g_surface);
+	xdg_surface_add_listener(g_xdg_surface, &xdg_surface_listener, NULL);
+	g_toplevel = xdg_surface_get_toplevel(g_xdg_surface);
+	xdg_toplevel_add_listener(g_toplevel, &xdg_toplevel_listener, NULL);
+	xdg_toplevel_set_app_id(g_toplevel, "dmabuf_pattern_test");
+	xdg_toplevel_set_title(g_toplevel, "dmabuf-pattern");
+	wl_surface_commit(g_surface);
+
+	while (g_running && wl_display_dispatch(g_display) >= 0) { }
+
+	if (g_buffer)        wl_buffer_destroy(g_buffer);
+	if (g_bo)            gbm_bo_destroy(g_bo);
+	if (g_gbm_dev)       gbm_device_destroy(g_gbm_dev);
+	if (g_drm_fd >= 0)   close(g_drm_fd);
+	if (g_toplevel)      xdg_toplevel_destroy(g_toplevel);
+	if (g_xdg_surface)   xdg_surface_destroy(g_xdg_surface);
+	if (g_surface)       wl_surface_destroy(g_surface);
+	wl_display_disconnect(g_display);
+	return 0;
+}


### PR DESCRIPTION
## Description
Replaces the direct `wlr_surface->buffer` readback in `luaA_client_get_content` with a `wlr_scene_node_for_each_buffer()` walk over `c->scene_surface`, using the same `composite_scene_buffer_to_cairo()` helper that `root.content` already uses. The direct readback returned blank pixels for clients whose buffers come back as DMA-BUFs (Firefox, hardware-accelerated apps); SHM-backed clients (terminals) worked because the data-pointer fast path succeeded before falling through to the GPU readback. The scene-tree path inherits wlroots' buffer synchronization, so the GPU texture readback now sees real pixels.

Lifts `composite_scene_buffer_to_cairo` and `screenshot_render_data` out of `root.c` into a small shared header (`screenshot_compose.h`). The function already handled SHM and DMA-BUF, and respects `scene_buffer.dst_width / dst_height` for HiDPI scaling — no per-buffer scaling math in `client.c`. Net diff is `-92` lines in `client.c`.

Forward-port of #544 (release/1.4). Closes #539.

## Test Plan
- New `tests/test-dmabuf-pattern-client.c` (gbm + `zwp_linux_dmabuf_v1`) plus `tests/test-client-content-dmabuf.lua` allocate a known DMA-BUF, attach it to an XDG toplevel, capture `c.content`, and assert each quadrant of a 4-color pattern. Skips when gbm is unavailable at build time or when no DRM render node is reachable at runtime.
- Existing `tests/test-client-content-pattern.lua` still passes (SHM regression — same scene-walk path now serves it).
- `make test-unit` and `make test-integration` (121 tests) pass on main.
- Manual: `somewm-client screenshot client /tmp/ff.png <firefox_id>` returns a real PNG (was blank). Verified at `screen.scale = 1.0` and `1.5`.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — change is in `objects/client.c` and `root.c` (C only)
- [x] Tests pass (`make test-unit && make test-integration`)