### PR TITLE
Cherry-pick wlroots 0.20 support to release/1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,23 @@ jobs:
             pkg: lua5.3
             dev_package: liblua5.3-dev
             interpreter: lua5.3
+        wlroots:
+          - ver: 0.20.0
+            short: '0.20'
+        # The Lua axis and the wlroots axis do not interact - the only
+        # version-conditional code in the tree is COMPAT_XWAYLAND_SET_CURSOR - so 0.19
+        # gets one leg rather than a full cross product.
+        include:
+          - lua:
+              name: LuaJIT
+              pkg: luajit
+              dev_package: libluajit-5.1-dev
+              interpreter: luajit
+            wlroots:
+              ver: 0.19.3
+              short: '0.19'
 
-    name: Build & Test (${{ matrix.lua.name }})
+    name: Build & Test (${{ matrix.lua.name }}, wlroots ${{ matrix.wlroots.short }})
 
     steps:
       - name: Checkout
@@ -122,7 +137,7 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/deps-install
-          key: deps-wlroots-v2${{ runner.os }}
+          key: deps-wlroots-${{ matrix.wlroots.ver }}-${{ runner.os }}
 
       - name: Cache Lua 5.2 CI deps
         if: matrix.lua.pkg == 'lua5.2'
@@ -131,15 +146,17 @@ jobs:
           path: ~/lua-5.2-ci
           key: deps-lua5.2-ci-lgi-0.9.2-busted-2.3.0-${{ runner.os }}}-v2
 
-      - name: Build wlroots 0.20
+      - name: Build wlroots ${{ matrix.wlroots.ver }}
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/deps-install
           export PKG_CONFIG_PATH=$HOME/deps-install/share/pkgconfig:$HOME/deps-install/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
           cd ~
-          git clone --depth 1 --branch 0.20.0 https://gitlab.freedesktop.org/wlroots/wlroots.git
+          git clone --depth 1 --branch ${{ matrix.wlroots.ver }} https://gitlab.freedesktop.org/wlroots/wlroots.git
           cd wlroots
-          meson setup build --prefix=$HOME/deps-install -Dexamples=false -Dxwayland=enabled
+          # 0.19.3 predates this runner's compiler; its own werror=true default would
+          # fail on warnings that are not ours to fix.
+          meson setup build --prefix=$HOME/deps-install -Dexamples=false -Dxwayland=enabled -Dwerror=false
           ninja -C build
           ninja -C build install
 
@@ -176,8 +193,12 @@ jobs:
           echo "PKG_CONFIG_PATH=$HOME/deps-install/share/pkgconfig:$HOME/deps-install/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$HOME/deps-install/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
+      # -Dxwayland=enabled is forced, not left on auto: COMPAT_XWAYLAND_SET_CURSOR is the
+      # only version-conditional code in the tree and it only compiles under XWAYLAND.
       - name: Build somewm
-        run: make build-test LUA_PKG=${{ matrix.lua.pkg }}
+        run: |
+          make build-test LUA_PKG=${{ matrix.lua.pkg }} \
+            MESON_OPTS="-Dwlroots_version=${{ matrix.wlroots.short }} -Dxwayland=enabled"
 
       - name: Run unit tests
         run: make test-unit
@@ -203,3 +224,80 @@ jobs:
           HEADLESS: 1
           LIBSEAT_BACKEND: noop
           TEST_TIMEOUT: 45
+
+  # Debian stable ships wayland-server 1.23.1, libdrm 2.4.124 and xkbcommon 1.7.0,
+  # all below wlroots 0.20's floors. Build there to keep the wlroots 0.19 path working.
+  build-debian-stable:
+    runs-on: ubuntu-latest
+    container: debian:trixie
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      TZ: Etc/UTC
+
+    name: Build (Debian stable, wlroots 0.19)
+
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            git \
+            meson \
+            ninja-build \
+            pkg-config \
+            wayland-protocols \
+            libwayland-dev \
+            libwayland-bin \
+            libxkbcommon-dev \
+            libinput-dev \
+            libdbus-1-dev \
+            libdrm-dev \
+            libgbm-dev \
+            libegl-dev \
+            libgles-dev \
+            libvulkan-dev \
+            libpixman-1-dev \
+            libudev-dev \
+            libseat-dev \
+            libxcb1-dev \
+            libxcb-icccm4-dev \
+            libxcb-composite0-dev \
+            libxcb-render0-dev \
+            libxcb-render-util0-dev \
+            libxcb-res0-dev \
+            libxcb-ewmh-dev \
+            libxcb-errors-dev \
+            libxcb-xfixes0-dev \
+            libxcb-xinput-dev \
+            libxcb-util-dev \
+            hwdata \
+            libdisplay-info-dev \
+            libliftoff-dev \
+            libpam0g-dev \
+            xwayland \
+            lua5.3 \
+            liblua5.3-dev \
+            lua-lgi \
+            libcairo2-dev \
+            libpango1.0-dev \
+            libgdk-pixbuf-2.0-dev \
+            libglib2.0-dev
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # No -Dwlroots_version here: auto must pick 0.19 on its own, which is what a
+      # user running plain `meson setup build` on Debian stable gets. -Dxwayland is
+      # forced because the 0.19/0.20 cursor difference only compiles under XWAYLAND.
+      # Build-only: busted is not packaged in Debian, so unit tests run on the
+      # ubuntu matrix legs instead.
+      - name: Configure
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          meson setup build -Dlua_pkg=lua5.3 -Dxwayland=enabled | tee setup.log
+          grep -q 'Using wlroots version: 0.19' setup.log
+
+      - name: Build
+        run: ninja -C build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: ["release/*"]
   pull_request:
@@ -30,7 +31,10 @@ jobs:
         run: make check-qa
 
   build-and-test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      TZ: Etc/UTC
 
     strategy:
       fail-fast: false
@@ -57,10 +61,14 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime
+          sudo sh -c 'echo Etc/UTC > /etc/timezone'
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends \
             build-essential \
+            dpkg-dev \
             ninja-build \
+            python3-pip \
             pkg-config \
             wayland-protocols \
             libwayland-dev \
@@ -79,6 +87,8 @@ jobs:
             libxcb-render-util0-dev \
             libxcb-res0-dev \
             libxcb-ewmh-dev \
+            libxcb-errors-dev \
+            libxcb-xfixes0-dev \
             libxcb-xinput-dev \
             libxcb-util-dev \
             hwdata \
@@ -88,6 +98,7 @@ jobs:
             ${{ matrix.lua.dev_package }} \
             lua-busted \
             lua-lgi \
+            luarocks \
             libcairo2-dev \
             libpango1.0-dev \
             libgdk-pixbuf-2.0-dev \
@@ -104,55 +115,61 @@ jobs:
             zsh
 
       - name: Upgrade meson
-        run: pip install --upgrade --break-system-packages meson
+        run: python3 -m pip install --upgrade --break-system-packages meson
 
       - name: Cache deps
         id: cache-deps
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/deps-install
-          key: deps-wayland-pixman-wlroots-v2-${{ runner.os }}
+          key: deps-wlroots-v2${{ runner.os }}
 
-      - name: Build wayland, pixman, and wayland-protocols
+      - name: Cache Lua 5.2 CI deps
+        if: matrix.lua.pkg == 'lua5.2'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/lua-5.2-ci
+          key: deps-lua5.2-ci-lgi-0.9.2-busted-2.3.0-${{ runner.os }}}-v2
+
+      - name: Build wlroots 0.20
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/deps-install
-
-          # Build wayland 1.23.1
-          cd ~
-          git clone --depth 1 --branch 1.23.1 https://gitlab.freedesktop.org/wayland/wayland.git
-          cd wayland
-          meson setup build --prefix=$HOME/deps-install -Ddocumentation=false -Dtests=false
-          ninja -C build
-          ninja -C build install
-
-          # Build pixman 0.44.2
-          cd ~
-          git clone --depth 1 --branch pixman-0.44.2 https://gitlab.freedesktop.org/pixman/pixman.git
-          cd pixman
-          meson setup build --prefix=$HOME/deps-install -Dtests=disabled -Ddemos=disabled
-          ninja -C build
-          ninja -C build install
-
-          # Build wayland-protocols 1.41
-          cd ~
-          git clone --depth 1 --branch 1.41 https://gitlab.freedesktop.org/wayland/wayland-protocols.git
-          cd wayland-protocols
-          meson setup build --prefix=$HOME/deps-install -Dtests=false
-          ninja -C build
-          ninja -C build install
-
-      - name: Build wlroots
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
           export PKG_CONFIG_PATH=$HOME/deps-install/share/pkgconfig:$HOME/deps-install/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
           cd ~
-          git clone --depth 1 --branch 0.19.0 https://gitlab.freedesktop.org/wlroots/wlroots.git
+          git clone --depth 1 --branch 0.20.0 https://gitlab.freedesktop.org/wlroots/wlroots.git
           cd wlroots
           meson setup build --prefix=$HOME/deps-install -Dexamples=false -Dxwayland=enabled
           ninja -C build
           ninja -C build install
 
+      - name: Prepare Lua 5.2 CI deps
+        if: matrix.lua.pkg == 'lua5.2'
+        run: |
+          set -eu
+          mkdir -p "$HOME/lua-5.2-ci"
+
+          # Ubuntu no longer ships these modules for Lua 5.2 (just 5.1 and 5.3), so build them from source.
+          if [ ! -f "$HOME/lua-5.2-ci/share/lua/5.2/lgi/init.lua" ]; then
+            sudo sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+            sudo apt-get update
+            cd /tmp
+            apt-get source lua-lgi
+            cd lua-lgi-*/
+            make -C lgi LUA_VERSION=5.2 PREFIX="$HOME/lua-5.2-ci" LUA_CFLAGS="$(pkg-config --cflags lua5.2)" VERSION=0.9.2
+            make -C lgi install LUA_VERSION=5.2 PREFIX="$HOME/lua-5.2-ci" LUA_CFLAGS="$(pkg-config --cflags lua5.2)" VERSION=0.9.2
+          fi
+
+          if [ ! -x "$HOME/lua-5.2-ci/bin/busted" ]; then
+            luarocks --lua-version=5.2 --tree="$HOME/lua-5.2-ci" install busted 2.3.0-1
+          fi
+
+          sudo mkdir -p /usr/local/share/lua/5.2 /usr/local/lib/lua/5.2
+          sudo cp -a "$HOME/lua-5.2-ci/share/lua/5.2/." /usr/local/share/lua/5.2/
+          sudo cp -a "$HOME/lua-5.2-ci/lib/lua/5.2/." /usr/local/lib/lua/5.2/
+          sudo install -Dm755 "$HOME/lua-5.2-ci/bin/busted" /usr/local/bin/busted
+
+        # Add manually built deps to paths
       - name: Set paths
         run: |
           echo "PATH=$HOME/deps-install/bin:$PATH" >> $GITHUB_ENV

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ build/
 build-bench/
 builddir/
 subprojects/wlroots/
+subprojects/wlroots-0.19/
+subprojects/wlroots-0.20/
 subprojects/packagecache/
 
 # Development tooling & reports (local only)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ asan:
 
 # Build for tests: NO ASAN (fast) - explicitly disable sanitizers, enable test PAM stub
 build-test:
-	@test -d build-test || meson setup build-test -Db_sanitize=none -Dtest_pam=true $(if $(LUA_PKG),-Dlua_pkg=$(LUA_PKG),)
+	@test -d build-test || meson setup build-test -Db_sanitize=none -Dtest_pam=true $(if $(LUA_PKG),-Dlua_pkg=$(LUA_PKG),) $(MESON_OPTS)
 	ninja -C build-test
 
 install:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # somewm - AwesomeWM for Wayland
 
-**somewm** is AwesomeWM ported to Wayland, built on [wlroots](https://gitlab.freedesktop.org/wlroots/wlroots) 0.19. It implements AwesomeWM's full Lua API - your `rc.lua`, widgets, and themes carry over with no changes. somewm supports LuaJIT as well as Lua 5.4, 5.3, 5.2, and 5.1.
+**somewm** is AwesomeWM ported to Wayland, built on [wlroots](https://gitlab.freedesktop.org/wlroots/wlroots) 0.20. It implements AwesomeWM's full Lua API - your `rc.lua`, widgets, and themes carry over with no changes. somewm supports LuaJIT as well as Lua 5.4, 5.3, 5.2, and 5.1.
 
 <p align="center">
   <img src="screenshots/default.png" alt="Default configuration" width="45%">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # somewm - AwesomeWM for Wayland
 
-**somewm** is AwesomeWM ported to Wayland, built on [wlroots](https://gitlab.freedesktop.org/wlroots/wlroots) 0.20. It implements AwesomeWM's full Lua API - your `rc.lua`, widgets, and themes carry over with no changes. somewm supports LuaJIT as well as Lua 5.4, 5.3, 5.2, and 5.1.
+**somewm** is AwesomeWM ported to Wayland, built on [wlroots](https://gitlab.freedesktop.org/wlroots/wlroots) 0.19 or 0.20. It implements AwesomeWM's full Lua API - your `rc.lua`, widgets, and themes carry over with no changes. somewm supports LuaJIT as well as Lua 5.4, 5.3, 5.2, and 5.1.
 
 <p align="center">
   <img src="screenshots/default.png" alt="Default configuration" width="45%">
@@ -42,6 +42,18 @@ sudo make install
 ```
 
 For Debian, Fedora, NixOS, and detailed instructions, see the [Installation Guide](https://somewm.org/docs/getting-started/installation).
+
+**wlroots version.** The build uses wlroots 0.20 if you already have it installed. If
+not, it picks 0.20 when your wayland-server, libdrm, xkbcommon, wayland-protocols and
+pixman are new enough to build it, and 0.19 otherwise. Older stable distributions
+(Debian 13, Ubuntu 24.04) fall into the 0.19 case. `meson setup` prints which version it
+chose, and when it falls back to 0.19 it names the dependencies that came up short.
+
+Override the choice with `meson setup build -Dwlroots_version=0.19` (or `0.20`). If
+wlroots is not installed, the matching version is built from `subprojects/`.
+
+The 0.19 path exists for these older distributions and will be dropped once they ship
+wlroots 0.20 or the dependency versions it needs.
 
 ## Run
 

--- a/client.h
+++ b/client.h
@@ -7,6 +7,7 @@
  */
 
 /* Need complete client_t definition for inline functions */
+#include <xdg-shell-protocol.h>
 #include <assert.h>
 #include "somewm_types.h"  /* For Client typedef and Monitor */
 #include "objects/client.h" /* For complete client_t definition */

--- a/client.h
+++ b/client.h
@@ -253,14 +253,12 @@ client_is_float_type(Client *c)
 		if (surface->modal)
 			return 1;
 
-#ifdef WLR_VERSION_0_19
 		if (COMPAT_XWAYLAND_HAS_WINDOW_TYPE(surface, WLR_XWAYLAND_NET_WM_WINDOW_TYPE_DIALOG)
 				|| COMPAT_XWAYLAND_HAS_WINDOW_TYPE(surface, WLR_XWAYLAND_NET_WM_WINDOW_TYPE_SPLASH)
 				|| COMPAT_XWAYLAND_HAS_WINDOW_TYPE(surface, WLR_XWAYLAND_NET_WM_WINDOW_TYPE_TOOLBAR)
 				|| COMPAT_XWAYLAND_HAS_WINDOW_TYPE(surface, WLR_XWAYLAND_NET_WM_WINDOW_TYPE_UTILITY)) {
 			return 1;
 		}
-#endif
 
 		return size_hints && size_hints->min_width > 0 && size_hints->min_height > 0
 			&& (size_hints->max_width == size_hints->min_width

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771848320,
-        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "lastModified": 1784007870,
+        "narHash": "sha256-djcLt/JJphyNt4eDY9XTly+/WbCK5lqWq9lSgCmJkkQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "rev": "18b9261cb3294b6d2a06d03f96872827b8fe2698",
         "type": "github"
       },
       "original": {

--- a/luaa.c
+++ b/luaa.c
@@ -70,7 +70,6 @@ static lua_State *luaA_create_fresh_state(void);
 #include <wlr/types/wlr_scene.h>
 #include <wlr/backend/wayland.h>
 #include <wlr/types/wlr_buffer.h>
-#include <wlr/interfaces/wlr_buffer.h>
 #include <drm_fourcc.h>
 #include <cairo/cairo.h>
 

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,20 @@ project(
     'c_std=gnu11',
     'warning_level=2',
     'werror=true',
-    'wlroots:werror=false',
+    # Vendored code is not ours to keep warning-clean, and wlroots 0.19.3 is old enough
+    # that newer compilers flag it. Subproject-scoped overrides are the only form that
+    # cascades to nested subprojects; subproject() default_options does not. Entries for
+    # subprojects that never get configured are ignored, so this lists everything wlroots
+    # can pull in: its own wraps, plus libdisplay-info's transitive v4l-utils.
+    'wlroots-0.19:werror=false',
+    'wlroots-0.20:werror=false',
+    'wayland:werror=false',
+    'wayland-protocols:werror=false',
+    'libdrm:werror=false',
+    'libxkbcommon:werror=false',
+    'pixman:werror=false',
+    'seatd:werror=false',
+    'libliftoff:werror=false',
     'libdisplay-info:werror=false',
     'v4l-utils:werror=false',
   ],
@@ -58,6 +71,10 @@ libinput = dependency('libinput')
 have_3fg_drag = cc.has_function('libinput_device_config_3fg_drag_get_finger_count',
                                  dependencies: libinput)
 libdrm = dependency('libdrm')
+# Not linked directly; wlroots pulls it in. Probed only so the wlroots version choice
+# below can read its version, so not required: with no pixman-1.pc at all, wlroots
+# resolves pixman through its own wrap and the floor below stops applying.
+pixman = dependency('pixman-1', required: false)
 dbus = dependency('dbus-1')
 glib = dependency('glib-2.0')
 gio = dependency('gio-2.0')
@@ -110,11 +127,61 @@ lgi_output = lgi_check_result.stdout().strip()
 lgi_version = lgi_output.split('Found lgi ')[-1].split('\n')[0]
 message('Found LGI version: ' + lgi_version)
 
-# wlroots 0.20 only - use system if available, otherwise build from subproject
-wlroots = dependency('wlroots-0.20', version : '>=0.20.0', static: false, required: false)
+# wlroots 0.19 or 0.20. wlroots 0.20 raises floors that stable distros do not meet yet
+# (Debian 13 ships wayland-server 1.23.1, libdrm 2.4.124, xkbcommon 1.7.0, pixman 0.44),
+# so fall back to 0.19 there rather than failing to configure.
+#
+# Mirrors what wlroots 0.20 asks of its own dependencies: meson.build for wayland-server,
+# libdrm and xkbcommon, protocol/meson.build for wayland-protocols, render/pixman for
+# pixman. All of these have a wrap fallback upstream except render/pixman's stricter
+# >=0.46.0, which has none and so hard-fails; the rest merely make wlroots source-build a
+# core system library, which is worth avoiding too. Hence all of them are listed.
+wlroots_020_floors = {
+  # name: [minimum, installed]
+  'wayland-server': ['>=1.24.0', wayland_server.version()],
+  'libdrm': ['>=2.4.129', libdrm.version()],
+  'xkbcommon': ['>=1.8.0', xkbcommon.version()],
+  'wayland-protocols': ['>=1.47', wayland_protocols.version()],
+}
+if pixman.found()
+  wlroots_020_floors += {'pixman-1': ['>=0.46.0', pixman.version()]}
+endif
+
+wlroots_020_unmet = []
+foreach name, floor : wlroots_020_floors
+  if not floor[1].version_compare(floor[0])
+    wlroots_020_unmet += name + ' ' + floor[1] + ' (need ' + floor[0] + ')'
+  endif
+endforeach
+
+# An installed wlroots 0.20 met those floors when it was built, so it outranks the probe:
+# a distro that backports 0.20 onto older deps should still get 0.20.
+wlroots_020 = dependency('wlroots-0.20', version: '>=0.20.0', static: false,
+                         required: false, allow_fallback: false)
+
+wlroots_version = get_option('wlroots_version')
+if wlroots_version == 'auto'
+  if wlroots_020.found() or wlroots_020_unmet.length() == 0
+    wlroots_version = '0.20'
+  else
+    wlroots_version = '0.19'
+    message('Selecting wlroots 0.19, too old for 0.20: ' + ', '.join(wlroots_020_unmet))
+  endif
+elif wlroots_version == '0.20' and not wlroots_020.found() and wlroots_020_unmet.length() != 0
+  error('wlroots 0.20 requires newer dependencies than this system has: '
+    + ', '.join(wlroots_020_unmet)
+    + '. Use -Dwlroots_version=0.19 or upgrade them.')
+endif
+
+if wlroots_version == '0.20'
+  wlroots = wlroots_020
+else
+  wlroots = dependency('wlroots-0.19', version: '>=0.19.3', static: false,
+                       required: false, allow_fallback: false)
+endif
 
 if not wlroots.found()
-  message('System wlroots 0.20 not found, building from subproject...')
+  message('System wlroots ' + wlroots_version + ' not found, building from subproject...')
 
   wlroots_options = [
     'examples=false',
@@ -126,11 +193,13 @@ if not wlroots.found()
     wlroots_options += 'xwayland=disabled'
   endif
 
-  wlroots_proj = subproject('wlroots', default_options: wlroots_options)
+  # One wrap per version: subprojects/wlroots-<version>.wrap, checked out into a
+  # matching directory. Adding a version is a new wrap plus a meson_options.txt choice.
+  wlroots_proj = subproject('wlroots-' + wlroots_version, default_options: wlroots_options)
   wlroots = wlroots_proj.get_variable('wlroots')
 endif
 
-wlroots_version = '0.20'
+# The Debian CI job greps this line to prove `auto` picks 0.19 there; keep the wording.
 message('Using wlroots version: ' + wlroots_version)
 
 # PAM authentication (optional, for lock screen)
@@ -267,9 +336,6 @@ add_project_arguments(
   '-DWITH_DBUS',
   language: 'c',
 )
-
-# Always 0.20 - we only support this version
-add_project_arguments('-DWLR_VERSION_0_20', language: 'c')
 
 if have_xwayland
   add_project_arguments('-DXWAYLAND', language: 'c')

--- a/meson.build
+++ b/meson.build
@@ -110,12 +110,11 @@ lgi_output = lgi_check_result.stdout().strip()
 lgi_version = lgi_output.split('Found lgi ')[-1].split('\n')[0]
 message('Found LGI version: ' + lgi_version)
 
-# wlroots 0.19 only - use system if available, otherwise build from subproject
-# We only support 0.19+ due to Xwayland bugs in earlier versions
-wlroots = dependency('wlroots-0.19', static: false, required: false)
+# wlroots 0.20 only - use system if available, otherwise build from subproject
+wlroots = dependency('wlroots-0.20', version : '>=0.20.0', static: false, required: false)
 
 if not wlroots.found()
-  message('System wlroots 0.19 not found, building from subproject...')
+  message('System wlroots 0.20 not found, building from subproject...')
 
   wlroots_options = [
     'examples=false',
@@ -131,7 +130,7 @@ if not wlroots.found()
   wlroots = wlroots_proj.get_variable('wlroots')
 endif
 
-wlroots_version = '0.19'
+wlroots_version = '0.20'
 message('Using wlroots version: ' + wlroots_version)
 
 # PAM authentication (optional, for lock screen)
@@ -269,8 +268,8 @@ add_project_arguments(
   language: 'c',
 )
 
-# Always 0.19 - we only support this version
-add_project_arguments('-DWLR_VERSION_0_19', language: 'c')
+# Always 0.20 - we only support this version
+add_project_arguments('-DWLR_VERSION_0_20', language: 'c')
 
 if have_xwayland
   add_project_arguments('-DXWAYLAND', language: 'c')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,14 @@ option(
 )
 
 option(
+  'wlroots_version',
+  type: 'combo',
+  choices: ['auto', '0.20', '0.19'],
+  value: 'auto',
+  description: 'wlroots version to build against. auto = 0.20 when it is already installed or the system deps satisfy its floors, else 0.19.',
+)
+
+option(
   'pam',
   type: 'feature',
   value: 'auto',

--- a/objects/wibox.c
+++ b/objects/wibox.c
@@ -20,7 +20,6 @@
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_buffer.h>
-#include <wlr/interfaces/wlr_buffer.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/backend.h>

--- a/package.nix
+++ b/package.nix
@@ -24,7 +24,7 @@
   wayland,
   wayland-protocols,
   wayland-scanner,
-  wlroots_0_19,
+  wlroots_0_20,
   xwayland,
   gtk3Support ? true,
   gtk3 ? null,
@@ -78,7 +78,7 @@ stdenv.mkDerivation {
     pango
     wayland
     wayland-protocols
-    wlroots_0_19
+    wlroots_0_20
     libxcb
     libxcb-wm
     libxcb-util

--- a/root.c
+++ b/root.c
@@ -36,7 +36,6 @@
 #include <wlr/render/wlr_texture.h>
 #include <wlr/render/pass.h>
 #include <wlr/types/wlr_buffer.h>
-#include <wlr/interfaces/wlr_buffer.h>
 #include <wlr/render/allocator.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <cairo.h>

--- a/somewm.c
+++ b/somewm.c
@@ -74,6 +74,7 @@
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/util/log.h>
 #include <wlr/util/region.h>
+#include <wlr/xcursor.h>
 #include <xkbcommon/xkbcommon.h>
 #ifdef XWAYLAND
 #include <wlr/xwayland.h>
@@ -7207,8 +7208,7 @@ xwaylandready(struct wl_listener *listener, void *data)
 	/* Set the default XWayland cursor to match the rest of somewm. */
 	if ((xcursor = wlr_xcursor_manager_get_xcursor(cursor_mgr, "default", 1)))
 		wlr_xwayland_set_cursor(xwayland,
-				xcursor->images[0]->buffer, xcursor->images[0]->width * 4,
-				xcursor->images[0]->width, xcursor->images[0]->height,
+				wlr_xcursor_image_get_buffer(xcursor->images[0]),
 				xcursor->images[0]->hotspot_x, xcursor->images[0]->hotspot_y);
 
 	/* Initialize XCB connection for EWMH support (AwesomeWM pattern) */

--- a/somewm.c
+++ b/somewm.c
@@ -1258,7 +1258,7 @@ cleanup(void)
 	destroykeyboardgroup(&kb_group->destroy, NULL);
 
 	/* Remove backend listeners immediately before destroying backend.
-	 * wlroots 0.19 asserts that all listeners are removed at destruction time. */
+	 * wlroots asserts that all listeners are removed at destruction time. */
 	wl_list_remove(&new_output.link);
 	wl_list_remove(&new_input_device.link);
 
@@ -1373,7 +1373,7 @@ cleanuplisteners(void)
 	wl_list_remove(&new_idle_inhibitor.link);
 	wl_list_remove(&layout_change.link);
 	/* NOTE: new_input_device and new_output are removed in cleanup()
-	 * immediately before wlr_backend_destroy() to satisfy wlroots 0.19
+	 * immediately before wlr_backend_destroy() to satisfy wlroots
 	 * assertions that require all backend listeners to be present until
 	 * backend destruction. */
 	wl_list_remove(&new_virtual_keyboard.link);

--- a/somewm.c
+++ b/somewm.c
@@ -7207,9 +7207,7 @@ xwaylandready(struct wl_listener *listener, void *data)
 
 	/* Set the default XWayland cursor to match the rest of somewm. */
 	if ((xcursor = wlr_xcursor_manager_get_xcursor(cursor_mgr, "default", 1)))
-		wlr_xwayland_set_cursor(xwayland,
-				wlr_xcursor_image_get_buffer(xcursor->images[0]),
-				xcursor->images[0]->hotspot_x, xcursor->images[0]->hotspot_y);
+		COMPAT_XWAYLAND_SET_CURSOR(xwayland, xcursor->images[0]);
 
 	/* Initialize XCB connection for EWMH support (AwesomeWM pattern) */
 	conn = xcb_connect(xwayland->display_name, NULL);

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -16,10 +16,11 @@
 #include <wlr/interfaces/wlr_keyboard.h>
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_xcursor_manager.h>
+#include <wlr/xcursor.h>
 #include <wlr/xwayland.h>
 
 #include "somewm_api.h"
-#include "wlr/xcursor.h"
+#include "wlr_compat.h"
 #include "xkb.h"
 #include "objects/signal.h"
 #include "objects/screen.h"
@@ -53,7 +54,8 @@ extern KeyboardGroup *kb_group;
 
 /* Mirror of wlroots' private keyboard_group_device struct (wlr_keyboard_group.c).
  * Needed to iterate member keyboards when setting layout group.
- * Must match the exact layout of the wlroots 0.20 struct. */
+ * Must match the exact layout of the wlroots struct; verified identical in 0.19.3
+ * and 0.20.0. */
 struct kb_group_device {
 	struct wlr_keyboard *keyboard;
 	struct wl_listener key;
@@ -623,9 +625,7 @@ some_update_cursor_theme(const char *theme_name, uint32_t size)
 	/* Sync XWayland cursor if running */
 	struct wlr_xcursor *xcursor = wlr_xcursor_manager_get_xcursor(cursor_mgr, "default", 1);
 	if (xcursor && xwayland) {
-		wlr_xwayland_set_cursor(xwayland,
-			wlr_xcursor_image_get_buffer(xcursor->images[0]),
-			xcursor->images[0]->hotspot_x, xcursor->images[0]->hotspot_y);
+		COMPAT_XWAYLAND_SET_CURSOR(xwayland, xcursor->images[0]);
 	}
 #endif
 }

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -19,6 +19,7 @@
 #include <wlr/xwayland.h>
 
 #include "somewm_api.h"
+#include "wlr/xcursor.h"
 #include "xkb.h"
 #include "objects/signal.h"
 #include "objects/screen.h"
@@ -623,8 +624,7 @@ some_update_cursor_theme(const char *theme_name, uint32_t size)
 	struct wlr_xcursor *xcursor = wlr_xcursor_manager_get_xcursor(cursor_mgr, "default", 1);
 	if (xcursor && xwayland) {
 		wlr_xwayland_set_cursor(xwayland,
-			xcursor->images[0]->buffer, xcursor->images[0]->width * 4,
-			xcursor->images[0]->width, xcursor->images[0]->height,
+			wlr_xcursor_image_get_buffer(xcursor->images[0]),
 			xcursor->images[0]->hotspot_x, xcursor->images[0]->hotspot_y);
 	}
 #endif

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -53,7 +53,7 @@ extern KeyboardGroup *kb_group;
 
 /* Mirror of wlroots' private keyboard_group_device struct (wlr_keyboard_group.c).
  * Needed to iterate member keyboards when setting layout group.
- * Must match the exact layout of the wlroots 0.19 struct. */
+ * Must match the exact layout of the wlroots 0.20 struct. */
 struct kb_group_device {
 	struct wlr_keyboard *keyboard;
 	struct wl_listener key;

--- a/subprojects/wlroots-0.19.wrap
+++ b/subprojects/wlroots-0.19.wrap
@@ -1,0 +1,8 @@
+[wrap-git]
+url = https://gitlab.freedesktop.org/wlroots/wlroots.git
+revision = 0.19.3
+depth = 1
+directory = wlroots-0.19
+
+[provide]
+dependency_names = wlroots-0.19

--- a/subprojects/wlroots-0.20.wrap
+++ b/subprojects/wlroots-0.20.wrap
@@ -2,6 +2,7 @@
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
 revision = 0.20.0
 depth = 1
+directory = wlroots-0.20
 
 [provide]
 dependency_names = wlroots-0.20

--- a/subprojects/wlroots.wrap
+++ b/subprojects/wlroots.wrap
@@ -1,7 +1,7 @@
 [wrap-git]
 url = https://gitlab.freedesktop.org/wlroots/wlroots.git
-revision = 0.19.2
+revision = 0.20.0
 depth = 1
 
 [provide]
-dependency_names = wlroots-0.19
+dependency_names = wlroots-0.20

--- a/wlr_compat.h
+++ b/wlr_compat.h
@@ -1,10 +1,9 @@
 /*
  * wlr_compat.h - wlroots version abstraction layer
  *
- * Provides macros to abstract wlroots API details. When wlroots 0.20
- * inevitably breaks APIs, only this file needs updating.
+ * Provides macros to abstract wlroots API details.
  *
- * Currently targets wlroots 0.19.
+ * Currently targets wlroots 0.20.
  */
 
 #ifndef WLR_COMPAT_H

--- a/wlr_compat.h
+++ b/wlr_compat.h
@@ -3,12 +3,15 @@
  *
  * Provides macros to abstract wlroots API details.
  *
- * Currently targets wlroots 0.20.
+ * Targets wlroots 0.19 and 0.20. Branch on WLR_VERSION_NUM from <wlr/version.h>, which
+ * describes the headers actually being compiled against; a define from meson could
+ * disagree with the include path.
  */
 
 #ifndef WLR_COMPAT_H
 #define WLR_COMPAT_H
 
+#include <wlr/version.h>
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/util/edges.h>
@@ -33,6 +36,17 @@
 /* XWayland: window type helper */
 #define COMPAT_XWAYLAND_HAS_WINDOW_TYPE(surface, type) \
     wlr_xwayland_surface_has_window_type((surface), (type))
+
+/* XWayland: 0.20 passes the cursor image as a wlr_buffer, 0.19 as raw pixels */
+#if WLR_VERSION_NUM >= ((0 << 16) | (20 << 8))
+#define COMPAT_XWAYLAND_SET_CURSOR(xw, image) \
+    wlr_xwayland_set_cursor((xw), wlr_xcursor_image_get_buffer(image), \
+        (image)->hotspot_x, (image)->hotspot_y)
+#else
+#define COMPAT_XWAYLAND_SET_CURSOR(xw, image) \
+    wlr_xwayland_set_cursor((xw), (image)->buffer, (image)->width * 4, \
+        (image)->width, (image)->height, (image)->hotspot_x, (image)->hotspot_y)
+#endif
 
 /* XDG surface geometry */
 #define COMPAT_XDG_SURFACE_GEOMETRY(surface) ((surface)->geometry)


### PR DESCRIPTION
## Description

Cherry-picks #632 (switch to wlroots 0.20) and #655 (0.19/0.20 dual support) from main. The build picks 0.20 when it is installed or the system can build it, and 0.19 otherwise; `-Dwlroots_version` overrides. CI moves to ubuntu-26.04 with a 0.20/0.19 matrix and a Debian 13 job covering the 0.19 path.

## Test Plan

- `make test-unit` 770 pass and `make test-integration` 129 pass, locally on both `-Dwlroots_version=0.19` and `0.20`
- `make check-qa` clean

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
