### PR TITLE
feat(input): support specifying XKB model and rules

### DIFF
--- a/DEVIATIONS.md
+++ b/DEVIATIONS.md
@@ -293,6 +293,8 @@ awful.input.left_handed = 0
 awful.input.xkb_layout = "us"
 awful.input.xkb_variant = ""
 awful.input.xkb_options = "ctrl:nocaps"
+awful.input.xkb_model = "pc105"
+awful.input.xkb_rules = "evdev"
 awful.input.repeat_rate = 25
 awful.input.repeat_delay = 600
 ```

--- a/globalconf.h
+++ b/globalconf.h
@@ -261,6 +261,8 @@ typedef struct
         char *xkb_layout;     /* Keyboard layout(s), e.g., "us,ru" */
         char *xkb_variant;    /* Layout variants, e.g., "dvorak," */
         char *xkb_options;    /* XKB options, e.g., "ctrl:nocaps,grp:alt_shift_toggle" */
+        char *xkb_model;      /* XKB model, e.g. "pc105" */
+        char *xkb_rules;      /* XKB model, e.g. "base" */
         int repeat_rate;      /* Key repeat rate (repeats per second) */
         int repeat_delay;     /* Key repeat delay (milliseconds) */
     } keyboard;

--- a/input.c
+++ b/input.c
@@ -1386,8 +1386,8 @@ createkeyboardgroup(void)
 	rules.layout = globalconf.keyboard.xkb_layout;
 	rules.variant = globalconf.keyboard.xkb_variant;
 	rules.options = globalconf.keyboard.xkb_options;
-	rules.rules = NULL;
-	rules.model = NULL;
+	rules.rules = globalconf.keyboard.xkb_rules;
+	rules.model = globalconf.keyboard.xkb_model;
 
 	if (!(keymap = xkb_keymap_new_from_names(context, &rules,
 				XKB_KEYMAP_COMPILE_NO_FLAGS)))

--- a/lua/awful/input.lua
+++ b/lua/awful/input.lua
@@ -44,6 +44,8 @@ local state = {
     xkb_layout = "",                -- keyboard layout (e.g., "us", "us,ru")
     xkb_variant = "",               -- layout variant (e.g., "dvorak")
     xkb_options = "",               -- XKB options (e.g., "ctrl:nocaps")
+    xkb_rules = "",
+    xkb_model = "",
 }
 
 -- Mapping from property names to their types for validation
@@ -71,6 +73,8 @@ local property_types = {
     xkb_layout = "string",
     xkb_variant = "string",
     xkb_options = "string",
+    xkb_model = "string",
+    xkb_rules = "string",
 }
 
 -- Properties that are pointer/input device settings (vs keyboard)

--- a/lua/awful/ipc.lua
+++ b/lua/awful/ipc.lua
@@ -2260,6 +2260,8 @@ local function register_builtin_commands()
     xkb_layout = { type = "string", desc = "XKB keyboard layout (e.g., 'us', 'us,ru')" },
     xkb_variant = { type = "string", desc = "XKB layout variant (e.g., 'dvorak')" },
     xkb_options = { type = "string", desc = "XKB options (e.g., 'ctrl:nocaps')" },
+    xkb_model = { type = "string", desc = "XKB model (e.g., 'pc105')" },
+    xkb_rules = { type = "string", desc = "XKB rules (e.g., 'base')" },
   }
 
   --- input [setting] [value] - Get or set libinput/keyboard configuration

--- a/luaa.c
+++ b/luaa.c
@@ -1191,6 +1191,16 @@ luaA_awesome_set_keyboard_setting(lua_State *L)
 		free(globalconf.keyboard.xkb_options);
 		globalconf.keyboard.xkb_options = strdup(val);
 		rebuild_keyboard_keymap();
+	} else if (strcmp(key, "xkb_model") == 0) {
+		const char *val = lua_isnil(L, 2) ? "" : luaL_checkstring(L, 2);
+		free(globalconf.keyboard.xkb_model);
+		globalconf.keyboard.xkb_model = strdup(val);
+		rebuild_keyboard_keymap();
+	} else if (strcmp(key, "xkb_rules") == 0) {
+		const char *val = lua_isnil(L, 2) ? "" : luaL_checkstring(L, 2);
+		free(globalconf.keyboard.xkb_rules);
+		globalconf.keyboard.xkb_rules = strdup(val);
+		rebuild_keyboard_keymap();
 	} else if (strcmp(key, "numlock") == 0) {
 		some_set_numlock(lua_toboolean(L, 2));
 	} else {

--- a/somewm.c
+++ b/somewm.c
@@ -1275,6 +1275,8 @@ setup(void)
 	globalconf.keyboard.xkb_layout = NULL;
 	globalconf.keyboard.xkb_variant = NULL;
 	globalconf.keyboard.xkb_options = NULL;
+	globalconf.keyboard.xkb_model = NULL;
+	globalconf.keyboard.xkb_rules = NULL;
 	globalconf.keyboard.repeat_rate = 25;
 	globalconf.keyboard.repeat_delay = 600;
 

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -1717,6 +1717,8 @@ some_rebuild_keyboard_keymap(void)
 	rules.layout = globalconf.keyboard.xkb_layout;
 	rules.variant = globalconf.keyboard.xkb_variant;
 	rules.options = globalconf.keyboard.xkb_options;
+	rules.model = globalconf.keyboard.xkb_model;
+	rules.rules = globalconf.keyboard.xkb_rules;
 
 	keymap = xkb_keymap_new_from_names(context, &rules,
 	                                   XKB_KEYMAP_COMPILE_NO_FLAGS);

--- a/spec/awful/input_spec.lua
+++ b/spec/awful/input_spec.lua
@@ -207,6 +207,24 @@ describe("awful.input", function()
             assert.is.equal("dvorak", input.xkb_variant)
         end)
 
+        it("xkb_model default value", function()
+            assert.is.equal("", input.xkb_model)
+        end)
+
+        it("xkb_model can be set", function()
+            input.xkb_model = "pc105"
+            assert.is.equal("pc105", input.xkb_model)
+        end)
+
+        it("xkb_rules default value", function()
+            assert.is.equal("", input.xkb_rules)
+        end)
+
+        it("xkb_rules can be set", function()
+            input.xkb_rules = "base"
+            assert.is.equal("base", input.xkb_rules)
+        end)
+
         it("xkb_options default value", function()
             assert.is.equal("", input.xkb_options)
         end)


### PR DESCRIPTION
## Description
Forward-port of #556 from `release/1.4`. Adds `awful.input.xkb_model` and
`awful.input.xkb_rules`. Fixes #518.

Cherry-picked from `0664f5e7` (sicelo's authorship preserved). The
`createkeyboardgroup()` chunk lives in `input.c` here, not `somewm.c`,
after the `6d88ee6c9` extraction; everything else applies identically.

## Test Plan
- `make test-unit`: 750/750 pass.
- `make build-test`: clean.
- No integration tests added; consistent with the existing
  `xkb_layout`/`variant`/`options` properties.

## Checklist
- [ ] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
    - `lua/awful/input.lua` and `lua/awful/ipc.lua` are somewm-specific modules with no AwesomeWM upstream equivalent
- [x] `make test-unit` passes