### PR TITLE
fix(hot-reload): assign all client screens before emitting restore signals

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -5402,13 +5402,17 @@ luaA_hot_reload(void)
 				num_clients * sizeof(client_t *));
 	}
 
+	/* Two passes are required: Phase E nulled c->screen for every
+	 * client. If a transient is iterated before its parent, the
+	 * transient's request::manage signal chain hits permissions.tag,
+	 * which dereferences c.transient_for.screen.* on a still-NULL
+	 * parent screen. Assign all screens first, then emit signals. */
 	for (i = 0; i < num_clients; i++) {
 		client_t *c = globalconf.clients.tab[i];
 
 		if (!client_snaps[i].was_mapped)
 			continue;
 
-		/* Assign client to first screen if not already set */
 		if (!c->screen && globalconf.screens.len > 0) {
 			int si = client_snaps[i].screen_index;
 			if (si >= 0 && si < globalconf.screens.len)
@@ -5416,6 +5420,13 @@ luaA_hot_reload(void)
 			else
 				c->screen = globalconf.screens.tab[0];
 		}
+	}
+
+	for (i = 0; i < num_clients; i++) {
+		client_t *c = globalconf.clients.tab[i];
+
+		if (!client_snaps[i].was_mapped)
+			continue;
 
 		luaA_object_push(L, c);
 

--- a/tests/test-hot-reload-transient-screen.lua
+++ b/tests/test-hot-reload-transient-screen.lua
@@ -1,0 +1,81 @@
+-- Regression for the hot-reload Phase F crash: when a transient appears
+-- before its parent in client.get(), awesome.restart() must not crash
+-- dereferencing the parent's not-yet-assigned screen. Compositor survival
+-- is the pass signal (see test-hot-reload-basic.lua for the same pattern).
+
+local runner = require("_runner")
+local utils = require("_utils")
+local awful = require("awful")
+
+local function find_test_client_binary()
+    local somewm = os.getenv("SOMEWM") or "./build-test/somewm"
+    local build_dir = somewm:match("^(.*)/somewm$") or "./build-test"
+    for _, candidate in ipairs({
+        build_dir .. "/test-transient-client",
+        "./build/test-transient-client",
+        "./build-test/test-transient-client",
+    }) do
+        local f = io.open(candidate, "r")
+        if f then f:close(); return candidate end
+    end
+    return nil
+end
+
+local TEST_TRANSIENT_CLIENT = find_test_client_binary()
+
+if not TEST_TRANSIENT_CLIENT then
+    io.stderr:write("SKIP: test-transient-client not found (run make build-test)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local PARENT_CLASS = "transient_test_parent"
+local parent_client
+local child_client
+local proc_pid
+
+local steps = {
+    function(count)
+        if count == 1 then
+            proc_pid = awful.spawn(TEST_TRANSIENT_CLIENT)
+        end
+        parent_client = utils.find_client_by_class(PARENT_CLASS)
+        if parent_client then return true end
+    end,
+
+    function(count)
+        if count == 1 then
+            awesome.kill(proc_pid, 10) -- SIGUSR1
+        end
+        child_client = utils.find_clients(function(c)
+            return c.transient_for == parent_client
+        end)[1]
+        if child_client then return true end
+    end,
+
+    function()
+        local parent_idx, child_idx
+        for i, c in ipairs(client.get()) do
+            if c == parent_client then parent_idx = i end
+            if c == child_client then child_idx = i end
+        end
+        assert(parent_idx and child_idx, "both clients must be in client.get()")
+        assert(child_idx < parent_idx,
+            "transient must come before parent for bug repro; got child="
+            .. child_idx .. " parent=" .. parent_idx)
+        assert(parent_client.screen, "parent must have a screen before reload")
+        return true
+    end,
+
+    function(count)
+        if count == 1 then
+            awesome.restart()
+        end
+        return true
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
## Description

With a transient window open, hot-reload's per-client restore loop emits
`request::manage` for the transient before its parent has been assigned a
screen, so `awful.permissions.tag` crashes dereferencing the parent's nil
screen.

Fix: assign screens to every client first, then emit signals.

Forward port of #558 (release/1.4). Cherry-picked cleanly; only the Pass 2
body differs because of main's event-queue refactor, which is unrelated to
this fix.

## Test Plan

- New `tests/test-hot-reload-transient-screen.lua` exercises the trigger.
- Existing hot-reload tests still pass.
- `make test-unit` (740/740 pass).

## Checklist

- [x] No Lua library changes (fix is in `luaa.c`)
- [x] Tests pass