### PR TITLE
fix(drawin): assign fake-screen wibars via Lua screen registry

### DIFF
--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -691,20 +691,24 @@ static void
 drawin_assign_screen(lua_State *L, drawin_t *drawin, int drawin_idx)
 {
 	Monitor *m;
-	screen_t *new_screen;
+	screen_t *new_screen = NULL;
 	screen_t *old_screen = drawin->screen;
 
-	/* Get monitor at drawin's position */
+	/* Prefer the wlroots layout: it covers physical outputs accurately. */
 	m = some_monitor_at((double)drawin->x, (double)drawin->y);
-	if (!m) {
-		/* No monitor at this position, try getting focused monitor */
-		m = some_get_focused_monitor();
-	}
-
 	if (m) {
 		new_screen = luaA_screen_get_by_monitor(L, m);
 	} else {
-		new_screen = NULL;
+		/* No physical monitor at this position. Fall back to the Lua
+		 * screen registry, which also includes fake screens added via
+		 * screen.fake_add(). screen_getbycoord() returns the screen
+		 * containing the point, or the nearest screen if none do. */
+		new_screen = screen_getbycoord(drawin->x, drawin->y);
+		if (!new_screen) {
+			m = some_get_focused_monitor();
+			if (m)
+				new_screen = luaA_screen_get_by_monitor(L, m);
+		}
 	}
 
 	/* If screen changed, update and emit signal */

--- a/tests/test-multi-screen-wibar-workarea.lua
+++ b/tests/test-multi-screen-wibar-workarea.lua
@@ -1,0 +1,62 @@
+---------------------------------------------------------------------------
+-- Each screen's workarea must reflect its own wibar's strut.
+--
+-- Regression: with two screens and one wibar per screen, screen 2's
+-- workarea was sometimes left equal to its full geometry (titlebars on
+-- screen 2 ended up under the wibar) while screen 1 was correct.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local awful = require("awful")
+local gtimer = require("gears.timer")
+
+local primary = screen.primary
+local fake_screen
+local wb1, wb2
+local settled = false
+
+local function workarea_shrunk(s, wibar_height)
+    return s.workarea.height == s.geometry.height - wibar_height
+       and s.workarea.y      == s.geometry.y      + wibar_height
+end
+
+local steps = {
+    function()
+        fake_screen = screen.fake_add(2000, 0, 800, 600)
+        assert(fake_screen and fake_screen.valid, "fake_add failed")
+        assert(screen.count() >= 2, "need >=2 screens")
+
+        wb1 = awful.wibar({ position = "top", screen = primary, height = 32 })
+        wb2 = awful.wibar({ position = "top", screen = fake_screen, height = 32 })
+        assert(wb1.visible and wb2.visible, "both wibars must be visible")
+
+        gtimer.delayed_call(function() settled = true end)
+        return true
+    end,
+
+    function()
+        if not settled then return nil end
+        return true
+    end,
+
+    function()
+        assert(workarea_shrunk(primary, 32),
+            string.format("primary workarea not shrunk: geom=%dx%d wa=%dx%d+%d+%d",
+                primary.geometry.width, primary.geometry.height,
+                primary.workarea.width, primary.workarea.height,
+                primary.workarea.x, primary.workarea.y))
+
+        assert(workarea_shrunk(fake_screen, 32),
+            string.format("fake_screen workarea not shrunk: geom=%dx%d wa=%dx%d+%d+%d",
+                fake_screen.geometry.width, fake_screen.geometry.height,
+                fake_screen.workarea.width, fake_screen.workarea.height,
+                fake_screen.workarea.x, fake_screen.workarea.y))
+
+        wb1.visible = false
+        wb2.visible = false
+        if fake_screen and fake_screen.valid then fake_screen:fake_remove() end
+        return true
+    end,
+}
+
+runner.run_steps(steps)


### PR DESCRIPTION
## Description
`drawin_assign_screen` only consulted `some_monitor_at`, which knows
wlroots monitors only. Wibars attached to fake screens (created via
`screen.fake_add()`) therefore got attributed to the focused real
monitor instead of their fake one. `screen_update_workarea` then
applied the strut to the wrong screen, leaving the fake screen's
workarea equal to its full geometry.

Fall back to `screen_getbycoord()` (which iterates the Lua screen
registry, including fake screens) before the focused-monitor fallback.
Real-screen behavior is unchanged because `some_monitor_at()` still
takes precedence whenever it returns a result.

## Test Plan
- New regression test `tests/test-multi-screen-wibar-workarea.lua`:
  creates a fake screen via `screen.fake_add`, attaches a wibar to the
  primary and the fake screen, asserts both workareas shrink by the
  wibar height. Passes.
- `make test-unit`: 758/758 pass.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)