### PR TITLE
fix(input): stop titlebar hover from leaking pointer events to clients

### DIFF
--- a/input.c
+++ b/input.c
@@ -1008,14 +1008,12 @@ pointerfocus(Client *c, struct wlr_surface *surface, double sx, double sy,
 {
 	struct timespec now;
 
-	/* If surface is NULL but client exists, use client's main surface as fallback.
-	 * This happens when cursor is over titlebar/border (compositor-drawn, not a
-	 * wlr_surface). Without this fallback, pointer focus would be cleared and the
-	 * client wouldn't receive hover/scroll events. */
-	if (!surface && c && client_surface(c) && client_surface(c)->mapped) {
-		surface = client_surface(c);
-		cursor_to_client_coordinates(c, &sx, &sy);
-	}
+	/* A NULL surface means the cursor is over compositor-drawn chrome
+	 * (titlebar/border), not the client. Clear pointer focus so the client gets
+	 * wl_pointer.leave. Do NOT fall back to the client's main surface here: the
+	 * cursor is above the content, so translating it yields an in-bounds top-row
+	 * coordinate that leaks hover/clicks onto the client (issue: titlebar event
+	 * propagation). */
 	if (!surface) {
 		wlr_seat_pointer_notify_clear_focus(seat);
 		return;

--- a/meson.build
+++ b/meson.build
@@ -463,6 +463,17 @@ test_content_pattern_client = executable(
   install: false,
 )
 
+# Test XDG toplevel client that logs decoded wl_pointer events to a marker file.
+# Used by test-titlebar-pointer-leak.lua to assert no pointer events leak to the
+# client while the cursor is over its titlebar.
+test_pointer_logger = executable(
+  'test-pointer-logger',
+  ['tests/test-pointer-logger.c', xdg_shell_client_code],
+  xdg_shell_client_header,
+  dependencies: [wayland_client],
+  install: false,
+)
+
 # DMA-BUF test client (gbm + zwp_linux_dmabuf_v1) for the GPU readback path
 # in c.content. Used by test-client-content-dmabuf.lua. Only built when gbm
 # is available; the Lua test skips itself otherwise.

--- a/somewm.c
+++ b/somewm.c
@@ -548,9 +548,16 @@ reap_children(gint fd, GIOCondition condition, gpointer data)
 void
 cursor_to_client_coordinates(Client *client, double *sx, double *sy) {
 	double bw = client->bw;
-	/* Compute coordinates (sx, sy) within the borderd geometry. */
-	*sx = cursor->x - (client->geometry.x + bw);
-	*sy = cursor->y - (client->geometry.y + bw);
+	/* The content surface is positioned inside the frame at (bw + titlebar_left,
+	 * bw + titlebar_top) (see apply_geometry_to_wlroots), so content-local
+	 * coordinates must subtract the titlebars too, not just the border. Without
+	 * this the values stay positive over a titlebar and leak onto the client's
+	 * top content rows; with it they go negative there (= pointer not in content).
+	 * Fullscreen has no titlebars. */
+	int tl = client->fullscreen ? 0 : client->titlebar[CLIENT_TITLEBAR_LEFT].size;
+	int tt = client->fullscreen ? 0 : client->titlebar[CLIENT_TITLEBAR_TOP].size;
+	*sx = cursor->x - (client->geometry.x + bw + tl);
+	*sy = cursor->y - (client->geometry.y + bw + tt);
 }
 
 

--- a/tests/test-pointer-logger.c
+++ b/tests/test-pointer-logger.c
@@ -1,0 +1,319 @@
+/**
+ * test-pointer-logger - Minimal xdg_toplevel client that logs pointer events.
+ *
+ * Maps a normal toplevel (so the compositor gives it a titlebar) and appends a
+ * line to a marker file for every wl_pointer event it receives, with decoded
+ * surface-local coordinates:
+ *
+ *     enter <sx> <sy>
+ *     motion <sx> <sy>
+ *     leave
+ *
+ * Used by tests/test-titlebar-pointer-leak.lua (and ad-hoc) to assert that the
+ * client receives NO pointer events while the cursor is over its titlebar, and
+ * correct content-local coordinates while over its content.
+ *
+ * Usage: test-pointer-logger --app-id ID --marker PATH [--size WxH]
+ */
+
+#include <signal.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <wayland-client.h>
+#include "xdg-shell-client-protocol.h"
+
+static struct wl_display *g_display;
+static struct wl_registry *g_registry;
+static struct wl_compositor *g_compositor;
+static struct wl_shm *g_shm;
+static struct wl_seat *g_seat;
+static struct wl_pointer *g_pointer;
+static struct xdg_wm_base *g_xdg_wm_base;
+static struct wl_surface *g_surface;
+static struct xdg_surface *g_xdg_surface;
+static struct xdg_toplevel *g_toplevel;
+
+static bool g_running = true;
+static int g_width = 600, g_height = 400;
+
+static const char *g_app_id = "pointer_logger";
+static const char *g_marker = NULL;
+
+static void handle_signal(int sig) {
+    (void)sig;
+    g_running = false;
+}
+
+/* Append one decoded pointer event to the marker file. */
+static void log_event(const char *fmt, ...) {
+    if (!g_marker)
+        return;
+    FILE *f = fopen(g_marker, "a");
+    if (!f)
+        return;
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(f, fmt, ap);
+    va_end(ap);
+    fputc('\n', f);
+    fclose(f);
+}
+
+static struct wl_buffer *create_buffer(int w, int h) {
+    int stride = w * 4;
+    int size = stride * h;
+
+    char name[] = "/tmp/test-pointer-logger-XXXXXX";
+    int fd = mkstemp(name);
+    if (fd < 0) {
+        perror("mkstemp");
+        return NULL;
+    }
+    unlink(name);
+
+    if (ftruncate(fd, size) < 0) {
+        perror("ftruncate");
+        close(fd);
+        return NULL;
+    }
+
+    void *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (data == MAP_FAILED) {
+        perror("mmap");
+        close(fd);
+        return NULL;
+    }
+    memset(data, 0xC0, size); /* opaque-ish solid fill */
+    munmap(data, size);
+
+    struct wl_shm_pool *pool = wl_shm_create_pool(g_shm, fd, size);
+    struct wl_buffer *buffer = wl_shm_pool_create_buffer(
+        pool, 0, w, h, stride, WL_SHM_FORMAT_ARGB8888);
+    wl_shm_pool_destroy(pool);
+    close(fd);
+    return buffer;
+}
+
+/* Pointer */
+static void pointer_enter(void *data, struct wl_pointer *ptr, uint32_t serial,
+        struct wl_surface *surf, wl_fixed_t sx, wl_fixed_t sy) {
+    (void)data; (void)ptr; (void)serial; (void)surf;
+    log_event("enter %d %d", wl_fixed_to_int(sx), wl_fixed_to_int(sy));
+}
+
+static void pointer_leave(void *data, struct wl_pointer *ptr, uint32_t serial,
+        struct wl_surface *surf) {
+    (void)data; (void)ptr; (void)serial; (void)surf;
+    log_event("leave");
+}
+
+static void pointer_motion(void *data, struct wl_pointer *ptr, uint32_t time,
+        wl_fixed_t sx, wl_fixed_t sy) {
+    (void)data; (void)ptr; (void)time;
+    log_event("motion %d %d", wl_fixed_to_int(sx), wl_fixed_to_int(sy));
+}
+
+static void pointer_button(void *data, struct wl_pointer *ptr, uint32_t serial,
+        uint32_t time, uint32_t button, uint32_t state) {
+    (void)data; (void)ptr; (void)serial; (void)time;
+    log_event("button %u %u", button, state);
+}
+
+static void pointer_axis(void *data, struct wl_pointer *ptr, uint32_t time,
+        uint32_t axis, wl_fixed_t value) {
+    (void)data; (void)ptr; (void)time;
+    log_event("axis %u %d", axis, wl_fixed_to_int(value));
+}
+
+static void pointer_frame(void *data, struct wl_pointer *ptr) { (void)data; (void)ptr; }
+static void pointer_axis_source(void *data, struct wl_pointer *ptr, uint32_t s) { (void)data; (void)ptr; (void)s; }
+static void pointer_axis_stop(void *data, struct wl_pointer *ptr, uint32_t t, uint32_t a) { (void)data; (void)ptr; (void)t; (void)a; }
+static void pointer_axis_discrete(void *data, struct wl_pointer *ptr, uint32_t a, int32_t d) { (void)data; (void)ptr; (void)a; (void)d; }
+
+static const struct wl_pointer_listener pointer_listener = {
+    .enter = pointer_enter,
+    .leave = pointer_leave,
+    .motion = pointer_motion,
+    .button = pointer_button,
+    .axis = pointer_axis,
+    .frame = pointer_frame,
+    .axis_source = pointer_axis_source,
+    .axis_stop = pointer_axis_stop,
+    .axis_discrete = pointer_axis_discrete,
+};
+
+/* Seat */
+static void seat_capabilities(void *data, struct wl_seat *st, uint32_t caps) {
+    (void)data;
+    if ((caps & WL_SEAT_CAPABILITY_POINTER) && !g_pointer) {
+        g_pointer = wl_seat_get_pointer(st);
+        wl_pointer_add_listener(g_pointer, &pointer_listener, NULL);
+    }
+}
+
+static void seat_name(void *data, struct wl_seat *st, const char *name) {
+    (void)data; (void)st; (void)name;
+}
+
+static const struct wl_seat_listener seat_listener = {
+    .capabilities = seat_capabilities,
+    .name = seat_name,
+};
+
+/* xdg_surface / toplevel / wm_base */
+static void xdg_surface_configure(void *data, struct xdg_surface *xs, uint32_t serial) {
+    (void)data;
+    xdg_surface_ack_configure(xs, serial);
+    struct wl_buffer *buffer = create_buffer(g_width, g_height);
+    if (buffer) {
+        wl_surface_attach(g_surface, buffer, 0, 0);
+        wl_surface_damage_buffer(g_surface, 0, 0, g_width, g_height);
+        wl_surface_commit(g_surface);
+    }
+}
+
+static const struct xdg_surface_listener xdg_surface_listener = {
+    .configure = xdg_surface_configure,
+};
+
+static void toplevel_configure(void *data, struct xdg_toplevel *t,
+        int32_t w, int32_t h, struct wl_array *states) {
+    (void)data; (void)t; (void)states;
+    if (w > 0) g_width = w;
+    if (h > 0) g_height = h;
+}
+
+static void toplevel_close(void *data, struct xdg_toplevel *t) {
+    (void)data; (void)t;
+    g_running = false;
+}
+
+static void toplevel_configure_bounds(void *data, struct xdg_toplevel *t, int32_t w, int32_t h) {
+    (void)data; (void)t; (void)w; (void)h;
+}
+
+static void toplevel_wm_capabilities(void *data, struct xdg_toplevel *t, struct wl_array *caps) {
+    (void)data; (void)t; (void)caps;
+}
+
+static const struct xdg_toplevel_listener toplevel_listener = {
+    .configure = toplevel_configure,
+    .close = toplevel_close,
+    .configure_bounds = toplevel_configure_bounds,
+    .wm_capabilities = toplevel_wm_capabilities,
+};
+
+static void xdg_wm_base_ping(void *data, struct xdg_wm_base *wm_base, uint32_t serial) {
+    (void)data;
+    xdg_wm_base_pong(wm_base, serial);
+}
+
+static const struct xdg_wm_base_listener xdg_wm_base_listener = {
+    .ping = xdg_wm_base_ping,
+};
+
+/* Registry */
+static void registry_global(void *data, struct wl_registry *reg,
+        uint32_t name, const char *interface, uint32_t version) {
+    (void)data; (void)version;
+    if (strcmp(interface, wl_compositor_interface.name) == 0) {
+        g_compositor = wl_registry_bind(reg, name, &wl_compositor_interface, 4);
+    } else if (strcmp(interface, wl_shm_interface.name) == 0) {
+        g_shm = wl_registry_bind(reg, name, &wl_shm_interface, 1);
+    } else if (strcmp(interface, wl_seat_interface.name) == 0) {
+        g_seat = wl_registry_bind(reg, name, &wl_seat_interface, 5);
+        wl_seat_add_listener(g_seat, &seat_listener, NULL);
+    } else if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
+        g_xdg_wm_base = wl_registry_bind(reg, name, &xdg_wm_base_interface, 5);
+        xdg_wm_base_add_listener(g_xdg_wm_base, &xdg_wm_base_listener, NULL);
+    }
+}
+
+static void registry_global_remove(void *data, struct wl_registry *reg, uint32_t name) {
+    (void)data; (void)reg; (void)name;
+}
+
+static const struct wl_registry_listener registry_listener = {
+    .global = registry_global,
+    .global_remove = registry_global_remove,
+};
+
+static void print_usage(const char *prog) {
+    fprintf(stderr, "Usage: %s --app-id ID --marker PATH [--size WxH]\n", prog);
+}
+
+int main(int argc, char *argv[]) {
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--app-id") == 0 && i + 1 < argc) {
+            g_app_id = argv[++i];
+        } else if (strcmp(argv[i], "--marker") == 0 && i + 1 < argc) {
+            g_marker = argv[++i];
+        } else if (strcmp(argv[i], "--size") == 0 && i + 1 < argc) {
+            int w, h;
+            if (sscanf(argv[++i], "%dx%d", &w, &h) == 2 && w > 0 && h > 0) {
+                g_width = w;
+                g_height = h;
+            }
+        } else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+            print_usage(argv[0]);
+            return 0;
+        } else {
+            fprintf(stderr, "Unknown argument: %s\n", argv[i]);
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    signal(SIGTERM, handle_signal);
+    signal(SIGINT, handle_signal);
+
+    g_display = wl_display_connect(NULL);
+    if (!g_display) {
+        fprintf(stderr, "Failed to connect to Wayland display\n");
+        return 1;
+    }
+
+    g_registry = wl_display_get_registry(g_display);
+    wl_registry_add_listener(g_registry, &registry_listener, NULL);
+    wl_display_roundtrip(g_display);
+
+    if (!g_compositor || !g_shm || !g_xdg_wm_base) {
+        fprintf(stderr, "Missing required Wayland globals\n");
+        return 1;
+    }
+
+    g_surface = wl_compositor_create_surface(g_compositor);
+    g_xdg_surface = xdg_wm_base_get_xdg_surface(g_xdg_wm_base, g_surface);
+    xdg_surface_add_listener(g_xdg_surface, &xdg_surface_listener, NULL);
+    g_toplevel = xdg_surface_get_toplevel(g_xdg_surface);
+    xdg_toplevel_add_listener(g_toplevel, &toplevel_listener, NULL);
+    xdg_toplevel_set_app_id(g_toplevel, g_app_id);
+    xdg_toplevel_set_title(g_toplevel, "pointer-logger");
+
+    wl_surface_commit(g_surface);
+    wl_display_roundtrip(g_display);
+
+    fprintf(stderr, "[test-pointer-logger] running (app_id=%s, marker=%s)\n",
+        g_app_id, g_marker ? g_marker : "(none)");
+
+    while (g_running && wl_display_dispatch(g_display) != -1) {
+        /* keep running */
+    }
+
+    if (g_toplevel) xdg_toplevel_destroy(g_toplevel);
+    if (g_xdg_surface) xdg_surface_destroy(g_xdg_surface);
+    if (g_surface) wl_surface_destroy(g_surface);
+    if (g_pointer) wl_pointer_destroy(g_pointer);
+    if (g_seat) wl_seat_destroy(g_seat);
+    if (g_shm) wl_shm_destroy(g_shm);
+    if (g_compositor) wl_compositor_destroy(g_compositor);
+    if (g_xdg_wm_base) xdg_wm_base_destroy(g_xdg_wm_base);
+    if (g_registry) wl_registry_destroy(g_registry);
+    wl_display_disconnect(g_display);
+    return 0;
+}

--- a/tests/test-titlebar-pointer-leak.lua
+++ b/tests/test-titlebar-pointer-leak.lua
@@ -1,0 +1,159 @@
+---------------------------------------------------------------------------
+--- Regression test: titlebar event propagation (issue 593).
+---
+--- The compositor must NOT deliver pointer events to a client while the cursor
+--- is over the client's server-side titlebar. The bug delivered wl_pointer
+--- motion to the content surface with a coordinate that omitted the titlebar
+--- height, so a titlebar hover landed on the client's top content rows.
+---
+--- test-pointer-logger maps an xdg_toplevel and appends every wl_pointer event
+--- it receives (with decoded surface-local coords) to a marker file:
+---     enter <sx> <sy> / motion <sx> <sy> / leave
+--- We drive the cursor with mouse.coords + mouse._fake_motion and assert:
+---   1. over content: an enter/motion arrives with correct content-local coords
+---   2. over the titlebar (incl. the 1px-above-content band): NO enter/motion
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local async  = require("_async")
+local awful  = require("awful")
+
+local CLIENT  = "./build-test/test-pointer-logger"
+local APP_ID  = "tbptr_leak"
+local TB_SIZE = 24
+
+-- This test needs a real pointer device: it spawns a client and asserts on the
+-- wl_pointer events the client receives. The headless backend (CI) has no input
+-- device and never delivers pointer events, so skip there (run it headful).
+if os.getenv("WLR_BACKENDS") == "headless" then
+    io.stderr:write("SKIP: needs a real pointer device (headless backend has none)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local function file_exists(path)
+    local f = io.open(path, "r"); if not f then return false end
+    f:close(); return true
+end
+
+if not file_exists(CLIENT) then
+    io.stderr:write("SKIP: " .. CLIENT .. " not found (run meson compile first)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local marker = string.format("/tmp/somewm-tbptr-%d.log", os.time() * 1000 + math.random(0, 999))
+os.remove(marker)
+
+local function clear_marker()
+    local f = io.open(marker, "w"); if f then f:close() end
+end
+
+-- Parse the marker into a list of {kind=, x=, y=} events.
+local function read_events()
+    local f = io.open(marker, "r"); if not f then return {} end
+    local out = {}
+    for line in f:lines() do
+        local kind, x, y = line:match("^(%a+)%s*(%-?%d*)%s*(%-?%d*)$")
+        if kind then
+            out[#out + 1] = { kind = kind, x = tonumber(x), y = tonumber(y) }
+        end
+    end
+    f:close()
+    return out
+end
+
+-- Drive a real motion event through motionnotify at (x, y): warp there, then
+-- nudge +/-1px so motionnotify runs (mouse.coords alone does not).
+local function probe_at(x, y)
+    mouse.coords({ x = x, y = y })
+    mouse._fake_motion(1, 0)
+    mouse._fake_motion(-1, 0)
+end
+
+local spawn_pid
+
+runner.run_async(function()
+    spawn_pid = awful.spawn(string.format("%s --app-id %s --marker %s", CLIENT, APP_ID, marker))
+    assert(type(spawn_pid) == "number", "spawn returned: " .. tostring(spawn_pid))
+
+    local c = async.wait_for_client(APP_ID, 5)
+    assert(c, "pointer-logger client did not appear")
+
+    -- Float at a known box and give it a top titlebar of known size.
+    c.floating = true
+    async.sleep(0.05)
+    c:geometry({ x = 200, y = 200, width = 600, height = 400 })
+    awful.titlebar(c, { size = TB_SIZE, position = "top" })
+    async.sleep(0.2)
+
+    local g  = c:geometry()
+    local bw = c.border_width or 0
+    -- Content origin (top-left titlebars only in this test): geometry + bw + titlebar.
+    local ox = g.x + bw
+    local oy = g.y + bw + TB_SIZE
+    io.stderr:write(string.format("[TEST] geometry %dx%d+%d+%d bw=%d tb=%d -> content origin (%d,%d)\n",
+        g.width, g.height, g.x, g.y, bw, TB_SIZE, ox, oy))
+
+    -----------------------------------------------------------------------
+    -- 1. Over content: enter/motion delivered at correct content-local coords.
+    -----------------------------------------------------------------------
+    clear_marker()
+    local cx, cy = ox + 100, oy + 100   -- well inside content
+    probe_at(cx, cy)
+    async.sleep(0.2)
+
+    local ev = read_events()
+    local hit = nil
+    for _, e in ipairs(ev) do
+        if (e.kind == "enter" or e.kind == "motion") and e.x and e.y
+                and math.abs(e.x - (cx - ox)) <= 2 and math.abs(e.y - (cy - oy)) <= 2 then
+            hit = e
+            break
+        end
+    end
+    assert(hit, string.format(
+        "[1] content hover: expected enter/motion near (%d,%d), got: %s",
+        cx - ox, cy - oy, (function()
+            local s = {} for _, e in ipairs(ev) do s[#s + 1] = e.kind .. " " .. tostring(e.x) .. " " .. tostring(e.y) end
+            return "[" .. table.concat(s, " | ") .. "]"
+        end)()))
+    io.stderr:write(string.format("[TEST 1] PASS - content enter/motion at (%d,%d)\n", hit.x, hit.y))
+
+    -----------------------------------------------------------------------
+    -- 2. Over the titlebar (middle AND 1px-above-content band): NO leak.
+    --    The cursor is above the content, so the client must receive no
+    --    enter/motion - only possibly a leave.
+    -----------------------------------------------------------------------
+    local function assert_no_leak(label, ty)
+        clear_marker()
+        probe_at(ox + 100, ty)
+        async.sleep(0.2)
+        for _, e in ipairs(read_events()) do
+            assert(e.kind ~= "enter" and e.kind ~= "motion", string.format(
+                "[2:%s] LEAK: cursor over titlebar (y=%d) delivered %s %s %s to the client",
+                label, ty, e.kind, tostring(e.x), tostring(e.y)))
+        end
+        io.stderr:write(string.format("[TEST 2:%s] PASS - no pointer events over titlebar y=%d\n", label, ty))
+    end
+
+    -- Re-enter content first so a leave is the only legitimate event on crossing.
+    probe_at(ox + 100, oy + 100); async.sleep(0.1)
+    assert_no_leak("middle", g.y + bw + math.floor(TB_SIZE / 2))
+    probe_at(ox + 100, oy + 100); async.sleep(0.1)
+    assert_no_leak("bottom-band", g.y + bw + TB_SIZE - 1)  -- 1px above content (old leak zone)
+
+    -----------------------------------------------------------------------
+    io.stderr:write("[ALL TESTS] PASS\n")
+
+    -- Cleanup
+    if c.valid then c:kill() end
+    if spawn_pid then os.execute("kill -9 " .. spawn_pid .. " 2>/dev/null") end
+    async.wait_for_no_clients(5)
+    os.remove(marker)
+    runner.done()
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=90

--- a/window.c
+++ b/window.c
@@ -1142,17 +1142,27 @@ unset_fullscreen:
 
 	luaA_emit_signal_global("client::map");
 
-	/* If cursor is within this new client's geometry, set pointer focus directly.
+	/* If the cursor is over this new client's CONTENT, set pointer focus directly.
 	 * Don't use motionnotify(0,...) because xytonode may not find the surface yet
-	 * (buffer not committed) and would CLEAR pointer focus instead. */
-	if (client_surface(c) && client_surface(c)->mapped
-			&& cursor->x >= c->geometry.x && cursor->x < c->geometry.x + c->geometry.width
-			&& cursor->y >= c->geometry.y && cursor->y < c->geometry.y + c->geometry.height) {
-		double sx, sy;
-		cursor_to_client_coordinates(c, &sx, &sy);
-		wlr_log(WLR_DEBUG, "[POINTER-REEVAL] mapnotify: setting pointer focus on %s (cursor in geometry)",
-			client_get_appid(c));
-		pointerfocus(c, client_surface(c), sx, sy, 0);
+	 * (buffer not committed) and would CLEAR pointer focus instead.
+	 * Gate on the content rect (geometry inset by border + titlebars), not the
+	 * full geometry: granting focus while the cursor is over the titlebar would
+	 * deliver a bogus coordinate to the client (issue: titlebar event
+	 * propagation). Mirrors the surface inset in apply_geometry_to_wlroots(). */
+	if (client_surface(c) && client_surface(c)->mapped) {
+		int tl = c->fullscreen ? 0 : c->titlebar[CLIENT_TITLEBAR_LEFT].size;
+		int tt = c->fullscreen ? 0 : c->titlebar[CLIENT_TITLEBAR_TOP].size;
+		int tr = c->fullscreen ? 0 : c->titlebar[CLIENT_TITLEBAR_RIGHT].size;
+		int tb = c->fullscreen ? 0 : c->titlebar[CLIENT_TITLEBAR_BOTTOM].size;
+		int x0 = c->geometry.x + (int)c->bw + tl;
+		int y0 = c->geometry.y + (int)c->bw + tt;
+		int x1 = c->geometry.x + c->geometry.width  - (int)c->bw - tr;
+		int y1 = c->geometry.y + c->geometry.height - (int)c->bw - tb;
+		if (cursor->x >= x0 && cursor->x < x1 && cursor->y >= y0 && cursor->y < y1) {
+			double sx, sy;
+			cursor_to_client_coordinates(c, &sx, &sy);
+			pointerfocus(c, client_surface(c), sx, sy, 0);
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

Hovering a server-side titlebar leaked pointer events to the client underneath, so browser tabs reacted to a hover that was actually on the titlebar (seen on Helium and LibreOffice). Fixes #593.

The titlebar is the compositor's, not the client's, so a cursor on it should give the client a pointer-leave. Instead the code kept the client focused and sent it motion at a coordinate that subtracted the border width but not the titlebar height, so the hover landed on the client's top content rows. The fix clears pointer focus over the titlebar, makes `cursor_to_client_coordinates()` titlebar-aware (which also corrects the drag and map-time paths that share it), and gates focus-on-map on the content rectangle.

## Test Plan

- New `test-titlebar-pointer-leak.lua` (with `test-pointer-logger`, a client that records the pointer events it receives): asserts no pointer events over the titlebar and correct content-local coordinates over content. Fails pre-fix, passes after. Skips on the headless CI backend (needs a real pointer device); runs in the headful suite.
- Verified live: hovering the titlebar delivers zero pointer events to the client; content hover delivers correct coordinates.
- `make test-integration` passes; `make test-unit` passes in CI (one menubar icon-path test fails only in my local environment, unrelated).

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
