### PR TITLE
nix: Fix SVG support

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -28,6 +28,7 @@
   xwayland,
   gtk3Support ? true,
   gtk3 ? null,
+  wrapGAppsHook3,
   extraGIPackages ? [ ],
   extraLuaPackages ? (_: [ ]),
 }:
@@ -56,6 +57,7 @@ stdenv.mkDerivation {
     ninja
     pkg-config
     wayland-scanner
+    wrapGAppsHook3
   ];
 
   buildInputs = [


### PR DESCRIPTION
## Description

Very small change, fixes SVG support, did not open my config otherwise.

## Test Plan

Currently trying to migrate

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)
