### PR TITLE
fix(input): gate motionnotify pin on seat button_count, not cursor_mode

### DIFF
--- a/input.c
+++ b/input.c
@@ -796,7 +796,7 @@ motionnotify(uint32_t time, struct wlr_input_device *device, double dx, double d
 	/* Find the client under the pointer and send the event along. */
 	xytonode(cursor->x, cursor->y, &surface, &c, NULL, NULL, NULL, &sx, &sy);
 
-	if (cursor_mode == CurPressed && !seat->drag
+	if (seat->pointer_state.button_count > 0 && !seat->drag
 			&& surface != seat->pointer_state.focused_surface
 			&& toplevel_from_wlr_surface(seat->pointer_state.focused_surface, &w, &l) >= 0) {
 		c = w;


### PR DESCRIPTION
## Description
Cherry-pick of the release/1.4 fix for #495 (raven2cz's one-line change, same block in input.c).

## Test Plan
`make test-unit` (756 passing) and `make test-integration` (129 passing).

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)