### PR TITLE
fix(lua): stop assigning to for-loop control variables

### DIFF
--- a/lua/awful/ipc.lua
+++ b/lua/awful/ipc.lua
@@ -2352,8 +2352,8 @@ local function register_builtin_commands()
   local function parse_modifiers(mod_str)
     if not mod_str or mod_str == "" then return {} end
     local mods = {}
-    for mod in mod_str:gmatch("[^+,]+") do
-      mod = mod:match("^%s*(.-)%s*$")  -- trim whitespace
+    for raw in mod_str:gmatch("[^+,]+") do
+      local mod = raw:match("^%s*(.-)%s*$")  -- trim whitespace
       if mod ~= "" then
         table.insert(mods, mod)
       end

--- a/lua/awful/layout/suit/fair.lua
+++ b/lua/awful/layout/suit/fair.lua
@@ -41,8 +41,8 @@ local function do_fair(p, orientation)
       cols = math.ceil(#cls / rows)
     end
 
-    for k, c in ipairs(cls) do
-      k = k - 1
+    for i, c in ipairs(cls) do
+      local k = i - 1
       local g = {}
 
       local row, col

--- a/lua/naughty/dbus.lua
+++ b/lua/naughty/dbus.lua
@@ -319,8 +319,7 @@ function notif_methods.Notify(sender, object_path, interface, method, parameters
             end
 
             for k, v in pairs(args) do
-                if k == "destroy" then k = "destroy_cb" end
-                notification[k] = v
+                notification[k == "destroy" and "destroy_cb" or k] = v
             end
 
             -- Update the icon if necessary.

--- a/lua/naughty/notification.lua
+++ b/lua/naughty/notification.lua
@@ -984,8 +984,8 @@ local function create(args)
         local naction = require("naughty.action")
         local new_actions = {}
 
-        for idx, name in pairs(args.actions) do
-            local cb, old_idx = nil, idx
+        for key, name in pairs(args.actions) do
+            local cb, idx = nil, key
 
             if type(name) == "function" then
                 cb = name
@@ -1004,7 +1004,7 @@ local function create(args)
                 a:connect_signal("invoked", cb)
             end
 
-            new_actions[old_idx] = a
+            new_actions[key] = a
         end
 
         for old_idx, a in pairs(new_actions) do


### PR DESCRIPTION
## Description
Lua 5.5 makes the for-loop control variable read-only. Four modules assigned
to it and failed to parse: `awful.ipc`, `awful.layout.suit.fair`,
`naughty.dbus`, `naughty.notification`. Each now uses a separate local.

## Test Plan
`luac5.5 -p` over all 389 Lua files is clean. Unit tests pass under 5.5 (769)
and 5.3 (756). 134/134 integration tests pass against a Lua 5.5 build.

## Checklist
- [ ] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)