### PR TITLE
fix(screen): C-side `screen:get_bounding_geometry` parity with old lua functionality

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771848320,
-        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
         "type": "github"
       },
       "original": {

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -869,6 +869,8 @@ luaA_screen_get_bounding_geometry(lua_State *L)
 	screen_t *screen;
 	struct wlr_box geo;
 	int honor_workarea, honor_padding;
+	/* 0 = left, 1 = right, 2 = top, 3 = bottom */
+	int margins[4] = { 0, 0, 0, 0 };
 
 	screen = luaA_checkscreen(L, 1);
 
@@ -889,12 +891,44 @@ luaA_screen_get_bounding_geometry(lua_State *L)
 		lua_getfield(L, 2, "honor_padding");
 		honor_padding = lua_toboolean(L, -1);
 		lua_pop(L, 1);
+
+		lua_getfield(L, 2, "margins");
+		if (lua_istable(L, -1)) {
+			lua_getfield(L, -1, "left");
+			margins[0] = lua_tointeger(L, -1);
+			lua_pop(L, 1);
+
+			lua_getfield(L, -1, "right");
+			margins[1] = lua_tointeger(L, -1);
+			lua_pop(L, 1);
+
+			lua_getfield(L, -1, "top");
+			margins[2] = lua_tointeger(L, -1);
+			lua_pop(L, 1);
+
+			lua_getfield(L, -1, "bottom");
+			margins[3] = lua_tointeger(L, -1);
+			lua_pop(L, 1);
+		} else if (lua_isnumber(L, -1)) {
+			margins[0] = lua_tointeger(L, -1);
+			margins[1] = lua_tointeger(L, -1);
+			margins[2] = lua_tointeger(L, -1);
+			margins[3] = lua_tointeger(L, -1);
+			lua_pop(L, 1);
+		}
+		lua_pop(L, 1);
 	}
 
 	/* Use workarea if requested, otherwise full geometry */
 	geo = honor_workarea ? screen->workarea : screen->geometry;
 
-	/* TODO: Apply honor_padding and margins if needed */
+	/* Apply margins */
+	geo.x += margins[0];
+	geo.y += margins[3];
+	geo.width -= (margins[0] + margins[1]);
+	geo.height -= (margins[2] + margins[3]);
+
+	/* TODO: Apply honor_padding */
 	(void)honor_padding;
 
 	lua_newtable(L);


### PR DESCRIPTION
## Description
- `luaA_screen_get_bounding_geometry`
  Apply the margin-based geometry adjustments like was done before
  in the lua function `screen.object.get_bounding_geometry`.

## Test Plan
<img width="1915" height="1078" alt="image" src="https://github.com/user-attachments/assets/835f9a95-e5ff-40e0-a104-ce6293657958" />
<img width="1920" height="1078" alt="image" src="https://github.com/user-attachments/assets/7d8cde09-6597-47a0-9bb6-00bb7d77d8ff" />
<img width="148" height="183" alt="image" src="https://github.com/user-attachments/assets/a45c9cf7-eb71-43d6-a937-ab5da037bac5" />

Tested with obnoxious useless_gap sizes in the theme and checking that the column, gap, and margin sizes are consistent.


## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)

## Notes
The function is still missing padding adjustments I want to talk
before I make these changes as I believe it need an additional
field in screen_t and getters/setters for that field.
The documentation above the function probably needs adjustment.