### PR TITLE
feat(cli): add -c NONE to skip user config

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -2574,10 +2574,19 @@ static int num_extra_search_paths = 0;
 
 /* Custom config file path - set via -c/--config flag */
 static const char *custom_confpath = NULL;
+/* Set when user passed -c NONE / --config NONE: skip user config search and
+ * load only the bundled default somewmrc.lua (akin to `nvim -u NONE`). */
+static bool force_default_config = false;
 
 void
 luaA_set_confpath(const char *path)
 {
+	if (path && strcmp(path, "NONE") == 0) {
+		force_default_config = true;
+		custom_confpath = NULL;
+		return;
+	}
+	force_default_config = false;
 	custom_confpath = path;
 }
 
@@ -4305,6 +4314,12 @@ luaA_loadrc(void)
 	/* If custom config path was specified via -c flag, use only that */
 	if (custom_confpath) {
 		config_paths[path_count++] = custom_confpath;
+		config_paths[path_count] = NULL;
+	} else if (force_default_config) {
+		/* -c NONE: skip user config entirely, load only the bundled default.
+		 * Mirrors `nvim -u NONE` for quick "is it my config?" debugging. */
+		config_paths[path_count++] = DATADIR "/somewm/somewmrc.lua";
+		config_paths[path_count++] = "./somewmrc.lua";  /* dev fallback */
 		config_paths[path_count] = NULL;
 	} else {
 		/* Build config search path following AwesomeWM pattern:

--- a/somewm.c
+++ b/somewm.c
@@ -7593,6 +7593,7 @@ usage:
 	    "      --verbose      Enable info-level logging (more output)\n"
 	    "  -d, --debug        Enable debug logging (maximum output)\n"
 	    "  -c, --config FILE  Use specified config file (AwesomeWM compatible)\n"
+	    "                     Pass NONE to skip user config and load the bundled default\n"
 	    "  -L, --search DIR   Add directory to Lua module search path\n"
 	    "  -s, --startup CMD  Run command after startup\n"
 	    "  -k, --check CONFIG       Check config for Wayland compatibility issues\n"


### PR DESCRIPTION
## Description
Adds a Neovim-style escape hatch (modeled on `nvim -u NONE`) for `-c` / `--config`. Passing `NONE` skips the entire user-config search (`~/.config/somewm/rc.lua`, `~/.config/awesome/rc.lua`, etc.) and loads only the bundled `DATADIR/somewm/somewmrc.lua`. Gives users an easy "is it my config or somewm?" bisection step without having to know where the package put the bundled rc.lua.

AwesomeWM has no equivalent; their `-c` is path-only, verified against `awesome.c` / `options.c` / `manpages/awesome.1.txt` on master. The sentinel is case-sensitive, so `-c none` (lowercase) continues to be treated as a literal path (matching Neovim semantics).

## Test Plan
- `make build-test` succeeds; `./build-test/somewm --help` shows the new line
- Manual headless smoke test (`WLR_BACKENDS=headless`) with a sentinel user `rc.lua` in a temp `$XDG_CONFIG_HOME`:
  - baseline (no `-c`): sentinel loads, proves wiring
  - `-c NONE`: sentinel **not** loaded, `awesome.conffile` resolves to the installed `/usr/local/share/somewm/somewmrc.lua`
  - `-c none` (lowercase): treated as literal path, fails with "no working Lua config found: tried: - none"
- `make test-integration` not run in this env (no `kitty` available locally)

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified**. If a bug surfaces in Lua, the fix belongs in C.
- [ ] Tests pass (`make test-unit && make test-integration`)