### PR TITLE
build: support Lua 5.5 and add lua_pkg override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 
 # Default build: WITH ASAN for development
 all:
-	@test -d build || meson setup build -Db_sanitize=address,undefined $(MESON_OPTS)
+	@test -d build || meson setup build -Db_sanitize=address,undefined $(if $(LUA_PKG),-Dlua_pkg=$(LUA_PKG),) $(MESON_OPTS)
 	ninja -C build
 
 # Alias for clarity
@@ -21,7 +21,7 @@ asan: all
 
 # Build for tests: NO ASAN (fast) - explicitly disable sanitizers, enable test PAM stub
 build-test:
-	@test -d build-test || meson setup build-test -Db_sanitize=none -Dtest_pam=true
+	@test -d build-test || meson setup build-test -Db_sanitize=none -Dtest_pam=true $(if $(LUA_PKG),-Dlua_pkg=$(LUA_PKG),)
 	ninja -C build-test
 
 install:

--- a/lgi-check.c
+++ b/lgi-check.c
@@ -81,6 +81,12 @@ int main(void)
         fprintf(stderr, "                sudo pacman -S lua51-lgi (for Lua 5.1)\n");
         fprintf(stderr, "  Debian/Ubuntu: sudo apt install lua-lgi\n");
         fprintf(stderr, "  Fedora:        sudo dnf install lua-lgi\n");
+#if LUA_VERSION_NUM >= 505
+        fprintf(stderr, "\n");
+        fprintf(stderr, "Note: Lua 5.5 support landed in lgi upstream (PR #359) but\n");
+        fprintf(stderr, "distros may not ship a matching package yet. Build lgi from\n");
+        fprintf(stderr, "source against Lua 5.5: https://github.com/lgi-devs/lgi\n");
+#endif
 #endif
         fprintf(stderr, "\n");
         fprintf(stderr, "To skip this check (not recommended), set %s=1\n", env);

--- a/luaa.h
+++ b/luaa.h
@@ -144,8 +144,8 @@ extern luaA_class_handlers_t mouse_handlers;
 int luaA_registerfct(lua_State *L, int idx, int *ref);
 
 /* Lua version compatibility - matches AwesomeWM pattern */
-#if !(501 <= LUA_VERSION_NUM && LUA_VERSION_NUM < 505)
-#error "somewm only supports Lua versions 5.1-5.4 and LuaJIT"
+#if !(501 <= LUA_VERSION_NUM && LUA_VERSION_NUM < 506)
+#error "somewm only supports Lua versions 5.1-5.5 and LuaJIT"
 #endif
 
 /* Lua version compatibility helpers */

--- a/meson.build
+++ b/meson.build
@@ -77,34 +77,21 @@ else
   have_xwayland = false
 endif
 
-# Lua detection - LuaJIT preferred, then 5.4 > 5.3 > 5.2 > 5.1
-lua_dep = dependency('luajit', required: false)
-if not lua_dep.found()
-  lua_dep = dependency('lua5.4', required: false)
-endif
-if not lua_dep.found()
-  lua_dep = dependency('lua-5.4', required: false)
-endif
-if not lua_dep.found()
-  lua_dep = dependency('lua5.3', required: false)
-endif
-if not lua_dep.found()
-  lua_dep = dependency('lua-5.3', required: false)
-endif
-if not lua_dep.found()
-  lua_dep = dependency('lua5.2', required: false)
-endif
-if not lua_dep.found()
-  lua_dep = dependency('lua-5.2', required: false)
-endif
-if not lua_dep.found()
-  lua_dep = dependency('lua5.1', required: false)
-endif
-if not lua_dep.found()
-  lua_dep = dependency('lua-5.1', required: false)
-endif
-if not lua_dep.found()
-  lua_dep = dependency('lua', required: true)
+# Lua detection - honor -Dlua_pkg=<name> if set, otherwise:
+# LuaJIT preferred, then 5.5 > 5.4 > 5.3 > 5.2 > 5.1
+lua_pkg_override = get_option('lua_pkg')
+if lua_pkg_override != ''
+  lua_dep = dependency(lua_pkg_override, required: true)
+else
+  lua_dep = dependency('luajit', required: false)
+  foreach pkg : ['lua5.5', 'lua-5.5', 'lua5.4', 'lua-5.4', 'lua5.3', 'lua-5.3', 'lua5.2', 'lua-5.2', 'lua5.1', 'lua-5.1']
+    if not lua_dep.found()
+      lua_dep = dependency(pkg, required: false)
+    endif
+  endforeach
+  if not lua_dep.found()
+    lua_dep = dependency('lua', required: true)
+  endif
 endif
 
 # LGI detection - compile and run lgi-check.c to verify lgi is installed

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -32,3 +32,10 @@ option(
   value: false,
   description: 'Enable benchmark instrumentation counters',
 )
+
+option(
+  'lua_pkg',
+  type: 'string',
+  value: '',
+  description: 'Force a specific Lua pkg-config name (e.g. lua5.5, luajit). Empty = autodetect (LuaJIT > 5.5 > 5.4 > ... > 5.1).',
+)


### PR DESCRIPTION
## Description

  Closes #91. Upstream `lgi-devs/lgi#359` merged Lua 5.5 support, so the
  blocker noted on the issue is gone. This makes somewm build against
  Lua 5.5.

  - `luaa.h` cap bumped to `< 506`. Existing `>= 502` compatibility
    shims and the `LUA_VERSION_NUM < 503` stubs in `luaa.c` stay valid.
  - `meson.build` probes `lua5.5` / `lua-5.5` between `luajit` and `lua5.4`;
    collapses the now-13-entry detection chain into a `foreach` loop.
  - New `lua_pkg` meson option lets builds pin a specific Lua. `LUA_PKG`
    is now threaded through the Makefile to `-Dlua_pkg=`. The Makefile
    was silently dropping `LUA_PKG`, so CI matrices that pass it had
    been building against whichever Lua meson found first.
  - `lgi-check.c` prints a from-source-LGI hint when `LUA_VERSION_NUM >= 505`,
    since distro `lua55-lgi` packages do not exist yet.

  A follow-up PR will cherry-pick this to `main`.

  ## Test Plan

  - `make clean && make build-test`: links against LuaJIT (autodetected).
  - `make clean && LUA_PKG=luajit make build-test`: override path works.
  - `make`: ASAN build links.
  - `make test-unit`: 758/758 pass.

  ## Checklist

  - [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** —
  if a bug surfaces in Lua, the fix belongs in C
  - [x] Tests pass (`make test-unit && make test-integration`)