### PR TITLE
Port nested test compositor mode to main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 
 -include .local.mk
 
-.PHONY: all install uninstall clean setup reconfigure test test-unit test-check test-integration test-asan test-one test-visual test-one-visual test-ci test-fast build-test build-bench bench-run bench-run-live bench-json bench-baseline bench-compare bench-check bench-memory bench-flamegraph bench-diff bench-heaptrack profile profile-lua profile-save profile-diff
+.PHONY: all install uninstall clean setup reconfigure test test-unit test-check test-integration test-orchestrator test-asan test-one test-visual test-one-visual test-ci test-fast build-test build-bench bench-run bench-run-live bench-json bench-baseline bench-compare bench-check bench-memory bench-flamegraph bench-diff bench-heaptrack profile profile-lua profile-save profile-diff
 
 # Default build: WITH ASAN for development
 all:
@@ -47,7 +47,7 @@ reconfigure:
 # =============================================================================
 
 # Run all tests (fast, no ASAN)
-test: test-unit test-check test-integration
+test: test-unit test-check test-orchestrator test-integration
 
 # Unit tests only (busted, no compositor needed)
 # Use - prefix to continue even if unit tests fail (some have known issues)
@@ -57,6 +57,10 @@ test-unit:
 # Check mode tests (no compositor needed, tests somewm --check)
 test-check: build-test
 	@./tests/test-check-mode.sh ./build-test/somewm
+
+# Test orchestrator (somewm-client test ...): spawns headless nested compositor
+test-orchestrator: build-test
+	@./tests/test-test-orchestrator.sh ./build-test/somewm ./build-test/somewm-client
 
 # Integration tests (visual mode by default, no ASAN)
 test-integration: build-test

--- a/lua/awful/test_marker.lua
+++ b/lua/awful/test_marker.lua
@@ -1,0 +1,53 @@
+---------------------------------------------------------------------------
+-- @author somewm contributors
+--
+-- Test-mode keybind helper. Swaps Mod4 -> Mod1 in user-bound keys when
+-- the outer Wayland compositor can't pass Mod4 combos through and the
+-- user hasn't opted out via --keybinds=none|inhibit. Loaded by the C
+-- startup hook only when SOMEWM_TEST_NAME is set.
+---------------------------------------------------------------------------
+
+local M = {}
+
+-- Pure-function helper: takes a modifiers table, returns (new_table,
+-- changed). Exposed for unit testing.
+function M.substitute_modifiers(modifiers)
+    local out = {}
+    local changed = false
+    for _, m in ipairs(modifiers) do
+        if m == "Mod4" then
+            table.insert(out, "Mod1")
+            changed = true
+        else
+            table.insert(out, m)
+        end
+    end
+    return out, changed
+end
+
+function M.apply()
+    if not os.getenv("SOMEWM_TEST_NAME") then return end
+    if os.getenv("SOMEWM_TEST_KEYBINDS_REMAP") ~= "1" then return end
+
+    if not (root and root.keys) then return end
+    local keys = root.keys()
+    if not keys then return end
+    local count = 0
+    for _, k in ipairs(keys) do
+        local mods = k.modifiers
+        if mods then
+            local new_mods, changed = M.substitute_modifiers(mods)
+            if changed then
+                k.modifiers = new_mods
+                count = count + 1
+            end
+        end
+    end
+    if count > 0 then
+        io.stderr:write(string.format(
+            "[test_marker] remapped Mod4 -> Mod1 on %d keybinding(s) " ..
+            "(outer compositor cannot forward shortcuts)\n", count))
+    end
+end
+
+return M

--- a/meson.build
+++ b/meson.build
@@ -184,7 +184,7 @@ foreach p : protocols
   )
 endforeach
 
-# Client protocol headers for test utilities
+# Client protocol headers for the compositor (shortcut inhibitor) and test utilities
 wayland_client = dependency('wayland-client')
 
 layer_shell_client_header = custom_target(
@@ -228,6 +228,23 @@ linux_dmabuf_client_code = custom_target(
   'linux-dmabuf-v1-client-protocol.c',
   input: wayland_protocols_dir / 'stable/linux-dmabuf/linux-dmabuf-v1.xml',
   output: 'linux-dmabuf-v1-client-protocol.c',
+  command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
+)
+
+# keyboard-shortcuts-inhibit-v1 client protocol: somewm binds this as a client
+# of the outer Wayland compositor when running nested, so Mod4 combos pass
+# through to the test instance.
+keyboard_shortcuts_inhibit_client_header = custom_target(
+  'keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h',
+  input: wayland_protocols_dir / 'unstable/keyboard-shortcuts-inhibit/keyboard-shortcuts-inhibit-unstable-v1.xml',
+  output: 'keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h',
+  command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+)
+
+keyboard_shortcuts_inhibit_client_code = custom_target(
+  'keyboard-shortcuts-inhibit-unstable-v1-client-protocol.c',
+  input: wayland_protocols_dir / 'unstable/keyboard-shortcuts-inhibit/keyboard-shortcuts-inhibit-unstable-v1.xml',
+  output: 'keyboard-shortcuts-inhibit-unstable-v1-client-protocol.c',
   command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
 )
 
@@ -321,6 +338,7 @@ somewm_sources = [
   'selection.c',
   'pam_auth.c',
   'bench.c',
+  'nested_inhibitor.c',
   # Common
   'common/luaclass.c',
   'common/luaobject.c',
@@ -357,6 +375,7 @@ somewm_sources = [
 
 all_deps = [
   wayland_server,
+  wayland_client,
   xkbcommon,
   libinput,
   libdrm,
@@ -384,6 +403,8 @@ somewm_exe = executable(
   'somewm',
   somewm_sources,
   protocol_headers,
+  keyboard_shortcuts_inhibit_client_header,
+  keyboard_shortcuts_inhibit_client_code,
   dependencies: all_deps,
   include_directories: include_directories('.'),
   install: true,
@@ -404,6 +425,7 @@ lgi_guard = shared_library(
 somewm_client = executable(
   'somewm-client',
   'somewm-client.c',
+  'test_orchestrator.c',
   install: true,
 )
 

--- a/monitor.c
+++ b/monitor.c
@@ -26,6 +26,7 @@
 #include "somewm.h"
 #include "somewm_api.h"
 #include "monitor.h"
+#include "nested_inhibitor.h"
 #include "protocols.h"
 #include "globalconf.h"
 #include "client.h"
@@ -218,6 +219,9 @@ createmon(struct wl_listener *listener, void *data)
 
 	if (!wlr_output_init_render(wlr_output, alloc, drw))
 		return;
+
+	/* Inhibit host shortcuts for this output when nested. */
+	nested_inhibitor_attach_output(wlr_output);
 
 	wlr_log(WLR_ERROR, "[HOTPLUG] createmon: %s enabled=%d mons=%d",
 		wlr_output->name, wlr_output->enabled, wl_list_length(&mons));

--- a/nested_inhibitor.c
+++ b/nested_inhibitor.c
@@ -1,0 +1,177 @@
+#define _GNU_SOURCE
+
+#include "nested_inhibitor.h"
+#include "keyboard-shortcuts-inhibit-unstable-v1-client-protocol.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <wayland-client.h>
+#include <wlr/backend.h>
+#include <wlr/backend/multi.h>
+#include <wlr/backend/wayland.h>
+#include <wlr/types/wlr_output.h>
+
+enum status {
+	S_NOT_APPLICABLE,
+	S_UNAVAILABLE,
+	S_ACTIVE,
+};
+
+static struct {
+	struct wl_display *outer_display;
+	struct wl_event_queue *probe_queue;
+	struct zwp_keyboard_shortcuts_inhibit_manager_v1 *manager;
+	struct wl_seat *outer_seat;
+	enum status status;
+} state = { .status = S_NOT_APPLICABLE };
+
+static void
+registry_global(void *data, struct wl_registry *reg, uint32_t name,
+                const char *interface, uint32_t version)
+{
+	(void)data;
+	if (strcmp(interface, zwp_keyboard_shortcuts_inhibit_manager_v1_interface.name) == 0) {
+		state.manager = wl_registry_bind(reg, name,
+			&zwp_keyboard_shortcuts_inhibit_manager_v1_interface, 1);
+	} else if (strcmp(interface, wl_seat_interface.name) == 0 && !state.outer_seat) {
+		uint32_t v = version > 4 ? 4 : version;
+		state.outer_seat = wl_registry_bind(reg, name, &wl_seat_interface, v);
+	}
+}
+
+static void
+registry_global_remove(void *data, struct wl_registry *reg, uint32_t name)
+{
+	(void)data; (void)reg; (void)name;
+}
+
+static const struct wl_registry_listener registry_listener = {
+	.global = registry_global,
+	.global_remove = registry_global_remove,
+};
+
+static void
+find_wl_backend(struct wlr_backend *backend, void *data)
+{
+	struct wlr_backend **out = data;
+	if (*out)
+		return;
+	if (wlr_backend_is_wl(backend))
+		*out = backend;
+}
+
+static void
+write_status_file(void)
+{
+	const char *dir = getenv("SOMEWM_TEST_STATE_DIR");
+	if (!dir || !*dir)
+		return;
+	char path[4096];
+	int n = snprintf(path, sizeof(path), "%s/keybinds_status", dir);
+	if (n <= 0 || (size_t)n >= sizeof(path))
+		return;
+	FILE *f = fopen(path, "w");
+	if (!f)
+		return;
+	fprintf(f, "%s\n", nested_inhibitor_status());
+	fclose(f);
+}
+
+/* Tell the test_marker Lua module to swap Mod4 -> Mod1. nested_inhibitor
+ * is the only place that knows both the user's --keybinds mode and the
+ * negotiated inhibitor result, so it's responsible for deciding. */
+static void
+arm_lua_remap(void)
+{
+	setenv("SOMEWM_TEST_KEYBINDS_REMAP", "1", 1);
+}
+
+void
+nested_inhibitor_init(struct wlr_backend *backend)
+{
+	const char *mode = getenv("SOMEWM_TEST_KEYBINDS_MODE");
+	if (mode && !strcmp(mode, "none")) {
+		state.status = S_NOT_APPLICABLE;
+		write_status_file();
+		return;
+	}
+	if (mode && !strcmp(mode, "remap")) {
+		state.status = S_NOT_APPLICABLE;
+		arm_lua_remap();
+		write_status_file();
+		return;
+	}
+
+	struct wlr_backend *wl_backend = NULL;
+	if (wlr_backend_is_wl(backend)) {
+		wl_backend = backend;
+	} else if (wlr_backend_is_multi(backend)) {
+		wlr_multi_for_each_backend(backend, find_wl_backend, &wl_backend);
+	}
+	if (!wl_backend) {
+		state.status = S_NOT_APPLICABLE;
+		write_status_file();
+		return;
+	}
+
+	struct wl_display *outer = wlr_wl_backend_get_remote_display(wl_backend);
+	if (!outer) {
+		state.status = S_NOT_APPLICABLE;
+		write_status_file();
+		return;
+	}
+	state.outer_display = outer;
+	state.probe_queue = wl_display_create_queue(outer);
+
+	struct wl_registry *reg = wl_display_get_registry(outer);
+	wl_proxy_set_queue((struct wl_proxy *)reg, state.probe_queue);
+	wl_registry_add_listener(reg, &registry_listener, NULL);
+	wl_display_roundtrip_queue(outer, state.probe_queue);
+	wl_registry_destroy(reg);
+
+	if (state.manager && state.outer_seat) {
+		state.status = S_ACTIVE;
+		fprintf(stderr,
+		        "[nested-inhibitor] outer compositor advertised "
+		        "zwp_keyboard_shortcuts_inhibit_manager_v1; Mod4 combos "
+		        "will pass through to this nested somewm\n");
+	} else {
+		state.status = S_UNAVAILABLE;
+		fprintf(stderr,
+		        "[nested-inhibitor] outer compositor did not advertise "
+		        "the shortcut inhibitor protocol; host will intercept Mod4 combos\n");
+		/* mode == NULL (treated as auto) or "auto" remaps as a fallback.
+		 * mode == "inhibit" was a hard request, so we honor it by not
+		 * arming the Lua remap; the user gets the shortcut grab. */
+		if (!mode || !strcmp(mode, "auto"))
+			arm_lua_remap();
+	}
+
+	write_status_file();
+}
+
+void
+nested_inhibitor_attach_output(struct wlr_output *output)
+{
+	if (state.status != S_ACTIVE)
+		return;
+	if (!wlr_output_is_wl(output))
+		return;
+	struct wl_surface *surface = wlr_wl_output_get_surface(output);
+	if (!surface)
+		return;
+	zwp_keyboard_shortcuts_inhibit_manager_v1_inhibit_shortcuts(
+		state.manager, surface, state.outer_seat);
+}
+
+const char *
+nested_inhibitor_status(void)
+{
+	switch (state.status) {
+	case S_ACTIVE:      return "active";
+	case S_UNAVAILABLE: return "unavailable";
+	default:            return "not-applicable";
+	}
+}

--- a/nested_inhibitor.h
+++ b/nested_inhibitor.h
@@ -1,0 +1,21 @@
+#ifndef SOMEWM_NESTED_INHIBITOR_H
+#define SOMEWM_NESTED_INHIBITOR_H
+
+/*
+ * Why: when somewm runs nested under another Wayland compositor, the
+ * host eats Mod4 combos unless we ask it to forward them via the
+ * shortcut inhibitor protocol. The test-mode Lua layer handles the
+ * fallback when this isn't possible.
+ */
+
+struct wlr_backend;
+struct wlr_output;
+
+void nested_inhibitor_init(struct wlr_backend *backend);
+void nested_inhibitor_attach_output(struct wlr_output *output);
+
+/* Returns one of "active", "unavailable", "not-applicable". Used by the
+ * orchestrator to print accurate keybind status after a test start. */
+const char *nested_inhibitor_status(void);
+
+#endif

--- a/somewm-client.c
+++ b/somewm-client.c
@@ -18,6 +18,8 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include "test_orchestrator.h"
+
 #define BUFFER_SIZE 65536
 #define SOCKET_NAME "somewm-socket"
 
@@ -187,6 +189,16 @@ print_usage(const char *progname)
 	fprintf(stderr, "  menubar                        Show menubar launcher\n");
 	fprintf(stderr, "  launcher                       Alias for menubar\n\n");
 
+	fprintf(stderr, "TEST MODE (nested compositor, inspired by AWMTT):\n");
+	fprintf(stderr, "  test start  [opts]             Spawn a nested somewm for safe rc.lua testing\n");
+	fprintf(stderr, "  test stop   [--name N]         Stop a nested instance\n");
+	fprintf(stderr, "  test list   [--json]           List running nested instances\n");
+	fprintf(stderr, "  test run    [--name N] -- CMD  Spawn a process inside the nested instance\n");
+	fprintf(stderr, "  test eval   [--name N] LUA     Evaluate Lua inside the nested instance\n");
+	fprintf(stderr, "  test reload [--name N]         Reload config in the nested instance\n");
+	fprintf(stderr, "  test logs   [--name N] [-f]    View or follow the nested instance's log\n");
+	fprintf(stderr, "    See `%s test --help` for full options.\n\n", progname);
+
 	fprintf(stderr, "EVENT SUBSCRIPTION:\n");
 	fprintf(stderr, "  --subscribe [event_types...]   Subscribe to compositor events\n");
 	fprintf(stderr, "    Event types: client_manage, client_unmanage, client_focus,\n");
@@ -293,7 +305,7 @@ send_command(int sock, int argc, char *argv[], int json_mode, int start_arg)
 	return 0;
 }
 
-static int
+int
 read_response(int sock)
 {
 	char buffer[BUFFER_SIZE];
@@ -413,7 +425,7 @@ print_completions(const char *shell)
 		printf("  prev=\"${COMP_WORDS[COMP_CWORD-1]}\"\n");
 		printf("\n");
 		printf("  # Top-level commands\n");
-		printf("  local categories=\"client dpms eval exec hotkeys idle input keybind launcher layout lock menubar mouse notify output ping quit reload restart rule screen screenshot subscribe tag theme titlebar version wallpaper wibar\"\n");
+		printf("  local categories=\"client dpms eval exec hotkeys idle input keybind launcher layout lock menubar mouse notify output ping quit reload restart rule screen screenshot subscribe tag test theme titlebar version wallpaper wibar\"\n");
 		printf("\n");
 		printf("  if [[ ${COMP_CWORD} -eq 1 ]]; then\n");
 		printf("    COMPREPLY=( $(compgen -W \"${categories} --json --subscribe --help\" -- \"${cur}\") )\n");
@@ -469,6 +481,9 @@ print_completions(const char *shell)
 		printf("    idle)\n");
 		printf("      COMPREPLY=( $(compgen -W \"timeout status clear\" -- \"${cur}\") )\n");
 		printf("      ;;\n");
+		printf("    test)\n");
+		printf("      COMPREPLY=( $(compgen -W \"start stop list run eval reload logs\" -- \"${cur}\") )\n");
+		printf("      ;;\n");
 		printf("  esac\n");
 		printf("}\n");
 		printf("complete -F _somewm_client somewm-client\n");
@@ -500,6 +515,7 @@ print_completions(const char *shell)
 		printf("    'screen:Screen management'\n");
 		printf("    'screenshot:Screenshot capture'\n");
 		printf("    'tag:Tag management'\n");
+		printf("    'test:Nested test compositor (inspired by AWMTT)'\n");
 		printf("    'theme:Theme queries'\n");
 		printf("    'titlebar:Titlebar management'\n");
 		printf("    'version:Version info'\n");
@@ -534,6 +550,7 @@ print_completions(const char *shell)
 		printf("        output) _values 'subcommand' list ;;\n");
 		printf("        dpms) _values 'subcommand' on off status ;;\n");
 		printf("        idle) _values 'subcommand' timeout status clear ;;\n");
+		printf("        test) _values 'subcommand' start stop list run eval reload logs ;;\n");
 		printf("      esac\n");
 		printf("      ;;\n");
 		printf("  esac\n");
@@ -571,6 +588,7 @@ print_completions(const char *shell)
 		printf("complete -c somewm-client -n '__fish_use_subcommand' -a 'screen' -d 'Screen management'\n");
 		printf("complete -c somewm-client -n '__fish_use_subcommand' -a 'screenshot' -d 'Screenshot capture'\n");
 		printf("complete -c somewm-client -n '__fish_use_subcommand' -a 'tag' -d 'Tag management'\n");
+		printf("complete -c somewm-client -n '__fish_use_subcommand' -a 'test' -d 'Nested test compositor (inspired by AWMTT)'\n");
 		printf("complete -c somewm-client -n '__fish_use_subcommand' -a 'theme' -d 'Theme queries'\n");
 		printf("complete -c somewm-client -n '__fish_use_subcommand' -a 'titlebar' -d 'Titlebar management'\n");
 		printf("complete -c somewm-client -n '__fish_use_subcommand' -a 'version' -d 'Version info'\n");
@@ -606,6 +624,8 @@ print_completions(const char *shell)
 		printf("complete -c somewm-client -n '__fish_seen_subcommand_from dpms' -a 'on off status'\n");
 		printf("# Idle subcommands\n");
 		printf("complete -c somewm-client -n '__fish_seen_subcommand_from idle' -a 'timeout status clear'\n");
+		printf("# Test subcommands\n");
+		printf("complete -c somewm-client -n '__fish_seen_subcommand_from test' -a 'start stop list run eval reload logs'\n");
 	} else {
 		fprintf(stderr, "Unknown shell: %s (supported: bash, zsh, fish)\n", shell);
 	}
@@ -687,6 +707,15 @@ main(int argc, char *argv[])
 		exit_code = subscribe_mode(sock);
 		close(sock);
 		return exit_code;
+	}
+
+	/* `test` subcommand handles its own lifecycle (no IPC to a single
+	 * default compositor; it spawns nested instances and addresses them
+	 * by --name). Dispatch before connect_to_socket(). */
+	if (strcmp(argv[start_arg], "test") == 0) {
+		return test_orchestrator_run(argc - start_arg - 1,
+		                              argv + start_arg + 1,
+		                              json_mode);
 	}
 
 	/* Connect to compositor */

--- a/somewm.1
+++ b/somewm.1
@@ -243,6 +243,36 @@ tell how to connect to the
 .Nm Xwayland
 server.
 .El
+.Pp
+When started by
+.Nm somewm-client test ,
+.Nm
+honors these additional variables:
+.Bl -tag -width SOMEWM_TEST_KEYBINDS_MODE
+.It Ev SOMEWM_TEST_NAME
+Name of the test instance. Loads the test-marker module after rc.lua
+to enable the optional modifier remap. Unset in normal sessions.
+.It Ev SOMEWM_TEST_STATE_DIR
+Per-instance state directory. The compositor writes
+.Pa keybinds_status
+here so the orchestrator can report whether the outer Wayland
+compositor accepted the shortcut inhibitor request.
+.It Ev SOMEWM_TEST_KEYBINDS_MODE
+One of
+.Em auto ,
+.Em inhibit ,
+.Em remap ,
+.Em none .
+Controls the test-marker module's fallback behavior.
+.It Ev SOMEWM_TEST_KEYBINDS_REMAP
+If set to
+.Em 1 ,
+forces the
+.Em Mod4
+->
+.Em Mod1
+remap in user-bound keys regardless of inhibitor state.
+.El
 .Sh EXAMPLES
 Start
 .Nm
@@ -251,8 +281,18 @@ with s6 in the background:
 .Sh SEE ALSO
 .Xr dwm 1 ,
 .Xr foot 1 ,
+.Xr somewm-client 1 ,
 .Xr wmenu 1 ,
 .Xr xkeyboard-config 7
+.Pp
+For testing
+.Pa rc.lua
+without touching your real session, see the
+.Sy test
+subcommand of
+.Xr somewm-client 1
+(inspired by AWMTT,
+.Lk https://github.com/serialoverflow/awmtt ).
 .Sh ACKNOWLEDGEMENTS
 .Nm
 is based on dwl, which was created by Devin J. Pohly and the dwl community.

--- a/somewm.c
+++ b/somewm.c
@@ -77,6 +77,7 @@
 #include "common/util.h"
 #include "common/lualib.h"
 #include "wlr_compat.h"
+#include "nested_inhibitor.h"
 #include "globalconf.h"
 #include "luaa.h"
 #include "stack.h"
@@ -859,6 +860,19 @@ run(char *startup_cmd)
 		/* Emit startup signal to initialize Lua modules (matches AwesomeWM) */
 		luaA_emit_signal_global("startup");
 
+		/* In a test instance, remap Mod4 -> Mod1 if the host can't forward shortcuts. */
+		if (getenv("SOMEWM_TEST_NAME")) {
+			if (luaL_dostring(globalconf_L,
+				"local ok, m = pcall(require, 'awful.test_marker'); "
+				"if ok and m and m.apply then m.apply() end") != 0) {
+				const char *err = lua_tostring(globalconf_L, -1);
+				fprintf(stderr,
+					"[test_marker] failed to apply: %s\n",
+					err ? err : "(no error)");
+				lua_pop(globalconf_L, 1);
+			}
+		}
+
 		/* Ensure all drawables created during startup have their content
 		 * pushed to scene buffers. This fixes the timing issue where wiboxes
 		 * don't appear until an external event triggers some_refresh().
@@ -1011,6 +1025,9 @@ setup(void)
 	 * if an X11 server is running. */
 	if (!(backend = wlr_backend_autocreate(event_loop, &session)))
 		die("couldn't create backend");
+
+	/* Ask the host compositor to forward Mod4 combos when nested. */
+	nested_inhibitor_init(backend);
 
 	/* Initialize the scene graph used to lay out windows */
 	scene = wlr_scene_create();

--- a/spec/awful/test_marker_spec.lua
+++ b/spec/awful/test_marker_spec.lua
@@ -1,0 +1,43 @@
+-- Validates the Mod4 -> Mod1 substitution used by awful.test_marker.
+-- .apply() mutates capi.root.keys; this spec covers only the pure helper.
+
+local tm = require("awful.test_marker")
+
+describe("awful.test_marker.substitute_modifiers", function()
+    it("replaces Mod4 with Mod1 and reports changed=true", function()
+        local out, changed = tm.substitute_modifiers({ "Mod4" })
+        assert.are.same({ "Mod1" }, out)
+        assert.is_true(changed)
+    end)
+
+    it("preserves other modifiers around Mod4", function()
+        local out, changed = tm.substitute_modifiers({ "Mod4", "Shift" })
+        assert.are.same({ "Mod1", "Shift" }, out)
+        assert.is_true(changed)
+    end)
+
+    it("preserves order and replaces Mod4 in the middle", function()
+        local out, changed = tm.substitute_modifiers({ "Control", "Mod4", "Shift" })
+        assert.are.same({ "Control", "Mod1", "Shift" }, out)
+        assert.is_true(changed)
+    end)
+
+    it("leaves bindings without Mod4 untouched and reports changed=false", function()
+        local out, changed = tm.substitute_modifiers({ "Control", "Shift" })
+        assert.are.same({ "Control", "Shift" }, out)
+        assert.is_false(changed)
+    end)
+
+    it("returns an empty table unchanged", function()
+        local out, changed = tm.substitute_modifiers({})
+        assert.are.same({}, out)
+        assert.is_false(changed)
+    end)
+
+    it("does not alias the input table", function()
+        local input = { "Mod4" }
+        local out = tm.substitute_modifiers(input)
+        out[1] = "tampered"
+        assert.are.same({ "Mod4" }, input)
+    end)
+end)

--- a/test_orchestrator.c
+++ b/test_orchestrator.c
@@ -1,0 +1,1006 @@
+/*
+ * Nested-compositor test mode for somewm-client: spawns a sandboxed
+ * somewm under the user's existing Wayland or X11 session and routes
+ * the regular IPC commands at it.
+ *
+ * Inspired by AWMTT (https://github.com/serialoverflow/awmtt).
+ */
+
+#define _GNU_SOURCE
+
+#include "test_orchestrator.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#define STATE_DIR_NAME        "somewm-test"
+#define DEFAULT_NAME          "test"
+#define WAIT_FOR_SOCKET_MS    30000
+#define STOP_GRACE_MS         5000
+#define KILL_GRACE_MS         2000
+#define POLL_INTERVAL_MS      50
+#define IPC_BUFFER_SIZE       65536
+
+enum host_mode { HOST_WAYLAND, HOST_X11, HOST_HEADLESS };
+enum keybinds_mode { KB_AUTO, KB_INHIBIT, KB_REMAP, KB_NONE };
+
+struct start_opts {
+	const char *name;
+	const char *config_path;
+	enum host_mode host;
+	enum keybinds_mode keybinds;
+	int no_marker;
+	int force;
+};
+
+
+static int
+runtime_dir(char *out, size_t cap)
+{
+	const char *rd = getenv("XDG_RUNTIME_DIR");
+	if (!rd || !*rd) {
+		fprintf(stderr, "Error: XDG_RUNTIME_DIR not set\n");
+		return -1;
+	}
+	if ((size_t)snprintf(out, cap, "%s", rd) >= cap)
+		return -1;
+	return 0;
+}
+
+static int
+state_dir_for(const char *name, char *out, size_t cap)
+{
+	char rd[PATH_MAX];
+	if (runtime_dir(rd, sizeof(rd)) < 0)
+		return -1;
+	if ((size_t)snprintf(out, cap, "%s/%s/%s", rd, STATE_DIR_NAME, name) >= cap)
+		return -1;
+	return 0;
+}
+
+static int
+mkdir_p(const char *path, mode_t mode)
+{
+	char buf[PATH_MAX];
+	size_t len = strnlen(path, sizeof(buf));
+	if (len >= sizeof(buf))
+		return -1;
+	memcpy(buf, path, len + 1);
+	for (char *p = buf + 1; *p; p++) {
+		if (*p == '/') {
+			*p = '\0';
+			if (mkdir(buf, mode) < 0 && errno != EEXIST)
+				return -1;
+			*p = '/';
+		}
+	}
+	if (mkdir(buf, mode) < 0 && errno != EEXIST)
+		return -1;
+	return 0;
+}
+
+static int
+rmtree(const char *path)
+{
+	DIR *d = opendir(path);
+	if (!d)
+		return (errno == ENOENT) ? 0 : -1;
+	struct dirent *e;
+	while ((e = readdir(d))) {
+		if (!strcmp(e->d_name, ".") || !strcmp(e->d_name, ".."))
+			continue;
+		char child[PATH_MAX];
+		if ((size_t)snprintf(child, sizeof(child), "%s/%s", path, e->d_name)
+		    >= sizeof(child)) {
+			closedir(d);
+			return -1;
+		}
+		struct stat st;
+		if (lstat(child, &st) < 0) {
+			closedir(d);
+			return -1;
+		}
+		if (S_ISDIR(st.st_mode)) {
+			if (rmtree(child) < 0) {
+				closedir(d);
+				return -1;
+			}
+		} else {
+			if (unlink(child) < 0 && errno != ENOENT) {
+				closedir(d);
+				return -1;
+			}
+		}
+	}
+	closedir(d);
+	if (rmdir(path) < 0 && errno != ENOENT)
+		return -1;
+	return 0;
+}
+
+
+static int
+info_write(const char *state_dir, const struct start_opts *opts, pid_t pid,
+           const char *wl_socket_name, const char *resolved_config,
+           const char *keybinds_status)
+{
+	char path[PATH_MAX + 16];
+	if ((size_t)snprintf(path, sizeof(path), "%s/info", state_dir)
+	    >= sizeof(path))
+		return -1;
+	FILE *f = fopen(path, "w");
+	if (!f)
+		return -1;
+	const char *host_str =
+		(opts->host == HOST_X11)       ? "x11"
+		: (opts->host == HOST_HEADLESS) ? "headless"
+		: "wayland";
+	const char *host_display =
+		(opts->host == HOST_X11)       ? getenv("DISPLAY")
+		: (opts->host == HOST_HEADLESS) ? ""
+		: getenv("WAYLAND_DISPLAY");
+	const char *kb_mode =
+		(opts->keybinds == KB_INHIBIT) ? "inhibit"
+		: (opts->keybinds == KB_REMAP) ? "remap"
+		: (opts->keybinds == KB_NONE)  ? "none"
+		: "auto";
+	fprintf(f, "name=%s\n", opts->name);
+	fprintf(f, "pid=%ld\n", (long)pid);
+	fprintf(f, "host=%s\n", host_str);
+	fprintf(f, "host_display=%s\n", host_display ? host_display : "");
+	fprintf(f, "config_path=%s\n", resolved_config ? resolved_config : "");
+	fprintf(f, "started_at=%lld\n", (long long)time(NULL));
+	fprintf(f, "keybinds_mode=%s\n", kb_mode);
+	fprintf(f, "keybinds_status=%s\n", keybinds_status ? keybinds_status : "not-applicable");
+	fprintf(f, "wl_socket_name=%s\n", wl_socket_name ? wl_socket_name : "");
+	fprintf(f, "no_marker=%d\n", opts->no_marker ? 1 : 0);
+	fclose(f);
+	return 0;
+}
+
+static int
+info_read_field(const char *state_dir, const char *key, char *out, size_t cap)
+{
+	char path[PATH_MAX];
+	if ((size_t)snprintf(path, sizeof(path), "%s/info", state_dir)
+	    >= sizeof(path))
+		return -1;
+	FILE *f = fopen(path, "r");
+	if (!f)
+		return -1;
+	size_t klen = strlen(key);
+	char line[2048];
+	int found = -1;
+	while (fgets(line, sizeof(line), f)) {
+		if (strncmp(line, key, klen) == 0 && line[klen] == '=') {
+			size_t len = strlen(line);
+			if (len && line[len - 1] == '\n')
+				line[len - 1] = '\0';
+			snprintf(out, cap, "%s", line + klen + 1);
+			found = 0;
+			break;
+		}
+	}
+	fclose(f);
+	return found;
+}
+
+
+static int
+write_pidfile_excl(const char *state_dir, pid_t pid)
+{
+	char path[PATH_MAX];
+	if ((size_t)snprintf(path, sizeof(path), "%s/pid", state_dir)
+	    >= sizeof(path))
+		return -1;
+	int fd = open(path, O_WRONLY | O_CREAT | O_EXCL, 0644);
+	if (fd < 0)
+		return -1;
+	char buf[32];
+	int n = snprintf(buf, sizeof(buf), "%ld\n", (long)pid);
+	if (write(fd, buf, n) != n) {
+		close(fd);
+		return -1;
+	}
+	close(fd);
+	return 0;
+}
+
+static pid_t
+read_pidfile(const char *state_dir)
+{
+	char path[PATH_MAX];
+	if ((size_t)snprintf(path, sizeof(path), "%s/pid", state_dir)
+	    >= sizeof(path))
+		return -1;
+	FILE *f = fopen(path, "r");
+	if (!f)
+		return -1;
+	long pid = -1;
+	if (fscanf(f, "%ld", &pid) != 1)
+		pid = -1;
+	fclose(f);
+	return (pid_t)pid;
+}
+
+static int
+socket_path_for(const char *state_dir, char *out, size_t cap)
+{
+	if ((size_t)snprintf(out, cap, "%s/ipc.sock", state_dir) >= cap)
+		return -1;
+	return 0;
+}
+
+static int
+try_connect_socket(const char *sock_path)
+{
+	int s = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (s < 0)
+		return -1;
+	struct sockaddr_un addr = {0};
+	addr.sun_family = AF_UNIX;
+	snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", sock_path);
+	if (connect(s, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+		close(s);
+		return -1;
+	}
+	return s;
+}
+
+/* Wait until the nested compositor's IPC server answers ping (not just
+ * until the socket is connectable - the compositor accepts connections
+ * only once its event loop runs). */
+static int
+wait_for_socket(const char *sock_path, int timeout_ms, pid_t child_pid)
+{
+	int elapsed = 0;
+	while (elapsed < timeout_ms) {
+		int s = try_connect_socket(sock_path);
+		if (s >= 0) {
+			const char *probe = "ping\n";
+			ssize_t w = write(s, probe, 5);
+			if (w == 5) {
+				char buf[256];
+				ssize_t n = read(s, buf, sizeof(buf) - 1);
+				if (n > 0) {
+					close(s);
+					return 0;
+				}
+			}
+			close(s);
+		}
+		int status;
+		pid_t r = waitpid(child_pid, &status, WNOHANG);
+		if (r == child_pid) {
+			fprintf(stderr,
+			        "Error: nested compositor exited before IPC was ready\n");
+			return -1;
+		}
+		struct timespec ts = { 0, POLL_INTERVAL_MS * 1000000L };
+		nanosleep(&ts, NULL);
+		elapsed += POLL_INTERVAL_MS;
+	}
+	fprintf(stderr,
+	        "Error: timed out waiting for nested compositor socket at %s\n",
+	        sock_path);
+	return -1;
+}
+
+static int
+pid_alive(pid_t pid)
+{
+	if (pid <= 1)
+		return 0;
+	return (kill(pid, 0) == 0 || errno == EPERM) ? 1 : 0;
+}
+
+static int
+kill_and_wait(pid_t pid, const char *sock_path)
+{
+	if (!pid_alive(pid))
+		return 0;
+	if (kill(pid, SIGTERM) < 0 && errno != ESRCH)
+		return -1;
+	int elapsed = 0;
+	while (elapsed < STOP_GRACE_MS) {
+		if (!pid_alive(pid))
+			return 0;
+		if (sock_path && access(sock_path, F_OK) != 0)
+			break;
+		struct timespec ts = { 0, POLL_INTERVAL_MS * 1000000L };
+		nanosleep(&ts, NULL);
+		elapsed += POLL_INTERVAL_MS;
+	}
+	if (!pid_alive(pid))
+		return 0;
+	kill(pid, SIGKILL);
+	elapsed = 0;
+	while (elapsed < KILL_GRACE_MS) {
+		if (!pid_alive(pid))
+			return 0;
+		struct timespec ts = { 0, POLL_INTERVAL_MS * 1000000L };
+		nanosleep(&ts, NULL);
+		elapsed += POLL_INTERVAL_MS;
+	}
+	return pid_alive(pid) ? -1 : 0;
+}
+
+
+extern int read_response(int sock);
+
+static int
+ipc_call(const char *sock_path, const char *command)
+{
+	int s = try_connect_socket(sock_path);
+	if (s < 0) {
+		fprintf(stderr, "Error: cannot connect to %s\n", sock_path);
+		return 4;
+	}
+	size_t cmd_len = strlen(command);
+	if ((size_t)write(s, command, cmd_len) != cmd_len) {
+		perror("write");
+		close(s);
+		return 4;
+	}
+	int rc = read_response(s);
+	close(s);
+	return rc < 0 ? 4 : rc;
+}
+
+
+static int
+parse_start_opts(int argc, char *argv[], struct start_opts *opts)
+{
+	opts->name = DEFAULT_NAME;
+	opts->config_path = NULL;
+	opts->host = HOST_WAYLAND;
+	opts->keybinds = KB_AUTO;
+	opts->no_marker = 0;
+	opts->force = 0;
+	for (int i = 0; i < argc; i++) {
+		const char *a = argv[i];
+		if (!strcmp(a, "--name") || !strcmp(a, "-n")) {
+			if (i + 1 >= argc) {
+				fprintf(stderr, "Error: %s requires a value\n", a);
+				return -1;
+			}
+			opts->name = argv[++i];
+		} else if (!strcmp(a, "--config") || !strcmp(a, "-c")) {
+			if (i + 1 >= argc) {
+				fprintf(stderr, "Error: %s requires a value\n", a);
+				return -1;
+			}
+			opts->config_path = argv[++i];
+		} else if (!strcmp(a, "--host")) {
+			if (i + 1 >= argc) {
+				fprintf(stderr, "Error: --host requires a value\n");
+				return -1;
+			}
+			const char *v = argv[++i];
+			if (!strcmp(v, "wayland"))
+				opts->host = HOST_WAYLAND;
+			else if (!strcmp(v, "x11"))
+				opts->host = HOST_X11;
+			else if (!strcmp(v, "headless"))
+				opts->host = HOST_HEADLESS;
+			else {
+				fprintf(stderr,
+				        "Error: --host must be 'wayland', 'x11', or 'headless' (got '%s')\n",
+				        v);
+				return -1;
+			}
+		} else if (!strcmp(a, "--keybinds")) {
+			if (i + 1 >= argc) {
+				fprintf(stderr, "Error: --keybinds requires a value\n");
+				return -1;
+			}
+			const char *v = argv[++i];
+			if (!strcmp(v, "auto"))         opts->keybinds = KB_AUTO;
+			else if (!strcmp(v, "inhibit")) opts->keybinds = KB_INHIBIT;
+			else if (!strcmp(v, "remap"))   opts->keybinds = KB_REMAP;
+			else if (!strcmp(v, "none"))    opts->keybinds = KB_NONE;
+			else {
+				fprintf(stderr,
+				        "Error: --keybinds must be auto|inhibit|remap|none (got '%s')\n",
+				        v);
+				return -1;
+			}
+		} else if (!strcmp(a, "--no-marker")) {
+			opts->no_marker = 1;
+		} else if (!strcmp(a, "--force") || !strcmp(a, "-f")) {
+			opts->force = 1;
+		} else {
+			fprintf(stderr, "Error: unknown option for `test start`: %s\n", a);
+			return -1;
+		}
+	}
+	return 0;
+}
+
+
+static int
+test_stop_named(const char *name)
+{
+	char state_dir[PATH_MAX];
+	if (state_dir_for(name, state_dir, sizeof(state_dir)) < 0)
+		return 6;
+	struct stat st;
+	if (stat(state_dir, &st) < 0) {
+		if (errno == ENOENT) {
+			fprintf(stderr, "No test instance named '%s'\n", name);
+			return 3;
+		}
+		perror("stat");
+		return 6;
+	}
+	pid_t pid = read_pidfile(state_dir);
+	char sock_path[PATH_MAX];
+	socket_path_for(state_dir, sock_path, sizeof(sock_path));
+	if (pid > 0 && pid_alive(pid)) {
+		if (kill_and_wait(pid, sock_path) < 0) {
+			fprintf(stderr, "Warning: nested compositor (pid %ld) did not exit cleanly\n",
+			        (long)pid);
+		}
+	}
+	if (rmtree(state_dir) < 0) {
+		perror("rmtree");
+		return 6;
+	}
+	printf("stopped test instance '%s'\n", name);
+	return 0;
+}
+
+
+static int
+exec_child(const struct start_opts *opts, const char *state_dir,
+           const char *runtime_subdir, const char *sock_path,
+           const char *log_path, const char *config_path)
+{
+	int log_fd = open(log_path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	if (log_fd < 0) {
+		perror("open log");
+		_exit(127);
+	}
+	setsid();
+	dup2(log_fd, STDOUT_FILENO);
+	dup2(log_fd, STDERR_FILENO);
+	close(log_fd);
+
+	/* libwayland resolves a relative WAYLAND_DISPLAY against the
+	 * child's XDG_RUNTIME_DIR. We're about to sandbox that, so anchor
+	 * WAYLAND_DISPLAY to the parent's runtime dir as an absolute path
+	 * before the override. */
+	if (opts->host == HOST_WAYLAND) {
+		const char *wd = getenv("WAYLAND_DISPLAY");
+		const char *xdr = getenv("XDG_RUNTIME_DIR");
+		if (wd && *wd && wd[0] != '/' && xdr && *xdr) {
+			char abs_wd[PATH_MAX];
+			snprintf(abs_wd, sizeof(abs_wd), "%s/%s", xdr, wd);
+			setenv("WAYLAND_DISPLAY", abs_wd, 1);
+		}
+	}
+
+	setenv("XDG_RUNTIME_DIR", runtime_subdir, 1);
+	setenv("SOMEWM_SOCKET", sock_path, 1);
+	setenv("SOMEWM_TEST_NAME", opts->name, 1);
+	setenv("SOMEWM_TEST_STATE_DIR", state_dir, 1);
+	const char *mode_str =
+		(opts->keybinds == KB_INHIBIT) ? "inhibit"
+		: (opts->keybinds == KB_REMAP) ? "remap"
+		: (opts->keybinds == KB_NONE)  ? "none"
+		: "auto";
+	setenv("SOMEWM_TEST_KEYBINDS_MODE", mode_str, 1);
+	if (opts->no_marker)
+		setenv("SOMEWM_TEST_NO_MARKER", "1", 1);
+	if (opts->host == HOST_X11) {
+		setenv("WLR_BACKENDS", "x11", 1);
+		if (!getenv("WLR_X11_OUTPUTS"))
+			setenv("WLR_X11_OUTPUTS", "1", 1);
+	} else if (opts->host == HOST_HEADLESS) {
+		setenv("WLR_BACKENDS", "headless", 1);
+		setenv("WLR_RENDERER", "pixman", 1);
+		if (!getenv("WLR_WL_OUTPUTS"))
+			setenv("WLR_WL_OUTPUTS", "1", 1);
+	} else {
+		setenv("WLR_BACKENDS", "wayland", 1);
+		if (!getenv("WLR_WL_OUTPUTS"))
+			setenv("WLR_WL_OUTPUTS", "1", 1);
+	}
+
+	const char *binary = getenv("SOMEWM_BINARY");
+	if (!binary || !*binary)
+		binary = "somewm";
+
+	if (config_path) {
+		execlp(binary, binary, "-c", config_path, (char *)NULL);
+	} else {
+		execlp(binary, binary, (char *)NULL);
+	}
+	fprintf(stderr, "exec %s: %s\n", binary, strerror(errno));
+	_exit(127);
+}
+
+static const char *
+detect_wl_socket_name(const char *runtime_subdir)
+{
+	DIR *d = opendir(runtime_subdir);
+	if (!d)
+		return NULL;
+	static char name[256];
+	name[0] = '\0';
+	struct dirent *e;
+	while ((e = readdir(d))) {
+		if (strncmp(e->d_name, "wayland-", 8) == 0
+		    && strstr(e->d_name, ".lock") == NULL) {
+			snprintf(name, sizeof(name), "%s", e->d_name);
+			break;
+		}
+	}
+	closedir(d);
+	return name[0] ? name : NULL;
+}
+
+/* Read the one-line keybinds_status file the nested compositor writes
+ * during startup. Returns "not-applicable" if absent or unreadable. */
+static void
+read_keybinds_status(const char *state_dir, char *out, size_t cap)
+{
+	char path[PATH_MAX + 32];
+	snprintf(path, sizeof(path), "%s/keybinds_status", state_dir);
+	FILE *f = fopen(path, "r");
+	if (!f) {
+		snprintf(out, cap, "not-applicable");
+		return;
+	}
+	if (!fgets(out, (int)cap, f)) {
+		snprintf(out, cap, "not-applicable");
+	} else {
+		size_t len = strlen(out);
+		if (len && out[len - 1] == '\n')
+			out[len - 1] = '\0';
+	}
+	fclose(f);
+}
+
+static void
+print_status_block(const struct start_opts *opts, pid_t pid,
+                   const char *wl_sock, const char *config_resolved,
+                   const char *log_path, const char *ipc_sock_path,
+                   const char *keybinds_status)
+{
+	const char *host =
+		(opts->host == HOST_X11)       ? "x11"
+		: (opts->host == HOST_HEADLESS) ? "headless"
+		: "wayland";
+	const char *display = wl_sock ? wl_sock : "(unknown)";
+	printf("test '%s': pid %ld on %s (host: %s), config %s\n",
+	       opts->name, (long)pid, display, host,
+	       config_resolved ? config_resolved : "(default)");
+	if (!strcmp(keybinds_status, "active")) {
+		printf("  keybinds: shortcut inhibitor ACTIVE on outer compositor, Mod4 passes through\n");
+	} else if (!strcmp(keybinds_status, "unavailable")) {
+		printf("  keybinds: ! outer compositor did not advertise shortcut inhibitor\n");
+		printf("            ! Mod4 combos will be intercepted by the host\n");
+	} else {
+		printf("  keybinds: host=%s, no shortcut-inhibitor negotiation needed\n", host);
+	}
+	printf("  log:      %s\n", log_path);
+	printf("  socket:   %s\n", ipc_sock_path);
+	printf("  next:     somewm-client test run  --name %s -- alacritty\n",
+	       opts->name);
+	printf("            somewm-client test eval --name %s 'return mouse.coords()'\n",
+	       opts->name);
+	printf("            somewm-client test stop --name %s\n", opts->name);
+}
+
+static int
+test_start(int argc, char *argv[])
+{
+	struct start_opts opts;
+	if (parse_start_opts(argc, argv, &opts) < 0)
+		return 1;
+
+	char state_dir[PATH_MAX];
+	if (state_dir_for(opts.name, state_dir, sizeof(state_dir)) < 0)
+		return 6;
+
+	struct stat st;
+	if (stat(state_dir, &st) == 0) {
+		pid_t prev = read_pidfile(state_dir);
+		if (prev > 0 && pid_alive(prev)) {
+			if (!opts.force) {
+				fprintf(stderr,
+				        "Error: test instance '%s' already running (pid %ld).\n",
+				        opts.name, (long)prev);
+				fprintf(stderr,
+				        "       Use --force to replace it, or pick a different --name.\n");
+				return 2;
+			}
+			fprintf(stderr, "Replacing existing '%s' (pid %ld)...\n",
+			        opts.name, (long)prev);
+			char prev_sock[PATH_MAX + 16];
+			socket_path_for(state_dir, prev_sock, sizeof(prev_sock));
+			kill_and_wait(prev, prev_sock);
+		}
+		if (rmtree(state_dir) < 0) {
+			perror("rmtree existing");
+			return 6;
+		}
+	}
+
+	char runtime_subdir[PATH_MAX + 16];
+	char log_path[PATH_MAX + 16];
+	char sock_path[PATH_MAX + 16];
+	snprintf(runtime_subdir, sizeof(runtime_subdir), "%s/runtime", state_dir);
+	snprintf(log_path, sizeof(log_path), "%s/log", state_dir);
+	socket_path_for(state_dir, sock_path, sizeof(sock_path));
+
+	if (mkdir_p(state_dir, 0755) < 0 || mkdir_p(runtime_subdir, 0700) < 0) {
+		perror("mkdir state dir");
+		return 6;
+	}
+
+	char config_resolved[PATH_MAX] = {0};
+	if (opts.config_path) {
+		if (!realpath(opts.config_path, config_resolved)) {
+			fprintf(stderr, "Error: config not found: %s\n", opts.config_path);
+			rmtree(state_dir);
+			return 6;
+		}
+	}
+
+	if (opts.host == HOST_WAYLAND && !getenv("WAYLAND_DISPLAY")) {
+		fprintf(stderr,
+		        "Error: WAYLAND_DISPLAY not set; cannot use --host wayland.\n"
+		        "       Use --host x11 if you are on an X11 session,\n"
+		        "       or --host headless for a non-graphical test instance.\n");
+		rmtree(state_dir);
+		return 6;
+	}
+	if (opts.host == HOST_X11 && !getenv("DISPLAY")) {
+		fprintf(stderr,
+		        "Error: DISPLAY not set; cannot use --host x11.\n");
+		rmtree(state_dir);
+		return 6;
+	}
+
+	pid_t pid = fork();
+	if (pid < 0) {
+		perror("fork");
+		rmtree(state_dir);
+		return 5;
+	}
+	if (pid == 0) {
+		exec_child(&opts, state_dir, runtime_subdir, sock_path, log_path,
+		           opts.config_path ? config_resolved : NULL);
+		_exit(127);
+	}
+
+	if (write_pidfile_excl(state_dir, pid) < 0) {
+		fprintf(stderr, "Error: could not write pidfile\n");
+		kill(pid, SIGTERM);
+		rmtree(state_dir);
+		return 6;
+	}
+
+	if (wait_for_socket(sock_path, WAIT_FOR_SOCKET_MS, pid) < 0) {
+		fprintf(stderr,
+		        "       Inspect %s for details.\n", log_path);
+		kill_and_wait(pid, sock_path);
+		if (!getenv("SOMEWM_TEST_KEEP_FAILED"))
+			rmtree(state_dir);
+		return 5;
+	}
+
+	const char *wl_sock = detect_wl_socket_name(runtime_subdir);
+	char keybinds_status[64];
+	read_keybinds_status(state_dir, keybinds_status, sizeof(keybinds_status));
+	info_write(state_dir, &opts, pid, wl_sock,
+	           opts.config_path ? config_resolved : NULL,
+	           keybinds_status);
+	print_status_block(&opts, pid, wl_sock,
+	                   opts.config_path ? config_resolved : NULL,
+	                   log_path, sock_path, keybinds_status);
+	return 0;
+}
+
+
+struct instance_summary {
+	char name[256];
+	char host[16];
+	char pid[32];
+	char display[64];
+	char config[PATH_MAX];
+	int alive;
+};
+
+static int
+load_instance_summary(const char *name, struct instance_summary *out)
+{
+	char state_dir[PATH_MAX];
+	if (state_dir_for(name, state_dir, sizeof(state_dir)) < 0)
+		return -1;
+	snprintf(out->name, sizeof(out->name), "%s", name);
+	if (info_read_field(state_dir, "host", out->host, sizeof(out->host)) < 0)
+		snprintf(out->host, sizeof(out->host), "?");
+	if (info_read_field(state_dir, "pid", out->pid, sizeof(out->pid)) < 0)
+		snprintf(out->pid, sizeof(out->pid), "?");
+	if (info_read_field(state_dir, "wl_socket_name", out->display,
+	                    sizeof(out->display)) < 0)
+		out->display[0] = '\0';
+	if (info_read_field(state_dir, "config_path", out->config,
+	                    sizeof(out->config)) < 0)
+		out->config[0] = '\0';
+	char sock_path[PATH_MAX];
+	socket_path_for(state_dir, sock_path, sizeof(sock_path));
+	int s = try_connect_socket(sock_path);
+	out->alive = (s >= 0);
+	if (s >= 0)
+		close(s);
+	return 0;
+}
+
+static int
+test_list(int json_mode)
+{
+	char rd[PATH_MAX];
+	if (runtime_dir(rd, sizeof(rd)) < 0)
+		return 6;
+	char root[PATH_MAX];
+	if ((size_t)snprintf(root, sizeof(root), "%s/%s", rd, STATE_DIR_NAME)
+	    >= sizeof(root))
+		return 6;
+
+	DIR *d = opendir(root);
+	if (!d) {
+		if (json_mode)
+			printf("[]\n");
+		else
+			printf("(no test instances)\n");
+		return 0;
+	}
+
+	int first = 1;
+	if (json_mode)
+		printf("[");
+	else
+		printf("%-16s %-7s %-10s %-12s %s\n",
+		       "NAME", "HOST", "PID", "DISPLAY", "CONFIG");
+
+	struct dirent *e;
+	while ((e = readdir(d))) {
+		if (e->d_name[0] == '.')
+			continue;
+		struct instance_summary s;
+		if (load_instance_summary(e->d_name, &s) < 0)
+			continue;
+		if (json_mode) {
+			printf("%s{\"name\":\"%s\",\"host\":\"%s\",\"pid\":%s,"
+			       "\"display\":\"%s\",\"config\":\"%s\",\"alive\":%s}",
+			       first ? "" : ",", s.name, s.host,
+			       s.pid[0] ? s.pid : "null",
+			       s.display, s.config, s.alive ? "true" : "false");
+		} else {
+			printf("%-16s %-7s %-10s %-12s %s%s\n", s.name, s.host, s.pid,
+			       s.display[0] ? s.display : "-",
+			       s.config[0] ? s.config : "-",
+			       s.alive ? "" : "  (stale)");
+		}
+		first = 0;
+	}
+	closedir(d);
+	if (json_mode)
+		printf("]\n");
+	return 0;
+}
+
+
+static int
+resolve_named_socket(const char *name, char *out, size_t cap)
+{
+	char state_dir[PATH_MAX];
+	if (state_dir_for(name, state_dir, sizeof(state_dir)) < 0)
+		return -1;
+	if (socket_path_for(state_dir, out, cap) < 0)
+		return -1;
+	if (access(out, F_OK) < 0) {
+		fprintf(stderr, "Error: no test instance named '%s'\n", name);
+		return -1;
+	}
+	return 0;
+}
+
+static const char *
+extract_name(int *argc, char **argv[])
+{
+	int n = *argc;
+	char **a = *argv;
+	const char *name = DEFAULT_NAME;
+	int i = 0;
+	while (i < n) {
+		if (!strcmp(a[i], "--name") || !strcmp(a[i], "-n")) {
+			if (i + 1 >= n)
+				return NULL;
+			name = a[i + 1];
+			for (int j = i; j + 2 < n; j++)
+				a[j] = a[j + 2];
+			n -= 2;
+		} else if (!strcmp(a[i], "--")) {
+			for (int j = i; j + 1 < n; j++)
+				a[j] = a[j + 1];
+			n -= 1;
+			break;
+		} else {
+			i++;
+		}
+	}
+	*argc = n;
+	*argv = a;
+	return name;
+}
+
+static int
+ipc_send_join(const char *sock_path, const char *verb, int argc, char *argv[])
+{
+	char cmd[IPC_BUFFER_SIZE];
+	int off = snprintf(cmd, sizeof(cmd), "%s", verb);
+	for (int i = 0; i < argc; i++) {
+		if (off + 1 >= (int)sizeof(cmd))
+			return 4;
+		off += snprintf(cmd + off, sizeof(cmd) - off, " %s", argv[i]);
+	}
+	if (off + 1 >= (int)sizeof(cmd))
+		return 4;
+	cmd[off++] = '\n';
+	cmd[off] = '\0';
+	return ipc_call(sock_path, cmd);
+}
+
+static int
+test_run(int argc, char *argv[])
+{
+	const char *name = extract_name(&argc, &argv);
+	if (!name)
+		return 1;
+	if (argc < 1) {
+		fprintf(stderr, "Usage: somewm-client test run [--name N] -- <command> [args...]\n");
+		return 1;
+	}
+	char sock_path[PATH_MAX];
+	if (resolve_named_socket(name, sock_path, sizeof(sock_path)) < 0)
+		return 3;
+	return ipc_send_join(sock_path, "exec", argc, argv);
+}
+
+static int
+test_eval(int argc, char *argv[])
+{
+	const char *name = extract_name(&argc, &argv);
+	if (!name)
+		return 1;
+	if (argc < 1) {
+		fprintf(stderr, "Usage: somewm-client test eval [--name N] <lua-code>\n");
+		return 1;
+	}
+	char sock_path[PATH_MAX];
+	if (resolve_named_socket(name, sock_path, sizeof(sock_path)) < 0)
+		return 3;
+	return ipc_send_join(sock_path, "eval", argc, argv);
+}
+
+static int
+test_reload(int argc, char *argv[])
+{
+	const char *name = extract_name(&argc, &argv);
+	if (!name)
+		return 1;
+	char sock_path[PATH_MAX];
+	if (resolve_named_socket(name, sock_path, sizeof(sock_path)) < 0)
+		return 3;
+	return ipc_call(sock_path, "reload\n");
+}
+
+
+static int
+test_logs(int argc, char *argv[])
+{
+	const char *name = DEFAULT_NAME;
+	int follow = 0;
+	for (int i = 0; i < argc; i++) {
+		if (!strcmp(argv[i], "--name") || !strcmp(argv[i], "-n")) {
+			if (i + 1 >= argc)
+				return 1;
+			name = argv[++i];
+		} else if (!strcmp(argv[i], "-f") || !strcmp(argv[i], "--follow")) {
+			follow = 1;
+		}
+	}
+	char state_dir[PATH_MAX];
+	if (state_dir_for(name, state_dir, sizeof(state_dir)) < 0)
+		return 6;
+	char log_path[PATH_MAX + 16];
+	snprintf(log_path, sizeof(log_path), "%s/log", state_dir);
+	if (access(log_path, F_OK) < 0) {
+		fprintf(stderr, "Error: no test instance named '%s' (no log at %s)\n",
+		        name, log_path);
+		return 3;
+	}
+	if (follow)
+		execlp("tail", "tail", "-n", "+1", "-F", log_path, (char *)NULL);
+	else
+		execlp("cat", "cat", log_path, (char *)NULL);
+	perror("exec");
+	return 6;
+}
+
+
+static int
+test_stop_cmd(int argc, char *argv[])
+{
+	const char *name = DEFAULT_NAME;
+	for (int i = 0; i < argc; i++) {
+		if (!strcmp(argv[i], "--name") || !strcmp(argv[i], "-n")) {
+			if (i + 1 >= argc) {
+				fprintf(stderr, "Error: --name requires a value\n");
+				return 1;
+			}
+			name = argv[++i];
+		}
+	}
+	return test_stop_named(name);
+}
+
+
+void
+test_orchestrator_print_usage(const char *progname)
+{
+	fprintf(stderr, "TEST MODE (inspired by AWMTT - https://github.com/serialoverflow/awmtt):\n");
+	fprintf(stderr, "  %s test start  [--config FILE] [--name NAME] [--host wayland|x11]\n", progname);
+	fprintf(stderr, "                       [--keybinds auto|inhibit|remap|none] [--no-marker] [--force]\n");
+	fprintf(stderr, "  %s test stop   [--name NAME]\n", progname);
+	fprintf(stderr, "  %s test list   [--json]\n", progname);
+	fprintf(stderr, "  %s test run    [--name NAME] -- <command> [args...]\n", progname);
+	fprintf(stderr, "  %s test eval   [--name NAME] <lua-code>\n", progname);
+	fprintf(stderr, "  %s test reload [--name NAME]\n", progname);
+	fprintf(stderr, "  %s test logs   [--name NAME] [-f]\n\n", progname);
+	fprintf(stderr, "  Default --name is 'test'. State lives at $XDG_RUNTIME_DIR/somewm-test/<name>/.\n");
+}
+
+int
+test_orchestrator_run(int argc, char *argv[], int json_mode)
+{
+	if (argc < 1) {
+		test_orchestrator_print_usage("somewm-client");
+		return 1;
+	}
+	const char *verb = argv[0];
+	int rest_argc = argc - 1;
+	char **rest = argv + 1;
+	if (!strcmp(verb, "start"))  return test_start(rest_argc, rest);
+	if (!strcmp(verb, "stop"))   return test_stop_cmd(rest_argc, rest);
+	if (!strcmp(verb, "list"))   return test_list(json_mode);
+	if (!strcmp(verb, "run"))    return test_run(rest_argc, rest);
+	if (!strcmp(verb, "eval"))   return test_eval(rest_argc, rest);
+	if (!strcmp(verb, "reload")) return test_reload(rest_argc, rest);
+	if (!strcmp(verb, "logs"))   return test_logs(rest_argc, rest);
+	if (!strcmp(verb, "--help") || !strcmp(verb, "-h")) {
+		test_orchestrator_print_usage("somewm-client");
+		return 0;
+	}
+	fprintf(stderr, "Error: unknown `test` verb: %s\n", verb);
+	test_orchestrator_print_usage("somewm-client");
+	return 1;
+}

--- a/test_orchestrator.h
+++ b/test_orchestrator.h
@@ -1,0 +1,17 @@
+#ifndef SOMEWM_TEST_ORCHESTRATOR_H
+#define SOMEWM_TEST_ORCHESTRATOR_H
+
+#include <stdbool.h>
+
+/*
+ * Inspired by AWMTT (https://github.com/serialoverflow/awmtt).
+ *
+ * Runs a nested somewm compositor in a sandboxed XDG environment so the user
+ * can iterate on rc.lua without touching their real session.
+ */
+
+int test_orchestrator_run(int argc, char *argv[], int json_mode);
+
+void test_orchestrator_print_usage(const char *progname);
+
+#endif

--- a/tests/test-test-orchestrator.sh
+++ b/tests/test-test-orchestrator.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Test suite for `somewm-client test ...` (issue #158 orchestrator).
+#
+# Spawns a headless nested somewm under the orchestrator and exercises the
+# start / eval / list / stop / --force / already-running paths. Does not
+# require a graphical session.
+#
+# Usage: ./tests/test-test-orchestrator.sh [path-to-somewm] [path-to-somewm-client]
+
+set -e
+
+SOMEWM="${1:-./build-test/somewm}"
+SOMEWM_CLIENT="${2:-./build-test/somewm-client}"
+
+if [ ! -x "$SOMEWM" ]; then
+    echo "Error: somewm binary not found at $SOMEWM" >&2
+    echo "Run 'make build-test' first" >&2
+    exit 1
+fi
+if [ ! -x "$SOMEWM_CLIENT" ]; then
+    echo "Error: somewm-client binary not found at $SOMEWM_CLIENT" >&2
+    exit 1
+fi
+
+# Isolated runtime dir so we don't collide with the user's daily session.
+TMP_RUNTIME=$(mktemp -d)
+chmod 700 "$TMP_RUNTIME"
+export XDG_RUNTIME_DIR="$TMP_RUNTIME"
+export SOMEWM_BINARY
+SOMEWM_BINARY=$(readlink -f "$SOMEWM")
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+TEST_RC="$REPO_ROOT/tests/rc.lua"
+if [ ! -f "$TEST_RC" ]; then
+    echo "Error: test rc.lua not found at $TEST_RC" >&2
+    exit 1
+fi
+
+cleanup() {
+    "$SOMEWM_CLIENT" test stop --name unit1 >/dev/null 2>&1 || true
+    "$SOMEWM_CLIENT" test stop --name unit2 >/dev/null 2>&1 || true
+    rm -rf "$TMP_RUNTIME"
+}
+trap cleanup EXIT INT TERM
+
+pass_count=0
+fail_count=0
+
+check() {
+    local desc="$1"
+    local actual="$2"
+    local expected="$3"
+    if [ "$actual" = "$expected" ]; then
+        echo "  ok: $desc"
+        pass_count=$((pass_count + 1))
+    else
+        echo "  FAIL: $desc"
+        echo "    expected: $expected"
+        echo "    actual:   $actual"
+        fail_count=$((fail_count + 1))
+    fi
+}
+
+check_match() {
+    local desc="$1"
+    local actual="$2"
+    local pattern="$3"
+    if echo "$actual" | grep -qE "$pattern"; then
+        echo "  ok: $desc"
+        pass_count=$((pass_count + 1))
+    else
+        echo "  FAIL: $desc"
+        echo "    pattern:  $pattern"
+        echo "    actual:   $actual"
+        fail_count=$((fail_count + 1))
+    fi
+}
+
+# === Test 1: start, info file present, socket connectable ===
+echo "Test 1: start a nested instance"
+START_OUT=$("$SOMEWM_CLIENT" test start --name unit1 --host headless --config "$TEST_RC" 2>&1)
+check_match "status block names the instance" "$START_OUT" "test 'unit1':"
+check_match "status block mentions headless host" "$START_OUT" "host: headless"
+check_match "headless status block reports no inhibitor negotiation" "$START_OUT" "no shortcut-inhibitor negotiation"
+
+STATE_DIR="$TMP_RUNTIME/somewm-test/unit1"
+[ -f "$STATE_DIR/pid" ] && pid_ok=yes || pid_ok=no
+check "pid file written" "$pid_ok" "yes"
+[ -S "$STATE_DIR/ipc.sock" ] && sock_ok=yes || sock_ok=no
+check "ipc socket exists" "$sock_ok" "yes"
+[ -f "$STATE_DIR/info" ] && info_ok=yes || info_ok=no
+check "info file written" "$info_ok" "yes"
+
+# === Test 2: eval over the named instance ===
+echo "Test 2: eval against the nested instance"
+EVAL_OUT=$("$SOMEWM_CLIENT" test eval --name unit1 'return 1+1' 2>&1)
+check_match "eval returns 2" "$EVAL_OUT" "(^|[^0-9])2($|[^0-9])"
+
+# === Test 3: list shows the instance ===
+echo "Test 3: list"
+LIST_OUT=$("$SOMEWM_CLIENT" test list 2>&1)
+check_match "list shows unit1" "$LIST_OUT" "unit1"
+
+# === Test 4: already-running rejection (no --force) ===
+echo "Test 4: re-start without --force is rejected"
+set +e
+DUP_OUT=$("$SOMEWM_CLIENT" test start --name unit1 --host headless --config "$TEST_RC" 2>&1)
+DUP_RC=$?
+set -e
+check_match "duplicate start prints already-running error" "$DUP_OUT" "already running"
+[ "$DUP_RC" -ne 0 ] && dup_failed=yes || dup_failed=no
+check "duplicate start exits non-zero" "$dup_failed" "yes"
+
+# === Test 5: --force replaces ===
+echo "Test 5: --force replaces existing instance"
+OLD_PID=$(cat "$STATE_DIR/pid")
+FORCE_OUT=$("$SOMEWM_CLIENT" test start --name unit1 --host headless --config "$TEST_RC" --force 2>&1)
+NEW_PID=$(cat "$STATE_DIR/pid")
+check_match "--force prints status block" "$FORCE_OUT" "test 'unit1':"
+if [ "$OLD_PID" != "$NEW_PID" ]; then
+    pid_changed=yes
+else
+    pid_changed=no
+fi
+check "pid changed after --force" "$pid_changed" "yes"
+
+# === Test 6: stop removes the state dir ===
+echo "Test 6: stop cleans up"
+"$SOMEWM_CLIENT" test stop --name unit1 >/dev/null
+[ -e "$STATE_DIR" ] && remains=yes || remains=no
+check "state dir is gone after stop" "$remains" "no"
+
+# === Test 7: stop on non-existent instance ===
+echo "Test 7: stop on missing instance fails gracefully"
+set +e
+MISS_OUT=$("$SOMEWM_CLIENT" test stop --name does-not-exist 2>&1)
+MISS_RC=$?
+set -e
+check_match "missing-instance stop prints helpful error" "$MISS_OUT" "No test instance"
+[ "$MISS_RC" -ne 0 ] && miss_failed=yes || miss_failed=no
+check "missing-instance stop exits non-zero" "$miss_failed" "yes"
+
+# === Summary ===
+echo
+echo "Passed: $pass_count"
+echo "Failed: $fail_count"
+[ "$fail_count" -eq 0 ]


### PR DESCRIPTION
Forward-port of #568 (the `somewm-client test` work shipped on
release/1.4) to main. Hook locations moved because feat/2.0/c-reorg
relocated createmon to monitor.c; rest is verbatim from release/1.4
and already includes the WAYLAND_DISPLAY fix from #569.

Verified:
- `LUA_PKG=luajit make build-test` clean
- `make test-unit` 746/0 (existing 740 + 6 new test_marker spec cases)
- `./tests/test-test-orchestrator.sh ./build-test/somewm ./build-test/somewm-client` 15/0
- Manual headless smoke: start, eval, stop, state-dir cleanup