### PR TITLE
fix(input): gate motionnotify pin on seat button_count, not cursor_mode

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -4207,7 +4207,7 @@ motionnotify(uint32_t time, struct wlr_input_device *device, double dx, double d
 	/* Find the client under the pointer and send the event along. */
 	xytonode(cursor->x, cursor->y, &surface, &c, NULL, NULL, NULL, &sx, &sy);
 
-	if (cursor_mode == CurPressed && !seat->drag
+	if (seat->pointer_state.button_count > 0 && !seat->drag
 			&& surface != seat->pointer_state.focused_surface
 			&& toplevel_from_wlr_surface(seat->pointer_state.focused_surface, &w, &l) >= 0) {
 		c = w;


### PR DESCRIPTION
## Description
Port of raven2cz's fix for #495. The motionnotify pin now checks wlroots' seat button count instead of the local CurPressed latch, which could stick when a button release never reached the compositor and pinned pointer focus to a stale surface.

## Test Plan
`make test-unit` (770 passing) and `make test-integration` (125 passing). User-confirmed on raven2cz's fork: scroll-on-hover works without a click, no regressions in selection, drag-and-drop, or move/resize.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)