### PR TITLE
ci: trigger only on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, "release/*"]
+    branches: ["release/*"]
   pull_request:
-    branches: [main, "release/*"]
+    branches: ["release/*"]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description
Drop `main` from this workflow copy's push/pull_request triggers. The release lineage's ci.yml (with the Luacheck job) should only run for release branches; main has its own ci.yml without luacheck.

## Test Plan
Trigger-only change; the Luacheck and Build & Test jobs already ran green on this file's job definitions in #652.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)