### PR TITLE
Support Lua 5.5

### DIFF
--- a/lua/awful/ipc.lua
+++ b/lua/awful/ipc.lua
@@ -2350,9 +2350,9 @@ local function register_builtin_commands()
     if not mod_str or mod_str == "" then return {} end
     local mods = {}
     for mod in mod_str:gmatch("[^+,]+") do
-      mod = mod:match("^%s*(.-)%s*$")  -- trim whitespace
-      if mod ~= "" then
-        table.insert(mods, mod)
+      local m = mod:match("^%s*(.-)%s*$")  -- trim whitespace
+      if m ~= "" then
+        table.insert(mods, m)
       end
     end
     return mods

--- a/lua/awful/layout/suit/fair.lua
+++ b/lua/awful/layout/suit/fair.lua
@@ -42,15 +42,15 @@ local function do_fair(p, orientation)
     end
 
     for k, c in ipairs(cls) do
-      k = k - 1
+      local i = k - 1
       local g = {}
 
       local row, col
-      row = k % rows
-      col = math.floor(k / rows)
+      row = i % rows
+      col = math.floor(i / rows)
 
       local lrows, lcols
-      if k >= rows * cols - rows then
+      if i >= rows * cols - rows then
         lrows = #cls - (rows * cols - rows)
         lcols = cols
       else

--- a/lua/naughty/dbus.lua
+++ b/lua/naughty/dbus.lua
@@ -319,8 +319,8 @@ function notif_methods.Notify(sender, object_path, interface, method, parameters
             end
 
             for k, v in pairs(args) do
-                if k == "destroy" then k = "destroy_cb" end
-                notification[k] = v
+                local key = k == "destroy" and "destroy_cb" or k
+                notification[key] = v
             end
 
             -- Update the icon if necessary.

--- a/lua/naughty/notification.lua
+++ b/lua/naughty/notification.lua
@@ -986,18 +986,19 @@ local function create(args)
 
         for idx, name in pairs(args.actions) do
             local cb, old_idx = nil, idx
+            local pos, label = idx, name
 
-            if type(name) == "function" then
-                cb = name
+            if type(label) == "function" then
+                cb = label
             end
 
-            if type(idx) == "string" then
-                name, idx = idx, #args.actions+1
+            if type(pos) == "string" then
+                label, pos = pos, #args.actions+1
             end
 
             local a = naction {
-                position = idx,
-                name     = name,
+                position = pos,
+                name     = label,
             }
 
             if cb then

--- a/somewm.c
+++ b/somewm.c
@@ -1626,12 +1626,9 @@ find_lgi_guard(void)
 	static char found[PATH_MAX];
 	const char *name = "/liblgi_closure_guard.so";
 
-	/* 1. Compiled-in libdir (fast path) */
-	snprintf(found, sizeof(found), "%s%s", SOMEWM_LIBDIR, name);
-	if (access(found, R_OK) == 0)
-		return found;
-
-	/* 2. Relative to the running binary (handles any prefix) */
+	/* 1. Relative to the running binary (handles any prefix, and ensures a
+	 * binary run from a build dir picks up its own matching guard instead
+	 * of a stale one left in the install prefix). */
 	char self[PATH_MAX];
 	ssize_t len = readlink("/proc/self/exe", self, sizeof(self) - 1);
 	if (len > 0) {
@@ -1651,6 +1648,11 @@ find_lgi_guard(void)
 			}
 		}
 	}
+
+	/* 2. Compiled-in libdir */
+	snprintf(found, sizeof(found), "%s%s", SOMEWM_LIBDIR, name);
+	if (access(found, R_OK) == 0)
+		return found;
 
 	/* 3. Common system paths */
 	const char *search[] = {


### PR DESCRIPTION
## Description

Make somewm's own code parse and run under Lua 5.5.

Lua 5.5 makes generic `for`-loop variables read-only. Four bundled modules
(`awful/ipc.lua`, `awful/layout/suit/fair.lua`, `naughty/dbus.lua`,
`naughty/notification.lua`) reassigned them, so the files no longer parsed.
Each now copies the loop variable into a mutable local.

`find_lgi_guard()` also searched the compiled-in libdir before the path
beside the running binary, so a binary run from a build directory could
preload a stale `liblgi_closure_guard.so` from the install prefix (for
example a luajit guard loaded into a Lua 5.5 process, which crashes on
startup). It now searches binary-relative first.

This is the somewm side only. Running somewm on Lua 5.5 end to end also
needs an lgi build that is 5.5-ready, which is an lgi-side concern. These
changes mean somewm itself is ready whenever that lands.

## Test Plan

- `luac5.5 -p` across the whole `lua/` tree: clean (4 files were failing before).
- `make build-test LUA_PKG=lua5.5`: builds clean against Lua 5.5.
- `make test-check`: 30/30.
- Integration suite (headless) on the Lua 5.5 build: 123/125. The 2 failures
  (`test-layer-shell-focus-escape`, `test-layer-shell-pointer-enter`) fail
  identically on the luajit build, so they are pre-existing headless-environment
  failures, not a regression from these changes.
- `make test-unit`: 750/750 (`run-unit.sh` runs busted under Lua 5.3).

## Checklist
- [ ] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
