### PR TITLE
fix(fullscreen): emit per-client geometry signals on xdg protocol path

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -5408,6 +5408,8 @@ setfullscreen(Client *c, int fullscreen)
 	client_set_fullscreen_internal(c, fullscreen);
 	wlr_scene_node_reparent(&c->scene->node, layers[c->fullscreen ? LyrFS : LyrTile]);
 
+	struct wlr_box old_geometry = c->geometry;
+
 	if (fullscreen) {
 		c->prev = c->geometry;
 		resize(c, c->mon->m, 0);
@@ -5416,12 +5418,32 @@ setfullscreen(Client *c, int fullscreen)
 		 * client positions are set by the user and cannot be recalculated */
 		resize(c, c->prev, 0);
 	}
-	/* Emit per-client property::fullscreen so Lua handlers run
-	 * (update_implicitly_floating, arrange_prop_nf) before arrange */
+	/* Sync emit: property::fullscreen handlers (update_implicitly_floating,
+	 * arrange_prop_nf) must run before the arrange(c->mon) below.
+	 * Geometry signals mirror client_resize_do (objects/client.c) so the
+	 * xdg-shell request_fullscreen path is observable to property::geometry
+	 * subscribers, matching the Lua-side client_set_fullscreen path. */
 	lua_State *L = globalconf_get_lua_State();
 	if (L) {
 		luaA_object_push(L, c);
 		luaA_object_emit_signal(L, -1, "property::fullscreen", 0);
+		if (!AREA_EQUAL(old_geometry, c->geometry)) {
+			luaA_object_emit_signal(L, -1, "property::geometry", 0);
+			if (old_geometry.x != c->geometry.x || old_geometry.y != c->geometry.y) {
+				luaA_object_emit_signal(L, -1, "property::position", 0);
+				if (old_geometry.x != c->geometry.x)
+					luaA_object_emit_signal(L, -1, "property::x", 0);
+				if (old_geometry.y != c->geometry.y)
+					luaA_object_emit_signal(L, -1, "property::y", 0);
+			}
+			if (old_geometry.width != c->geometry.width || old_geometry.height != c->geometry.height) {
+				luaA_object_emit_signal(L, -1, "property::size", 0);
+				if (old_geometry.width != c->geometry.width)
+					luaA_object_emit_signal(L, -1, "property::width", 0);
+				if (old_geometry.height != c->geometry.height)
+					luaA_object_emit_signal(L, -1, "property::height", 0);
+			}
+		}
 		lua_pop(L, 1);
 	}
 

--- a/tests/test-fullscreen-protocol-geometry.lua
+++ b/tests/test-fullscreen-protocol-geometry.lua
@@ -60,7 +60,6 @@ local function first_index(name)
 end
 
 local steps = {
-    -- Step 1: Spawn the test client
     function(count)
         if count == 1 then
             io.stderr:write("[TEST] Spawning test-fullscreen-client\n")
@@ -73,7 +72,6 @@ local steps = {
         end
     end,
 
-    -- Step 2: Attach signal recorders and let layout settle
     function(count)
         if count == 1 then
             c_test:connect_signal("property::fullscreen", record("property::fullscreen"))
@@ -87,7 +85,6 @@ local steps = {
         return true
     end,
 
-    -- Step 3: SIGUSR1 -> xdg-shell request_fullscreen -> setfullscreen
     function(count)
         if count == 1 then
             events = {}
@@ -119,7 +116,6 @@ local steps = {
         return true
     end,
 
-    -- Step 4: SIGUSR2 -> xdg-shell unset_fullscreen -> setfullscreen
     function(count)
         if count == 1 then
             events = {}
@@ -151,7 +147,6 @@ local steps = {
         return true
     end,
 
-    -- Cleanup
     function(count)
         if count == 1 then
             io.stderr:write("[TEST] Cleanup\n")

--- a/tests/test-fullscreen-protocol-geometry.lua
+++ b/tests/test-fullscreen-protocol-geometry.lua
@@ -1,0 +1,182 @@
+---------------------------------------------------------------------------
+-- Test: xdg-shell request_fullscreen emits property::geometry and
+-- property::fullscreen to per-client subscribers, in the same order the
+-- Lua-side client_set_fullscreen path uses (fullscreen before geometry).
+--
+-- Before the fix, setfullscreen() in somewm.c emitted only
+-- property::fullscreen for the C protocol path. The Lua path
+-- (client_set_fullscreen -> client_resize_do) emitted both, leaving
+-- subscribers to property::geometry blind to client-initiated transitions
+-- (e.g. mpv pressing F).
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local utils = require("_utils")
+local awful = require("awful")
+
+local TEST_FULLSCREEN_CLIENT = "./build-test/test-fullscreen-client"
+
+local function is_test_client_available()
+    local f = io.open(TEST_FULLSCREEN_CLIENT, "r")
+    if f then
+        f:close()
+        return true
+    end
+    return false
+end
+
+if not is_test_client_available() then
+    io.stderr:write("SKIP: test-fullscreen-client not found (run make build-test)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local c_test
+local proc_pid
+local events = {}
+
+local function record(signal_name)
+    return function()
+        table.insert(events, signal_name)
+        io.stderr:write(string.format("[TEST] saw %s (event #%d)\n",
+            signal_name, #events))
+    end
+end
+
+local function event_count(name)
+    local n = 0
+    for _, e in ipairs(events) do
+        if e == name then n = n + 1 end
+    end
+    return n
+end
+
+local function first_index(name)
+    for i, e in ipairs(events) do
+        if e == name then return i end
+    end
+    return nil
+end
+
+local steps = {
+    -- Step 1: Spawn the test client
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning test-fullscreen-client\n")
+            proc_pid = awful.spawn(TEST_FULLSCREEN_CLIENT)
+        end
+        c_test = utils.find_client_by_class("fullscreen_test")
+        if c_test then
+            io.stderr:write("[TEST] Client appeared\n")
+            return true
+        end
+    end,
+
+    -- Step 2: Attach signal recorders and let layout settle
+    function(count)
+        if count == 1 then
+            c_test:connect_signal("property::fullscreen", record("property::fullscreen"))
+            c_test:connect_signal("property::geometry",   record("property::geometry"))
+            c_test:connect_signal("property::position",   record("property::position"))
+            c_test:connect_signal("property::size",       record("property::size"))
+            io.stderr:write("[TEST] Signal recorders attached\n")
+        end
+        if count < 5 then return nil end
+        assert(not c_test.fullscreen, "client should start non-fullscreen")
+        return true
+    end,
+
+    -- Step 3: SIGUSR1 -> xdg-shell request_fullscreen -> setfullscreen
+    function(count)
+        if count == 1 then
+            events = {}
+            io.stderr:write("[TEST] Sending SIGUSR1 (xdg request_fullscreen)\n")
+            awesome.kill(proc_pid, 10) -- SIGUSR1
+        end
+        if not c_test.fullscreen then
+            if count > 30 then
+                error("Timed out waiting for c.fullscreen = true after SIGUSR1")
+            end
+            return nil
+        end
+        if count < 5 then return nil end -- one extra tick for queued signals
+
+        local fc = event_count("property::fullscreen")
+        local gc = event_count("property::geometry")
+        assert(fc >= 1, string.format(
+            "property::fullscreen should fire on enter, got %d", fc))
+        assert(gc >= 1, string.format(
+            "property::geometry should fire on enter, got %d", gc))
+
+        local f_idx = first_index("property::fullscreen")
+        local g_idx = first_index("property::geometry")
+        assert(f_idx < g_idx, string.format(
+            "property::fullscreen (idx %d) must fire before property::geometry (idx %d)",
+            f_idx, g_idx))
+
+        io.stderr:write("[TEST] PASS: enter-fullscreen signals fired in order\n")
+        return true
+    end,
+
+    -- Step 4: SIGUSR2 -> xdg-shell unset_fullscreen -> setfullscreen
+    function(count)
+        if count == 1 then
+            events = {}
+            io.stderr:write("[TEST] Sending SIGUSR2 (xdg unset_fullscreen)\n")
+            awesome.kill(proc_pid, 12) -- SIGUSR2
+        end
+        if c_test.fullscreen then
+            if count > 30 then
+                error("Timed out waiting for c.fullscreen = false after SIGUSR2")
+            end
+            return nil
+        end
+        if count < 5 then return nil end
+
+        local fc = event_count("property::fullscreen")
+        local gc = event_count("property::geometry")
+        assert(fc >= 1, string.format(
+            "property::fullscreen should fire on exit, got %d", fc))
+        assert(gc >= 1, string.format(
+            "property::geometry should fire on exit, got %d", gc))
+
+        local f_idx = first_index("property::fullscreen")
+        local g_idx = first_index("property::geometry")
+        assert(f_idx < g_idx, string.format(
+            "property::fullscreen (idx %d) must fire before property::geometry (idx %d) on exit",
+            f_idx, g_idx))
+
+        io.stderr:write("[TEST] PASS: exit-fullscreen signals fired in order\n")
+        return true
+    end,
+
+    -- Cleanup
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Cleanup\n")
+            if proc_pid then
+                awful.spawn("kill " .. proc_pid)
+            end
+        end
+
+        if #client.get() == 0 then
+            io.stderr:write("[TEST] Cleanup: done\n")
+            return true
+        end
+
+        if count >= 10 then
+            io.stderr:write("[TEST] Cleanup: force killing\n")
+            if proc_pid then
+                os.execute("kill -9 " .. proc_pid .. " 2>/dev/null")
+            end
+            os.execute("pkill -9 test-fullscreen 2>/dev/null")
+            for _, c in ipairs(client.get()) do
+                c:kill()
+            end
+            return true
+        end
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })


### PR DESCRIPTION
## Description

When a client requested fullscreen via xdg-shell (`fullscreennotify` → `setfullscreen`), the C path emitted only `property::fullscreen`. The Lua path (`client_set_fullscreen` → `client_resize_do`) emitted both `property::fullscreen` and `property::geometry` (plus `property::position`/`x`/`y`/`size`/`width`/`height`). Lua handlers subscribed to `property::geometry` silently missed client-initiated fullscreen transitions (e.g. mpv pressing F).

Mirrors `client_resize_do`'s emission block inside `setfullscreen`, in the order the Lua path uses: `property::fullscreen` first (its handlers must run before the `arrange(c->mon)` call below), then geometry signals guarded by `AREA_EQUAL` and per-field comparison against the pre-resize geometry.

Bug report and reproduction credited to raven2cz (PR #478) via `Co-Authored-By` trailer.

## Test Plan
- New `tests/test-fullscreen-protocol-geometry.lua` spawns `test-fullscreen-client`, attaches per-instance recorders, sends SIGUSR1 (xdg `set_fullscreen`) and SIGUSR2 (xdg `unset_fullscreen`), asserts both signals fire in correct order on each transition.
- Verified failing before the C edit (`property::geometry should fire on enter, got 0`), passing after.
- `make test-integration` passes (122 tests).
- `make test-unit` passes (758 tests, 1 unrelated GDK-env skip).

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** - if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)