### PR TITLE
Pin lgi's C libraries across the hot-reload state close

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -4487,6 +4487,12 @@ luaA_state_teardown_lua(lua_State *L, bool lua_safe)
 static void
 luaA_state_teardown_c(const char *label, bool exit_emitted)
 {
+	/* lua_close() dlcloses the C modules the state loaded, and
+	 * libgirepository cannot survive an unload/reload cycle (GType
+	 * registration is process-global). Pin lgi's libraries resident
+	 * before the state goes away. */
+	somewm_pin_lgi_libs();
+
 	/* Layer surfaces last: detaching earlier would make arrangelayers() take
 	 * the no-Lua-object branch mid-teardown, which force-grants keyboard
 	 * focus to whichever surface asked for it. */

--- a/somewm.c
+++ b/somewm.c
@@ -3,6 +3,7 @@
  */
 #define _GNU_SOURCE
 #include <dlfcn.h>
+#include <link.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
@@ -7652,6 +7653,38 @@ ensure_lgi_guard(int argc, char *argv[])
 
 	execvp(argv[0], argv);
 	/* If exec fails, continue without the guard */
+}
+
+/* lua_close() dlcloses every C module the package library loaded, but
+ * GObject type registration is process-global and permanent, so
+ * libgirepository cannot be unloaded and loaded again: the fresh state's
+ * require("lgi") re-registers the GIRepository type, GLib refuses, and
+ * gi_require crashes on the failed object. */
+static int
+pin_lgi_lib_cb(struct dl_phdr_info *info, size_t size, void *data)
+{
+	(void)size;
+	(void)data;
+
+	if (!info->dlpi_name || !info->dlpi_name[0])
+		return 0;
+	if (!strstr(info->dlpi_name, "corelgilua") &&
+	    !strstr(info->dlpi_name, "libgirepository"))
+		return 0;
+
+	if (!dlopen(info->dlpi_name, RTLD_LAZY | RTLD_NOLOAD | RTLD_NODELETE))
+		fprintf(stderr, "somewm: hot-reload: failed to pin %s: %s\n",
+			info->dlpi_name, dlerror());
+	return 0;
+}
+
+/** Promote lgi's C libraries to RTLD_NODELETE so closing the Lua state
+ * leaves them resident and the next require("lgi") re-binds to the copy
+ * whose GTypes are already registered. No-op if lgi was never loaded. */
+void
+somewm_pin_lgi_libs(void)
+{
+	dl_iterate_phdr(pin_lgi_lib_cb, NULL);
 }
 
 int

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -288,6 +288,7 @@ static inline bool session_is_locked(void) {
 void client_remove_all_listeners(client_t *c);
 void client_reregister_listeners(client_t *c);
 void some_refresh(void);
+void somewm_pin_lgi_libs(void);
 
 /*
  * Test helpers - headless output hotplug simulation


### PR DESCRIPTION
## Description

Since #662, every hot-reload crashed to TTY. lua_close() dlcloses the C modules the state loaded, and libgirepository cannot be unloaded and loaded again: GType registration is process-global, so the fresh state's require("lgi") crashed in gi_require. Pin corelgilua and libgirepository resident with RTLD_NODELETE before the teardown.

## Test Plan

- restart 30 pass (restart-executes.sh reproduced the crash before the fix), unit 770 pass, integration 125 pass
- Three live reloads in a real session: no GLib criticals, no coredump, same pid

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)