### PR TITLE
fix(titlebar): floating button toggles floating state

### DIFF
--- a/lua/awful/titlebar.lua
+++ b/lua/awful/titlebar.lua
@@ -1089,7 +1089,9 @@ end
 -- @usebeautiful beautiful.titlebar_floating_button_focus_inactive_hover
 -- @usebeautiful beautiful.titlebar_floating_button_focus_inactive_press
 function titlebar.widget.floatingbutton(c)
-    local widget = titlebar.widget.button(c, "floating", aclient.object.get_floating, aclient.floating.toggle)
+    local widget = titlebar.widget.button(c, "floating", aclient.object.get_floating, function(cl, state)
+        cl.floating = not state
+    end)
     update_on_signal(c, "property::floating", widget)
     return widget
 end

--- a/tests/test-titlebar-floating-button.lua
+++ b/tests/test-titlebar-floating-button.lua
@@ -1,0 +1,41 @@
+---------------------------------------------------------------------------
+-- The titlebar floating button toggles the client's floating state.
+--
+-- Regression: awful.client.floating.toggle was removed as deprecated, but
+-- titlebar.widget.floatingbutton still passed it as the button's click action.
+-- A nil action makes titlebar.widget.button install a no-op handler, so the
+-- button silently did nothing. The fix wires the toggle inline (cl.floating =
+-- not state), like the maximize/close buttons. This clicks the button via the
+-- awful.button :trigger() (press+release, exactly what a real click runs) and
+-- asserts the floating state flips, then flips back.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local async = require("_async")
+local awful = require("awful")
+local test_client = require("_client")
+
+if not test_client.is_available() then
+    return runner.skip("no terminal available for test clients")
+end
+
+runner.run_async(function()
+    test_client("tbfloat")
+    local c = async.wait_for_client("tbfloat", 10)
+    assert(c, "client did not appear")
+
+    c.floating = false  -- deterministic starting point
+
+    local widget = awful.titlebar.widget.floatingbutton(c)
+    local btn = widget.buttons[1]
+    assert(btn and btn._is_awful_button, "floating button must carry an awful.button")
+
+    btn:trigger()
+    assert(c.floating == true, "clicking the floating button must enable floating")
+
+    btn:trigger()
+    assert(c.floating == false, "clicking again must disable floating")
+
+    c:kill()
+    runner.done()
+end)


### PR DESCRIPTION
## Description

Clicking the floating button on a client's titlebar does nothing.

`awful.client.floating.toggle` was removed in a deprecated-function cleanup, but `titlebar.widget.floatingbutton` still passed it as the button's click action. A `nil` action makes `titlebar.widget.button` install a handler that only updates the button image, so the click had no effect. The close and maximize buttons were unaffected because they use inline closures rather than that function.

This wires the toggle inline (`cl.floating = not state`), matching the maximize, ontop, and sticky buttons in the same file. No public API change.

## Test Plan

- New `tests/test-titlebar-floating-button.lua`: spawns a client, builds the floating button, and fires its `awful.button` via `:trigger()` (press + release, the same path a real click takes), asserting `c.floating` flips on and then back off.
- Passes with the fix; reverting the one-line change makes it fail, confirming it guards the regression.
- `make test-unit`: 755 passing. The one `menubar/utils_spec` failure (HOME-dependent icon path) and the `gears/surface_spec` no-display skip are both present on unmodified `main` and unrelated to this change.

## Checklist
- [ ] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)