### PR TITLE
fix(somewm): terminate on SIGTERM/SIGINT and Ctrl-Alt-Backspace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 
 -include .local.mk
 
-.PHONY: all install uninstall clean setup reconfigure test test-unit test-check test-integration test-orchestrator test-asan test-one test-visual test-one-visual test-ci test-fast build-test build-bench bench-run bench-run-live bench-flamegraph bench-diff bench-heaptrack
+.PHONY: all install uninstall clean setup reconfigure test test-unit test-check test-signal test-integration test-orchestrator test-asan test-one test-visual test-one-visual test-ci test-fast build-test build-bench bench-run bench-run-live bench-flamegraph bench-diff bench-heaptrack
 
 # Default build: optimized release, no sanitizers
 all:
@@ -49,7 +49,7 @@ reconfigure:
 # =============================================================================
 
 # Run all tests (fast, no ASAN)
-test: test-unit test-check test-orchestrator test-integration
+test: test-unit test-check test-signal test-orchestrator test-integration
 
 # Unit tests only (busted, no compositor needed)
 # Use - prefix to continue even if unit tests fail (some have known issues)
@@ -59,6 +59,10 @@ test-unit:
 # Check mode tests (no compositor needed, tests somewm --check)
 test-check: build-test
 	@./tests/test-check-mode.sh ./build-test/somewm
+
+# SIGTERM regression test (issue 613): a headless somewm must exit on SIGTERM
+test-signal: build-test
+	@./tests/test-signal-term.sh ./build-test/somewm
 
 # Test orchestrator (somewm-client test ...): spawns headless nested compositor
 test-orchestrator: build-test
@@ -73,7 +77,7 @@ test-asan: asan
 	@SOMEWM=./build-asan/somewm SOMEWM_CLIENT=./build-asan/somewm-client ./tests/run-integration.sh
 
 # CI mode: headless (for automated testing environments)
-test-ci: build-test test-unit
+test-ci: build-test test-unit test-signal
 	@HEADLESS=1 \
 	 SOMEWM=./build-test/somewm \
 	 SOMEWM_CLIENT=./build-test/somewm-client \

--- a/somewm.c
+++ b/somewm.c
@@ -3242,9 +3242,19 @@ handlesig(int signo)
 			int res = write(sigchld_pipe[1], " ", 1);
 			(void) res;  /* Ignore write errors in signal handler */
 		}
-	} else if (signo == SIGINT || signo == SIGTERM) {
-		wl_display_terminate(dpy);
 	}
+}
+
+/** GLib unix-signal callback for SIGINT/SIGTERM. Runs in main-loop context, so
+ * it can stop g_main_loop_run() cleanly. Routes through some_compositor_quit()
+ * so every termination path (signals, Ctrl-Alt-Backspace, awesome.quit) shares
+ * one implementation. Mirrors AwesomeWM's exit_on_signal. */
+static gboolean
+quit_on_signal(gpointer data)
+{
+	(void) data;
+	some_compositor_quit();
+	return G_SOURCE_CONTINUE;
 }
 
 /** GLib callback for SIGCHLD pipe (AwesomeWM pattern).
@@ -3417,7 +3427,9 @@ keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_
 		if (sym == XKB_KEY_Terminate_Server) {
 			if (session_is_locked())
 				return 1;
-			wl_display_terminate(dpy);
+			/* Quits the GLib main loop; wl_display_terminate() alone is a
+			 * no-op here since g_main_loop_run() is the primary loop. */
+			some_compositor_quit();
 			return 1;
 		}
 		/* Ctrl-Alt-F1..F12: Switch to VT 1-12
@@ -5641,7 +5653,7 @@ setsel(struct wl_listener *listener, void *data)
 void
 setup(void)
 {
-	int i, sig[] = {SIGCHLD, SIGINT, SIGTERM, SIGPIPE};
+	int i, sig[] = {SIGCHLD, SIGPIPE};
 	struct sigaction sa = {.sa_flags = SA_RESTART, .sa_handler = handlesig};
 	sigemptyset(&sa.sa_mask);
 
@@ -5655,6 +5667,13 @@ setup(void)
 
 	/* Setup GLib watch for SIGCHLD pipe */
 	g_unix_fd_add(sigchld_pipe[0], G_IO_IN, reap_children, NULL);
+
+	/* SIGINT/SIGTERM quit via GLib's unix-signal source: the callback runs in
+	 * main-loop context and stops g_main_loop_run() cleanly (AwesomeWM's
+	 * exit_on_signal pattern). A bare sigaction handler could only call
+	 * wl_display_terminate(), a no-op here since the GLib loop is primary. */
+	g_unix_signal_add(SIGINT, quit_on_signal, NULL);
+	g_unix_signal_add(SIGTERM, quit_on_signal, NULL);
 
 	for (i = 0; i < (int)LENGTH(sig); i++)
 		sigaction(sig[i], &sa, NULL);

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -696,10 +696,13 @@ some_get_allocator(void)
 void
 some_compositor_quit(void)
 {
+	/* The primary loop is g_main_loop_run(), not wl_display_run(), so quitting
+	 * the GLib loop is what actually stops somewm. wl_display_terminate() would
+	 * be a no-op here (nothing calls wl_display_run); Wayland teardown happens
+	 * in cleanup() after the loop returns. */
 	if (globalconf.loop) {
 		g_main_loop_quit(globalconf.loop);
 	}
-	wl_display_terminate(dpy);
 }
 
 /*

--- a/tests/test-signal-term.sh
+++ b/tests/test-signal-term.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Regression test: somewm must terminate on SIGTERM (issue 613).
+#
+# Before the fix, the SIGINT/SIGTERM handler called wl_display_terminate(),
+# which is a no-op because the primary loop is g_main_loop_run(), not
+# wl_display_run(). So `kill <pid>` (SIGTERM) did nothing and only SIGKILL
+# worked. This starts a headless somewm, sends SIGTERM only, and asserts the
+# process exits on its own with no SIGKILL fallback.
+#
+# It cannot be a Lua/IPC integration test: terminating the compositor would
+# kill the test runner, so this is a process-level test instead.
+#
+# Usage: ./tests/test-signal-term.sh [path-to-somewm-binary]
+
+set -u
+
+SOMEWM_ARG="${1:-./build-test/somewm}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ ! -x "$SOMEWM_ARG" ]; then
+    echo "Error: somewm binary not found at $SOMEWM_ARG" >&2
+    echo "Run 'make build-test' first" >&2
+    exit 1
+fi
+# Resolve to an absolute path so we can spawn it after isolating the environment.
+SOMEWM="$(cd "$(dirname "$SOMEWM_ARG")" && pwd)/$(basename "$SOMEWM_ARG")"
+
+START_TIMEOUT=15   # seconds to wait for the compositor to come up
+TERM_TIMEOUT=5     # seconds SIGTERM has to work before we force-kill
+
+# Isolated, headless environment so the test never touches a real session.
+TMP_DIR="$(mktemp -d)"
+RUNTIME_DIR="$TMP_DIR/runtime"
+mkdir -p "$RUNTIME_DIR"
+chmod 700 "$RUNTIME_DIR"
+CONFIG_DIR="$TMP_DIR/config/somewm"
+mkdir -p "$CONFIG_DIR"
+cp "$ROOT_DIR/tests/rc.lua" "$CONFIG_DIR/rc.lua"
+
+export WLR_BACKENDS=headless
+export WLR_RENDERER=pixman
+export WLR_WL_OUTPUTS=1
+export NO_AT_BRIDGE=1
+export XDG_RUNTIME_DIR="$RUNTIME_DIR"
+export XDG_CONFIG_HOME="$TMP_DIR/config"
+export LUA_PATH="$ROOT_DIR/lua/?.lua;$ROOT_DIR/lua/?/init.lua;$ROOT_DIR/tests/?.lua;;"
+# Force the headless backend: a stale DISPLAY/WAYLAND_DISPLAY can make wlroots
+# pick the wrong backend.
+unset DISPLAY WAYLAND_DISPLAY SOMEWM_SOCKET
+
+SOCKET="$XDG_RUNTIME_DIR/somewm-socket"
+LOG="$TMP_DIR/somewm.log"
+
+SOMEWM_PID=""
+cleanup() {
+    [ -n "$SOMEWM_PID" ] && kill -KILL "$SOMEWM_PID" 2>/dev/null
+    rm -rf "$TMP_DIR" 2>/dev/null
+    return 0
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+    echo "--- FAIL: $1"
+    echo "Last 30 lines of somewm log:"
+    tail -30 "$LOG" 2>/dev/null | sed 's/^/    /'
+    exit 1
+}
+
+# Start the compositor directly (no `timeout` wrapper: we send the signal, and
+# $! must be somewm itself, not a wrapper process).
+"$SOMEWM" >"$LOG" 2>&1 &
+SOMEWM_PID=$!
+
+# Wait for startup: the IPC socket appears once the main loop is serving.
+count=0
+max=$(( START_TIMEOUT * 10 ))
+while [ ! -S "$SOCKET" ] && [ "$count" -lt "$max" ]; do
+    if ! kill -0 "$SOMEWM_PID" 2>/dev/null; then
+        fail "somewm exited during startup"
+    fi
+    sleep 0.1
+    count=$(( count + 1 ))
+done
+[ -S "$SOCKET" ] || fail "timed out waiting for somewm to start (${START_TIMEOUT}s)"
+
+echo "--- INFO: somewm up (pid $SOMEWM_PID); sending SIGTERM"
+
+# The assertion: SIGTERM alone must terminate it within TERM_TIMEOUT.
+kill -TERM "$SOMEWM_PID"
+
+# Watchdog: if SIGTERM is ignored, force-kill after the timeout and leave a marker.
+( sleep "$TERM_TIMEOUT"; touch "$TMP_DIR/forced"; kill -KILL "$SOMEWM_PID" 2>/dev/null ) &
+WATCHDOG_PID=$!
+
+# Block until somewm exits (via SIGTERM, or the watchdog's SIGKILL).
+STATUS=0
+wait "$SOMEWM_PID" 2>/dev/null || STATUS=$?
+
+# Stop the watchdog if it is still sleeping.
+kill "$WATCHDOG_PID" 2>/dev/null || true
+wait "$WATCHDOG_PID" 2>/dev/null || true
+
+SOMEWM_PID=""   # reaped above; don't let cleanup() kill a recycled pid
+
+if [ -f "$TMP_DIR/forced" ]; then
+    fail "SIGTERM ignored: somewm did not exit within ${TERM_TIMEOUT}s (needed SIGKILL)"
+fi
+
+echo "--- PASS: somewm terminated on SIGTERM (exit status $STATUS)"
+echo "PASS"
+exit 0


### PR DESCRIPTION
## Description

`kill <pid>` (SIGTERM) did nothing to somewm; only SIGKILL worked. Fixes #613.

somewm's primary loop is GLib's `g_main_loop_run()` (the wlroots event loop is a
GSource under it), but the SIGINT/SIGTERM handler and the Ctrl-Alt-Backspace
keybinding stopped the compositor with `wl_display_terminate()`, a leftover from
dwl's `wl_display_run()` model. `wl_display_run()` is never called in somewm, so
`wl_display_terminate()` is a no-op and those paths never exited. `awesome.quit()`
worked only because `some_compositor_quit()` also calls `g_main_loop_quit()`.

This routes every termination path through `some_compositor_quit()`, which now
just quits the GLib loop (the no-op `wl_display_terminate()` is removed).
SIGINT/SIGTERM move from the bare `sigaction` handler to GLib's unix-signal
source (`g_unix_signal_add`) so the callback runs in main-loop context, matching
AwesomeWM's `exit_on_signal`. SIGCHLD/SIGPIPE stay on `sigaction`.

Co-authored with @raven2cz, who diagnosed and first fixed this on his fork.

## Test Plan

- New `tests/test-signal-term.sh` (wired into `make test`/`test-ci`): headless
  somewm, SIGTERM only, asserts it exits with no SIGKILL fallback. Verified red on
  the unfixed binary and green with the fix.
- `make test-unit`: pass (770/0).
- The full headless integration suite was run on the identical change (see the
  companion `main` PR): no new failures versus base; remaining failures are
  pre-existing headless flakes.
- Manual: Ctrl-Alt-Backspace exits the session cleanly.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified**: if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
