### PR TITLE
fix(screen): aggregate drawin struts by explicit screen pointer

### DIFF
--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -1372,10 +1372,14 @@ luaA_drawin_struts(lua_State *L)
 			luaA_awm_object_emit_signal(L, -1, "property::struts", 0);
 			lua_pop(L, 1);
 
-			/* Update workarea if drawin is visible */
-			if (drawin->visible && drawin->screen) {
-				screen_update_workarea(drawin->screen);
-			}
+			/* We don't know the correct screen, update them all.
+			 * globalconf.screens is unpopulated here; the live list is
+			 * behind luaA_screen_get_all(). */
+			screen_t *all[16];
+			int n = countof(all);
+			luaA_screen_get_all(L, all, &n);
+			for (int i = 0; i < n; i++)
+				screen_update_workarea(all[i]);
 		}
 
 		return 0;

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -736,13 +736,11 @@ screen_update_workarea(screen_t *screen)
 		} \
 	}
 
+	/* Use the explicit drawin->screen pointer (matches client filter above);
+	 * coord-based lookup races with staggered geometry updates at startup. */
 	foreach(drawin, globalconf.drawins)
-		if((*drawin)->visible)
-		{
-			screen_t *d_screen = screen_getbycoord((*drawin)->x, (*drawin)->y);
-			if (d_screen == screen)
-				COMPUTE_DRAWIN_STRUT(*drawin)
-		}
+		if((*drawin)->visible && (*drawin)->screen == screen)
+			COMPUTE_DRAWIN_STRUT(*drawin)
 
 #undef COMPUTE_DRAWIN_STRUT
 


### PR DESCRIPTION
## Description
Closes #553. At startup with two monitors, the wibar on the secondary screen
didn't subtract its strut from the workarea; clients tiled at y=0 under it.

Two changes in `screen_update_workarea` and `luaA_drawin_struts`:

1. Drawin filter used `screen_getbycoord(drawin->x, drawin->y)` to decide
   which screen owned each drawin's strut. Screen geometries arrive in
   waves at startup (scale/mode settling) and transiently overlap, so the
   secondary wibar gets mis-attributed to the still-wide primary. Switch
   to `(*drawin)->screen == screen`, matching the client filter above.

2. Strut setter only recomputed `drawin->screen`'s workarea, gated on
   non-NULL. When the pointer is stale or NULL, recompute was silently
   skipped. Iterate all screens instead, matching upstream
   `luaA_window_struts`.

## Test Plan
- Logged out, logged back in with both monitors; `somewm-client eval`
  reports `s2.workarea.height == s2.geometry.height - wibar.height`.
- Opened Ghostty and Firefox on s2 in tiling mode; titlebars sit below
  the wibar.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)