### PR TITLE
fix: present timer-driven widget redraws on an idle session

### DIFF
--- a/globalconf.h
+++ b/globalconf.h
@@ -305,6 +305,12 @@ typedef struct
     bool somewm_ready_seen;
     bool xwayland_ready_seen;
 
+    /** Count of presented output frames (incremented in rendermon only when a
+     *  commit actually had damage to present). Lets tests observe that a redraw
+     *  reached the screen; exposed to Lua as awesome._test_frame_count. Not
+     *  preserved across hot-reload (globalconf is zeroed by globalconf_wipe). */
+    unsigned long frame_commit_count;
+
 
     /* ========== WALLPAPER SUPPORT ========== */
 

--- a/luaa.c
+++ b/luaa.c
@@ -2136,6 +2136,13 @@ luaA_awesome_index(lua_State *L)
 		return 1;
 	}
 
+	/* Monotonic count of presented output frames. Test hook for observing that a
+	 * redraw actually reached the screen (see tests/test-widget-idle-repaint.lua). */
+	if (A_STREQ(key, "_test_frame_count")) {
+		lua_pushinteger(L, (lua_Integer)globalconf.frame_commit_count);
+		return 1;
+	}
+
 	if (A_STREQ(key, "bypass_surface_visibility")) {
 		lua_pushboolean(L, globalconf.appearance.bypass_surface_visibility);
 		return 1;

--- a/monitor.c
+++ b/monitor.c
@@ -508,6 +508,7 @@ rendermon(struct wl_listener *listener, void *data)
 	Monitor *m = wl_container_of(listener, m, frame);
 	Client *c;
 	struct timespec now;
+	bool presented = false;
 
 	/* Safety: scene_output may not exist yet if frame fires before createmon
 	 * finishes (possible on NVIDIA), or output may be disabled */
@@ -528,16 +529,22 @@ rendermon(struct wl_listener *listener, void *data)
 	struct timespec bench_render_start, bench_render_end;
 	clock_gettime(CLOCK_MONOTONIC, &bench_render_start);
 #endif
-	if (!wlr_scene_output_commit(m->scene_output, NULL))
+	/* needs_frame is true only when there is something to present;
+	 * wlr_scene_output_commit() returns true without presenting otherwise, so
+	 * sample it first to count only real presents. */
+	presented = wlr_scene_output_needs_frame(m->scene_output);
+	if (!wlr_scene_output_commit(m->scene_output, NULL)) {
 		wlr_log(WLR_DEBUG, "[HOTPLUG] rendermon commit failed: %s",
 			m->wlr_output->name);
+	} else {
+		if (presented)
+			globalconf.frame_commit_count++;
 #ifdef SOMEWM_BENCH
-	else {
 		clock_gettime(CLOCK_MONOTONIC, &bench_render_end);
 		bench_render_record(timespec_diff_ns(&bench_render_start, &bench_render_end));
 		bench_input_commit_flush();
-	}
 #endif
+	}
 
 skip:
 	clock_gettime(CLOCK_MONOTONIC, &now);

--- a/somewm.c
+++ b/somewm.c
@@ -701,6 +701,17 @@ some_glib_poll(GPollFD *ufds, guint nfsd, gint timeout)
 	 * Clients won't receive data until we flush */
 	wl_display_flush_clients(dpy);
 
+	/* Drain wlroots idle sources before sleeping. wlr_output_schedule_frame()
+	 * (called by drawin_refresh_drawable() when a wibox redraws) queues the frame
+	 * as a wl_event_loop idle, and idles only run inside wl_event_loop_dispatch().
+	 * That otherwise happens solely when the loop fd is readable from input or
+	 * client traffic (via wayland_source_dispatch), so a timer-driven redraw (e.g.
+	 * textclock / awful.widget.watch) updates the scene buffer but is never
+	 * committed on an idle session and the widget freezes until the next input.
+	 * dispatch_idle runs exactly the queued idles (not fd sources, which stay with
+	 * the GSource), presenting those frames every iteration. */
+	wl_event_loop_dispatch_idle(wl_display_get_event_loop(dpy));
+
 	/* Check iteration performance (matches AwesomeWM) */
 	gettimeofday(&now, NULL);
 	timersub(&now, &last_wakeup, &length_time);

--- a/tests/test-widget-idle-repaint.lua
+++ b/tests/test-widget-idle-repaint.lua
@@ -1,0 +1,108 @@
+---------------------------------------------------------------------------
+-- Test: widgets repaint on a timer with no input (issue #609)
+--
+-- A gears.timer-driven widget update (textclock, awful.widget.watch, ...) must
+-- reach the screen even when nothing is focused and no input arrives. The redraw
+-- path ends in wlr_output_schedule_frame(), which queues the frame as a
+-- wl_event_loop idle; that idle only runs inside wl_event_loop_dispatch(). The
+-- compositor's poll function (some_glib_poll) must dispatch the wl event loop
+-- every iteration, otherwise the idle is stranded until unrelated fd traffic
+-- (input, a client commit) wakes the loop, and the widget freezes.
+--
+-- We observe presents via awesome._test_frame_count (incremented in rendermon
+-- after each successful wlr_scene_output_commit).
+--
+-- Reliability note: the assertion needs a quiescent window with no fd traffic
+-- between the update and the present, since any traffic would flush the stranded
+-- idle and mask the bug. The runner steps via gears.timer (a GLib timeout, which
+-- does not touch the Wayland fd), and we first wait for the frame loop to go
+-- quiet, so a headless run with no clients reproduces the freeze. A nested
+-- backend with a busy parent can still mask it; the authoritative check is the
+-- manual one in the issue.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local awful  = require("awful")
+local wibox  = require("wibox")
+
+local wb, tb
+local baseline
+
+-- Quiescence tracking for step 1.
+local last_count, stable_samples = nil, 0
+
+local steps = {
+    -- Step 1: show a wibox with a textbox, then wait for the initial render and
+    -- for the frame loop to go idle (frame count unchanged across several 0.1s
+    -- samples). This guarantees step 2 measures from a quiet state.
+    function(count)
+        if count == 1 then
+            tb = wibox.widget.textbox("init")
+            wb = wibox {
+                x = 0, y = 0, width = 120, height = 24,
+                bg = "#000000", visible = true,
+                screen = awful.screen.focused(),
+            }
+            wb.widget = tb
+            last_count, stable_samples = nil, 0
+            return nil
+        end
+
+        local now = awesome._test_frame_count
+        if last_count ~= nil and now == last_count then
+            stable_samples = stable_samples + 1
+        else
+            stable_samples = 0
+        end
+        last_count = now
+
+        -- ~0.3s of no new frames, and at least one frame already presented.
+        if stable_samples >= 3 and now > 0 then
+            return true
+        end
+        return nil
+    end,
+
+    -- Step 2: with the session idle (no input, no clients, no IPC in flight),
+    -- update the widget. On a fixed build the frame is presented within an
+    -- iteration or two; on a broken build the count never moves and the step
+    -- times out (the frozen-widget bug).
+    function(count)
+        if count == 1 then
+            baseline = awesome._test_frame_count
+            tb.text = "updated"
+            return nil
+        end
+
+        if awesome._test_frame_count > baseline then
+            io.stderr:write("[PASS] timer-driven redraw presented with no input\n")
+            return true
+        end
+        return nil
+    end,
+
+    -- Cleanup.
+    function()
+        if wb then
+            wb.visible = false
+            wb = nil
+        end
+        return true
+    end,
+}
+
+-- This regression only reproduces on a quiescent session: any Wayland-fd traffic
+-- (a nested parent compositor's frame callbacks, a client commit, input) drains
+-- the stranded frame idle and would mask the freeze. Under the nested wayland
+-- backend (the default for `make test-one`) the parent keeps the fd busy, so the
+-- check is only meaningful on the headless backend (HEADLESS=1, as CI runs it).
+-- Skip elsewhere rather than pass without actually exercising the bug.
+if not (os.getenv("WLR_BACKENDS") or ""):find("headless", 1, true) then
+    runner.run_direct()
+    io.stderr:write("[SKIP] test-widget-idle-repaint: needs the headless backend "
+        .. "(HEADLESS=1); a nested parent compositor masks the bug under test.\n")
+    runner.done()
+    return
+end
+
+runner.run_steps(steps)


### PR DESCRIPTION
## Description
Timer-driven widgets like the `textclock` and `awful.widget.watch` stop updating on screen when nothing is focused and no input arrives. The clock freezes, then jumps to the current time the moment you move the mouse or press a key (#609).

The redraw is scheduled as a Wayland idle via `wlr_output_schedule_frame()`, but those idles only run when the compositor dispatches the Wayland event loop, which it did only when the fd had input or client traffic. On an idle session the frame was never committed. `some_glib_poll` now drains pending idles every iteration with `wl_event_loop_dispatch_idle`, so the redraw reaches the screen on its own.

## Test Plan
- New headless test `tests/test-widget-idle-repaint.lua`: updates a widget with no input and asserts the frame is presented. Times out without the fix, passes with it.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
