### PR TITLE
fix(client): emit unfocus when a focused client is destroyed

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -6268,20 +6268,24 @@ unmapnotify(struct wl_listener *listener, void *data)
 		c->toplevel_handle = NULL;
 	}
 
-	/* CRITICAL: If this is the focused client, clear focus immediately
-	 * to prevent client_focus_refresh() from accessing dangling surface pointers */
-	if (globalconf.focus.client == c) {
-		globalconf.focus.client = NULL;
-		globalconf.focus.need_update = true;
-		/* Clear seat keyboard focus to prevent focusclient() from trying to
-		 * deactivate this surface during focus restoration. The XDG surface
-		 * is already uninitialized by the time unmapnotify fires, so any
-		 * wlr_xdg_toplevel_set_activated() call would assert. */
-		if (seat->keyboard_state.focused_surface == client_surface(c))
-			wlr_seat_keyboard_clear_focus(seat);
-	}
+	/* Clear seat keyboard focus to prevent focusclient() from trying to
+	 * deactivate this surface during focus restoration. The XDG surface
+	 * is already uninitialized by the time unmapnotify fires, so any
+	 * wlr_xdg_toplevel_set_activated() call would assert. */
+	if (globalconf.focus.client == c
+			&& seat->keyboard_state.focused_surface == client_surface(c))
+		wlr_seat_keyboard_clear_focus(seat);
 
 	if (client_is_unmanaged(c)) {
+		/* Unmanaged clients never reach client_unmanage(), so clear the
+		 * focus pointer here: the scene is destroyed below and a later
+		 * focusclient() would touch its freed borders. focusclient() skips
+		 * unmanaged clients, so they never got a "focus" signal and there
+		 * is no "unfocus" to emit. */
+		if (globalconf.focus.client == c) {
+			globalconf.focus.client = NULL;
+			globalconf.focus.need_update = true;
+		}
 		if (c == exclusive_focus) {
 			exclusive_focus = NULL;
 			focus_restore(c->mon ? c->mon : selmon);
@@ -6290,6 +6294,8 @@ unmapnotify(struct wl_listener *listener, void *data)
 		/* AwesomeWM pattern: call client_unmanage() from unmapnotify.
 		 * This emits request::unmanage while c->screen is still valid,
 		 * allowing Lua's check_focus_delayed to restore focus properly.
+		 * It also calls client_unfocus() while the client is still focused,
+		 * which is what emits "unfocus" + property::active=false.
 		 * destroynotify() will see client already removed from array and skip. */
 		client_unmanage(c, CLIENT_UNMANAGE_UNMAP);
 	}

--- a/tests/test-client-unfocus-on-close.lua
+++ b/tests/test-client-unfocus-on-close.lua
@@ -1,0 +1,66 @@
+---------------------------------------------------------------------------
+--- Test: closing a focused client emits "unfocus"
+--
+-- AwesomeWM emits "unfocus" (and property::active=false) from
+-- client_unmanage(), before request::unmanage and while the client is
+-- still valid. somewm used to clear globalconf.focus.client in
+-- unmapnotify(), so client_unmanage() found no focused client and the
+-- signal was never emitted.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local async = require("_async")
+local test_client = require("_client")
+
+if not test_client.is_available() then
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local events = {}
+local unfocused, valid_at_unfocus
+
+client.connect_signal("unfocus", function(c)
+    if c.class ~= "unfocus_close" then return end
+    table.insert(events, "unfocus")
+    unfocused = c
+    valid_at_unfocus = c.valid
+end)
+
+client.connect_signal("property::active", function(c)
+    if c.class ~= "unfocus_close" or c.active then return end
+    table.insert(events, "property::active")
+end)
+
+client.connect_signal("request::unmanage", function(c)
+    if c.class ~= "unfocus_close" then return end
+    table.insert(events, "request::unmanage")
+end)
+
+runner.run_async(function()
+    test_client("unfocus_close")
+    local c = async.wait_for_client("unfocus_close", 5)
+    assert(c, "Client did not appear")
+    assert(async.wait_for_focus("unfocus_close", 2), "Client should have focus")
+
+    -- kitty ignores the close request while its child (sleep infinity) runs,
+    -- so kill the process to get a real surface destroy.
+    assert(c.pid, "Client has no pid")
+    os.execute("kill " .. c.pid)
+    async.wait_for_condition(function() return #events >= 3 end, 10)
+
+    assert(unfocused, "unfocus was not emitted when the focused client closed")
+    assert(unfocused == c, "unfocus was emitted for the wrong client")
+    assert(valid_at_unfocus, "client should still be valid when unfocus fires")
+
+    assert(events[1] == "property::active",
+        "expected property::active first, got " .. tostring(events[1]))
+    assert(events[2] == "unfocus",
+        "expected unfocus before request::unmanage, got " .. tostring(events[2]))
+    assert(events[3] == "request::unmanage",
+        "expected request::unmanage last, got " .. tostring(events[3]))
+    assert(#events == 3, "expected exactly 3 events, got " .. #events)
+
+    runner.done()
+end)


### PR DESCRIPTION
## Description
Closing a focused client emitted no `unfocus` (and no `property::active = false`).
AwesomeWM emits both from `client_unmanage()`, before `request::unmanage` and
while the client is still valid.

`unmapnotify()` cleared `globalconf.focus.client` itself, so by the time
`client_unmanage()` ran, its `if (globalconf.focus.client == c) client_unfocus(c)`
guard was already false. The seat-level `wlr_seat_keyboard_clear_focus()` is the
part that actually protects the uninitialized XDG surface, so that stays; the
manual pointer clear now only runs for unmanaged clients, which never reach
`client_unmanage()` from that path (and never got a `focus` signal either, so
they have no `unfocus` to emit).

Fixes #628

## Test Plan
- New `tests/test-client-unfocus-on-close.lua`: asserts `unfocus` fires once for
  the closed client, that the client is still `valid` when it fires, and that the
  order is `property::active` -> `unfocus` -> `request::unmanage`. Fails on base,
  passes with the fix.
- `make test-unit` (770 pass) and `make test-integration` (128 pass).
- ASAN: closing a focused client with titlebars, with a settle delay so the
  deferred titlebar redraw fires after teardown. No sanitizer reports.
- Verified in a live session: closing a focused xterm now logs `unfocus` before
  `request::unmanage`.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
