### PR TITLE
build: handle GLib 2.88 lgi enum-class break

### DIFF
--- a/lgi-check.c
+++ b/lgi-check.c
@@ -22,17 +22,25 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-const char commands[] =
+/* Phase 1: is lgi installed / requireable at all? A failure here means lgi
+ * is genuinely missing. */
+const char probe_lgi[] =
 "pcall(require, 'luarocks.loader')\n"
 "local lua_version = jit and jit.version or _VERSION\n"
 "print(string.format('Building for %s', lua_version))\n"
-"local ok, lgi = pcall(require, 'lgi')\n"
-"if not ok then\n"
-"    error('lgi module not found: ' .. tostring(lgi))\n"
-"end\n"
+"assert(require('lgi'))\n"
+;
+
+/* Phase 2: lgi loads, so it is installed. Is it new enough and are the
+ * namespaces somewm uses actually usable? Touching a namespace makes lgi
+ * build its enums, which is where a GLib/gobject-introspection version skew
+ * throws (lgi's own ffi.lua / core.record.fromarray). A failure here means
+ * lgi is present but unusable, not missing. */
+const char commands[] =
+"local lgi = require('lgi')\n"
 "local lgi_version = require('lgi.version')\n"
 "print(string.format('Found lgi %s', lgi_version))\n"
-"_, _, major_minor, patch = string.find(lgi_version, '^(%d%.%d)%.(%d)')\n"
+"local _, _, major_minor, patch = string.find(lgi_version, '^(%d%.%d)%.(%d)')\n"
 "if tonumber(major_minor) < 0.8 or (tonumber(major_minor) == 0.8 and tonumber(patch) < 0) then\n"
 "    error(string.format('lgi is too old, need at least version %s, got %s.',\n"
 "        '0.8.0', lgi_version))\n"
@@ -46,23 +54,25 @@ const char commands[] =
 "print('LGI check passed!')\n"
 ;
 
-int main(void)
+/* Print guidance for a failed check and decide the exit code. When installed
+ * is false lgi could not be required (missing); when true lgi is present but a
+ * version/namespace check failed (usually a packaging mismatch). Returns the
+ * process exit code, honoring SOMEWM_IGNORE_LGI. */
+static int fail(lua_State *L, int installed)
 {
-    int result = 0;
     const char *env = "SOMEWM_IGNORE_LGI";
-    lua_State *L = luaL_newstate();
-    luaL_openlibs(L);
+    const char *err = lua_tostring(L, -1);
 
-    if (luaL_dostring(L, commands))
+    fprintf(stderr, "\n");
+    fprintf(stderr, "ERROR: %s\n", err);
+    fprintf(stderr, "\n");
+    fprintf(stderr, "========================================\n");
+    fprintf(stderr, "         LGI CHECK FAILED\n");
+    fprintf(stderr, "========================================\n");
+    fprintf(stderr, "\n");
+
+    if (!installed)
     {
-        const char *err = lua_tostring(L, -1);
-        fprintf(stderr, "\n");
-        fprintf(stderr, "ERROR: %s\n", err);
-        fprintf(stderr, "\n");
-        fprintf(stderr, "========================================\n");
-        fprintf(stderr, "         LGI CHECK FAILED\n");
-        fprintf(stderr, "========================================\n");
-        fprintf(stderr, "\n");
         fprintf(stderr, "somewm requires the lgi (Lua GObject Introspection) library.\n");
         fprintf(stderr, "You must install the lgi package that matches your Lua version.\n");
         fprintf(stderr, "\n");
@@ -91,12 +101,44 @@ int main(void)
         fprintf(stderr, "\n");
         fprintf(stderr, "To skip this check (not recommended), set %s=1\n", env);
         fprintf(stderr, "\n");
-
-        if (getenv(env) == NULL)
-            result = 1;
-        else
-            fprintf(stderr, "Continuing anyway due to %s=1\n", env);
     }
+    else
+    {
+        fprintf(stderr, "lgi is installed, but somewm could not load the GObject\n");
+        fprintf(stderr, "namespaces it needs (see the error above).\n");
+        fprintf(stderr, "\n");
+        fprintf(stderr, "If that error mentions 'fromarray' / 'lgi.record expected,\n");
+        fprintf(stderr, "got table', your lgi predates GLib 2.88's enum-class change\n");
+        fprintf(stderr, "and needs the upstream fix (lgi-devs/lgi#352, not yet\n");
+        fprintf(stderr, "released). Any lgi without that patch breaks on GLib >= 2.88.\n");
+        fprintf(stderr, "This is not a somewm bug.\n");
+        fprintf(stderr, "\n");
+        fprintf(stderr, "Update lgi to a build that includes the fix, or pin\n");
+        fprintf(stderr, "GLib < 2.88 until your distro ships it.\n");
+        fprintf(stderr, "\n");
+        fprintf(stderr, "Setting %s=1 lets the build finish, but lgi will fail the\n", env);
+        fprintf(stderr, "same way when somewm loads your config.\n");
+        fprintf(stderr, "\n");
+    }
+
+    if (getenv(env) != NULL)
+    {
+        fprintf(stderr, "Continuing anyway due to %s=1\n", env);
+        return 0;
+    }
+    return 1;
+}
+
+int main(void)
+{
+    int result = 0;
+    lua_State *L = luaL_newstate();
+    luaL_openlibs(L);
+
+    if (luaL_dostring(L, probe_lgi))
+        result = fail(L, 0);
+    else if (luaL_dostring(L, commands))
+        result = fail(L, 1);
 
     lua_close(L);
     return result;

--- a/lgi-glib-2.88-enum.patch
+++ b/lgi-glib-2.88-enum.patch
@@ -1,0 +1,31 @@
+diff --git a/lgi/ffi.lua b/lgi/ffi.lua
+index b382a97e..f1aa61d1 100644
+--- a/lgi/ffi.lua
++++ b/lgi/ffi.lua
+@@ -75,16 +75,22 @@ end
+ 
+ -- Creates new enum/flags table with all values from specified gtype.
+ function ffi.load_enum(gtype, name)
+-   local GObject = core.repo.GObject
++   local GLib, GObject = core.repo.GLib, core.repo.GObject
+    local is_flags = GObject.Type.is_a(gtype, GObject.Type.FLAGS)
+    local enum_component = component.create(
+       gtype, is_flags and enum.bitflags_mt or enum.enum_mt, name)
+    local type_class = GObject.TypeClass.ref(gtype)
+    local enum_class = core.record.cast(
+       type_class, is_flags and GObject.FlagsClass or GObject.EnumClass)
+-   for i = 0, enum_class.n_values - 1 do
+-      local val = core.record.fromarray(enum_class.values, i)
+-      enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
++   if GLib.check_version(2, 87, 0) then
++      for i = 0, enum_class.n_values - 1 do
++         local val = core.record.fromarray(enum_class.values, i)
++         enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
++      end
++   else
++      for _, val in ipairs(enum_class.values) do
++         enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
++      end
+    end
+    type_class:unref()
+    return enum_component

--- a/meson.build
+++ b/meson.build
@@ -95,12 +95,9 @@ endif
 # This approach only requires the Lua library, not the interpreter executable
 lgi_check_result = cc.run(files('lgi-check.c'), dependencies: [lua_dep], name: 'LGI check')
 if lgi_check_result.returncode() != 0
-  error('LGI (Lua GObject Introspection) not found for ' + lua_dep.name() + '.\n' +
-        lgi_check_result.stderr() + '\n' +
-        'Install the matching lgi package:\n' +
-        '  Arch Linux: sudo pacman -S lua-lgi (Lua 5.4) or lua51-lgi (LuaJIT)\n' +
-        '  Debian/Ubuntu: sudo apt install lua-lgi\n' +
-        '  Fedora: sudo dnf install lua-lgi')
+  # lgi-check.c already prints category-specific guidance (missing vs installed
+  # but unusable); surface it as-is rather than re-asserting "not found".
+  error('lgi check failed:\n\n' + lgi_check_result.stderr())
 endif
 # Parse lgi version from output (format: "Found lgi X.Y.Z")
 lgi_output = lgi_check_result.stdout().strip()

--- a/package.nix
+++ b/package.nix
@@ -39,7 +39,13 @@ let
     ps:
     with ps;
     [
-      lgi
+      # nixpkgs lgi does not yet carry the fix for GLib 2.88's enum-class
+      # introspection change (lgi-devs/lgi#352), so loading any namespace with
+      # enums crashes ("lgi.record expected, got table"). Patch it here until
+      # the fix is released / lands in nixpkgs. No-op on GLib < 2.87.
+      (lgi.overrideAttrs (old: {
+        patches = (old.patches or [ ]) ++ [ ./lgi-glib-2.88-enum.patch ];
+      }))
       ldbus
     ]
     ++ (extraLuaPackages ps)


### PR DESCRIPTION
## Description
On GLib 2.88, an lgi without the upstream fix (lgi-devs/lgi#352) crashes in `core.record.fromarray`, but somewm's build check reported this as "lgi not installed" and told users to reinstall a package that was already there. This splits the check so it tells a missing lgi apart from an installed-but-broken one, and vendors the lgi#352 patch in `package.nix` so the Nix flake builds on current nixpkgs. Fixes #588.

## Test Plan
- `make` and `make test-unit` (752 passing) are green.
- Ran `lgi-check.c` standalone across all paths: healthy lgi passes; missing lgi shows the install message; a GLib-2.88-broken lgi shows the new "installed but unusable" message; `SOMEWM_IGNORE_LGI=1` is honored in both failure cases.
- Confirmed the vendored patch applies to lgi 0.9.2 and yields valid Lua (a full `nix build` was not run here — no nix daemon on this box).

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)
