### PR TITLE
fix(ipc): define resolve_client before its handler closures

### DIFF
--- a/lua/awful/ipc.lua
+++ b/lua/awful/ipc.lua
@@ -400,6 +400,22 @@ local function register_builtin_commands()
     return nil
   end
 
+  -- Helper: resolve target to a client object (numeric ID or "focused").
+  -- Defined here, before the command registrations, so every handler closure
+  -- captures it (the client.kill/client.close handlers are created above the
+  -- old definition site and were binding a nil global).
+  local function resolve_client(target)
+    target = target or "focused"
+    if target == "focused" then
+      local c = capi.client.focus
+      if not c then error("No focused client") end
+      return c
+    end
+    local c = find_client_by_id(target)
+    if not c then error("Client not found: " .. target) end
+    return c
+  end
+
   -- =================================================================
   -- BASIC COMMANDS
   -- =================================================================
@@ -1271,19 +1287,6 @@ local function register_builtin_commands()
   -- =================================================================
   -- CLIENT PROPERTY COMMANDS
   -- =================================================================
-
-  -- Helper: resolve target to a client object
-  local function resolve_client(target)
-    target = target or "focused"
-    if target == "focused" then
-      local c = capi.client.focus
-      if not c then error("No focused client") end
-      return c
-    end
-    local c = find_client_by_id(target)
-    if not c then error("Client not found: " .. target) end
-    return c
-  end
 
   -- Helper: register a boolean client property command
   local function register_bool_prop(name)


### PR DESCRIPTION
## Description
`somewm-client client close` and `client kill` fail with `attempt to call global 'resolve_client' (a nil value)`. The `client.kill` and `client.close` IPC handlers are registered before `resolve_client` is defined as a `local function`, so their closures capture a nil global instead of the helper. (The handlers registered after the definition work, which is why luacheck flagged only these two.) Move `resolve_client` up beside `find_client_by_id`, before all command registrations, so every handler closure captures it. Pure move, no logic change.

## Test Plan
- `luacheck lua/awful/ipc.lua`: the two `accessing undefined variable resolve_client` warnings at the kill/close handlers are gone; no new warnings.
- `make test-unit`: 755 pass / 1 failure (pre-existing menubar icon-path test, unrelated) / 1 pending.
- Live (after a rebuild to load the changed Lua): `somewm-client client close <id>` / `client kill <id>` resolve the target instead of erroring.

## Checklist
- [ ] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — N/A: `awful/ipc.lua` is somewm-original IPC code (not AwesomeWM-mirrored), and this is a Lua-only scoping bug with no C equivalent.
- [x] Tests pass — `make test-unit` 755/1 (pre-existing menubar). `make test-integration` not run: the suite doesn't load `ipc.lua` (it needs the compositor capi), so it can't exercise this change.
