### PR TITLE
fix(ci): bump wlroots to 0.19.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         run: |
           export PKG_CONFIG_PATH=$HOME/deps-install/share/pkgconfig:$HOME/deps-install/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
           cd ~
-          git clone --depth 1 --branch 0.19.0 https://gitlab.freedesktop.org/wlroots/wlroots.git
+          git clone --depth 1 --branch 0.19.3 https://gitlab.freedesktop.org/wlroots/wlroots.git
           cd wlroots
           meson setup build --prefix=$HOME/deps-install -Dexamples=false -Dxwayland=enabled
           ninja -C build

--- a/meson.build
+++ b/meson.build
@@ -106,7 +106,7 @@ message('Found LGI version: ' + lgi_version)
 
 # wlroots 0.19 only - use system if available, otherwise build from subproject
 # We only support 0.19+ due to Xwayland bugs in earlier versions
-wlroots = dependency('wlroots-0.19', static: false, required: false)
+wlroots = dependency('wlroots-0.19', version : '>=0.19.3', static: false, required: false)
 
 if not wlroots.found()
   message('System wlroots 0.19 not found, building from subproject...')

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 0.19.2
+revision = 0.19.3
 depth = 1
 
 [provide]


### PR DESCRIPTION
## Description
Upgrade to the latest 0.19.x series of wlroots


## Test Plan
Works for building and running somewm on my Debian sid machine

```
sicelo@afrika:~$  dpkg -l libwlroots-0.19
┌── Desired=Unknown/Install/Remove/Purge/Hold
│┌─ Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
││┌ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
│││ Name                  Version      Architecture Description
├┼┼─═════════════════════─════════════─════════════─═══════════════════════════════════════════════════
ii  libwlroots-0.19:amd64 0.19.3-1     amd64        Modular wayland compositor library - shared library
sicelo@afrika:~$  somewm --version
## somewm version info

**somewm:** 2.0.0-dev (unknown)
**wlroots:** 0.19
**Lua:** LuaJIT 2.1.1761786044 (compiled: Lua 5.1.4)
**LGI:** 0.9.2
**Build:** D-Bus=yes, XWayland=yes

**System:**
- Distro: Debian GNU/Linux forky/sid
- Kernel: 7.0.14+deb14-amd64
- Arch: x86_64
- GPU: i915 (8086:7D41)
- Session: wayland (nested: yes)
```

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
