### PR TITLE
fix: line-buffer stdout so print() reaches redirected logs

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -7580,6 +7580,12 @@ ensure_lgi_guard(int argc, char *argv[])
 int
 main(int argc, char *argv[])
 {
+	/* Line-buffer stdout so rc.lua print() output appears promptly even when
+	 * stdout is redirected to a file or pipe (e.g. `somewm-client test`, tee,
+	 * journald). Without this glibc block-buffers a non-TTY stdout and the
+	 * output is never flushed while the compositor runs. stderr is unbuffered. */
+	setvbuf(stdout, NULL, _IOLBF, 0);
+
 	ensure_lgi_guard(argc, argv);
 	unsetenv("LD_PRELOAD");  /* Guard is loaded; don't leak to children */
 


### PR DESCRIPTION
## Description

`print()` writes to stdout, which glibc block-buffers when stdout isn't a TTY (`somewm-client test`, a pipe, journald), so it never flushes while the compositor runs. Line-buffer stdout at startup.

Fixes #622.

## Test Plan

- `make test-unit`: 770/770 pass.
- Live (`somewm 2>&1 | tee log`): `somewm-client eval 'print("x")'` now shows in the log immediately.

## Checklist

- [x] Lua libraries not modified — C-only change (`somewm.c`)
- [ ] Tests pass — unit pass; integration not run