### PR TITLE
build: support wlroots 0.19 alongside 0.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,23 @@ jobs:
             pkg: lua5.3
             dev_package: liblua5.3-dev
             interpreter: lua5.3
+        wlroots:
+          - ver: 0.20.0
+            short: '0.20'
+        # The Lua axis and the wlroots axis do not interact - the only
+        # version-conditional code in the tree is COMPAT_XWAYLAND_SET_CURSOR - so 0.19
+        # gets one leg rather than a full cross product.
+        include:
+          - lua:
+              name: LuaJIT
+              pkg: luajit
+              dev_package: libluajit-5.1-dev
+              interpreter: luajit
+            wlroots:
+              ver: 0.19.3
+              short: '0.19'
 
-    name: Build & Test (${{ matrix.lua.name }})
+    name: Build & Test (${{ matrix.lua.name }}, wlroots ${{ matrix.wlroots.short }})
 
     steps:
       - name: Checkout
@@ -107,7 +122,7 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/deps-install
-          key: deps-wlroots-v2${{ runner.os }}
+          key: deps-wlroots-${{ matrix.wlroots.ver }}-${{ runner.os }}
 
       - name: Cache Lua 5.2 CI deps
         if: matrix.lua.pkg == 'lua5.2'
@@ -116,15 +131,17 @@ jobs:
           path: ~/lua-5.2-ci
           key: deps-lua5.2-ci-lgi-0.9.2-busted-2.3.0-${{ runner.os }}}-v2
 
-      - name: Build wlroots 0.20
+      - name: Build wlroots ${{ matrix.wlroots.ver }}
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/deps-install
           export PKG_CONFIG_PATH=$HOME/deps-install/share/pkgconfig:$HOME/deps-install/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
           cd ~
-          git clone --depth 1 --branch 0.20.0 https://gitlab.freedesktop.org/wlroots/wlroots.git
+          git clone --depth 1 --branch ${{ matrix.wlroots.ver }} https://gitlab.freedesktop.org/wlroots/wlroots.git
           cd wlroots
-          meson setup build --prefix=$HOME/deps-install -Dexamples=false -Dxwayland=enabled
+          # 0.19.3 predates this runner's compiler; its own werror=true default would
+          # fail on warnings that are not ours to fix.
+          meson setup build --prefix=$HOME/deps-install -Dexamples=false -Dxwayland=enabled -Dwerror=false
           ninja -C build
           ninja -C build install
 
@@ -161,8 +178,12 @@ jobs:
           echo "PKG_CONFIG_PATH=$HOME/deps-install/share/pkgconfig:$HOME/deps-install/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$HOME/deps-install/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
+      # -Dxwayland=enabled is forced, not left on auto: COMPAT_XWAYLAND_SET_CURSOR is the
+      # only version-conditional code in the tree and it only compiles under XWAYLAND.
       - name: Build somewm
-        run: make build-test LUA_PKG=${{ matrix.lua.pkg }}
+        run: |
+          make build-test LUA_PKG=${{ matrix.lua.pkg }} \
+            MESON_OPTS="-Dwlroots_version=${{ matrix.wlroots.short }} -Dxwayland=enabled"
 
       - name: Run unit tests
         run: make test-unit
@@ -188,3 +209,80 @@ jobs:
           HEADLESS: 1
           LIBSEAT_BACKEND: noop
           TEST_TIMEOUT: 45
+
+  # Debian stable ships wayland-server 1.23.1, libdrm 2.4.124 and xkbcommon 1.7.0,
+  # all below wlroots 0.20's floors. Build there to keep the wlroots 0.19 path working.
+  build-debian-stable:
+    runs-on: ubuntu-latest
+    container: debian:trixie
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      TZ: Etc/UTC
+
+    name: Build (Debian stable, wlroots 0.19)
+
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            git \
+            meson \
+            ninja-build \
+            pkg-config \
+            wayland-protocols \
+            libwayland-dev \
+            libwayland-bin \
+            libxkbcommon-dev \
+            libinput-dev \
+            libdbus-1-dev \
+            libdrm-dev \
+            libgbm-dev \
+            libegl-dev \
+            libgles-dev \
+            libvulkan-dev \
+            libpixman-1-dev \
+            libudev-dev \
+            libseat-dev \
+            libxcb1-dev \
+            libxcb-icccm4-dev \
+            libxcb-composite0-dev \
+            libxcb-render0-dev \
+            libxcb-render-util0-dev \
+            libxcb-res0-dev \
+            libxcb-ewmh-dev \
+            libxcb-errors-dev \
+            libxcb-xfixes0-dev \
+            libxcb-xinput-dev \
+            libxcb-util-dev \
+            hwdata \
+            libdisplay-info-dev \
+            libliftoff-dev \
+            libpam0g-dev \
+            xwayland \
+            lua5.3 \
+            liblua5.3-dev \
+            lua-lgi \
+            libcairo2-dev \
+            libpango1.0-dev \
+            libgdk-pixbuf-2.0-dev \
+            libglib2.0-dev
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # No -Dwlroots_version here: auto must pick 0.19 on its own, which is what a
+      # user running plain `meson setup build` on Debian stable gets. -Dxwayland is
+      # forced because the 0.19/0.20 cursor difference only compiles under XWAYLAND.
+      # Build-only: busted is not packaged in Debian, so unit tests run on the
+      # ubuntu matrix legs instead.
+      - name: Configure
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          meson setup build -Dlua_pkg=lua5.3 -Dxwayland=enabled | tee setup.log
+          grep -q 'Using wlroots version: 0.19' setup.log
+
+      - name: Build
+        run: ninja -C build

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ build/
 build-bench/
 builddir/
 subprojects/wlroots/
+subprojects/wlroots-0.19/
+subprojects/wlroots-0.20/
 subprojects/packagecache/
 
 # Development tooling & reports (local only)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ asan:
 
 # Build for tests: NO ASAN (fast) - explicitly disable sanitizers, enable test PAM stub
 build-test:
-	@test -d build-test || meson setup build-test -Db_sanitize=none -Dtest_pam=true $(if $(LUA_PKG),-Dlua_pkg=$(LUA_PKG),)
+	@test -d build-test || meson setup build-test -Db_sanitize=none -Dtest_pam=true $(if $(LUA_PKG),-Dlua_pkg=$(LUA_PKG),) $(MESON_OPTS)
 	ninja -C build-test
 
 install:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Lua framework for building your Wayland desktop. Layouts, widgets, keybindings
 
 SomeWM has a complete widget system, a signal-driven object model, and a compositor runtime, all wired together so every piece can talk to every other piece. Write a widget that reacts to window focus changes. Build a layout that adapts to screen geometry. Script your entire workflow from `rc.lua` or from the command line.
 
-Built on [wlroots](https://gitlab.freedesktop.org/wlroots/wlroots) 0.20. Compatible with [AwesomeWM's](https://github.com/awesomeWM/awesome) Lua API - existing configs, widgets, and themes carry over.
+Built on [wlroots](https://gitlab.freedesktop.org/wlroots/wlroots) 0.19 or 0.20. Compatible with [AwesomeWM's](https://github.com/awesomeWM/awesome) Lua API - existing configs, widgets, and themes carry over.
 
 > **This branch (`main`) is 2.0-dev.** If you want 100% AwesomeWM parity, use the [`release/1.4`](https://github.com/trip-zip/somewm/tree/release/1.4) branch or install `somewm` from the [AUR](https://aur.archlinux.org/packages/somewm).
 
@@ -33,6 +33,18 @@ sudo make install
 ```
 
 For Debian, Fedora, NixOS, and detailed instructions, see the [Installation Guide](https://somewm.org/docs/next/getting-started/installation).
+
+**wlroots version.** The build uses wlroots 0.20 if you already have it installed. If
+not, it picks 0.20 when your wayland-server, libdrm, xkbcommon, wayland-protocols and
+pixman are new enough to build it, and 0.19 otherwise. Older stable distributions
+(Debian 13, Ubuntu 24.04) fall into the 0.19 case. `meson setup` prints which version it
+chose, and when it falls back to 0.19 it names the dependencies that came up short.
+
+Override the choice with `meson setup build -Dwlroots_version=0.19` (or `0.20`). If
+wlroots is not installed, the matching version is built from `subprojects/`.
+
+The 0.19 path exists for these older distributions and will be dropped once they ship
+wlroots 0.20 or the dependency versions it needs.
 
 ## Run
 

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,22 @@ project(
     'c_std=gnu11',
     'warning_level=2',
     'werror=true',
+    # Vendored code is not ours to keep warning-clean, and wlroots 0.19.3 is old enough
+    # that newer compilers flag it. Subproject-scoped overrides are the only form that
+    # cascades to nested subprojects; subproject() default_options does not. Entries for
+    # subprojects that never get configured are ignored, so this lists everything wlroots
+    # can pull in: its own wraps, plus libdisplay-info's transitive v4l-utils.
+    'wlroots-0.19:werror=false',
+    'wlroots-0.20:werror=false',
+    'wayland:werror=false',
+    'wayland-protocols:werror=false',
+    'libdrm:werror=false',
+    'libxkbcommon:werror=false',
+    'pixman:werror=false',
+    'seatd:werror=false',
+    'libliftoff:werror=false',
+    'libdisplay-info:werror=false',
+    'v4l-utils:werror=false',
   ],
 )
 
@@ -55,6 +71,10 @@ libinput = dependency('libinput')
 have_3fg_drag = cc.has_function('libinput_device_config_3fg_drag_get_finger_count',
                                  dependencies: libinput)
 libdrm = dependency('libdrm')
+# Not linked directly; wlroots pulls it in. Probed only so the wlroots version choice
+# below can read its version, so not required: with no pixman-1.pc at all, wlroots
+# resolves pixman through its own wrap and the floor below stops applying.
+pixman = dependency('pixman-1', required: false)
 dbus = dependency('dbus-1')
 glib = dependency('glib-2.0')
 gio = dependency('gio-2.0')
@@ -104,11 +124,61 @@ lgi_output = lgi_check_result.stdout().strip()
 lgi_version = lgi_output.split('Found lgi ')[-1].split('\n')[0]
 message('Found LGI version: ' + lgi_version)
 
-# wlroots 0.20 only - use system if available, otherwise build from subproject
-wlroots = dependency('wlroots-0.20', version : '>=0.20.0', static: false, required: false)
+# wlroots 0.19 or 0.20. wlroots 0.20 raises floors that stable distros do not meet yet
+# (Debian 13 ships wayland-server 1.23.1, libdrm 2.4.124, xkbcommon 1.7.0, pixman 0.44),
+# so fall back to 0.19 there rather than failing to configure.
+#
+# Mirrors what wlroots 0.20 asks of its own dependencies: meson.build for wayland-server,
+# libdrm and xkbcommon, protocol/meson.build for wayland-protocols, render/pixman for
+# pixman. All of these have a wrap fallback upstream except render/pixman's stricter
+# >=0.46.0, which has none and so hard-fails; the rest merely make wlroots source-build a
+# core system library, which is worth avoiding too. Hence all of them are listed.
+wlroots_020_floors = {
+  # name: [minimum, installed]
+  'wayland-server': ['>=1.24.0', wayland_server.version()],
+  'libdrm': ['>=2.4.129', libdrm.version()],
+  'xkbcommon': ['>=1.8.0', xkbcommon.version()],
+  'wayland-protocols': ['>=1.47', wayland_protocols.version()],
+}
+if pixman.found()
+  wlroots_020_floors += {'pixman-1': ['>=0.46.0', pixman.version()]}
+endif
+
+wlroots_020_unmet = []
+foreach name, floor : wlroots_020_floors
+  if not floor[1].version_compare(floor[0])
+    wlroots_020_unmet += name + ' ' + floor[1] + ' (need ' + floor[0] + ')'
+  endif
+endforeach
+
+# An installed wlroots 0.20 met those floors when it was built, so it outranks the probe:
+# a distro that backports 0.20 onto older deps should still get 0.20.
+wlroots_020 = dependency('wlroots-0.20', version: '>=0.20.0', static: false,
+                         required: false, allow_fallback: false)
+
+wlroots_version = get_option('wlroots_version')
+if wlroots_version == 'auto'
+  if wlroots_020.found() or wlroots_020_unmet.length() == 0
+    wlroots_version = '0.20'
+  else
+    wlroots_version = '0.19'
+    message('Selecting wlroots 0.19, too old for 0.20: ' + ', '.join(wlroots_020_unmet))
+  endif
+elif wlroots_version == '0.20' and not wlroots_020.found() and wlroots_020_unmet.length() != 0
+  error('wlroots 0.20 requires newer dependencies than this system has: '
+    + ', '.join(wlroots_020_unmet)
+    + '. Use -Dwlroots_version=0.19 or upgrade them.')
+endif
+
+if wlroots_version == '0.20'
+  wlroots = wlroots_020
+else
+  wlroots = dependency('wlroots-0.19', version: '>=0.19.3', static: false,
+                       required: false, allow_fallback: false)
+endif
 
 if not wlroots.found()
-  message('System wlroots 0.20 not found, building from subproject...')
+  message('System wlroots ' + wlroots_version + ' not found, building from subproject...')
 
   wlroots_options = [
     'examples=false',
@@ -120,11 +190,13 @@ if not wlroots.found()
     wlroots_options += 'xwayland=disabled'
   endif
 
-  wlroots_proj = subproject('wlroots', default_options: wlroots_options)
+  # One wrap per version: subprojects/wlroots-<version>.wrap, checked out into a
+  # matching directory. Adding a version is a new wrap plus a meson_options.txt choice.
+  wlroots_proj = subproject('wlroots-' + wlroots_version, default_options: wlroots_options)
   wlroots = wlroots_proj.get_variable('wlroots')
 endif
 
-wlroots_version = '0.20'
+# The Debian CI job greps this line to prove `auto` picks 0.19 there; keep the wording.
 message('Using wlroots version: ' + wlroots_version)
 
 # PAM authentication (optional, for lock screen)
@@ -261,9 +333,6 @@ add_project_arguments(
   '-DWITH_DBUS',
   language: 'c',
 )
-
-# Always 0.20 - we only support this version
-add_project_arguments('-DWLR_VERSION_0_20', language: 'c')
 
 if have_xwayland
   add_project_arguments('-DXWAYLAND', language: 'c')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,14 @@ option(
 )
 
 option(
+  'wlroots_version',
+  type: 'combo',
+  choices: ['auto', '0.20', '0.19'],
+  value: 'auto',
+  description: 'wlroots version to build against. auto = 0.20 when it is already installed or the system deps satisfy its floors, else 0.19.',
+)
+
+option(
   'pam',
   type: 'feature',
   value: 'auto',

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -16,10 +16,11 @@
 #include <wlr/interfaces/wlr_keyboard.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_xcursor_manager.h>
+#include <wlr/xcursor.h>
 #include <wlr/xwayland.h>
 
 #include "somewm_api.h"
-#include "wlr/xcursor.h"
+#include "wlr_compat.h"
 #include "xkb.h"
 #include "objects/signal.h"
 #include "objects/screen.h"
@@ -37,7 +38,8 @@
 
 /* Mirror of wlroots' private keyboard_group_device struct (wlr_keyboard_group.c).
  * Needed to iterate member keyboards when setting layout group.
- * Must match the exact layout of the wlroots 0.20 struct. */
+ * Must match the exact layout of the wlroots struct; verified identical in 0.19.3
+ * and 0.20.0. */
 struct kb_group_device {
 	struct wlr_keyboard *keyboard;
 	struct wl_listener key;
@@ -554,9 +556,7 @@ some_update_cursor_theme(const char *theme_name, uint32_t size)
 	/* Sync XWayland cursor if running */
 	struct wlr_xcursor *xcursor = wlr_xcursor_manager_get_xcursor(cursor_mgr, "default", 1);
 	if (xcursor && xwayland) {
-		wlr_xwayland_set_cursor(xwayland,
-			wlr_xcursor_image_get_buffer(xcursor->images[0]),
-			xcursor->images[0]->hotspot_x, xcursor->images[0]->hotspot_y);
+		COMPAT_XWAYLAND_SET_CURSOR(xwayland, xcursor->images[0]);
 	}
 #endif
 }

--- a/subprojects/wlroots-0.19.wrap
+++ b/subprojects/wlroots-0.19.wrap
@@ -1,0 +1,8 @@
+[wrap-git]
+url = https://gitlab.freedesktop.org/wlroots/wlroots.git
+revision = 0.19.3
+depth = 1
+directory = wlroots-0.19
+
+[provide]
+dependency_names = wlroots-0.19

--- a/subprojects/wlroots-0.20.wrap
+++ b/subprojects/wlroots-0.20.wrap
@@ -2,6 +2,7 @@
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
 revision = 0.20.0
 depth = 1
+directory = wlroots-0.20
 
 [provide]
 dependency_names = wlroots-0.20

--- a/wlr_compat.h
+++ b/wlr_compat.h
@@ -3,12 +3,15 @@
  *
  * Provides macros to abstract wlroots API details.
  *
- * Currently targets wlroots 0.20.
+ * Targets wlroots 0.19 and 0.20. Branch on WLR_VERSION_NUM from <wlr/version.h>, which
+ * describes the headers actually being compiled against; a define from meson could
+ * disagree with the include path.
  */
 
 #ifndef WLR_COMPAT_H
 #define WLR_COMPAT_H
 
+#include <wlr/version.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/util/edges.h>
@@ -33,6 +36,17 @@
 /* XWayland: window type helper */
 #define COMPAT_XWAYLAND_HAS_WINDOW_TYPE(surface, type) \
     wlr_xwayland_surface_has_window_type((surface), (type))
+
+/* XWayland: 0.20 passes the cursor image as a wlr_buffer, 0.19 as raw pixels */
+#if WLR_VERSION_NUM >= ((0 << 16) | (20 << 8))
+#define COMPAT_XWAYLAND_SET_CURSOR(xw, image) \
+    wlr_xwayland_set_cursor((xw), wlr_xcursor_image_get_buffer(image), \
+        (image)->hotspot_x, (image)->hotspot_y)
+#else
+#define COMPAT_XWAYLAND_SET_CURSOR(xw, image) \
+    wlr_xwayland_set_cursor((xw), (image)->buffer, (image)->width * 4, \
+        (image)->width, (image)->height, (image)->hotspot_x, (image)->hotspot_y)
+#endif
 
 /* XDG surface geometry */
 #define COMPAT_XDG_SURFACE_GEOMETRY(surface) ((surface)->geometry)

--- a/xwayland.c
+++ b/xwayland.c
@@ -15,12 +15,14 @@
 #include <wlr/types/wlr_fractional_scale_v1.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_xcursor_manager.h>
+#include <wlr/xcursor.h>
 #include <wlr/xwayland.h>
 #include <xcb/xcb.h>
 #include <xcb/xcb_icccm.h>
 
 #include "somewm.h"
 #include "somewm_api.h"
+#include "wlr_compat.h"
 #include "event_queue.h"
 #include "xwayland.h"
 #include "globalconf.h"
@@ -228,9 +230,7 @@ xwaylandready(struct wl_listener *listener, void *data)
 
 	/* Set the default XWayland cursor to match the rest of somewm. */
 	if ((xcursor = wlr_xcursor_manager_get_xcursor(cursor_mgr, "default", 1)))
-		wlr_xwayland_set_cursor(xwayland,
-				wlr_xcursor_image_get_buffer(xcursor->images[0]),
-				xcursor->images[0]->hotspot_x, xcursor->images[0]->hotspot_y);
+		COMPAT_XWAYLAND_SET_CURSOR(xwayland, xcursor->images[0]);
 
 	/* Initialize XCB connection for EWMH support (AwesomeWM pattern) */
 	conn = xcb_connect(xwayland->display_name, NULL);


### PR DESCRIPTION
## Description

somewm requires wlroots 0.20, which needs newer wayland-server, libdrm, xkbcommon, wayland-protocols and pixman than Debian 13 or Ubuntu 24.04 provide. `meson setup` fails there, so somewm currently cannot be built on Debian stable at all.

The build now uses wlroots 0.20 when it is installed, or when the system has the versions needed to build it, and 0.19 otherwise. `-Dwlroots_version` overrides the choice. Only one function differs between the two versions, `wlr_xwayland_set_cursor`, handled in `wlr_compat.h`.

CI builds on Debian 13 so the 0.19 path keeps working. Support for 0.19 is temporary and should be removed once these distributions carry wlroots 0.20.

Fixes #653
