### PR TITLE
fix(hotplug): bail out of createmon when output commit fails

### DIFF
--- a/monitor.c
+++ b/monitor.c
@@ -255,7 +255,17 @@ createmon(struct wl_listener *listener, void *data)
 	LISTEN(&wlr_output->events.request_state, &m->request_state, requestmonstate);
 
 	wlr_output_state_set_enabled(&state, 1);
-	wlr_output_commit_state(wlr_output, &state);
+	if (!wlr_output_commit_state(wlr_output, &state)) {
+		wlr_log(WLR_ERROR, "[HOTPLUG] createmon: %s commit FAILED, aborting",
+			wlr_output->name);
+		wlr_output_state_finish(&state);
+		wl_list_remove(&m->frame.link);
+		wl_list_remove(&m->destroy.link);
+		wl_list_remove(&m->request_state.link);
+		wlr_output->data = NULL;
+		free(m);
+		return;
+	}
 	wlr_output_state_finish(&state);
 
 	wl_list_insert(&mons, &m->link);
@@ -409,6 +419,11 @@ outputmgrapplyortest(struct wlr_output_configuration_v1 *config, int test)
 		struct wlr_output *wlr_output = config_head->state.output;
 		Monitor *m = wlr_output->data;
 		struct wlr_output_state state;
+
+		/* Orphan output: createmon bailed (commit or render init failed).
+		 * Skip; there is no Monitor to reconfigure. */
+		if (!m)
+			continue;
 
 		/* Ensure displays previously disabled by wlr-output-power-management-v1
 		 * are properly handled*/


### PR DESCRIPTION
## Description

Forward-port of #557 to `main`. The 2.0 C-reorg moved this code from
`somewm.c` to `monitor.c`, so #557 does not cherry-pick; this is the
same fix applied by hand.

`main` has the identical bug: when `wlr_output_commit_state` fails on a
hotplugged output, `createmon` ignores the return value and adds the
disabled output to the layout anyway, which re-enters `updatemons` via
`layout::change` and causes a use-after-free. `outputmgrapplyortest`
also dereferenced `wlr_output->data` with no NULL check for the
resulting orphan output.

Bails on commit failure in `createmon` and NULL-guards
`outputmgrapplyortest`.

Same root cause as #531 (filed against release/1.4).

## Test Plan

- `make build-test`: clean compile.
- `make test-unit`: 750 passing.
- `make test-integration`: 125 passing. The 13 `test-xwayland-*`
  failures are a pre-existing environment limitation (no X display in
  the test shell) and reproduce identically on clean `main`.

The commit-failure path can't be exercised by the headless or nested
test backends, which always commit successfully; it needs a real DRM
modeset rejection. This PR is a hand-applied mirror of the reviewed
#557 change.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)