### PR TITLE
fix(client): drop scene-coords offset from c.content walk

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -4641,7 +4641,6 @@ luaA_client_get_content(lua_State *L, client_t *c)
     cairo_t *cr;
     int dst_width  = c->geometry.width;
     int dst_height = c->geometry.height;
-    int origin_x, origin_y;
     struct screenshot_render_data rdata;
 
     /* Logical client size without decorations - what we return to Lua. */
@@ -4654,12 +4653,6 @@ luaA_client_get_content(lua_State *L, client_t *c)
     if (!c->scene_surface)
         return 0;
 
-    /* Anchor the walk at the client's surface root in scene coords so we can
-     * subtract it from each per-buffer (sx, sy) and end up at (0, 0) in the
-     * destination cairo surface. */
-    if (!wlr_scene_node_coords(&c->scene_surface->node, &origin_x, &origin_y))
-        return 0;
-
     surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, dst_width, dst_height);
     if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS)
         return 0;
@@ -4669,13 +4662,17 @@ luaA_client_get_content(lua_State *L, client_t *c)
     /* Walk the client's scene subtree and composite each buffer. The shared
      * helper handles SHM (terminals) and the GPU/DMA-BUF readback (Firefox,
      * GPU-accelerated apps); reading via the scene buffer ensures wlroots'
-     * synchronization, which is what was missing in the previous
+     * synchronization, which was missing in the previous
      * direct-from-wlr_surface->buffer path that came back blank for DMA-BUF
-     * clients (issue #539). */
+     * clients (issue #539).
+     *
+     * wlr_scene_node_for_each_buffer reports (sx, sy) accumulated from the
+     * starting node down, NOT scene-absolute. So buffer positions are already
+     * relative to c->scene_surface's frame; no offset subtraction needed. */
     rdata.cr        = cr;
     rdata.renderer  = drw;
-    rdata.offset_x  = -origin_x;
-    rdata.offset_y  = -origin_y;
+    rdata.offset_x  = 0;
+    rdata.offset_y  = 0;
     wlr_scene_node_for_each_buffer(&c->scene_surface->node,
                                    composite_scene_buffer_to_cairo, &rdata);
 

--- a/tests/test-client-content-dmabuf.lua
+++ b/tests/test-client-content-dmabuf.lua
@@ -91,6 +91,15 @@ runner.run_async(function()
         return
     end
 
+    -- Position the client at a non-zero scene coord. The first version of the
+    -- scene-tree-walk fix (#539) used wlr_scene_node_coords as an "origin" to
+    -- offset buffer positions; that math broke for any client not at (0, 0)
+    -- because wlr_scene_node_for_each_buffer reports positions relative to
+    -- the starting node, not scene-absolute. Tests that left the client at
+    -- the screen origin missed this. Float + move to expose it.
+    c.floating = true
+    c:geometry { x = 137, y = 91, width = c:geometry().width, height = c:geometry().height }
+
     -- Give one event-loop tick for the buffer to actually attach.
     async.sleep(0.1)
 

--- a/tests/test-client-content-pattern.lua
+++ b/tests/test-client-content-pattern.lua
@@ -111,6 +111,15 @@ local function run_at_scale(target_scale, pids)
     local c = async.wait_for_client(APP_ID, 5)
     assert(c, "Client never appeared at scale=" .. tostring(target_scale))
 
+    -- Move the client off the scene origin so c.content's scene-tree walk
+    -- exercises non-zero buffer positions. A regression here (commit
+    -- introducing #539's scene-walk) only manifested when the client was
+    -- somewhere other than (0, 0).
+    c.floating = true
+    local g = c:geometry()
+    c:geometry { x = 173, y = 109, width = g.width, height = g.height }
+    async.sleep(0.05)
+
     -- Wait for the buffer at the target scale to actually be committed.
     -- At scale=1 this is the first commit; at scale=2 the C client first
     -- commits at scale=1 (default) then re-renders after preferred_buffer_scale.


### PR DESCRIPTION
## Description
Forward-port of #548. The scene-tree-walk fix for c.content placed buffers at negative cairo coords for any client not at scene (0, 0), so real-world windows (Firefox, ghostty, Slack) captured fully transparent.

`wlr_scene_node_for_each_buffer` reports positions accumulated from the starting node down, not scene-absolute. The original code subtracted `wlr_scene_node_coords` (scene-absolute) as an offset, which only works when the client is at the scene origin. The integration tests passed because the nested test compositor places spawned clients exactly there.

## Test Plan
- Both client-content tests now move the spawned client to a non-origin geometry. Verified that with the test changes but C reverted, the test fails with `TL=yellow` instead of `red`.
- `make test-unit` and `make test-integration` pass on main.
- Manual on a live release/1.4 session: `screenshot client` of Firefox / ghostty / Slack now produce 300-530KB PNGs at 97-98% nonzero pixels (was 11-14KB / 0% before).

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — C-only change in `objects/client.c`; test changes only.
- [x] Tests pass (`make test-unit && make test-integration`)