### PR TITLE
build: default to release build without sanitizers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,15 @@
 
 .PHONY: all install uninstall clean setup reconfigure test test-unit test-check test-integration test-orchestrator test-asan test-one test-visual test-one-visual test-ci test-fast build-test build-bench bench-run bench-run-live bench-flamegraph bench-diff bench-heaptrack
 
-# Default build: WITH ASAN for development
+# Default build: optimized release, no sanitizers
 all:
-	@test -d build || meson setup build -Db_sanitize=address,undefined $(if $(LUA_PKG),-Dlua_pkg=$(LUA_PKG),) $(MESON_OPTS)
+	@test -d build || meson setup build -Dbuildtype=release -Db_sanitize=none $(if $(LUA_PKG),-Dlua_pkg=$(LUA_PKG),) $(MESON_OPTS)
 	ninja -C build
 
-# Alias for clarity
-asan: all
+# AddressSanitizer + UBSan build (separate dir, for development)
+asan:
+	@test -d build-asan || meson setup build-asan -Db_sanitize=address,undefined $(if $(LUA_PKG),-Dlua_pkg=$(LUA_PKG),) $(MESON_OPTS)
+	ninja -C build-asan
 
 # Build for tests: NO ASAN (fast) - explicitly disable sanitizers, enable test PAM stub
 build-test:
@@ -31,7 +33,7 @@ uninstall:
 	ninja -C build uninstall
 
 clean:
-	rm -rf build build-test
+	rm -rf build build-test build-asan
 
 # Just setup (useful for IDE integration)
 setup:
@@ -67,8 +69,8 @@ test-integration: build-test
 	@SOMEWM=./build-test/somewm SOMEWM_CLIENT=./build-test/somewm-client ./tests/run-integration.sh
 
 # Integration tests with ASAN (slower, catches memory bugs)
-test-asan: all
-	@SOMEWM=./build/somewm SOMEWM_CLIENT=./build/somewm-client ./tests/run-integration.sh
+test-asan: asan
+	@SOMEWM=./build-asan/somewm SOMEWM_CLIENT=./build-asan/somewm-client ./tests/run-integration.sh
 
 # CI mode: headless (for automated testing environments)
 test-ci: build-test test-unit

--- a/test_orchestrator.c
+++ b/test_orchestrator.c
@@ -222,7 +222,13 @@ info_read_field(const char *state_dir, const char *key, char *out, size_t cap)
 			size_t len = strlen(line);
 			if (len && line[len - 1] == '\n')
 				line[len - 1] = '\0';
-			snprintf(out, cap, "%s", line + klen + 1);
+			/* value is intentionally truncated to fit `out` */
+			const char *val = line + klen + 1;
+			size_t n = strlen(val);
+			if (n >= cap)
+				n = cap - 1;
+			memcpy(out, val, n);
+			out[n] = '\0';
 			found = 0;
 			break;
 		}
@@ -285,7 +291,11 @@ try_connect_socket(const char *sock_path)
 		return -1;
 	struct sockaddr_un addr = {0};
 	addr.sun_family = AF_UNIX;
-	snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", sock_path);
+	if ((size_t)snprintf(addr.sun_path, sizeof(addr.sun_path), "%s",
+	                     sock_path) >= sizeof(addr.sun_path)) {
+		close(s);
+		return -1;
+	}
 	if (connect(s, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
 		close(s);
 		return -1;
@@ -509,7 +519,7 @@ test_stop_named(const char *name)
 		return 6;
 	}
 	pid_t pid = read_pidfile(state_dir);
-	char sock_path[PATH_MAX];
+	char sock_path[PATH_MAX + 16];
 	socket_path_for(state_dir, sock_path, sizeof(sock_path));
 	if (pid > 0 && pid_alive(pid)) {
 		if (kill_and_wait(pid, sock_path) < 0) {
@@ -816,7 +826,7 @@ load_instance_summary(const char *name, struct instance_summary *out)
 	if (info_read_field(state_dir, "config_path", out->config,
 	                    sizeof(out->config)) < 0)
 		out->config[0] = '\0';
-	char sock_path[PATH_MAX];
+	char sock_path[PATH_MAX + 16];
 	socket_path_for(state_dir, sock_path, sizeof(sock_path));
 	int s = try_connect_socket(sock_path);
 	out->alive = (s >= 0);


### PR DESCRIPTION
## Description

The default `make` configured the build with AddressSanitizer + UBSan, so anyone building somewm from source ran an instrumented binary as their everyday compositor. This makes the default an optimized release build (`-Db_sanitize=none`) and moves the sanitizers to a `make asan` target that builds into `build-asan/`.

Building at release optimization surfaced three latent `-Wformat-truncation` errors in `test_orchestrator.c` that the old `-O0` ASAN default never triggered; fixed in place.

Side benefit: idle RSS drops ~150M.

## Test Plan

- `make` produces a no-sanitizer binary; `make asan` produces the instrumented one in `build-asan/`.
- `make test-unit`: 768 pass, 0 fail.
- `make test-orchestrator`: 15/15 pass.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified**
- [x] Tests pass