### PR TITLE
fix(permissions): guard nil transient_for.screen in request::tag

### DIFF
--- a/lua/awful/permissions/init.lua
+++ b/lua/awful/permissions/init.lua
@@ -316,10 +316,23 @@ function permissions.tag(c, t, hints) --luacheck: no unused
 
     if not t then
         if c.transient_for and not (hints and hints.reason == "screen") then
+            -- transient_for.screen can be nil while the parent is still being
+            -- managed (notably during hot-reload re-management). Capture the
+            -- fallback BEFORE c.screen is reassigned (the assignment would
+            -- otherwise clobber the client's own screen), then guard every
+            -- index. Indexing transient_for.screen unconditionally crashes
+            -- the request::tag handler.
+            local fallback_screen = c.transient_for.screen or c.screen
             c.screen = c.transient_for.screen
             if not c.sticky then
                 local tags = c.transient_for:tags()
-                c:tags(#tags > 0 and tags or c.transient_for.screen.selected_tags)
+                if #tags > 0 then
+                    c:tags(tags)
+                elseif fallback_screen then
+                    c:tags(fallback_screen.selected_tags)
+                else
+                    c:to_selected_tags()
+                end
             end
         else
             c:to_selected_tags()

--- a/spec/awful/permissions_spec.lua
+++ b/spec/awful/permissions_spec.lua
@@ -58,4 +58,60 @@ describe("awful.permissions.client_geometry_requests", function()
     end)
 end)
 
+describe("awful.permissions.tag", function()
+    package.loaded["awful.client"] = {}
+    package.loaded["awful.layout"] = {}
+    package.loaded["awful.screen"] = {}
+    package.loaded["awful.tag"] = {}
+    package.loaded["gears.timer"] = {}
+    _G.client = {
+        connect_signal = function() end,
+        get = function() return {} end,
+    }
+    _G.screen = { connect_signal = function() end }
+    _G.tag = { connect_signal = function() end }
+    _G.awesome = {
+        api_level      = 4,
+        connect_signal = function() end,
+    }
+    _G.drawin = {
+        set_index_miss_handler    = function() end,
+        set_newindex_miss_handler = function() end,
+    }
+
+    local permissions = require("awful.permissions")
+
+    -- Regression for issue #575: a transient client requests a tag while
+    -- its parent (transient_for) has no screen assigned yet and no tags.
+    -- The handler must not dereference the parent's nil screen.
+    it("falls back instead of crashing when transient_for.screen is nil", function()
+        local parent = { screen = nil, sticky = false }
+        function parent:tags() return {} end
+
+        local fellback = false
+        local c = { screen = nil, sticky = false, transient_for = parent }
+        function c:tags() return {} end
+        function c:to_selected_tags() fellback = true end
+
+        assert.has_no.errors(function()
+            permissions.tag(c, nil, {})
+        end)
+        assert.is_true(fellback)
+    end)
+
+    it("inherits the parent's tags when the parent has them", function()
+        local parent_tags = { {}, {} }
+        local parent = { screen = nil, sticky = false }
+        function parent:tags() return parent_tags end
+
+        local applied
+        local c = { screen = nil, sticky = false, transient_for = parent }
+        function c:tags(t) if t then applied = t end return {} end
+        function c:to_selected_tags() end
+
+        permissions.tag(c, nil, {})
+        assert.are.equal(parent_tags, applied)
+    end)
+end)
+
 -- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
## Description

`permissions.tag` crashes ("attempt to index field 'screen'") when a transient's parent has no screen and no tags. #558 fixed the hot-reload trigger; the Lua handler is still unguarded for other paths. Restores raven2cz's nil-safe fallback. Complements #558.

Fixes #575

## Test Plan

New `permissions_spec` case (red without the guard, green with it). `make test-unit` + transient/tag-persistence integration tests pass.

## Checklist
- [x] Lua modified intentionally (2.0: `lua/` is ours; #558 doesn't cover this handler)
- [x] Tests pass