### PR TITLE
fix(menubar): Look under scalable/ for icons again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,8 @@ reconfigure:
 test: test-unit test-check test-signal test-orchestrator test-integration
 
 # Unit tests only (busted, no compositor needed)
-# Use - prefix to continue even if unit tests fail (some have known issues)
 test-unit:
-	-@./tests/run-unit.sh
+	@./tests/run-unit.sh
 
 # Check mode tests (no compositor needed, tests somewm --check)
 test-check: build-test

--- a/lua/menubar/utils.lua
+++ b/lua/menubar/utils.lua
@@ -115,7 +115,7 @@ do
 end
 
 local all_icon_sizes = {
-    -- 'scalable', -- There is no Pixbuf loader for SVG shipped with someWM
+    'scalable',
     '256x256',
     '128x128',
     '96x96',
@@ -131,6 +131,16 @@ local all_icon_sizes = {
 
 --- List of supported icon exts.
 local supported_icon_file_exts = { png = 1, xpm = 2, svg = 3 }
+
+-- Not every install ships a gdk-pixbuf SVG loader, and picking an icon we
+-- cannot load leaves the caller with nothing.
+do
+    local has_svg = false
+    for _, format in ipairs(lgi.GdkPixbuf.Pixbuf.get_formats()) do
+        if format:get_name() == "svg" then has_svg = true break end
+    end
+    if not has_svg then supported_icon_file_exts.svg = nil end
+end
 
 local icon_lookup_path = nil
 


### PR DESCRIPTION
e997160da dropped `scalable` from `all_icon_sizes`, so icons a theme only ships there stopped being found: rofi, nautilus, mpd, transmission-qt on stock Arch. It also broke `spec/menubar/utils_spec.lua`, which the `-` on the `test-unit` make target hid. Both fixed here.

#592 skipped the directory because gdk-pixbuf can't always load SVG. This skips `svg` itself when there's no loader instead, which is narrower: `scalable/` also holds PNGs, and SVGs in other size directories were picked anyway.

No-loader path verified by shimming `get_formats`, not on a real system without one.
