### PR TITLE
switch to wlroots 0.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
@@ -15,7 +16,10 @@ concurrency:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      TZ: Etc/UTC
 
     strategy:
       fail-fast: false
@@ -42,10 +46,14 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime
+          sudo sh -c 'echo Etc/UTC > /etc/timezone'
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends \
             build-essential \
+            dpkg-dev \
             ninja-build \
+            python3-pip \
             pkg-config \
             wayland-protocols \
             libwayland-dev \
@@ -64,6 +72,8 @@ jobs:
             libxcb-render-util0-dev \
             libxcb-res0-dev \
             libxcb-ewmh-dev \
+            libxcb-errors-dev \
+            libxcb-xfixes0-dev \
             libxcb-xinput-dev \
             libxcb-util-dev \
             hwdata \
@@ -73,6 +83,7 @@ jobs:
             ${{ matrix.lua.dev_package }} \
             lua-busted \
             lua-lgi \
+            luarocks \
             libcairo2-dev \
             libpango1.0-dev \
             libgdk-pixbuf-2.0-dev \
@@ -89,55 +100,61 @@ jobs:
             zsh
 
       - name: Upgrade meson
-        run: pip install --upgrade --break-system-packages meson
+        run: python3 -m pip install --upgrade --break-system-packages meson
 
       - name: Cache deps
         id: cache-deps
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/deps-install
-          key: deps-wayland-pixman-wlroots-v2-${{ runner.os }}
+          key: deps-wlroots-v2${{ runner.os }}
 
-      - name: Build wayland, pixman, and wayland-protocols
+      - name: Cache Lua 5.2 CI deps
+        if: matrix.lua.pkg == 'lua5.2'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/lua-5.2-ci
+          key: deps-lua5.2-ci-lgi-0.9.2-busted-2.3.0-${{ runner.os }}}-v2
+
+      - name: Build wlroots 0.20
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/deps-install
-
-          # Build wayland 1.23.1
-          cd ~
-          git clone --depth 1 --branch 1.23.1 https://gitlab.freedesktop.org/wayland/wayland.git
-          cd wayland
-          meson setup build --prefix=$HOME/deps-install -Ddocumentation=false -Dtests=false
-          ninja -C build
-          ninja -C build install
-
-          # Build pixman 0.44.2
-          cd ~
-          git clone --depth 1 --branch pixman-0.44.2 https://gitlab.freedesktop.org/pixman/pixman.git
-          cd pixman
-          meson setup build --prefix=$HOME/deps-install -Dtests=disabled -Ddemos=disabled
-          ninja -C build
-          ninja -C build install
-
-          # Build wayland-protocols 1.41
-          cd ~
-          git clone --depth 1 --branch 1.41 https://gitlab.freedesktop.org/wayland/wayland-protocols.git
-          cd wayland-protocols
-          meson setup build --prefix=$HOME/deps-install -Dtests=false
-          ninja -C build
-          ninja -C build install
-
-      - name: Build wlroots
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
           export PKG_CONFIG_PATH=$HOME/deps-install/share/pkgconfig:$HOME/deps-install/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
           cd ~
-          git clone --depth 1 --branch 0.19.3 https://gitlab.freedesktop.org/wlroots/wlroots.git
+          git clone --depth 1 --branch 0.20.0 https://gitlab.freedesktop.org/wlroots/wlroots.git
           cd wlroots
           meson setup build --prefix=$HOME/deps-install -Dexamples=false -Dxwayland=enabled
           ninja -C build
           ninja -C build install
 
+      - name: Prepare Lua 5.2 CI deps
+        if: matrix.lua.pkg == 'lua5.2'
+        run: |
+          set -eu
+          mkdir -p "$HOME/lua-5.2-ci"
+
+          # Ubuntu no longer ships these modules for Lua 5.2 (just 5.1 and 5.3), so build them from source.
+          if [ ! -f "$HOME/lua-5.2-ci/share/lua/5.2/lgi/init.lua" ]; then
+            sudo sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+            sudo apt-get update
+            cd /tmp
+            apt-get source lua-lgi
+            cd lua-lgi-*/
+            make -C lgi LUA_VERSION=5.2 PREFIX="$HOME/lua-5.2-ci" LUA_CFLAGS="$(pkg-config --cflags lua5.2)" VERSION=0.9.2
+            make -C lgi install LUA_VERSION=5.2 PREFIX="$HOME/lua-5.2-ci" LUA_CFLAGS="$(pkg-config --cflags lua5.2)" VERSION=0.9.2
+          fi
+
+          if [ ! -x "$HOME/lua-5.2-ci/bin/busted" ]; then
+            luarocks --lua-version=5.2 --tree="$HOME/lua-5.2-ci" install busted 2.3.0-1
+          fi
+
+          sudo mkdir -p /usr/local/share/lua/5.2 /usr/local/lib/lua/5.2
+          sudo cp -a "$HOME/lua-5.2-ci/share/lua/5.2/." /usr/local/share/lua/5.2/
+          sudo cp -a "$HOME/lua-5.2-ci/lib/lua/5.2/." /usr/local/lib/lua/5.2/
+          sudo install -Dm755 "$HOME/lua-5.2-ci/bin/busted" /usr/local/bin/busted
+
+        # Add manually built deps to paths
       - name: Set paths
         run: |
           echo "PATH=$HOME/deps-install/bin:$PATH" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Lua framework for building your Wayland desktop. Layouts, widgets, keybindings
 
 SomeWM has a complete widget system, a signal-driven object model, and a compositor runtime, all wired together so every piece can talk to every other piece. Write a widget that reacts to window focus changes. Build a layout that adapts to screen geometry. Script your entire workflow from `rc.lua` or from the command line.
 
-Built on [wlroots](https://gitlab.freedesktop.org/wlroots/wlroots) 0.19. Compatible with [AwesomeWM's](https://github.com/awesomeWM/awesome) Lua API - existing configs, widgets, and themes carry over.
+Built on [wlroots](https://gitlab.freedesktop.org/wlroots/wlroots) 0.20. Compatible with [AwesomeWM's](https://github.com/awesomeWM/awesome) Lua API - existing configs, widgets, and themes carry over.
 
 > **This branch (`main`) is 2.0-dev.** If you want 100% AwesomeWM parity, use the [`release/1.4`](https://github.com/trip-zip/somewm/tree/release/1.4) branch or install `somewm` from the [AUR](https://aur.archlinux.org/packages/somewm).
 

--- a/client.h
+++ b/client.h
@@ -255,14 +255,12 @@ client_is_float_type(Client *c)
 		if (surface->modal)
 			return 1;
 
-#ifdef WLR_VERSION_0_19
 		if (COMPAT_XWAYLAND_HAS_WINDOW_TYPE(surface, WLR_XWAYLAND_NET_WM_WINDOW_TYPE_DIALOG)
 				|| COMPAT_XWAYLAND_HAS_WINDOW_TYPE(surface, WLR_XWAYLAND_NET_WM_WINDOW_TYPE_SPLASH)
 				|| COMPAT_XWAYLAND_HAS_WINDOW_TYPE(surface, WLR_XWAYLAND_NET_WM_WINDOW_TYPE_TOOLBAR)
 				|| COMPAT_XWAYLAND_HAS_WINDOW_TYPE(surface, WLR_XWAYLAND_NET_WM_WINDOW_TYPE_UTILITY)) {
 			return 1;
 		}
-#endif
 
 		return size_hints && size_hints->min_width > 0 && size_hints->min_height > 0
 			&& (size_hints->max_width == size_hints->min_width

--- a/client.h
+++ b/client.h
@@ -7,6 +7,7 @@
  */
 
 /* Need complete client_t definition for inline functions */
+#include <xdg-shell-protocol.h>
 #include <assert.h>
 #include "somewm_types.h"  /* For Client typedef and Monitor */
 #include "objects/client.h" /* For complete client_t definition */

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771848320,
-        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "lastModified": 1784007870,
+        "narHash": "sha256-djcLt/JJphyNt4eDY9XTly+/WbCK5lqWq9lSgCmJkkQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "rev": "18b9261cb3294b6d2a06d03f96872827b8fe2698",
         "type": "github"
       },
       "original": {

--- a/luaa.c
+++ b/luaa.c
@@ -75,7 +75,6 @@ static lua_State *luaA_create_fresh_state(void);
 #include <wlr/types/wlr_scene.h>
 #include <wlr/backend/wayland.h>
 #include <wlr/types/wlr_buffer.h>
-#include <wlr/interfaces/wlr_buffer.h>
 #include <drm_fourcc.h>
 #include <cairo/cairo.h>
 

--- a/meson.build
+++ b/meson.build
@@ -104,12 +104,11 @@ lgi_output = lgi_check_result.stdout().strip()
 lgi_version = lgi_output.split('Found lgi ')[-1].split('\n')[0]
 message('Found LGI version: ' + lgi_version)
 
-# wlroots 0.19 only - use system if available, otherwise build from subproject
-# We only support 0.19+ due to Xwayland bugs in earlier versions
-wlroots = dependency('wlroots-0.19', version : '>=0.19.3', static: false, required: false)
+# wlroots 0.20 only - use system if available, otherwise build from subproject
+wlroots = dependency('wlroots-0.20', version : '>=0.20.0', static: false, required: false)
 
 if not wlroots.found()
-  message('System wlroots 0.19 not found, building from subproject...')
+  message('System wlroots 0.20 not found, building from subproject...')
 
   wlroots_options = [
     'examples=false',
@@ -125,7 +124,7 @@ if not wlroots.found()
   wlroots = wlroots_proj.get_variable('wlroots')
 endif
 
-wlroots_version = '0.19'
+wlroots_version = '0.20'
 message('Using wlroots version: ' + wlroots_version)
 
 # PAM authentication (optional, for lock screen)
@@ -263,8 +262,8 @@ add_project_arguments(
   language: 'c',
 )
 
-# Always 0.19 - we only support this version
-add_project_arguments('-DWLR_VERSION_0_19', language: 'c')
+# Always 0.20 - we only support this version
+add_project_arguments('-DWLR_VERSION_0_20', language: 'c')
 
 if have_xwayland
   add_project_arguments('-DXWAYLAND', language: 'c')

--- a/objects/wibox.c
+++ b/objects/wibox.c
@@ -20,7 +20,6 @@
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_buffer.h>
-#include <wlr/interfaces/wlr_buffer.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/backend.h>

--- a/package.nix
+++ b/package.nix
@@ -24,7 +24,7 @@
   wayland,
   wayland-protocols,
   wayland-scanner,
-  wlroots_0_19,
+  wlroots_0_20,
   xwayland,
   gtk3Support ? true,
   gtk3 ? null,
@@ -74,7 +74,7 @@ stdenv.mkDerivation {
     pango
     wayland
     wayland-protocols
-    wlroots_0_19
+    wlroots_0_20
     libxcb
     libxcb-wm
     libxcb-util

--- a/root.c
+++ b/root.c
@@ -36,7 +36,6 @@
 #include <wlr/render/wlr_texture.h>
 #include <wlr/render/pass.h>
 #include <wlr/types/wlr_buffer.h>
-#include <wlr/interfaces/wlr_buffer.h>
 #include <wlr/render/allocator.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <cairo.h>

--- a/somewm.c
+++ b/somewm.c
@@ -312,7 +312,7 @@ cleanup(void)
 	destroykeyboardgroup(&kb_group->destroy, NULL);
 
 	/* Remove backend listeners immediately before destroying backend.
-	 * wlroots 0.19 asserts that all listeners are removed at destruction time. */
+	 * wlroots asserts that all listeners are removed at destruction time. */
 	wl_list_remove(&new_output.link);
 	wl_list_remove(&new_input_device.link);
 
@@ -346,7 +346,7 @@ cleanuplisteners(void)
 	wl_list_remove(&new_idle_inhibitor.link);
 	wl_list_remove(&layout_change.link);
 	/* NOTE: new_input_device and new_output are removed in cleanup()
-	 * immediately before wlr_backend_destroy() to satisfy wlroots 0.19
+	 * immediately before wlr_backend_destroy() to satisfy wlroots
 	 * assertions that require all backend listeners to be present until
 	 * backend destruction. */
 	wl_list_remove(&new_virtual_keyboard.link);

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -19,6 +19,7 @@
 #include <wlr/xwayland.h>
 
 #include "somewm_api.h"
+#include "wlr/xcursor.h"
 #include "xkb.h"
 #include "objects/signal.h"
 #include "objects/screen.h"
@@ -554,8 +555,7 @@ some_update_cursor_theme(const char *theme_name, uint32_t size)
 	struct wlr_xcursor *xcursor = wlr_xcursor_manager_get_xcursor(cursor_mgr, "default", 1);
 	if (xcursor && xwayland) {
 		wlr_xwayland_set_cursor(xwayland,
-			xcursor->images[0]->buffer, xcursor->images[0]->width * 4,
-			xcursor->images[0]->width, xcursor->images[0]->height,
+			wlr_xcursor_image_get_buffer(xcursor->images[0]),
 			xcursor->images[0]->hotspot_x, xcursor->images[0]->hotspot_y);
 	}
 #endif

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -37,7 +37,7 @@
 
 /* Mirror of wlroots' private keyboard_group_device struct (wlr_keyboard_group.c).
  * Needed to iterate member keyboards when setting layout group.
- * Must match the exact layout of the wlroots 0.19 struct. */
+ * Must match the exact layout of the wlroots 0.20 struct. */
 struct kb_group_device {
 	struct wlr_keyboard *keyboard;
 	struct wl_listener key;

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,7 +1,7 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 0.19.3
+revision = 0.20.0
 depth = 1
 
 [provide]
-dependency_names = wlroots-0.19
+dependency_names = wlroots-0.20

--- a/wlr_compat.h
+++ b/wlr_compat.h
@@ -1,10 +1,9 @@
 /*
  * wlr_compat.h - wlroots version abstraction layer
  *
- * Provides macros to abstract wlroots API details. When wlroots 0.20
- * inevitably breaks APIs, only this file needs updating.
+ * Provides macros to abstract wlroots API details.
  *
- * Currently targets wlroots 0.19.
+ * Currently targets wlroots 0.20.
  */
 
 #ifndef WLR_COMPAT_H

--- a/xwayland.c
+++ b/xwayland.c
@@ -229,8 +229,7 @@ xwaylandready(struct wl_listener *listener, void *data)
 	/* Set the default XWayland cursor to match the rest of somewm. */
 	if ((xcursor = wlr_xcursor_manager_get_xcursor(cursor_mgr, "default", 1)))
 		wlr_xwayland_set_cursor(xwayland,
-				xcursor->images[0]->buffer, xcursor->images[0]->width * 4,
-				xcursor->images[0]->width, xcursor->images[0]->height,
+				wlr_xcursor_image_get_buffer(xcursor->images[0]),
 				xcursor->images[0]->hotspot_x, xcursor->images[0]->hotspot_y);
 
 	/* Initialize XCB connection for EWMH support (AwesomeWM pattern) */


### PR DESCRIPTION

## Description
switch to wlroots 0.20.0 for #579. The latest versions of most distros have wlroots 0.20.x but if needed I can change the pr to keep support for 0.19.3.
### Progress
- [x] Compile and pass tests with wlroots 0.20
- [x] Update CI
- [x] Investigate api usage to verify that there are no regressions
- [x] Update code comments and other documentation 




## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
