### PR TITLE
fix(input): handle KeyRelease events

### DIFF
--- a/input.c
+++ b/input.c
@@ -100,7 +100,7 @@ void motionnotify(uint32_t time, struct wlr_input_device *device, double dx, dou
 		double dx_unaccel, double dy_unaccel);
 void pointerfocus(Client *c, struct wlr_surface *surface, double sx, double sy,
 		uint32_t time);
-int keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym);
+int keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym, bool is_keypress);
 void createkeyboard(struct wlr_keyboard *keyboard);
 KeyboardGroup *createkeyboardgroup(void);
 void createpointer(struct wlr_pointer *pointer);
@@ -1093,7 +1093,7 @@ pointerfocus(Client *c, struct wlr_surface *surface, double sx, double sy,
 }
 
 int
-keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym)
+keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym, bool is_keypress)
 {
 	client_t *focused;
 	struct wlr_surface *surface;
@@ -1116,12 +1116,12 @@ keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_
 	focused = surface ? some_client_from_surface(surface) : NULL;
 
 	/* Check client-specific Lua key objects first (AwesomeWM pattern)
-	 * Client keybindings pass the client as argument to the "press" signal */
-	if (focused && luaA_client_key_check_and_emit(focused, CLEANMASK(mods), keycode, sym, base_sym))
+	 * Client keybindings pass the client as argument to the "press" or "release" signal */
+	if (focused && luaA_client_key_check_and_emit(focused, CLEANMASK(mods), keycode, sym, base_sym, is_keypress))
 		return 1;
 
 	/* Check global Lua key objects (AwesomeWM pattern) */
-	if (luaA_key_check_and_emit(CLEANMASK(mods), keycode, sym, base_sym))
+	if (luaA_key_check_and_emit(CLEANMASK(mods), keycode, sym, base_sym, is_keypress))
 		return 1;
 
 	/* Hardcoded VT switching (compositor-level, non-configurable)
@@ -1219,9 +1219,13 @@ keypress(struct wl_listener *listener, void *data)
 	/* On _press_ if there is no active screen locker,
 	 * attempt to process a compositor keybinding.
 	 * Block for both ext-session-lock-v1 (locked) and Lua lock (some_is_lua_locked). */
-	if (!session_is_locked() && event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
-		for (i = 0; i < nsyms; i++)
-			handled = keybinding(mods, keycode, syms[i], base_sym) || handled;
+	if (!session_is_locked()) {
+		bool is_keypress = event->state == WL_KEYBOARD_KEY_STATE_PRESSED;
+		for (i = 0; i < nsyms; i++) {
+			bool binding_handled = keybinding(mods, keycode, syms[i], base_sym, is_keypress);
+			if (is_keypress)
+				handled = binding_handled || handled;
+		}
 	}
 
 	if (handled && group->wlr_group->keyboard.repeat_info.delay > 0) {
@@ -1305,7 +1309,9 @@ keyrepeat(void *data)
 			1000 / group->wlr_group->keyboard.repeat_info.rate);
 
 	for (i = 0; i < group->nsyms; i++)
-		keybinding(group->mods, group->keycode, group->keysyms[i], group->base_sym);
+		/* Hardcode is_keypress = true for the keybinding() call since
+		 * keyrepeat only matters for key down condition */
+		keybinding(group->mods, group->keycode, group->keysyms[i], group->base_sym, true);
 
 	return 0;
 }

--- a/input.h
+++ b/input.h
@@ -36,7 +36,7 @@ void pointerfocus(Client *c, struct wlr_surface *surface,
 
 /* Keyboard */
 int keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym,
-		xkb_keysym_t base_sym);
+		xkb_keysym_t base_sym, bool is_keypress);
 void keypress(struct wl_listener *listener, void *data);
 void keypressmod(struct wl_listener *listener, void *data);
 int keyrepeat(void *data);

--- a/objects/keybinding.c
+++ b/objects/keybinding.c
@@ -255,7 +255,7 @@ luaA_keybind(lua_State *L)
  * \return 1 if handled, 0 if not
  */
 int
-luaA_key_check_and_emit(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym)
+luaA_key_check_and_emit(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym, bool is_keypress)
 {
 	xkb_keysym_t lower_base = xkb_keysym_to_lower(base_sym);
 	int i;
@@ -285,7 +285,7 @@ luaA_key_check_and_emit(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_k
 		if (key->modifiers == mods && (keycode_match || keysym_match)) {
 			/* Push key object onto stack and emit signal using AwesomeWM's proper function */
 			luaA_object_push(global_L, key);
-			luaA_awm_object_emit_signal(global_L, -1, "press", 0);
+			luaA_awm_object_emit_signal(global_L, -1, is_keypress ? "press" : "release", 0);
 			lua_pop(global_L, 1);
 
 			/* Return after emitting - no need for further processing */
@@ -307,7 +307,7 @@ luaA_key_check_and_emit(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_k
  * \return 1 if handled, 0 if not
  */
 int
-luaA_client_key_check_and_emit(client_t *c, uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym)
+luaA_client_key_check_and_emit(client_t *c, uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym, bool is_keypress)
 {
 	xkb_keysym_t lower_base = xkb_keysym_to_lower(base_sym);
 	int i;
@@ -344,7 +344,7 @@ luaA_client_key_check_and_emit(client_t *c, uint32_t mods, uint32_t keycode, xkb
 			luaA_object_push_item(global_L, -1, key);
 			/* Emit signal with client as argument (1 arg) - client is at -2, key at -1 */
 			lua_pushvalue(global_L, -2);  /* Copy client to top for signal arg */
-			luaA_awm_object_emit_signal(global_L, -2, "press", 1);
+			luaA_awm_object_emit_signal(global_L, -2, is_keypress ? "press" : "release", 1);
 			/* Pop key object and client */
 			lua_pop(global_L, 2);
 

--- a/objects/keybinding.h
+++ b/objects/keybinding.h
@@ -3,6 +3,7 @@
 
 #include <lua.h>
 #include <xkbcommon/xkbcommon.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 /* Forward declare client_t */
@@ -11,10 +12,10 @@ typedef struct client_t client_t;
 void luaA_keybinding_setup(lua_State *L);
 
 /* NEW AwesomeWM-compatible system: key objects with signals */
-int luaA_key_check_and_emit(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym);
+int luaA_key_check_and_emit(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym, bool is_keypress);
 
 /* Client-specific keybindings - checks client's keys array and passes client as arg */
-int luaA_client_key_check_and_emit(client_t *c, uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym);
+int luaA_client_key_check_and_emit(client_t *c, uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym, bool is_keypress);
 
 /* OLD DEPRECATED system: direct callback storage */
 int luaA_keybind_check(uint32_t mods, xkb_keysym_t sym, xkb_keysym_t base_sym);


### PR DESCRIPTION
Closes #620

## Description
Adds handling for KeyRelease events. Currently somewm is hardcoded to only handle KeyPress events.


## Test Plan
Used the configuration from #620


## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
