### PR TITLE
fix(client): emit unfocus when a focused client is destroyed

### DIFF
--- a/objects/client.c
+++ b/objects/client.c
@@ -1908,9 +1908,13 @@ client_getbyframewin(xcb_window_t w)
 
 /** Unfocus a client (internal).
  * \param c The client.
+ * \param sync Emit the signals now instead of queueing them. Required when the
+ *             client is about to be invalidated (client_unmanage): the queue is
+ *             drained at the frame boundary, and luaA_object_emit_signal() drops
+ *             signals whose object no longer passes client_checker().
  */
 static void
-client_unfocus_internal(client_t *c)
+client_unfocus_internal(client_t *c, bool sync)
 {
     lua_State *L = globalconf_get_lua_State();
     globalconf.focus.client = NULL;
@@ -1918,18 +1922,27 @@ client_unfocus_internal(client_t *c)
     luaA_object_push(L, c);
 
     lua_pushboolean(L, false);
-    some_event_queue_signal(L, -2, SIG_PROPERTY_ACTIVE, 1);
-    some_event_queue_signal0(L, -1, SIG_UNFOCUS);
+    if (sync)
+    {
+        luaA_object_emit_signal(L, -2, "property::active", 1);
+        luaA_object_emit_signal(L, -1, "unfocus", 0);
+    }
+    else
+    {
+        some_event_queue_signal(L, -2, SIG_PROPERTY_ACTIVE, 1);
+        some_event_queue_signal0(L, -1, SIG_UNFOCUS);
+    }
     lua_pop(L, 1);
 }
 
 /** Unfocus a client.
  * \param c The client.
+ * \param sync Emit the signals now instead of queueing them.
  */
 static void
-client_unfocus(client_t *c)
+client_unfocus(client_t *c, bool sync)
 {
-    client_unfocus_internal(c);
+    client_unfocus_internal(c, sync);
     globalconf.focus.need_update = true;
 }
 
@@ -1954,7 +1967,7 @@ void client_ban_unfocus(client_t *c)
 {
     /* Wait until the last moment to take away the focus from the window. */
     if(globalconf.focus.client == c) {
-        client_unfocus(c);
+        client_unfocus(c, false);
     }
 }
 
@@ -2032,7 +2045,7 @@ client_focus_update(client_t *c)
          * because the client which has focus now could be using globally
          * active input model (or 'no input').
          */
-        client_unfocus_internal(globalconf.focus.client);
+        client_unfocus_internal(globalconf.focus.client, false);
     }
 
     focused_new = globalconf.focus.client != c;
@@ -3176,8 +3189,11 @@ client_unmanage(client_t *c, client_unmanage_t reason)
             tc->transient_for = NULL;
     }
 
+    /* Emit synchronously: this client is invalidated before the event queue is
+     * next drained, and drain drops signals on invalid objects. AwesomeWM emits
+     * unfocus here too, before request::unmanage, with the client still valid. */
     if(globalconf.focus.client == c)
-        client_unfocus(c);
+        client_unfocus(c, true);
 
     /* Clear pre-lock focused client if it references this client.
      * Prevents use-after-free when unlocking after the saved client is destroyed. */
@@ -5155,7 +5171,7 @@ luaA_client_module_newindex(lua_State *L)
         if (c)
             client_focus(c);
         else if (globalconf.focus.client)
-            client_unfocus(globalconf.focus.client);
+            client_unfocus(globalconf.focus.client, false);
     }
 
     return 0;

--- a/tests/test-client-unfocus-on-close.lua
+++ b/tests/test-client-unfocus-on-close.lua
@@ -1,0 +1,70 @@
+---------------------------------------------------------------------------
+--- Test: closing a focused client emits "unfocus"
+--
+-- AwesomeWM emits "unfocus" (and property::active=false) from
+-- client_unmanage(), before request::unmanage and while the client is
+-- still valid. somewm used to clear globalconf.focus.client in
+-- unmapnotify(), so client_unmanage() found no focused client and the
+-- signal was never emitted.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local async = require("_async")
+local test_client = require("_client")
+
+if not test_client.is_available() then
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local events = {}
+local unfocused, valid_at_unfocus
+
+client.connect_signal("unfocus", function(c)
+    if c.class ~= "unfocus_close" then return end
+    table.insert(events, "unfocus")
+    unfocused = c
+    valid_at_unfocus = c.valid
+end)
+
+client.connect_signal("property::active", function(c)
+    if c.class ~= "unfocus_close" or c.active then return end
+    table.insert(events, "property::active")
+end)
+
+client.connect_signal("request::unmanage", function(c)
+    if c.class ~= "unfocus_close" then return end
+    table.insert(events, "request::unmanage")
+end)
+
+runner.run_async(function()
+    test_client("unfocus_close")
+    local c = async.wait_for_client("unfocus_close", 5)
+    assert(c, "Client did not appear")
+
+    -- Focus explicitly: the test config has no rules, and new clients are only
+    -- focused by rules.
+    client.focus = c
+    assert(async.wait_for_focus("unfocus_close", 2), "Client should have focus")
+
+    -- kitty ignores both the close request and SIGTERM while its child
+    -- (sleep infinity) runs, so SIGKILL it to get a real surface destroy.
+    assert(c.pid, "Client has no pid")
+    os.execute("kill -9 " .. c.pid)
+    async.wait_for_condition(function() return #events >= 3 end, 10)
+
+    assert(unfocused, "unfocus was not emitted when the focused client closed")
+    assert(unfocused == c, "unfocus was emitted for the wrong client")
+    assert(valid_at_unfocus, "client should still be valid when unfocus fires")
+
+    assert(events[1] == "property::active",
+        "expected property::active first, got " .. tostring(events[1]))
+    assert(events[2] == "unfocus",
+        "expected unfocus before request::unmanage, got " .. tostring(events[2]))
+    assert(events[3] == "request::unmanage",
+        "expected request::unmanage last, got " .. tostring(events[3]))
+    assert(#events == 3, "expected exactly 3 events, got " .. #events)
+
+    runner.done()
+end)

--- a/window.c
+++ b/window.c
@@ -1769,20 +1769,24 @@ unmapnotify(struct wl_listener *listener, void *data)
 		c->toplevel_handle = NULL;
 	}
 
-	/* CRITICAL: If this is the focused client, clear focus immediately
-	 * to prevent client_focus_refresh() from accessing dangling surface pointers */
-	if (globalconf.focus.client == c) {
-		globalconf.focus.client = NULL;
-		globalconf.focus.need_update = true;
-		/* Clear seat keyboard focus to prevent focusclient() from trying to
-		 * deactivate this surface during focus restoration. The XDG surface
-		 * is already uninitialized by the time unmapnotify fires, so any
-		 * wlr_xdg_toplevel_set_activated() call would assert. */
-		if (seat->keyboard_state.focused_surface == client_surface(c))
-			wlr_seat_keyboard_clear_focus(seat);
-	}
+	/* Clear seat keyboard focus to prevent focusclient() from trying to
+	 * deactivate this surface during focus restoration. The XDG surface
+	 * is already uninitialized by the time unmapnotify fires, so any
+	 * wlr_xdg_toplevel_set_activated() call would assert. */
+	if (globalconf.focus.client == c
+			&& seat->keyboard_state.focused_surface == client_surface(c))
+		wlr_seat_keyboard_clear_focus(seat);
 
 	if (client_is_unmanaged(c)) {
+		/* Unmanaged clients never reach client_unmanage(), so clear the
+		 * focus pointer here: the scene is destroyed below and a later
+		 * focusclient() would touch its freed borders. focusclient() skips
+		 * unmanaged clients, so they never got a "focus" signal and there
+		 * is no "unfocus" to emit. */
+		if (globalconf.focus.client == c) {
+			globalconf.focus.client = NULL;
+			globalconf.focus.need_update = true;
+		}
 		if (c == exclusive_focus) {
 			exclusive_focus = NULL;
 			focus_restore(c->mon ? c->mon : selmon);
@@ -1791,6 +1795,8 @@ unmapnotify(struct wl_listener *listener, void *data)
 		/* AwesomeWM pattern: call client_unmanage() from unmapnotify.
 		 * This emits request::unmanage while c->screen is still valid,
 		 * allowing Lua's check_focus_delayed to restore focus properly.
+		 * It also calls client_unfocus() while the client is still focused,
+		 * which is what emits "unfocus" + property::active=false.
 		 * destroynotify() will see client already removed from array and skip. */
 		client_unmanage(c, CLIENT_UNMANAGE_UNMAP);
 	}


### PR DESCRIPTION
## Description
Cherry-pick of #640 to main.

Closing a focused client emitted no `unfocus` (and no `property::active = false`).
`unmapnotify()` cleared `globalconf.focus.client` itself, so `client_unmanage()`
no longer saw the client as focused and never called `client_unfocus()`.

main needs one thing 1.4 did not: `client_unfocus()` takes a `sync` flag and
`client_unmanage()` passes `true`. The event queue drains at the frame boundary,
by which point the client is invalidated and `luaA_object_emit_signal()` drops the
signal via `client_checker()`. AwesomeWM emits this synchronously too.

## Test Plan
- `tests/test-client-unfocus-on-close.lua` fails on main without the C change, passes with it.
- `make test-unit` passes; integration failure set is unchanged by this PR.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
