### PR TITLE
fix(client): defer client flush out of map signal emit

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -933,13 +933,17 @@ rebuild_keyboard_keymap(void)
 	some_rebuild_keyboard_keymap();
 }
 
-/** awesome.sync() - Synchronize with the compositor */
+/** awesome.sync() - Flush pending events to clients.
+ * Deferred to an idle source (see schedule_flush_clients) so it is safe to call
+ * from inside a signal handler. Best-effort: some_glib_poll() flushes every
+ * client before each g_poll, so pending data leaves the compositor before it
+ * next blocks, not synchronously on return. */
 static int
 luaA_awesome_sync(lua_State *L)
 {
 	struct wl_display *display = some_get_display();
 	if (display) {
-		wl_display_flush_clients(display);
+		schedule_flush_clients(display);
 	}
 	return 0;
 }

--- a/meson.build
+++ b/meson.build
@@ -451,6 +451,16 @@ test_fullscreen_client = executable(
   install: false,
 )
 
+# Test client that disconnects right after the mapping commit. Reproducer for
+# the wl_display_flush_clients re-entrance crash inside mapnotify.
+test_disconnect_mid_map_client = executable(
+  'test-disconnect-mid-map-client',
+  ['tests/test-disconnect-mid-map-client.c', xdg_shell_client_code],
+  xdg_shell_client_header,
+  dependencies: [wayland_client],
+  install: false,
+)
+
 # Test XDG client that renders a 4-quadrant pattern at the preferred buffer
 # scale, used by test-client-content-pattern.lua to verify HiDPI c.content.
 test_content_pattern_client = executable(

--- a/somewm.c
+++ b/somewm.c
@@ -3640,6 +3640,33 @@ cursor_to_client_coordinates(Client *client, double *sx, double *sy) {
 	*sy = cursor->y - (client->geometry.y + bw + tt);
 }
 
+static struct wl_event_source *pending_flush_source;
+
+static void
+flush_clients_idle(void *data)
+{
+	struct wl_display *display = data;
+	pending_flush_source = NULL;
+	wl_display_flush_clients(display);
+}
+
+/* Defer the flush out of the signal-emit stack. Flushing synchronously from
+ * mapnotify can re-enter wl_client_destroy() for a hung-up peer and tear down
+ * the surface whose events.map signal is still being emitted (issue #530).
+ * Repeated calls in one dispatch cycle coalesce into a single idle source.
+ * Delivery timing is preserved by some_glib_poll(), which flushes every client
+ * before each g_poll, so the configure still ships before the client composites
+ * a frame at the old geometry; the idle is a backstop that fires at the end of
+ * the next wl_event_loop_dispatch. */
+void
+schedule_flush_clients(struct wl_display *display)
+{
+	if (pending_flush_source != NULL)
+		return;
+	struct wl_event_loop *loop = wl_display_get_event_loop(display);
+	pending_flush_source = wl_event_loop_add_idle(loop, flush_clients_idle, display);
+}
+
 void
 mapnotify(struct wl_listener *listener, void *data)
 {
@@ -3827,11 +3854,11 @@ mapnotify(struct wl_listener *listener, void *data)
 		/* Apply geometry BEFORE enabling scene node to send configure event.
 		 * Fixes Firefox tiling issue (#10).
 		 * Reset c->resize to force re-send configure even if setmon()->resize()
-		 * already sent one (unflushed). This ensures the configure is flushed
-		 * before we enable the scene node. */
+		 * already sent one (unflushed). The flush is deferred (see
+		 * schedule_flush_clients). */
 		c->resize = 0;
 		apply_geometry_to_wlroots(c);
-		wl_display_flush_clients(dpy);
+		schedule_flush_clients(dpy);
 
 		/* Enable scene node for transient client */
 		if (client_on_selected_tags(c)) {
@@ -3961,10 +3988,10 @@ mapnotify(struct wl_listener *listener, void *data)
 		c->resize = 0;
 		apply_geometry_to_wlroots(c);
 
-		/* Flush configure event to client immediately so it receives the tiled
-		 * geometry before we make it visible. Without this, the configure is
-		 * queued but not sent until the next poll cycle. */
-		wl_display_flush_clients(dpy);
+		/* Flush configure event to client so it receives the tiled geometry
+		 * before we make it visible. The flush is deferred (see
+		 * schedule_flush_clients). */
+		schedule_flush_clients(dpy);
 
 		/* Enable scene node for new client if on selected tags (Wayland-specific).
 		 * Unlike AwesomeWM, we don't call arrange() here - that's triggered by Lua signals.

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -206,6 +206,10 @@ struct wlr_layer_shell_v1 *some_get_layer_shell(void);
 struct wlr_renderer *some_get_renderer(void);
 struct wlr_allocator *some_get_allocator(void);
 
+/* Defer wl_display_flush_clients() to an idle source (see somewm.c). Safe to
+ * call from inside a wlroots signal emit; coalesces within a dispatch cycle. */
+void schedule_flush_clients(struct wl_display *display);
+
 /*
  * XKB Keyboard Layout API
  * AwesomeWM-compatible keyboard layout switching and querying

--- a/tests/test-disconnect-mid-map-client.c
+++ b/tests/test-disconnect-mid-map-client.c
@@ -1,0 +1,204 @@
+/**
+ * test-disconnect-mid-map-client - XDG client that disconnects right after the
+ * mapping commit. Used to reproduce the wl_display_flush_clients re-entrance
+ * crash inside mapnotify (somewm.c).
+ *
+ * Sequence:
+ *   1. Connect, bind compositor + shm + xdg_wm_base.
+ *   2. Create xdg_surface + xdg_toplevel.
+ *   3. Initial commit, wait for configure, ack.
+ *   4. Attach a real SHM buffer and commit (mapping commit).
+ *   5. Flush, then close the wl_display fd and _exit(0) without dispatching
+ *      any further events. The compositor sees the EOF on the next poll
+ *      and tears the client down. If the tear-down lands while the
+ *      surface->events.map signal is still being emitted (mapnotify on the
+ *      stack), wlroots aborts on
+ *        assert(wl_list_empty(&surface->events.map.listener_list))
+ *      in types/wlr_compositor.c:735.
+ *
+ * The race is timing-sensitive but reliably hit when the client is launched
+ * many times in quick succession against a compositor that is otherwise idle.
+ */
+
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <wayland-client.h>
+#include "xdg-shell-client-protocol.h"
+
+static struct wl_display *g_display;
+static struct wl_compositor *g_compositor;
+static struct wl_shm *g_shm;
+static struct xdg_wm_base *g_xdg_wm_base;
+
+static struct wl_surface *g_surface;
+static struct xdg_surface *g_xdg_surface;
+static struct xdg_toplevel *g_toplevel;
+
+static int g_configured = 0;
+static uint32_t g_width = 64, g_height = 64;
+
+static struct wl_buffer *
+create_buffer(uint32_t w, uint32_t h)
+{
+	int stride = w * 4;
+	int size = stride * h;
+
+	char tmpl[] = "/tmp/test-disconnect-shm-XXXXXX";
+	int fd = mkstemp(tmpl);
+	if (fd < 0)
+		return NULL;
+	unlink(tmpl);
+
+	if (ftruncate(fd, size) < 0) {
+		close(fd);
+		return NULL;
+	}
+
+	uint32_t *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (data == MAP_FAILED) {
+		close(fd);
+		return NULL;
+	}
+	for (int i = 0; i < (int)(w * h); i++)
+		data[i] = 0xFF223366;
+	munmap(data, size);
+
+	struct wl_shm_pool *pool = wl_shm_create_pool(g_shm, fd, size);
+	struct wl_buffer *buf = wl_shm_pool_create_buffer(
+		pool, 0, w, h, stride, WL_SHM_FORMAT_ARGB8888);
+	wl_shm_pool_destroy(pool);
+	close(fd);
+	return buf;
+}
+
+static void
+xdg_surface_configure(void *data, struct xdg_surface *xs, uint32_t serial)
+{
+	(void)data;
+	xdg_surface_ack_configure(xs, serial);
+	g_configured = 1;
+}
+
+static const struct xdg_surface_listener xdg_surface_listener = {
+	.configure = xdg_surface_configure,
+};
+
+static void
+toplevel_configure(void *data, struct xdg_toplevel *t,
+                   int32_t w, int32_t h, struct wl_array *states)
+{
+	(void)data; (void)t; (void)states;
+	if (w > 0) g_width = w;
+	if (h > 0) g_height = h;
+}
+
+static void toplevel_close(void *d, struct xdg_toplevel *t)
+{ (void)d; (void)t; }
+static void toplevel_configure_bounds(void *d, struct xdg_toplevel *t,
+                                      int32_t w, int32_t h)
+{ (void)d; (void)t; (void)w; (void)h; }
+static void toplevel_wm_capabilities(void *d, struct xdg_toplevel *t,
+                                     struct wl_array *caps)
+{ (void)d; (void)t; (void)caps; }
+
+static const struct xdg_toplevel_listener toplevel_listener = {
+	.configure = toplevel_configure,
+	.close = toplevel_close,
+	.configure_bounds = toplevel_configure_bounds,
+	.wm_capabilities = toplevel_wm_capabilities,
+};
+
+static void
+xdg_wm_base_ping(void *data, struct xdg_wm_base *b, uint32_t serial)
+{
+	(void)data;
+	xdg_wm_base_pong(b, serial);
+}
+
+static const struct xdg_wm_base_listener xdg_wm_base_listener = {
+	.ping = xdg_wm_base_ping,
+};
+
+static void
+registry_global(void *data, struct wl_registry *reg,
+                uint32_t name, const char *iface, uint32_t version)
+{
+	(void)data; (void)version;
+	if (strcmp(iface, wl_compositor_interface.name) == 0)
+		g_compositor = wl_registry_bind(reg, name, &wl_compositor_interface, 4);
+	else if (strcmp(iface, wl_shm_interface.name) == 0)
+		g_shm = wl_registry_bind(reg, name, &wl_shm_interface, 1);
+	else if (strcmp(iface, xdg_wm_base_interface.name) == 0) {
+		g_xdg_wm_base = wl_registry_bind(reg, name, &xdg_wm_base_interface, 5);
+		xdg_wm_base_add_listener(g_xdg_wm_base, &xdg_wm_base_listener, NULL);
+	}
+}
+
+static void
+registry_global_remove(void *data, struct wl_registry *reg, uint32_t name)
+{ (void)data; (void)reg; (void)name; }
+
+static const struct wl_registry_listener registry_listener = {
+	.global = registry_global,
+	.global_remove = registry_global_remove,
+};
+
+int
+main(int argc, char **argv)
+{
+	(void)argc; (void)argv;
+
+	g_display = wl_display_connect(NULL);
+	if (!g_display) {
+		fprintf(stderr, "connect failed\n");
+		return 1;
+	}
+
+	struct wl_registry *reg = wl_display_get_registry(g_display);
+	wl_registry_add_listener(reg, &registry_listener, NULL);
+	wl_display_roundtrip(g_display);
+
+	if (!g_compositor || !g_shm || !g_xdg_wm_base) {
+		fprintf(stderr, "missing globals\n");
+		return 1;
+	}
+
+	g_surface = wl_compositor_create_surface(g_compositor);
+	g_xdg_surface = xdg_wm_base_get_xdg_surface(g_xdg_wm_base, g_surface);
+	xdg_surface_add_listener(g_xdg_surface, &xdg_surface_listener, NULL);
+	g_toplevel = xdg_surface_get_toplevel(g_xdg_surface);
+	xdg_toplevel_add_listener(g_toplevel, &toplevel_listener, NULL);
+	xdg_toplevel_set_app_id(g_toplevel, "somewm.test.disconnect_mid_map");
+	xdg_toplevel_set_title(g_toplevel, "disconnect mid map");
+
+	wl_surface_commit(g_surface);
+
+	while (!g_configured) {
+		if (wl_display_dispatch(g_display) < 0) {
+			fprintf(stderr, "dispatch failed before configure\n");
+			return 1;
+		}
+	}
+
+	struct wl_buffer *buf = create_buffer(g_width, g_height);
+	if (!buf) {
+		fprintf(stderr, "buffer creation failed\n");
+		return 1;
+	}
+	wl_surface_attach(g_surface, buf, 0, 0);
+	wl_surface_damage_buffer(g_surface, 0, 0, g_width, g_height);
+	wl_surface_commit(g_surface);
+
+	wl_display_flush(g_display);
+
+	int fd = wl_display_get_fd(g_display);
+	if (fd >= 0)
+		close(fd);
+
+	_exit(0);
+}

--- a/tests/test-mapnotify-disconnect-race.sh
+++ b/tests/test-mapnotify-disconnect-race.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+#
+# Reproducer for the wl_display_flush_clients re-entrance crash inside
+# mapnotify (somewm.c). See trip-zip/somewm#530.
+#
+# Spawns a nested somewm and repeatedly launches a tiny xdg-shell client that
+# disconnects right after its mapping commit. Without the fix, one of the
+# iterations triggers
+#
+#   somewm: types/wlr_compositor.c:735: surface_handle_resource_destroy:
+#     Assertion `wl_list_empty(&surface->events.map.listener_list)' failed.
+#
+# and the compositor dies with SIGABRT. With the fix, the compositor survives
+# all iterations.
+#
+# Exit codes:
+#   0  compositor survived all iterations (PASS)
+#   1  compositor died (REPRO confirmed; either a missing fix or a regression)
+#   2  test infrastructure problem (binary missing, sandbox setup failed, ...)
+#
+# Env knobs:
+#   ITERATIONS=200   how many disconnect-mid-map clients to spawn (default 200)
+#   ROUND_DELAY=0    seconds to sleep between iterations (default 0, fastest)
+#   SOMEWM_BINARY    explicit somewm binary (otherwise auto-pick build-test/build/...)
+#   SOMEWM_CLIENT    explicit somewm-client binary
+#   TEST_CLIENT      explicit test-disconnect-mid-map-client binary
+#   KEEP_LOGS=1      do not delete the compositor/client logs on success
+
+set -u
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ITERATIONS=${ITERATIONS:-200}
+ROUND_DELAY=${ROUND_DELAY:-0}
+KEEP_LOGS=${KEEP_LOGS:-0}
+
+# A bad ITERATIONS must not silently run zero iterations and report a
+# meaningless PASS.
+case $ITERATIONS in
+	'' | *[!0-9]*)
+		echo "ERROR: ITERATIONS must be a positive integer, got '$ITERATIONS'" >&2
+		exit 2
+		;;
+esac
+if [ "$ITERATIONS" -lt 1 ]; then
+	echo "ERROR: ITERATIONS must be >= 1, got '$ITERATIONS'" >&2
+	exit 2
+fi
+
+# The nested somewm loads the in-tree lua/ tree; make require() resolve
+# regardless of the caller's CWD (matches tests/run-integration.sh).
+export LUA_PATH="$ROOT_DIR/lua/?.lua;$ROOT_DIR/lua/?/init.lua;$ROOT_DIR/tests/?.lua;;"
+
+pick() {
+	local var=$1; shift
+	local current=${!var:-}
+	if [ -n "$current" ] && [ -x "$current" ]; then
+		printf '%s\n' "$current"
+		return 0
+	fi
+	for c in "$@"; do
+		[ -x "$c" ] && { printf '%s\n' "$c"; return 0; }
+	done
+	return 1
+}
+
+SOMEWM=$(pick SOMEWM_BINARY \
+	"$ROOT_DIR/build-test/somewm" \
+	"$ROOT_DIR/build/somewm" \
+	"$ROOT_DIR/build-fx/somewm") || {
+	echo "ERROR: no somewm binary; build with 'make build-test' or set SOMEWM_BINARY" >&2
+	exit 2
+}
+
+CLIENT=$(pick SOMEWM_CLIENT \
+	"$ROOT_DIR/build-test/somewm-client" \
+	"$ROOT_DIR/build/somewm-client" \
+	"$ROOT_DIR/build-fx/somewm-client") || {
+	echo "ERROR: no somewm-client binary" >&2
+	exit 2
+}
+
+TESTC=$(pick TEST_CLIENT \
+	"$ROOT_DIR/build-test/test-disconnect-mid-map-client" \
+	"$ROOT_DIR/build/test-disconnect-mid-map-client" \
+	"$ROOT_DIR/build-fx/test-disconnect-mid-map-client") || {
+	echo "ERROR: test-disconnect-mid-map-client not built; run meson + ninja" >&2
+	exit 2
+}
+
+if [ -z "${XDG_RUNTIME_DIR:-}" ]; then
+	echo "ERROR: XDG_RUNTIME_DIR is not set" >&2
+	exit 2
+fi
+if [ -z "${WAYLAND_DISPLAY:-}" ]; then
+	echo "ERROR: WAYLAND_DISPLAY is not set; this test needs a parent Wayland session" >&2
+	exit 2
+fi
+
+LOGDIR=$(mktemp -d)
+COMP_LOG="$LOGDIR/compositor.log"
+SOCKET="$XDG_RUNTIME_DIR/somewm-disconnect-test-$$.sock"
+PARENT_DISPLAY=$WAYLAND_DISPLAY
+
+cleanup() {
+	local code=$?
+	if [ -n "${COMP_PID:-}" ] && kill -0 "$COMP_PID" 2>/dev/null; then
+		# The nested somewm under WLR_BACKENDS=wayland does not always
+		# react to SIGTERM (it stays inside its event loop). Give it a
+		# short grace period and then SIGKILL so cleanup never wedges.
+		kill -TERM "$COMP_PID" 2>/dev/null || true
+		for _ in $(seq 1 10); do
+			kill -0 "$COMP_PID" 2>/dev/null || break
+			sleep 0.1
+		done
+		kill -KILL "$COMP_PID" 2>/dev/null || true
+		wait "$COMP_PID" 2>/dev/null || true
+	fi
+	rm -f "$SOCKET"
+	if [ "$KEEP_LOGS" = "0" ] && [ "$code" = "0" ]; then
+		rm -rf "$LOGDIR"
+	else
+		echo "logs kept at $LOGDIR" >&2
+	fi
+	exit "$code"
+}
+# Arm cleanup before anything that can exit (e.g. the rc.lua check below), so
+# the temp dir created above is always removed.
+trap cleanup EXIT INT TERM
+
+# Use the in-tree minimal rc.lua (no quickshell, no systray). This keeps the
+# nested compositor quiet and removes spurious xdg/layer surfaces that would
+# otherwise interleave with the disconnect-mid-map clients we are trying to
+# stress.
+TEST_RC="$ROOT_DIR/tests/rc.lua"
+if [ ! -f "$TEST_RC" ]; then
+	echo "ERROR: tests/rc.lua not found at $TEST_RC" >&2
+	exit 2
+fi
+TEST_HOME="$LOGDIR/config"
+mkdir -p "$TEST_HOME/somewm"
+cp "$TEST_RC" "$TEST_HOME/somewm/rc.lua"
+
+# Start nested compositor (wayland backend; this is the same path Steam hit).
+SOMEWM_SOCKET="$SOCKET" \
+	XDG_CONFIG_HOME="$TEST_HOME" \
+	WLR_BACKENDS=wayland \
+	WLR_WL_OUTPUTS=1 \
+	NO_AT_BRIDGE=1 \
+	"$SOMEWM" -d >"$COMP_LOG" 2>&1 &
+COMP_PID=$!
+
+# Wait for IPC to come up.
+for _ in $(seq 1 100); do
+	if [ -S "$SOCKET" ] \
+		&& SOMEWM_SOCKET="$SOCKET" "$CLIENT" ping >/dev/null 2>&1; then
+		break
+	fi
+	if ! kill -0 "$COMP_PID" 2>/dev/null; then
+		echo "ERROR: compositor died during startup. Log:" >&2
+		tail -40 "$COMP_LOG" >&2
+		exit 2
+	fi
+	sleep 0.1
+done
+
+if ! SOMEWM_SOCKET="$SOCKET" "$CLIENT" ping >/dev/null 2>&1; then
+	echo "ERROR: compositor IPC never came up" >&2
+	tail -40 "$COMP_LOG" >&2
+	exit 2
+fi
+
+# Discover the nested WAYLAND_DISPLAY. somewm-client eval prints "OK" on
+# the first line, the Lua return value on the second line, and a trailing
+# blank line — so a naive `tail -1` grabs the blank line. Strip empties
+# and the leading "OK" before picking the value.
+NESTED_DISPLAY=""
+for _ in $(seq 1 50); do
+	raw=$(SOMEWM_SOCKET="$SOCKET" "$CLIENT" eval \
+		'return os.getenv("WAYLAND_DISPLAY") or ""' 2>/dev/null \
+		| awk 'NF && $0 != "OK" { print; exit }')
+	if [ -n "$raw" ]; then
+		NESTED_DISPLAY=$raw
+		break
+	fi
+	sleep 0.1
+done
+if [ -z "$NESTED_DISPLAY" ]; then
+	echo "ERROR: could not discover nested WAYLAND_DISPLAY" >&2
+	exit 2
+fi
+
+echo "test driver: nested somewm pid=$COMP_PID display=$NESTED_DISPLAY"
+echo "test driver: spawning $ITERATIONS disconnect-mid-map clients..."
+
+died_at=""
+mapped=0
+for i in $(seq 1 "$ITERATIONS"); do
+	# Count clients that connected and completed their mapping commit (exit 0),
+	# so a run that exercised nothing cannot report PASS (see check below).
+	if WAYLAND_DISPLAY="$NESTED_DISPLAY" "$TESTC" >/dev/null 2>&1; then
+		mapped=$((mapped + 1))
+	fi
+
+	# Brief settle before checking liveness; client closes its fd
+	# asynchronously and the compositor needs one more poll cycle to act.
+	sleep 0.02
+
+	if ! kill -0 "$COMP_PID" 2>/dev/null; then
+		died_at=$i
+		break
+	fi
+
+	if [ "$ROUND_DELAY" != "0" ]; then
+		sleep "$ROUND_DELAY"
+	fi
+
+	if (( i % 50 == 0 )); then
+		echo "  ... $i iterations, compositor still up"
+	fi
+done
+
+if [ -n "$died_at" ]; then
+	echo "FAIL: compositor crashed after iteration $died_at" >&2
+	echo "tail of compositor log:" >&2
+	tail -30 "$COMP_LOG" >&2
+	# Promote to coredumpctl if available.
+	if command -v coredumpctl >/dev/null 2>&1; then
+		echo "--- coredumpctl info (this run's somewm, pid=$COMP_PID) ---" >&2
+		coredumpctl info "$COMP_PID" 2>&1 | tail -25 >&2 || true
+	fi
+	exit 1
+fi
+
+# Proof of work: if not one client connected and completed its mapping commit,
+# the harness exercised nothing and "survived" is meaningless.
+if [ "$mapped" -eq 0 ]; then
+	echo "ERROR: 0/$ITERATIONS clients connected to the nested compositor;" >&2
+	echo "       nothing was mapped, so the disconnect-mid-map path was not tested." >&2
+	tail -30 "$COMP_LOG" >&2
+	exit 2
+fi
+
+# Final liveness probe.
+if ! SOMEWM_SOCKET="$SOCKET" "$CLIENT" ping >/dev/null 2>&1; then
+	echo "FAIL: compositor stopped responding to IPC after $ITERATIONS iterations" >&2
+	tail -30 "$COMP_LOG" >&2
+	exit 1
+fi
+
+echo "PASS: compositor survived $ITERATIONS disconnect-mid-map iterations ($mapped mapped)"
+exit 0


### PR DESCRIPTION
## Description

`mapnotify()` flushed clients synchronously while still inside the
`surface->events.map` signal emit. If a peer client had hung up, the flush
re-entered `wl_client_destroy()`, which tore down the surface whose map signal
was being emitted, and wlroots aborted on the
`wl_list_empty(&surface->events.map.listener_list)` assertion. Steam triggers
it reliably during its post-update self-restart.

This adds `schedule_flush_clients()`, which defers the flush to a
`wl_event_loop_add_idle()` source, coalesced per dispatch cycle, so it no longer
runs inside the emit. Delivery timing is unchanged: `some_glib_poll()` already
flushes every client before each `poll()`, so the configure still ships before
the client can composite at the old geometry (preserves the #10 tiling fix).
Both `mapnotify` call sites and `awesome.sync()` route through it; `awesome.sync()`
is now best-effort deferred, noted in its docstring.

Reported and root-caused by @raven2cz in #530, who verified the same approach on
their fork (Steam self-restart on an RTX 5070 Ti, no more abort).

## Test Plan

- `make build-test`: clean
- `make test-unit`: 770 passed
- `make test-integration`: 125 passed (headful), including
  `test-xdg-unmap-focus-transfer`, `test-xwayland-remap`, `test-transient-stacking`,
  `test-titlebar-geometry`
- Ports @raven2cz's disconnect-mid-map reproducer
  (`tests/test-disconnect-mid-map-client.c` + `tests/test-mapnotify-disconnect-race.sh`)
  as an opt-in probe, not wired into the gating suite. It asserts at least one client
  actually mapped, so it cannot report a vacuous PASS.
- No deterministic repro: the crash is a sub-millisecond protocol race. Locally the
  unfixed parent survives 1000 iterations plain and 2000 under ASAN without tripping,
  matching the reporter's note that the harness does not reliably trip it; the reporter
  live-tested the real Steam restart.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
