### PR TITLE
test: settle focus and geometry in carousel tests

### DIFF
--- a/tests/_utils.lua
+++ b/tests/_utils.lua
@@ -380,6 +380,46 @@ function utils.step_wait_for_focus(class)
     end
 end
 
+--- Create a step that focuses a client and waits until focus actually
+-- lands on it, then arranges. autofocus from a still-mapping client can
+-- override client.focus right after it is set, which would leave a layout
+-- centered on the wrong client; re-assert each poll until focus sticks.
+-- @tparam function get_client Returns the target client (evaluated each poll)
+-- @treturn function Step function for runner.run_steps()
+function utils.step_focus(get_client)
+    return function()
+        local c = get_client()
+        if not c or not c.valid then return nil end
+        if client.focus ~= c then
+            client.focus = c
+            c:raise()
+            return nil
+        end
+        awful.layout.arrange(c.screen or awful.screen.focused())
+        return true
+    end
+end
+
+--- Create a step that arranges and waits until a client's geometry stops
+-- changing (identical across two consecutive polls). Use before asserting
+-- on geometry that results from a deferred arrange, so the assertion does
+-- not run against a half-applied layout.
+-- @tparam function get_client Returns the target client (evaluated each poll)
+-- @treturn function Step function for runner.run_steps()
+function utils.step_settle_geometry(get_client)
+    local last
+    return function()
+        local c = get_client()
+        if not c or not c.valid then return nil end
+        awful.layout.arrange(c.screen or awful.screen.focused())
+        local g = c:geometry()
+        local key = string.format("%d,%d,%d,%d", g.x, g.y, g.width, g.height)
+        if last == key then return true end
+        last = key
+        return nil
+    end
+end
+
 --- Activate a client and verify focus.
 -- Helper to properly activate a client using request::activate signal.
 -- @tparam client c The client to activate

--- a/tests/test-carousel-animation.lua
+++ b/tests/test-carousel-animation.lua
@@ -37,30 +37,25 @@ local steps = {
     function(count)
         if count == 1 then test_client("anim_a") end
         c1 = utils.find_client_by_class("anim_a")
-        if c1 then return true end
+        if c1 and client.focus == c1 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("anim_b") end
         c2 = utils.find_client_by_class("anim_b")
-        if c2 then return true end
+        if c2 and client.focus == c2 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("anim_c") end
         c3 = utils.find_client_by_class("anim_c")
-        if c3 then return true end
+        if c3 and client.focus == c3 then return true end
     end,
 
     -- Test instant snap (duration=0): focus c1, verify immediately positioned
-    function(count)
-        if count == 1 then
-            client.focus = c1
-            c1:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-
+    utils.step_focus(function() return c1 end),
+    utils.step_settle_geometry(function() return c1 end),
+    function()
         local wa = screen.primary.workarea
         local g1 = c1:geometry()
         io.stderr:write(string.format(

--- a/tests/test-carousel-centering-modes.lua
+++ b/tests/test-carousel-centering-modes.lua
@@ -40,19 +40,19 @@ local steps = {
     function(count)
         if count == 1 then test_client("center_a") end
         c1 = utils.find_client_by_class("center_a")
-        if c1 then return true end
+        if c1 and client.focus == c1 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("center_b") end
         c2 = utils.find_client_by_class("center_b")
-        if c2 then return true end
+        if c2 and client.focus == c2 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("center_c") end
         c3 = utils.find_client_by_class("center_c")
-        if c3 then return true end
+        if c3 and client.focus == c3 then return true end
     end,
 
     -- Set all columns to 1/3 width so they fit side by side
@@ -78,14 +78,9 @@ local steps = {
     end,
 
     -- Test "always" mode: focused column should be centered
-    function(count)
-        if count == 1 then
-            client.focus = c1
-            c1:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-
+    utils.step_focus(function() return c1 end),
+    utils.step_settle_geometry(function() return c1 end),
+    function()
         local wa = screen.primary.workarea
         local g1 = c1:geometry()
         local col_center = g1.x + g1.width / 2
@@ -105,16 +100,11 @@ local steps = {
     end,
 
     -- Switch to "never" mode
-    function(count)
-        if count == 1 then
-            carousel.set_center_mode("never")
-            -- Focus c1 which should be visible
-            client.focus = c1
-            c1:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-
+    function() carousel.set_center_mode("never") return true end,
+    -- Focus c1 which should be visible
+    utils.step_focus(function() return c1 end),
+    utils.step_settle_geometry(function() return c1 end),
+    function()
         local wa = screen.primary.workarea
         local g1 = c1:geometry()
 
@@ -131,15 +121,10 @@ local steps = {
     end,
 
     -- Switch to "on-overflow" mode and verify
-    function(count)
-        if count == 1 then
-            carousel.set_center_mode("on-overflow")
-            client.focus = c2
-            c2:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-
+    function() carousel.set_center_mode("on-overflow") return true end,
+    utils.step_focus(function() return c2 end),
+    utils.step_settle_geometry(function() return c2 end),
+    function()
         local wa = screen.primary.workarea
         local g2 = c2:geometry()
 
@@ -214,14 +199,9 @@ local steps = {
     end,
 
     -- Focus c3 (offscreen right): should align right edge to viewport right
-    function(count)
-        if count == 1 then
-            client.focus = c3
-            c3:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-
+    utils.step_focus(function() return c3 end),
+    utils.step_settle_geometry(function() return c3 end),
+    function()
         local wa = screen.primary.workarea
         local g3 = c3:geometry()
         local bw = c3.border_width or 0
@@ -243,14 +223,9 @@ local steps = {
     end,
 
     -- Focus c1 (offscreen left): should align left edge to viewport left
-    function(count)
-        if count == 1 then
-            client.focus = c1
-            c1:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-
+    utils.step_focus(function() return c1 end),
+    utils.step_settle_geometry(function() return c1 end),
+    function()
         local wa = screen.primary.workarea
         local g1 = c1:geometry()
 

--- a/tests/test-carousel-column-movement.lua
+++ b/tests/test-carousel-column-movement.lua
@@ -37,19 +37,19 @@ local steps = {
     function(count)
         if count == 1 then test_client("move_a") end
         c1 = utils.find_client_by_class("move_a")
-        if c1 then return true end
+        if c1 and client.focus == c1 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("move_b") end
         c2 = utils.find_client_by_class("move_b")
-        if c2 then return true end
+        if c2 and client.focus == c2 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("move_c") end
         c3 = utils.find_client_by_class("move_c")
-        if c3 then return true end
+        if c3 and client.focus == c3 then return true end
     end,
 
     -- Let layout settle, focus c1
@@ -88,15 +88,7 @@ local steps = {
     end,
 
     -- Wait and then focus c2 (middle column) for the move test
-    function(count)
-        if count == 1 then
-            client.focus = c2
-            c2:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-        return true
-    end,
+    utils.step_focus(function() return c2 end),
 
     -- Record positions before move
     function(count)

--- a/tests/test-carousel-column-widths.lua
+++ b/tests/test-carousel-column-widths.lua
@@ -40,25 +40,17 @@ local steps = {
     function(count)
         if count == 1 then test_client("width_a") end
         c1 = utils.find_client_by_class("width_a")
-        if c1 then return true end
+        if c1 and client.focus == c1 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("width_b") end
         c2 = utils.find_client_by_class("width_b")
-        if c2 then return true end
+        if c2 and client.focus == c2 then return true end
     end,
 
-    -- Step 4: Focus c1 and let layout settle
-    function(count)
-        if count == 1 then
-            client.focus = c1
-            c1:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-        return true
-    end,
+    -- Step 4: Focus c1 and wait for focus to settle
+    utils.step_focus(function() return c1 end),
 
     -- Step 5: Cycle column width (deferred arrange)
     function(count)

--- a/tests/test-carousel-edge-focus.lua
+++ b/tests/test-carousel-edge-focus.lua
@@ -37,31 +37,25 @@ local steps = {
     function(count)
         if count == 1 then test_client("efocus_a") end
         c1 = utils.find_client_by_class("efocus_a")
-        if c1 then return true end
+        if c1 and client.focus == c1 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("efocus_b") end
         c2 = utils.find_client_by_class("efocus_b")
-        if c2 then return true end
+        if c2 and client.focus == c2 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("efocus_c") end
         c3 = utils.find_client_by_class("efocus_c")
-        if c3 then return true end
+        -- Wait for c3's focus-on-map to land before proceeding, so a delayed
+        -- steal cannot fire after a later step has set focus elsewhere.
+        if c3 and client.focus == c3 then return true end
     end,
 
     -- Focus middle column
-    function(count)
-        if count == 1 then
-            client.focus = c2
-            c2:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-        return true
-    end,
+    utils.step_focus(function() return c2 end),
 
     -- focus_first_column: should focus c1
     function(count)
@@ -70,9 +64,8 @@ local steps = {
             return nil
         end
 
-        assert(client.focus == c1,
-            string.format("Expected focus on c1 (%s), got %s",
-                c1.class, client.focus and client.focus.class or "nil"))
+        -- focus_first_column changes focus asynchronously; wait for it to land.
+        if client.focus ~= c1 then return nil end
 
         local wa = screen.primary.workarea
         local g1 = c1:geometry()
@@ -94,9 +87,8 @@ local steps = {
             return nil
         end
 
-        assert(client.focus == c3,
-            string.format("Expected focus on c3 (%s), got %s",
-                c3.class, client.focus and client.focus.class or "nil"))
+        -- focus_last_column changes focus asynchronously; wait for it to land.
+        if client.focus ~= c3 then return nil end
 
         local wa = screen.primary.workarea
         local g3 = c3:geometry()
@@ -119,8 +111,8 @@ local steps = {
             return nil
         end
 
-        assert(client.focus == c1,
-            "focus_first_column should return to c1 after focus_last_column")
+        -- Wait for the round-trip focus change to land back on c1.
+        if client.focus ~= c1 then return nil end
 
         local wa = screen.primary.workarea
         local g1 = c1:geometry()

--- a/tests/test-carousel-focus-navigation.lua
+++ b/tests/test-carousel-focus-navigation.lua
@@ -39,32 +39,23 @@ local steps = {
     function(count)
         if count == 1 then test_client("nav_a") end
         c1 = utils.find_client_by_class("nav_a")
-        if c1 then return true end
+        if c1 and client.focus == c1 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("nav_b") end
         c2 = utils.find_client_by_class("nav_b")
-        if c2 then return true end
+        if c2 and client.focus == c2 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("nav_c") end
         c3 = utils.find_client_by_class("nav_c")
-        if c3 then return true end
+        if c3 and client.focus == c3 then return true end
     end,
 
-    -- Step 5: Focus c1, let layout settle
-    function(count)
-        if count == 1 then
-            client.focus = c1
-            c1:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-        assert(client.focus == c1, "c1 should be focused")
-        return true
-    end,
+    -- Step 5: Focus c1, wait for focus to settle before navigating
+    utils.step_focus(function() return c1 end),
 
     -- Step 6: bydirection("right") moves focus from c1 to the next column
     function(count)

--- a/tests/test-carousel-gesture-scrolling.lua
+++ b/tests/test-carousel-gesture-scrolling.lua
@@ -43,19 +43,19 @@ local steps = {
     function(count)
         if count == 1 then test_client("gest_a") end
         c1 = utils.find_client_by_class("gest_a")
-        if c1 then return true end
+        if c1 and client.focus == c1 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("gest_b") end
         c2 = utils.find_client_by_class("gest_b")
-        if c2 then return true end
+        if c2 and client.focus == c2 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("gest_c") end
         c3 = utils.find_client_by_class("gest_c")
-        if c3 then return true end
+        if c3 and client.focus == c3 then return true end
     end,
 
     -- Set all to 1/2 width so strip overflows

--- a/tests/test-carousel-layout.lua
+++ b/tests/test-carousel-layout.lua
@@ -106,15 +106,9 @@ local steps = {
     end,
 
     -- Step 6: Focus c1 (should be a different client) and verify scroll
-    function(count)
-        if count == 1 then
-            -- Focus a specific client
-            client.focus = c1
-            c1:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-
+    utils.step_focus(function() return c1 end),
+    utils.step_settle_geometry(function() return c1 end),
+    function()
         local wa = screen.primary.workarea
         local g1 = c1:geometry()
         io.stderr:write(string.format("[TEST] After focus c1: x=%d, width=%d\n", g1.x, g1.width))

--- a/tests/test-carousel-peek.lua
+++ b/tests/test-carousel-peek.lua
@@ -44,19 +44,16 @@ local steps = {
     function(count)
         if count == 1 then test_client("peek_a") end
         c1 = utils.find_client_by_class("peek_a")
-        if c1 then return true end
+        if c1 and client.focus == c1 then return true end
     end,
 
-    -- Set peek_width = 50, verify inset
-    function(count)
-        if count == 1 then
-            carousel.peek_width = 50
-            client.focus = c1
-            c1:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
+    -- Set peek_width = 50, then settle focus and the deferred arrange
+    function() carousel.peek_width = 50 return true end,
+    utils.step_focus(function() return c1 end),
+    utils.step_settle_geometry(function() return c1 end),
 
+    -- Verify inset
+    function()
         local wa = screen.primary.workarea
         local g = c1:geometry()
         local bw = c1.border_width or 0
@@ -88,14 +85,12 @@ local steps = {
         return true
     end,
 
-    -- Set peek_width = 0, verify full-width
-    function(count)
-        if count == 1 then
-            carousel.peek_width = 0
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
+    -- Set peek_width = 0, then settle the deferred arrange
+    function() carousel.peek_width = 0 return true end,
+    utils.step_settle_geometry(function() return c1 end),
 
+    -- Verify full-width
+    function()
         local wa = screen.primary.workarea
         local g = c1:geometry()
         local bw = c1.border_width or 0
@@ -130,31 +125,27 @@ local steps = {
     function(count)
         if count == 1 then test_client("peek_b") end
         c1 = utils.find_client_by_class("peek_b")
-        if c1 then return true end
+        if c1 and client.focus == c1 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("peek_c") end
         c2 = utils.find_client_by_class("peek_c")
-        if c2 then return true end
+        if c2 and client.focus == c2 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("peek_d") end
         c3 = utils.find_client_by_class("peek_d")
-        if c3 then return true end
+        if c3 and client.focus == c3 then return true end
     end,
 
     -- Set peek=50, focus middle column (c2), check adjacent column edges
-    function(count)
-        if count == 1 then
-            carousel.peek_width = 50
-            client.focus = c2
-            c2:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
+    function() carousel.peek_width = 50 return true end,
+    utils.step_focus(function() return c2 end),
+    utils.step_settle_geometry(function() return c2 end),
 
+    function()
         local wa = screen.primary.workarea
         local g1 = c1:geometry()
         local g2 = c2:geometry()

--- a/tests/test-carousel-push-window.lua
+++ b/tests/test-carousel-push-window.lua
@@ -40,19 +40,19 @@ local steps = {
     function(count)
         if count == 1 then test_client("push_a") end
         c1 = utils.find_client_by_class("push_a")
-        if c1 then return true end
+        if c1 and client.focus == c1 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("push_b") end
         c2 = utils.find_client_by_class("push_b")
-        if c2 then return true end
+        if c2 and client.focus == c2 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("push_c") end
         c3 = utils.find_client_by_class("push_c")
-        if c3 then return true end
+        if c3 and client.focus == c3 then return true end
     end,
 
     -- Let layout settle, set all to 1/3 width
@@ -78,15 +78,7 @@ local steps = {
     end,
 
     -- Focus c2 (middle), push right -> c2 joins c3's column
-    function(count)
-        if count == 1 then
-            client.focus = c2
-            c2:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-        return true
-    end,
+    utils.step_focus(function() return c2 end),
 
     function(count)
         if count == 1 then
@@ -146,15 +138,7 @@ local steps = {
     -- Focus c1 (leftmost), push right -> c1 joins its right neighbor's column
     -- Note: after push+expel above, column order is c1, c3, c2.
     -- Pushing c1 right joins c1 with c3's column.
-    function(count)
-        if count == 1 then
-            client.focus = c1
-            c1:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-        return true
-    end,
+    utils.step_focus(function() return c1 end),
 
     function(count)
         if count == 1 then
@@ -192,15 +176,7 @@ local steps = {
     -- Boundary: push left from leftmost column -> no-op
     -- After push+expel ops, column order is [c3], [c1], [c2].
     -- c3 is leftmost, so push c3 left should be no-op.
-    function(count)
-        if count == 1 then
-            client.focus = c3
-            c3:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-        return true
-    end,
+    utils.step_focus(function() return c3 end),
 
     function(count)
         if count == 1 then
@@ -225,15 +201,7 @@ local steps = {
 
     -- Boundary: push right from rightmost column -> no-op
     -- c2 is rightmost, so push c2 right should be no-op.
-    function(count)
-        if count == 1 then
-            client.focus = c2
-            c2:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-        return true
-    end,
+    utils.step_focus(function() return c2 end),
 
     function(count)
         if count == 1 then

--- a/tests/test-carousel-regression-bugs.lua
+++ b/tests/test-carousel-regression-bugs.lua
@@ -43,39 +43,31 @@ local steps = {
     function(count)
         if count == 1 then test_client("regbug_a") end
         c1 = utils.find_client_by_class("regbug_a")
-        if c1 then return true end
+        if c1 and client.focus == c1 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("regbug_b") end
         c2 = utils.find_client_by_class("regbug_b")
-        if c2 then return true end
+        if c2 and client.focus == c2 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("regbug_c") end
         c3 = utils.find_client_by_class("regbug_c")
-        if c3 then return true end
+        -- Wait for c3's focus-on-map to land before proceeding, so a delayed
+        -- steal cannot fire after a later step has set focus elsewhere.
+        if c3 and client.focus == c3 then return true end
     end,
 
     -- Focus c2 (middle column), consume c1 to the left (column destroyed)
-    function(count)
-        if count == 1 then
-            client.focus = c2
-            c2:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-        return true
-    end,
+    utils.step_focus(function() return c2 end),
 
-    function(count)
-        if count == 1 then
-            -- Consume the left neighbor (c1) into c2's column
-            carousel.consume_window(-1)
-            return nil
-        end
+    -- Consume the left neighbor (c1) into c2's column
+    function() carousel.consume_window(-1) return true end,
+    utils.step_settle_geometry(function() return c2 end),
 
+    function()
         -- c1 is now stacked in c2's column. c1's old column is destroyed.
         -- c2 should still be visible (viewport followed the focused column).
         local wa = screen.primary.workarea
@@ -96,18 +88,18 @@ local steps = {
     end,
 
     -- Expel c1 back out (column created). c2 should still be visible.
-    function(count)
-        if count == 1 then
-            client.focus = c1
-            c1:raise()
-            carousel.expel_window()
-            -- Re-focus c2
-            client.focus = c2
-            c2:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
+    function()
+        client.focus = c1
+        c1:raise()
+        carousel.expel_window()
+        -- Re-focus c2
+        client.focus = c2
+        c2:raise()
+        return true
+    end,
+    utils.step_settle_geometry(function() return c2 end),
 
+    function()
         local wa = screen.primary.workarea
         local g2 = c2:geometry()
         io.stderr:write(string.format(

--- a/tests/test-carousel-stacking.lua
+++ b/tests/test-carousel-stacking.lua
@@ -38,19 +38,19 @@ local steps = {
     function(count)
         if count == 1 then test_client("stack_a") end
         c1 = utils.find_client_by_class("stack_a")
-        if c1 then return true end
+        if c1 and client.focus == c1 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("stack_b") end
         c2 = utils.find_client_by_class("stack_b")
-        if c2 then return true end
+        if c2 and client.focus == c2 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("stack_c") end
         c3 = utils.find_client_by_class("stack_c")
-        if c3 then return true end
+        if c3 and client.focus == c3 then return true end
     end,
 
     -- Let layout settle with focus on c1. Wait until focus actually lands on

--- a/tests/test-carousel-strip-boundaries.lua
+++ b/tests/test-carousel-strip-boundaries.lua
@@ -39,18 +39,14 @@ local steps = {
     function(count)
         if count == 1 then test_client("bound_a") end
         c1 = utils.find_client_by_class("bound_a")
-        if c1 then return true end
+        if c1 and client.focus == c1 then return true end
     end,
 
     -- Set to 1/3 width and verify centering (strip narrower than viewport)
-    function(count)
-        if count == 1 then
-            client.focus = c1
-            c1:raise()
-            carousel.set_column_width(1/3)
-            return nil
-        end
-
+    function() carousel.set_column_width(1/3) return true end,
+    utils.step_focus(function() return c1 end),
+    utils.step_settle_geometry(function() return c1 end),
+    function()
         local wa = screen.primary.workarea
         local g1 = c1:geometry()
         local col_center = g1.x + g1.width / 2
@@ -73,13 +69,13 @@ local steps = {
     function(count)
         if count == 1 then test_client("bound_b") end
         c2 = utils.find_client_by_class("bound_b")
-        if c2 then return true end
+        if c2 and client.focus == c2 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("bound_c") end
         c3 = utils.find_client_by_class("bound_c")
-        if c3 then return true end
+        if c3 and client.focus == c3 then return true end
     end,
 
     -- Set all to full width for boundary clamping tests
@@ -106,14 +102,9 @@ local steps = {
 
     -- Focus c1 (leftmost), verify left boundary clamp.
     -- In on-overflow mode, centering c1 wants negative offset, clamped to 0.
-    function(count)
-        if count == 1 then
-            client.focus = c1
-            c1:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-
+    utils.step_focus(function() return c1 end),
+    utils.step_settle_geometry(function() return c1 end),
+    function()
         local wa = screen.primary.workarea
         local g1 = c1:geometry()
 
@@ -129,14 +120,9 @@ local steps = {
     end,
 
     -- Focus c3 (rightmost), verify right boundary clamp
-    function(count)
-        if count == 1 then
-            client.focus = c3
-            c3:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-
+    utils.step_focus(function() return c3 end),
+    utils.step_settle_geometry(function() return c3 end),
+    function()
         local wa = screen.primary.workarea
         local g3 = c3:geometry()
 

--- a/tests/test-carousel-vertical-animation.lua
+++ b/tests/test-carousel-vertical-animation.lua
@@ -39,19 +39,19 @@ local steps = {
     function(count)
         if count == 1 then test_client("vanim_a") end
         c1 = utils.find_client_by_class("vanim_a")
-        if c1 then return true end
+        if c1 and client.focus == c1 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("vanim_b") end
         c2 = utils.find_client_by_class("vanim_b")
-        if c2 then return true end
+        if c2 and client.focus == c2 then return true end
     end,
 
     function(count)
         if count == 1 then test_client("vanim_c") end
         c3 = utils.find_client_by_class("vanim_c")
-        if c3 then return true end
+        if c3 and client.focus == c3 then return true end
     end,
 
     -- Test instant snap (duration=0): focus c1, verify it settles into view.

--- a/tests/test-carousel-vertical-basic.lua
+++ b/tests/test-carousel-vertical-basic.lua
@@ -109,14 +109,9 @@ local steps = {
     end,
 
     -- Step 6: Focus c1 and verify vertical scroll
-    function(count)
-        if count == 1 then
-            client.focus = c1
-            c1:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-
+    utils.step_focus(function() return c1 end),
+    utils.step_settle_geometry(function() return c1 end),
+    function()
         local wa = screen.primary.workarea
         local g1 = c1:geometry()
         io.stderr:write(string.format("[TEST] After focus c1: y=%d, height=%d\n",

--- a/tests/test-carousel-vertical-operations.lua
+++ b/tests/test-carousel-vertical-operations.lua
@@ -57,15 +57,7 @@ local steps = {
     end,
 
     -- Let layout settle with focus on c1
-    function(count)
-        if count == 1 then
-            client.focus = c1
-            c1:raise()
-            awful.layout.arrange(screen.primary)
-            return nil
-        end
-        return true
-    end,
+    utils.step_focus(function() return c1 end),
 
     -- Consume c2 (next row) into c1's row
     function(count)


### PR DESCRIPTION
## Description

Forward-port of #638 from `release/1.4`. Identical carousel test files and helpers.

Carousel integration tests flaked under the headless backend because they asserted on focus and geometry before those settled. Root cause: a spawned client's focus-on-map fires asynchronously and could land after a later step set focus elsewhere, so the carousel followed the wrong client and left the intended one off-screen. Spawn steps now wait for each client's focus-on-map before proceeding. Two helpers, `step_focus` and `step_settle_geometry`, replace the fragile "set focus, then assert geometry on a fixed poll" pattern with explicit waits. Test-only; no compositor or Lua library code changed.

## Test Plan

- Full headless suite 10x consecutive on `main`: 10/10 clean (131 tests each). Previously ~2 flaky carousel tests per run, rotating across the family.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
