### PR TITLE
fix(seat): advertise pointer and keyboard capabilities at startup

### DIFF
--- a/input.c
+++ b/input.c
@@ -1373,7 +1373,6 @@ inputdevice(struct wl_listener *listener, void *data)
 	/* This event is raised by the backend when a new input device becomes
 	 * available. */
 	struct wlr_input_device *device = data;
-	uint32_t caps;
 
 	switch (device->type) {
 	case WLR_INPUT_DEVICE_KEYBOARD:
@@ -1390,14 +1389,7 @@ inputdevice(struct wl_listener *listener, void *data)
 		break;
 	}
 
-	/* We need to let the wlr_seat know what our capabilities are, which is
-	 * communiciated to the client. In somewm we always have a cursor, even if
-	 * there are no pointer devices, so we always include that capability. */
-	/* TODO do we actually require a cursor? */
-	caps = WL_SEAT_CAPABILITY_POINTER;
-	if (!wl_list_empty(&kb_group->wlr_group->devices))
-		caps |= WL_SEAT_CAPABILITY_KEYBOARD;
-	wlr_seat_set_capabilities(seat, caps);
+	/* Seat capabilities are constant; advertised once in setup(). */
 }
 
 void

--- a/somewm.c
+++ b/somewm.c
@@ -1393,6 +1393,13 @@ setup(void)
 	kb_group = createkeyboardgroup();
 	wl_list_init(&kb_group->destroy.link);
 
+	/* The cursor and the group keyboard exist regardless of physical devices,
+	 * so advertise both capabilities once here. Waiting for a device event
+	 * leaves them at zero on headless backends and clients can bind neither
+	 * wl_pointer nor wl_keyboard. */
+	wlr_seat_set_capabilities(seat,
+		WL_SEAT_CAPABILITY_POINTER | WL_SEAT_CAPABILITY_KEYBOARD);
+
 	output_mgr = wlr_output_manager_v1_create(dpy);
 	wl_signal_add(&output_mgr->events.apply, &output_mgr_apply);
 	wl_signal_add(&output_mgr->events.test, &output_mgr_test);


### PR DESCRIPTION
## Description

Backport of #635 (`release/1.4`) to `main`. The input-device handler lives in `input.c` on 2.x; the fix is otherwise identical.

On backends without input devices (headless), the `new_input` handler never fires, so `wlr_seat_set_capabilities` was never called and the seat advertised zero capabilities. Clients could bind neither `wl_pointer` nor `wl_keyboard`, and pointer-enter and key events were never delivered.

The cursor and the group keyboard exist regardless of physical devices, so this advertises `POINTER | KEYBOARD` once in `setup()`. `inputdevice()` no longer recomputes capabilities on device events; they are constant, so there is a single source of truth and no advertise-on-every-hotplug churn.

## Test Plan

- The two previously failing headless tests pass on this branch: `test-layer-shell-pointer-enter` and `test-layer-shell-focus-escape` under `HEADLESS=1`.
- `make build-test` compiles clean.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
