### PR TITLE
Stop accounting for border width in client geometry (port of #645)

### DIFF
--- a/DEVIATIONS.md
+++ b/DEVIATIONS.md
@@ -25,8 +25,9 @@ This document tracks all known differences between somewm and AwesomeWM. These e
 
 **Titlebar Border Positioning**
 - In X11, borders are drawn OUTSIDE the window frame by the X server
-- In Wayland, borders are scene rects at geometry edges
-- Titlebars must start INSIDE the border area, hence `border_width` inset
+- In Wayland, somewm draws borders as scene rects around the geometry: the scene tree origin is the outer border corner and the client footprint is `geometry` plus `border_width` on each side
+- `c->geometry` excludes the border, matching AwesomeWM
+- Titlebars are inside the geometry and must start INSIDE the border area, hence `border_width` inset
 - See `titlebar_get_area()` in `objects/client.c`
 
 **WM Restart**

--- a/client.h
+++ b/client.h
@@ -167,8 +167,8 @@ client_get_clip(Client *c, struct wlr_box *clip)
 	int tt = c->fullscreen ? 0 : c->titlebar[CLIENT_TITLEBAR_TOP].size;
 	int tr = c->fullscreen ? 0 : c->titlebar[CLIENT_TITLEBAR_RIGHT].size;
 	int tb = c->fullscreen ? 0 : c->titlebar[CLIENT_TITLEBAR_BOTTOM].size;
-	int cw = c->geometry.width - 2 * c->bw - tl - tr;
-	int ch = c->geometry.height - 2 * c->bw - tt - tb;
+	int cw = c->geometry.width - tl - tr;
+	int ch = c->geometry.height - tt - tb;
 	if (cw < 1) cw = 1;
 	if (ch < 1) ch = 1;
 

--- a/client.h
+++ b/client.h
@@ -159,10 +159,8 @@ client_get_appid(Client *c)
 static inline void
 client_get_clip(Client *c, struct wlr_box *clip)
 {
-	/* Clip must match the content area: geometry minus borders AND titlebars.
-	 * The surface node is positioned at (bw + tl, bw + tt) in the parent,
-	 * so clip dimensions must be the content size to prevent the surface
-	 * from bleeding past the bottom/right borders. */
+	/* Content area: geometry minus titlebars (borders sit outside the
+	 * geometry). Clipping to it keeps oversized buffers off the borders. */
 	int tl = c->fullscreen ? 0 : c->titlebar[CLIENT_TITLEBAR_LEFT].size;
 	int tt = c->fullscreen ? 0 : c->titlebar[CLIENT_TITLEBAR_TOP].size;
 	int tr = c->fullscreen ? 0 : c->titlebar[CLIENT_TITLEBAR_RIGHT].size;

--- a/luaa.c
+++ b/luaa.c
@@ -1257,7 +1257,8 @@ luaA_awesome_shadow_reload(lua_State *L)
 		const shadow_config_t *config = shadow_get_effective_config(
 			(*c)->shadow_config, false);
 		shadow_update_config(&(*c)->shadow, (*c)->scene, config,
-			(*c)->geometry.width, (*c)->geometry.height);
+			(*c)->geometry.width + 2 * (*c)->bw,
+			(*c)->geometry.height + 2 * (*c)->bw);
 	}
 
 	/* Update all existing drawin shadows */

--- a/objects/client.c
+++ b/objects/client.c
@@ -2747,7 +2747,7 @@ client_resize_do(client_t *c, area_t geometry, bool silent)
 }
 
 /** Resize client window.
- * The sizes given as parameters are with borders!
+ * The sizes given as parameters are *without* borders!
  * \param c Client to resize.
  * \param geometry New window geometry.
  * \param honor_hints Use size hints.

--- a/objects/client.c
+++ b/objects/client.c
@@ -2140,21 +2140,12 @@ client_border_refresh(void)
         if(!c->scene || !c->border[0])
             continue;
 
-        /* Sync wlroots border width (bw) with Lua-facing border_width */
-        c->bw = c->border_width;
-
-        /* Update border rectangle sizes based on new border width
-         * Border layout: [0]=top, [1]=bottom, [2]=left, [3]=right
-         * This matches the code in somewm.c:applybounds() */
-        wlr_scene_rect_set_size(c->border[0], c->geometry.width, c->border_width);
-        wlr_scene_rect_set_size(c->border[1], c->geometry.width, c->border_width);
-        wlr_scene_rect_set_size(c->border[2], c->border_width, c->geometry.height - 2 * c->border_width);
-        wlr_scene_rect_set_size(c->border[3], c->border_width, c->geometry.height - 2 * c->border_width);
-
-        /* Update border positions (bottom and right borders depend on geometry + border width) */
-        wlr_scene_node_set_position(&c->border[1]->node, 0, c->geometry.height - c->border_width);
-        wlr_scene_node_set_position(&c->border[2]->node, 0, c->border_width);
-        wlr_scene_node_set_position(&c->border[3]->node, c->geometry.width - c->border_width, c->border_width);
+        /* Sync wlroots border width (bw) with Lua-facing border_width;
+         * client_geometry_refresh() runs right after this and applies the
+         * new width to the border rects, surface offset and shadow.
+         * Fullscreen keeps bw at 0 (matches setfullscreen()), so a
+         * border_color change while fullscreen doesn't re-grow the frame. */
+        c->bw = c->fullscreen ? 0 : c->border_width;
 
         /* Update border color if initialized (matches AwesomeWM window_border_refresh pattern) */
         if(c->border_color.initialized) {
@@ -2197,8 +2188,9 @@ client_geometry_refresh(void)
 void
 client_refresh(void)
 {
-    client_geometry_refresh();
+    /* Border refresh first: it syncs c->bw, which the geometry pass reads */
     client_border_refresh();
+    client_geometry_refresh();
     client_focus_refresh();
 }
 
@@ -3794,8 +3786,9 @@ titlebar_get_area(client_t *c, client_titlebar_t bar)
 
     /* Wayland deviation: titlebars must be inset by border_width.
      * In X11, borders are drawn OUTSIDE the frame by the X server.
-     * In Wayland, we draw borders as scene rects at geometry edges,
-     * so titlebars must start INSIDE the border area. */
+     * In Wayland, we draw borders as scene rects outside the geometry,
+     * with the scene tree origin at the outer border corner, so
+     * titlebars (inside the geometry) start at a border_width inset. */
     result.x = bw;
     result.y = bw;
 
@@ -3814,13 +3807,13 @@ titlebar_get_area(client_t *c, client_titlebar_t bar)
 
     switch (bar) {
     case CLIENT_TITLEBAR_BOTTOM:
-        result.y = c->geometry.height + bw - c->titlebar[bar].size;
+        result.y = bw + c->geometry.height - c->titlebar[bar].size;
         /* Fall through */
     case CLIENT_TITLEBAR_TOP:
         result.height = c->titlebar[bar].size;
         break;
     case CLIENT_TITLEBAR_RIGHT:
-        result.x = c->geometry.width + bw - c->titlebar[bar].size;
+        result.x = bw + c->geometry.width - c->titlebar[bar].size;
         /* Fall through */
     case CLIENT_TITLEBAR_LEFT:
         result.y = bw + c->titlebar[CLIENT_TITLEBAR_TOP].size;
@@ -4469,7 +4462,7 @@ luaA_client_set_shadow(lua_State *L, client_t *c)
     /* Update shadow if client is mapped */
     if (c->scene) {
         shadow_update_config(&c->shadow, c->scene, &new_config,
-            c->geometry.width, c->geometry.height);
+            c->geometry.width + 2 * c->bw, c->geometry.height + 2 * c->bw);
     }
 
     luaA_object_emit_signal(L, -3, "property::shadow", 0);
@@ -4661,12 +4654,13 @@ luaA_client_get_content(lua_State *L, client_t *c)
      * clients (issue #539).
      *
      * wlr_scene_node_for_each_buffer reports (sx, sy) accumulated from the
-     * starting node down, NOT scene-absolute. So buffer positions are already
-     * relative to c->scene_surface's frame; no offset subtraction needed. */
+     * starting node down INCLUDING the starting node's own position, which
+     * for c->scene_surface is the (bw + titlebar) inset within c->scene.
+     * Subtract it so buffers land at the content origin of the capture. */
     rdata.cr        = cr;
     rdata.renderer  = drw;
-    rdata.offset_x  = 0;
-    rdata.offset_y  = 0;
+    rdata.offset_x  = -c->scene_surface->node.x;
+    rdata.offset_y  = -c->scene_surface->node.y;
     wlr_scene_node_for_each_buffer(&c->scene_surface->node,
                                    composite_scene_buffer_to_cairo, &rdata);
 

--- a/objects/client.c
+++ b/objects/client.c
@@ -3798,8 +3798,6 @@ titlebar_get_area(client_t *c, client_titlebar_t bar)
      * so titlebars must start INSIDE the border area. */
     result.x = bw;
     result.y = bw;
-    result.width -= 2 * bw;
-    result.height -= 2 * bw;
 
     // Let's try some ascii art (with borders):
     // +---------------------------+  <- border
@@ -3816,13 +3814,13 @@ titlebar_get_area(client_t *c, client_titlebar_t bar)
 
     switch (bar) {
     case CLIENT_TITLEBAR_BOTTOM:
-        result.y = c->geometry.height - bw - c->titlebar[bar].size;
+        result.y = c->geometry.height + bw - c->titlebar[bar].size;
         /* Fall through */
     case CLIENT_TITLEBAR_TOP:
         result.height = c->titlebar[bar].size;
         break;
     case CLIENT_TITLEBAR_RIGHT:
-        result.x = c->geometry.width - bw - c->titlebar[bar].size;
+        result.x = c->geometry.width + bw - c->titlebar[bar].size;
         /* Fall through */
     case CLIENT_TITLEBAR_LEFT:
         result.y = bw + c->titlebar[CLIENT_TITLEBAR_TOP].size;

--- a/screenshot_compose.h
+++ b/screenshot_compose.h
@@ -14,6 +14,10 @@
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_scene.h>
 
+/* wlr_scene_node_for_each_buffer() reports (sx, sy) accumulated from the
+ * starting node down INCLUDING the starting node's own position. Callers
+ * that start from a non-root node must pass offset_x/y = -node->x/-node->y
+ * to get subtree-relative coordinates. */
 struct screenshot_render_data {
 	cairo_t *cr;
 	struct wlr_renderer *renderer;

--- a/somewm.c
+++ b/somewm.c
@@ -449,12 +449,11 @@ some_has_exclusive_focus(void)
 void
 applybounds(Client *c, struct wlr_box *bbox)
 {
-	/* Minimum geometry must fit borders AND titlebars with at least 1px content */
-	int min_w = 1 + 2 * (int)c->bw
-		+ c->titlebar[CLIENT_TITLEBAR_LEFT].size
+	/* Minimum geometry must fit titlebars with at least 1px content;
+	 * borders sit outside the geometry */
+	int min_w = 1 + c->titlebar[CLIENT_TITLEBAR_LEFT].size
 		+ c->titlebar[CLIENT_TITLEBAR_RIGHT].size;
-	int min_h = 1 + 2 * (int)c->bw
-		+ c->titlebar[CLIENT_TITLEBAR_TOP].size
+	int min_h = 1 + c->titlebar[CLIENT_TITLEBAR_TOP].size
 		+ c->titlebar[CLIENT_TITLEBAR_BOTTOM].size;
 	c->geometry.width = MAX(min_w, c->geometry.width);
 	c->geometry.height = MAX(min_h, c->geometry.height);
@@ -3749,15 +3748,8 @@ mapnotify(struct wl_listener *listener, void *data)
 		c->border[i]->node.data = c;
 	}
 
-	/* Create shadow (compositor-level, replaces picom shadows) */
-	{
-		const shadow_config_t *shadow_config = shadow_get_effective_config(
-			c->shadow_config, false);
-		if (shadow_config && shadow_config->enabled) {
-			shadow_create(c->scene, &c->shadow, shadow_config,
-				c->geometry.width, c->geometry.height);
-		}
-	}
+	/* Shadow is lazily created by apply_geometry_to_wlroots() on the first
+	 * refresh cycle after the map */
 
 	/* Create foreign toplevel handle for external tools (rofi, taskbars, etc.) */
 	if (foreign_toplevel_mgr) {
@@ -4062,8 +4054,8 @@ unset_fullscreen:
 		int tb = c->fullscreen ? 0 : c->titlebar[CLIENT_TITLEBAR_BOTTOM].size;
 		int x0 = c->geometry.x + (int)c->bw + tl;
 		int y0 = c->geometry.y + (int)c->bw + tt;
-		int x1 = c->geometry.x + c->geometry.width  - (int)c->bw - tr;
-		int y1 = c->geometry.y + c->geometry.height - (int)c->bw - tb;
+		int x1 = c->geometry.x + (int)c->bw + c->geometry.width  - tr;
+		int y1 = c->geometry.y + (int)c->bw + c->geometry.height - tb;
 		if (cursor->x >= x0 && cursor->x < x1 && cursor->y >= y0 && cursor->y < y1) {
 			double sx, sy;
 			cursor_to_client_coordinates(c, &sx, &sy);
@@ -4767,6 +4759,7 @@ apply_geometry_to_wlroots(Client *c)
 {
 	struct wlr_box clip;
 	int titlebar_left, titlebar_top;
+	int frame_w, frame_h;
 
 	if (!c->scene || !client_surface(c) || !client_surface(c)->mapped)
 		return;
@@ -4776,17 +4769,21 @@ apply_geometry_to_wlroots(Client *c)
 	titlebar_left = c->fullscreen ? 0 : c->titlebar[CLIENT_TITLEBAR_LEFT].size;
 	titlebar_top = c->fullscreen ? 0 : c->titlebar[CLIENT_TITLEBAR_TOP].size;
 
+	/* The frame footprint is the geometry plus the border drawn outside it */
+	frame_w = c->geometry.width + 2 * c->bw;
+	frame_h = c->geometry.height + 2 * c->bw;
+
 	/* Update scene-graph position and borders */
 	wlr_scene_node_set_position(&c->scene->node, c->geometry.x, c->geometry.y);
 	/* Offset scene_surface by titlebar sizes (titlebars occupy space in geometry) */
 	wlr_scene_node_set_position(&c->scene_surface->node, c->bw + titlebar_left, c->bw + titlebar_top);
-	wlr_scene_rect_set_size(c->border[0], c->geometry.width + 2 * c->bw, c->bw);
-	wlr_scene_rect_set_size(c->border[1], c->geometry.width + 2 * c->bw, c->bw);
+	wlr_scene_rect_set_size(c->border[0], frame_w, c->bw);
+	wlr_scene_rect_set_size(c->border[1], frame_w, c->bw);
 	wlr_scene_rect_set_size(c->border[2], c->bw, c->geometry.height);
 	wlr_scene_rect_set_size(c->border[3], c->bw, c->geometry.height);
-	wlr_scene_node_set_position(&c->border[1]->node, 0, c->geometry.height + c->bw);
+	wlr_scene_node_set_position(&c->border[1]->node, 0, frame_h - c->bw);
 	wlr_scene_node_set_position(&c->border[2]->node, 0, c->bw);
-	wlr_scene_node_set_position(&c->border[3]->node, c->geometry.width + c->bw, c->bw);
+	wlr_scene_node_set_position(&c->border[3]->node, frame_w - c->bw, c->bw);
 
 	/* Update shadow geometry (lazy creation if needed) */
 	{
@@ -4795,10 +4792,10 @@ apply_geometry_to_wlroots(Client *c)
 		if (shadow_config && shadow_config->enabled) {
 			if (c->shadow.tree) {
 				shadow_update_geometry(&c->shadow, shadow_config,
-					c->geometry.width + c->bw, c->geometry.height + c->bw);
+					frame_w, frame_h);
 			} else {
 				shadow_create(c->scene, &c->shadow, shadow_config,
-					c->geometry.width + c->bw, c->geometry.height + c->bw);
+					frame_w, frame_h);
 			}
 		}
 	}
@@ -4823,7 +4820,7 @@ apply_geometry_to_wlroots(Client *c)
 			client_set_fullscreen_internal(c, c->fullscreen);
 #endif
 		if (c->fullscreen) {
-			/* Fullscreen: client gets full geometry minus borders only */
+			/* Fullscreen: no titlebars (and bw is 0), client gets the full geometry */
 			c->resize = client_set_size(c, c->geometry.width, c->geometry.height);
 		} else {
 			int sw = c->geometry.width
@@ -4946,7 +4943,7 @@ resize(Client *c, struct wlr_box geo, int interact)
 	applybounds(c, bbox);
 
 	/* Apply aspect ratio constraint (Wayland equivalent of ICCCM aspect hints).
-	 * Works on full geometry (including borders/titlebars) to match
+	 * Works on full geometry (including titlebars) to match
 	 * the ratio captured from Lua (geo.width / geo.height). */
 	if (c->aspect_ratio > 0 && !c->fullscreen && !c->maximized) {
 		int w = c->geometry.width;
@@ -7086,8 +7083,8 @@ configurex11(struct wl_listener *listener, void *data)
 	}
 	if (some_client_get_floating(c)) {
 		resize(c, (struct wlr_box){.x = event->x - c->bw,
-				.y = event->y - c->bw, .width = event->width + c->bw * 2,
-				.height = event->height + c->bw * 2}, 0);
+				.y = event->y - c->bw, .width = event->width,
+				.height = event->height}, 0);
 	} else {
 		arrange(c->mon);
 	}

--- a/somewm.c
+++ b/somewm.c
@@ -4784,13 +4784,13 @@ apply_geometry_to_wlroots(Client *c)
 	wlr_scene_node_set_position(&c->scene->node, c->geometry.x, c->geometry.y);
 	/* Offset scene_surface by titlebar sizes (titlebars occupy space in geometry) */
 	wlr_scene_node_set_position(&c->scene_surface->node, c->bw + titlebar_left, c->bw + titlebar_top);
-	wlr_scene_rect_set_size(c->border[0], c->geometry.width, c->bw);
-	wlr_scene_rect_set_size(c->border[1], c->geometry.width, c->bw);
-	wlr_scene_rect_set_size(c->border[2], c->bw, c->geometry.height - 2 * c->bw);
-	wlr_scene_rect_set_size(c->border[3], c->bw, c->geometry.height - 2 * c->bw);
-	wlr_scene_node_set_position(&c->border[1]->node, 0, c->geometry.height - c->bw);
+	wlr_scene_rect_set_size(c->border[0], c->geometry.width + 2 * c->bw, c->bw);
+	wlr_scene_rect_set_size(c->border[1], c->geometry.width + 2 * c->bw, c->bw);
+	wlr_scene_rect_set_size(c->border[2], c->bw, c->geometry.height);
+	wlr_scene_rect_set_size(c->border[3], c->bw, c->geometry.height);
+	wlr_scene_node_set_position(&c->border[1]->node, 0, c->geometry.height + c->bw);
 	wlr_scene_node_set_position(&c->border[2]->node, 0, c->bw);
-	wlr_scene_node_set_position(&c->border[3]->node, c->geometry.width - c->bw, c->bw);
+	wlr_scene_node_set_position(&c->border[3]->node, c->geometry.width + c->bw, c->bw);
 
 	/* Update shadow geometry (lazy creation if needed) */
 	{
@@ -4799,10 +4799,10 @@ apply_geometry_to_wlroots(Client *c)
 		if (shadow_config && shadow_config->enabled) {
 			if (c->shadow.tree) {
 				shadow_update_geometry(&c->shadow, shadow_config,
-					c->geometry.width, c->geometry.height);
+					c->geometry.width + c->bw, c->geometry.height + c->bw);
 			} else {
 				shadow_create(c->scene, &c->shadow, shadow_config,
-					c->geometry.width, c->geometry.height);
+					c->geometry.width + c->bw, c->geometry.height + c->bw);
 			}
 		}
 	}
@@ -4828,13 +4828,11 @@ apply_geometry_to_wlroots(Client *c)
 #endif
 		if (c->fullscreen) {
 			/* Fullscreen: client gets full geometry minus borders only */
-			c->resize = client_set_size(c,
-					c->geometry.width - 2 * c->bw,
-					c->geometry.height - 2 * c->bw);
+			c->resize = client_set_size(c, c->geometry.width, c->geometry.height);
 		} else {
-			int sw = c->geometry.width - 2 * c->bw
+			int sw = c->geometry.width
 				- titlebar_left - c->titlebar[CLIENT_TITLEBAR_RIGHT].size;
-			int sh = c->geometry.height - 2 * c->bw
+			int sh = c->geometry.height
 				- titlebar_top - c->titlebar[CLIENT_TITLEBAR_BOTTOM].size;
 			if (sw < 1) sw = 1;
 			if (sh < 1) sh = 1;

--- a/somewm.c
+++ b/somewm.c
@@ -3782,10 +3782,6 @@ mapnotify(struct wl_listener *listener, void *data)
 		}
 	}
 
-	/* Initialize client geometry with room for border */
-	c->geometry.width += 2 * c->bw;
-	c->geometry.height += 2 * c->bw;
-
 	/* Client was already added to arrays in createnotify() (matches AwesomeWM pattern)
 	 * No need to add again here - doing so would create duplicates */
 

--- a/tests/test-client-border-content.lua
+++ b/tests/test-client-border-content.lua
@@ -1,0 +1,117 @@
+---------------------------------------------------------------------------
+--- Regression test: border_width must not shrink the client's content.
+---
+--- c->geometry excludes the border; a regression that subtracts
+--- border_width again when sizing the surface leaves a blank
+--- 2*border_width strip at the bottom/right of every bordered client.
+--- Probes c.content 3px inside the bottom-right corner, which must show
+--- the pattern client's BR quadrant color (see
+--- test-client-content-pattern.lua for the wl_shm pattern client).
+---
+--- Run: make test-one TEST=tests/test-client-border-content.lua
+---------------------------------------------------------------------------
+
+local awful  = require("awful")
+local gears  = require("gears")
+local runner = require("_runner")
+local async  = require("_async")
+
+local ok_ffi, ffi = pcall(require, "ffi")
+if not ok_ffi then
+    io.stderr:write("SKIP: ffi not available (non-LuaJIT build); pixel sampling needs FFI\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+ffi.cdef[[
+void cairo_surface_flush(void *surface);
+unsigned char *cairo_image_surface_get_data(void *surface);
+int cairo_image_surface_get_stride(void *surface);
+]]
+
+local APP_ID = "content_pattern_test"
+local BORDER_WIDTH = 12
+
+local function find_binary()
+    local somewm = os.getenv("SOMEWM") or "./build-test/somewm"
+    local build_dir = somewm:match("^(.*)/somewm$") or "./build-test"
+    for _, candidate in ipairs({
+        build_dir .. "/test-content-pattern-client",
+        "./build/test-content-pattern-client",
+        "./build-test/test-content-pattern-client",
+    }) do
+        local f = io.open(candidate, "r")
+        if f then f:close(); return candidate end
+    end
+    return nil
+end
+
+local BINARY = find_binary()
+if not BINARY then
+    io.stderr:write("SKIP: test-content-pattern-client not found (run `make` or `make build-test`)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+-- ARGB32 is native-endian 32-bit; on little-endian the bytes are B, G, R, A.
+local function pixel_rgb(raw_surface, x, y)
+    ffi.C.cairo_surface_flush(raw_surface)
+    local data   = ffi.C.cairo_image_surface_get_data(raw_surface)
+    local stride = ffi.C.cairo_image_surface_get_stride(raw_surface)
+    local off = y * stride + x * 4
+    return data[off + 2], data[off + 1], data[off + 0]   -- R, G, B
+end
+
+-- Sample the corners of a fresh c.content capture. Returns nil before the
+-- client has committed a full-size buffer.
+local function sample_corners(c)
+    local raw = c.content
+    if not raw then return nil end
+    local img = gears.surface(raw)
+    local w, h = img:get_width(), img:get_height()
+    if w < 50 or h < 50 then return nil end
+    local tr, tg, tb = pixel_rgb(raw, 2, 2)
+    local br, bg, bb = pixel_rgb(raw, w - 3, h - 3)
+    return {
+        desc = string.format("surface=%dx%d TL=rgb(%d,%d,%d) BR=rgb(%d,%d,%d)",
+            w, h, tr, tg, tb, br, bg, bb),
+        -- TL red proves the capture works at all; BR yellow proves the
+        -- committed buffer reaches the bottom-right of the content area.
+        painted = tr > 200 and tg < 80
+            and br > 200 and bg > 200 and bb < 80,
+    }
+end
+
+runner.run_async(function()
+    local pid = awful.spawn({BINARY})
+    assert(type(pid) == "number" and pid > 0,
+        "Failed to spawn binary: " .. tostring(pid))
+
+    local c = async.wait_for_client(APP_ID, 5)
+    assert(c, "Pattern client never appeared")
+
+    c.floating = true
+    c.border_width = BORDER_WIDTH
+    c:geometry { x = 100, y = 80, width = 300, height = 200 }
+
+    async.wait_for_condition(function()
+        local s = sample_corners(c)
+        return s and s.painted
+    end, 5, 0.1)
+
+    local s = sample_corners(c)
+    local desc = s and s.desc or "never captured"
+    io.stderr:write("[border-content] " .. desc .. "\n")
+    assert(s and s.painted,
+        "bottom-right content never painted with border_width=" ..
+        BORDER_WIDTH .. " (" .. desc .. "); the border is eating into " ..
+        "the client's content area")
+
+    c:kill()
+    async.wait_for_no_clients(3)
+    runner.done()
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
## Description
Port of #645 to release/1.4, fixing #626.

## Test Plan
- New regression test `tests/test-client-border-content.lua`: fails on release/1.4 base, passes on this branch
- `make test-unit`: 770/770; full integration suite passes

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)