### PR TITLE
feat(input): support specifying XKB model and rules

### DIFF
--- a/DEVIATIONS.md
+++ b/DEVIATIONS.md
@@ -226,6 +226,8 @@ awful.input.left_handed = 0
 awful.input.xkb_layout = "us"
 awful.input.xkb_variant = ""
 awful.input.xkb_options = "ctrl:nocaps"
+awful.input.xkb_model = "pc105"
+awful.input.xkb_rules = "evdev"
 awful.input.repeat_rate = 25
 awful.input.repeat_delay = 600
 ```

--- a/globalconf.h
+++ b/globalconf.h
@@ -261,6 +261,8 @@ typedef struct
         char *xkb_layout;     /* Keyboard layout(s), e.g., "us,ru" */
         char *xkb_variant;    /* Layout variants, e.g., "dvorak," */
         char *xkb_options;    /* XKB options, e.g., "ctrl:nocaps,grp:alt_shift_toggle" */
+        char *xkb_model;      /* XKB model, e.g. "pc105" */
+        char *xkb_rules;      /* XKB model, e.g. "base" */
         int repeat_rate;      /* Key repeat rate (repeats per second) */
         int repeat_delay;     /* Key repeat delay (milliseconds) */
     } keyboard;

--- a/lua/awful/input.lua
+++ b/lua/awful/input.lua
@@ -44,6 +44,8 @@ local state = {
     xkb_layout = "",                -- keyboard layout (e.g., "us", "us,ru")
     xkb_variant = "",               -- layout variant (e.g., "dvorak")
     xkb_options = "",               -- XKB options (e.g., "ctrl:nocaps")
+    xkb_rules = "",
+    xkb_model = "",
 }
 
 -- Mapping from property names to their types for validation
@@ -71,6 +73,8 @@ local property_types = {
     xkb_layout = "string",
     xkb_variant = "string",
     xkb_options = "string",
+    xkb_model = "string",
+    xkb_rules = "string",
 }
 
 -- Properties that are pointer/input device settings (vs keyboard)

--- a/lua/awful/ipc.lua
+++ b/lua/awful/ipc.lua
@@ -2260,6 +2260,8 @@ local function register_builtin_commands()
     xkb_layout = { type = "string", desc = "XKB keyboard layout (e.g., 'us', 'us,ru')" },
     xkb_variant = { type = "string", desc = "XKB layout variant (e.g., 'dvorak')" },
     xkb_options = { type = "string", desc = "XKB options (e.g., 'ctrl:nocaps')" },
+    xkb_model = { type = "string", desc = "XKB model (e.g., 'pc105')" },
+    xkb_rules = { type = "string", desc = "XKB rules (e.g., 'base')" },
   }
 
   --- input [setting] [value] - Get or set libinput/keyboard configuration

--- a/luaa.c
+++ b/luaa.c
@@ -1186,6 +1186,16 @@ luaA_awesome_set_keyboard_setting(lua_State *L)
 		free(globalconf.keyboard.xkb_options);
 		globalconf.keyboard.xkb_options = strdup(val);
 		rebuild_keyboard_keymap();
+	} else if (strcmp(key, "xkb_model") == 0) {
+		const char *val = lua_isnil(L, 2) ? "" : luaL_checkstring(L, 2);
+		free(globalconf.keyboard.xkb_model);
+		globalconf.keyboard.xkb_model = strdup(val);
+		rebuild_keyboard_keymap();
+	} else if (strcmp(key, "xkb_rules") == 0) {
+		const char *val = lua_isnil(L, 2) ? "" : luaL_checkstring(L, 2);
+		free(globalconf.keyboard.xkb_rules);
+		globalconf.keyboard.xkb_rules = strdup(val);
+		rebuild_keyboard_keymap();
 	} else if (strcmp(key, "numlock") == 0) {
 		some_set_numlock(lua_toboolean(L, 2));
 	} else {

--- a/somewm.c
+++ b/somewm.c
@@ -1732,8 +1732,8 @@ createkeyboardgroup(void)
 	rules.layout = globalconf.keyboard.xkb_layout;
 	rules.variant = globalconf.keyboard.xkb_variant;
 	rules.options = globalconf.keyboard.xkb_options;
-	rules.rules = NULL;
-	rules.model = NULL;
+	rules.rules = globalconf.keyboard.xkb_rules;
+	rules.model = globalconf.keyboard.xkb_model;
 
 	if (!(keymap = xkb_keymap_new_from_names(context, &rules,
 				XKB_KEYMAP_COMPILE_NO_FLAGS)))
@@ -5842,6 +5842,8 @@ setup(void)
 	globalconf.keyboard.xkb_layout = NULL;
 	globalconf.keyboard.xkb_variant = NULL;
 	globalconf.keyboard.xkb_options = NULL;
+	globalconf.keyboard.xkb_model = NULL;
+	globalconf.keyboard.xkb_rules = NULL;
 	globalconf.keyboard.repeat_rate = 25;
 	globalconf.keyboard.repeat_delay = 600;
 

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -1789,6 +1789,8 @@ some_rebuild_keyboard_keymap(void)
 	rules.layout = globalconf.keyboard.xkb_layout;
 	rules.variant = globalconf.keyboard.xkb_variant;
 	rules.options = globalconf.keyboard.xkb_options;
+	rules.model = globalconf.keyboard.xkb_model;
+	rules.rules = globalconf.keyboard.xkb_rules;
 
 	keymap = xkb_keymap_new_from_names(context, &rules,
 	                                   XKB_KEYMAP_COMPILE_NO_FLAGS);

--- a/spec/awful/input_spec.lua
+++ b/spec/awful/input_spec.lua
@@ -207,6 +207,24 @@ describe("awful.input", function()
             assert.is.equal("dvorak", input.xkb_variant)
         end)
 
+        it("xkb_model default value", function()
+            assert.is.equal("", input.xkb_model)
+        end)
+
+        it("xkb_model can be set", function()
+            input.xkb_model = "pc105"
+            assert.is.equal("pc105", input.xkb_model)
+        end)
+
+        it("xkb_rules default value", function()
+            assert.is.equal("", input.xkb_rules)
+        end)
+
+        it("xkb_rules can be set", function()
+            input.xkb_rules = "base"
+            assert.is.equal("base", input.xkb_rules)
+        end)
+
         it("xkb_options default value", function()
             assert.is.equal("", input.xkb_options)
         end)


### PR DESCRIPTION
## Description
<!-- What does this change and why? -->
Allows specifying xkb model and xkb rules. Aims to fix #518

## Test Plan
<!-- How did you verify this works? -->
Tested on device with keyboard that requires model to be explicitly set

## Checklist
- [ ] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
    [x] `lua/awful/input.lua` and `lua/awful/ipc.lua` were modified, but I think/believe this is expected due to the nature of the PR
- [x] Tests pass (`make test-unit && make test-integration`)

```
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++.++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
762 successes / 0 failures / 0 errors / 1 pending : 4.006164 seconds

Pending -> spec/gears/surface_spec.lua @ 12
gears.surface SKIPPED: GDK not available (no display)
spec/gears/surface_spec.lua:12: GDK requires a display environment
```
   