### PR TITLE
fix: wake the poll for timers armed during the refresh cycle

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -678,11 +678,63 @@ create_wayland_source(struct wl_event_loop *loop)
 	return source;
 }
 
-/* Custom poll function - THE KEY INTEGRATION POINT
+/* RefreshSource - runs the refresh cycle in GLib's prepare phase.
  *
- * This is called by GLib before every poll() syscall and is where we
- * implement AwesomeWM's refresh cycle pattern. By doing refresh here,
- * we ensure all deferred changes are applied before sleeping.
+ * some_refresh() executes Lua (the "refresh" signal, gears.timer delayed
+ * calls, coroutines resumed from them), which can arm new GLib timeout
+ * sources. GLib computes the poll timeout during the prepare phase, and a
+ * same-thread g_source_attach() does not wake an already-computed poll, so
+ * a timer armed any later in the iteration is invisible to it: on an idle
+ * session the loop sleeps indefinitely while the timer is due, until an
+ * unrelated fd event happens to wake it. Running the refresh here, at a
+ * higher priority than the default-priority timeout sources, means sources
+ * it arms are inserted into buckets this same prepare pass visits
+ * afterwards, so they are included in this iteration's poll timeout. */
+static gboolean
+refresh_source_prepare(GSource *source, gint *timeout)
+{
+	lua_State *L = globalconf_get_lua_State();
+
+	some_refresh();
+
+	/* Check Lua stack integrity (matches AwesomeWM) */
+	if (L && lua_gettop(L) != 0) {
+		fprintf(stderr, "WARNING: Something left %d items on Lua stack, this is a bug!\n",
+		        lua_gettop(L));
+		luaA_dumpstack(L);
+		lua_settop(L, 0);
+	}
+
+	/* Never ready: this source only does work in prepare */
+	*timeout = -1;
+	return FALSE;
+}
+
+static gboolean
+refresh_source_check(GSource *source)
+{
+	return FALSE;
+}
+
+static gboolean
+refresh_source_dispatch(GSource *source, GSourceFunc callback, gpointer user_data)
+{
+	return G_SOURCE_CONTINUE;
+}
+
+static GSourceFuncs refresh_source_funcs = {
+	refresh_source_prepare,
+	refresh_source_check,
+	refresh_source_dispatch,
+	NULL,  /* finalize */
+	NULL,  /* closure_callback */
+	NULL   /* closure_marshal */
+};
+
+/* Custom poll function - called by GLib before every poll() syscall.
+ * The refresh cycle itself runs in refresh_source_prepare() so that timers
+ * it arms count toward this iteration's poll timeout; what remains here is
+ * the work that must happen after every prepare and right before sleeping.
  *
  * Matches AwesomeWM's awesome.c:a_glib_poll()
  */
@@ -693,19 +745,6 @@ some_glib_poll(GPollFD *ufds, guint nfsd, gint timeout)
 	struct timeval now, length_time;
 	float length;
 	int saved_errno;
-	lua_State *L = globalconf_get_lua_State();
-
-	/* CRITICAL: Do all deferred work before sleeping
-	 * This applies layout calculations from Lua to Wayland scene graph */
-	some_refresh();
-
-	/* Check Lua stack integrity (matches AwesomeWM) */
-	if (L && lua_gettop(L) != 0) {
-		fprintf(stderr, "WARNING: Something left %d items on Lua stack, this is a bug!\n",
-		        lua_gettop(L));
-		luaA_dumpstack(L);
-		lua_settop(L, 0);
-	}
 
 	/* Flush pending Wayland client data before polling
 	 * Clients won't receive data until we flush */
@@ -967,13 +1006,21 @@ run(char *startup_cmd)
 	 *
 	 * This is the SAME architecture as AwesomeWM:
 	 * - GLib main loop is primary (g_main_loop_run)
-	 * - Custom poll function (some_glib_poll) calls refresh before polling
+	 * - Refresh cycle runs in the prepare phase (refresh_source_prepare)
 	 * - Backend events (Wayland) integrated via GSource
 	 * - D-Bus, timers, and other GLib sources work automatically
 	 */
 
 	/* Get Wayland event loop */
 	loop = wl_display_get_event_loop(dpy);
+
+	/* Run the refresh cycle in the prepare phase (see refresh_source_prepare).
+	 * G_PRIORITY_HIGH so it is prepared before the default-priority timeout
+	 * sources the refresh Lua may arm. Attached before wayland_source so its
+	 * id stays below glib_source_baseline and survives hot-reload cleanup. */
+	GSource *refresh_source = g_source_new(&refresh_source_funcs, sizeof(GSource));
+	g_source_set_priority(refresh_source, G_PRIORITY_HIGH);
+	g_source_attach(refresh_source, NULL);
 
 	/* Create and attach Wayland GSource to GLib main context */
 	wayland_source = create_wayland_source(loop);
@@ -1008,6 +1055,7 @@ run(char *startup_cmd)
 	g_main_loop_run(globalconf.loop);
 
 	/* Cleanup */
+	g_source_destroy(refresh_source);
 	g_source_destroy(wayland_source);
 	g_main_loop_unref(globalconf.loop);
 	globalconf.loop = NULL;

--- a/tests/test-keyboardlayout-cycle.lua
+++ b/tests/test-keyboardlayout-cycle.lua
@@ -1,0 +1,79 @@
+---------------------------------------------------------------------------
+--- Reproduction test for issue #438: keyboardlayout widget errors when
+--- cycling layouts via mouse click at the wrap-around point.
+---
+--- The next_layout() modulo arithmetic produced an out-of-range group
+--- number when wrapping from the last layout back to the first.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local async = require("_async")
+local awful = require("awful")
+local kb_widget = require("awful.widget.keyboardlayout")
+
+runner.run_async(function()
+    ------------------------------------------------------------------
+    -- Setup: configure multi-layout keyboard
+    ------------------------------------------------------------------
+    io.stderr:write("[TEST] Setting up multi-layout keyboard: us,cz\n")
+    awful.input.xkb_layout = "us,cz"
+    async.sleep(0.3)
+
+    local instance = kb_widget()
+
+    io.stderr:write("[TEST] Widget state: #_layout=" .. tostring(#instance._layout) .. "\n")
+    assert(#instance._layout == 2,
+        "Expected 2 layouts, got " .. #instance._layout)
+
+    ------------------------------------------------------------------
+    -- Test A: next_layout() from group 0 should not error
+    ------------------------------------------------------------------
+    awesome.xkb_set_layout_group(0)
+    async.sleep(0.2)
+    -- Manually sync _current since signal may be delayed in nested mode
+    instance._current = awesome.xkb_get_layout_group()
+
+    io.stderr:write("[TEST] Calling next_layout() from group 0\n")
+    local ok, err = pcall(instance.next_layout)
+    assert(ok, "next_layout() from group 0 errored: " .. tostring(err))
+    io.stderr:write("[TEST] PASS: next_layout() from group 0 succeeded\n")
+
+    async.sleep(0.2)
+
+    ------------------------------------------------------------------
+    -- Test B: next_layout() from group 1 should wrap to 0, not error
+    -- This is the actual bug: before the fix, this produced group 2
+    ------------------------------------------------------------------
+    awesome.xkb_set_layout_group(1)
+    async.sleep(0.2)
+    -- Manually sync _current since signal may be delayed in nested mode
+    instance._current = awesome.xkb_get_layout_group()
+    assert(instance._current == 1,
+        "Expected _current=1, got " .. tostring(instance._current))
+
+    io.stderr:write("[TEST] Calling next_layout() from group 1 (wrap-around)\n")
+    ok, err = pcall(instance.next_layout)
+    assert(ok, "next_layout() from group 1 errored (wrap-around bug): " .. tostring(err))
+    io.stderr:write("[TEST] PASS: next_layout() wrap-around succeeded\n")
+
+    ------------------------------------------------------------------
+    -- Test C: set_layout rejects out-of-range group numbers
+    ------------------------------------------------------------------
+    ok, err = pcall(instance.set_layout, #instance._layout)
+    assert(not ok, "set_layout(#_layout) should error but succeeded")
+    io.stderr:write("[TEST] PASS: set_layout rejects group=" .. #instance._layout .. "\n")
+
+    ok, err = pcall(instance.set_layout, -1)
+    assert(not ok, "set_layout(-1) should error but succeeded")
+    io.stderr:write("[TEST] PASS: set_layout rejects group=-1\n")
+
+    ------------------------------------------------------------------
+    -- Cleanup: reset to single layout
+    ------------------------------------------------------------------
+    awesome.xkb_set_layout_group(0)
+    awful.input.xkb_layout = "us"
+
+    runner.done()
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-numlock-setting.lua
+++ b/tests/test-numlock-setting.lua
@@ -1,0 +1,45 @@
+---------------------------------------------------------------------------
+--- Test for issue #239: NumLock breaks wibar scroll bindings.
+---
+--- Verifies that awesome._set_keyboard_setting("numlock", bool) toggles
+--- NumLock without crashing, exercising the full path:
+---   Lua -> luaA_awesome_set_keyboard_setting("numlock") -> some_set_numlock()
+---     -> xkb_state_serialize_mods -> wlr_keyboard_notify_modifiers
+---
+--- Note: The CLEANMASK regression (scroll/button bindings firing with NumLock
+--- active) cannot currently be tested from the Lua integration layer because
+--- root.fake_input("button_press") uses wlr_seat_pointer_notify_button, which
+--- delivers to Wayland clients rather than triggering buttonnotify/axisnotify.
+--- A full regression test would require virtual pointer injection
+--- (wlr_virtual_pointer_v1).
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local async  = require("_async")
+
+runner.run_async(function()
+    ------------------------------------------------------------------
+    -- Test: toggle NumLock on and off without error
+    ------------------------------------------------------------------
+    io.stderr:write("[TEST] Enabling NumLock via _set_keyboard_setting\n")
+    awesome._set_keyboard_setting("numlock", true)
+    async.sleep(0.2)
+
+    io.stderr:write("[TEST] Disabling NumLock via _set_keyboard_setting\n")
+    awesome._set_keyboard_setting("numlock", false)
+    async.sleep(0.1)
+
+    io.stderr:write("[TEST] Re-enabling NumLock\n")
+    awesome._set_keyboard_setting("numlock", true)
+    async.sleep(0.1)
+
+    io.stderr:write("[TEST] Disabling NumLock again\n")
+    awesome._set_keyboard_setting("numlock", false)
+    async.sleep(0.1)
+
+    io.stderr:write("[TEST] PASS: _set_keyboard_setting('numlock') toggles without crashing\n")
+
+    runner.done()
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-timer-idle-wakeup.lua
+++ b/tests/test-timer-idle-wakeup.lua
@@ -1,0 +1,40 @@
+---------------------------------------------------------------------------
+--- Test that a timer armed during the refresh cycle fires on an idle session.
+---
+--- gears.timer delayed calls run from the "refresh" signal, which the
+--- compositor emits while preparing to sleep. A timer armed there used to be
+--- invisible to the poll timeout the event loop had already computed, so on
+--- an idle session (no input, no client traffic) it never fired until an
+--- unrelated event woke the loop. This stranded every _async wait between
+--- steps and froze rc.lua timers armed from delayed_call context.
+---
+--- The chain below reproduces it: the outer timer fires in the dispatch
+--- phase and queues a delayed call; the delayed call runs during refresh and
+--- arms the inner timer there, with no other event-loop activity left.
+--- Without the fix the inner timer never fires and the test times out.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local timer = require("gears.timer")
+
+runner.run_direct()
+
+timer.start_new(1.0, function()
+    timer.delayed_call(function()
+        local armed_at = os.time()
+        timer.start_new(0.5, function()
+            -- A rescue event (like the harness SIGTERM at timeout) can fire a
+            -- stranded timer late, so completing is not enough: it must fire
+            -- close to its deadline.
+            local elapsed = os.time() - armed_at
+            if elapsed > 5 then
+                runner.done(string.format(
+                    "timer armed during refresh was stranded for %d seconds", elapsed))
+            else
+                runner.done()
+            end
+            return false
+        end)
+    end)
+    return false
+end)


### PR DESCRIPTION
## Description
Cherry-pick of #633 to main. The refresh cycle ran inside the custom poll function, after GLib had computed the poll timeout, so a `gears.timer` armed there was invisible to the poll and an idle session slept indefinitely with the timer due. The refresh now runs in a prepare-phase GSource at high priority, so sources it arms count toward the same iteration's poll timeout. Also restores the two keyboard integration tests dropped by #617: their slowness was this bug, and they now run in about a second.

## Test Plan
- `tests/test-timer-idle-wakeup.lua` and both restored tests pass repeatedly on a quiet system with the session bus severed (the conditions that previously hung them).
- Full headless suite: identical failure set to origin/main base (only the two layer-shell headless input gaps), with 3 more tests and ~35s less wall time.
- `make test-unit`: 755/1, the 1 failure (`spec/menubar/utils_spec.lua`) reproduces identically on base.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)