### PR TITLE
fix(input): clickfinger_button_map missed NULL init

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -1385,6 +1385,7 @@ setup(void)
 	globalconf.input.accel_profile = NULL;  /* String property - set via Lua */
 	globalconf.input.accel_speed = 0.0;
 	globalconf.input.tap_button_map = NULL;  /* String property - set via Lua */
+	globalconf.input.clickfinger_button_map = NULL;  /* String property - set via Lua */
 
 	/* Logging defaults (only set if not already set by -d flag) */
 	if (globalconf.log_level == 0)


### PR DESCRIPTION
A minor fix of a missing NULL init of a string variable.