### PR TITLE
feat: Add client icon support for 256x256 sizes & drop scalable support

### DIFF
--- a/lua/menubar/utils.lua
+++ b/lua/menubar/utils.lua
@@ -115,7 +115,8 @@ do
 end
 
 local all_icon_sizes = {
-    'scalable',
+    -- 'scalable', -- There is no Pixbuf loader for SVG shipped with someWM
+    '256x256',
     '128x128',
     '96x96',
     '72x72',


### PR DESCRIPTION
## Description
This adds support for bigger sizes in client icons, this fixes the issue that I have with my icons. It appears some of my applications only provide 256px icons.

Also, this disables `scalable` icons as they cannot be handled by GdkPixbuf, it would need the SVG loader to do so. I could implement a check for it at runtime if it happens to be an issue with the nixpkg.

## Test Plan
Opened a session to see the icons on my wibar being displayed, tested with helium and kitty which used to not show up.


## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)
