### PR TITLE
fix(naughty): always reply to notification D-Bus method calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,23 @@ jobs:
 
   # Debian stable ships wayland-server 1.23.1, libdrm 2.4.124 and xkbcommon 1.7.0,
   # all below wlroots 0.20's floors. Build there to keep the wlroots 0.19 path working.
+  lua-compat:
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Lua interpreters
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            luajit lua5.1 lua5.2 lua5.3 lua5.4
+
+      - name: Parse lua/ with every interpreter
+        run: ./tests/check-lua-compat.sh
+        env:
+          LUA_COMPAT_REQUIRED: luajit lua5.1 lua5.2 lua5.3 lua5.4
+
   build-debian-stable:
     runs-on: ubuntu-latest
     container: debian:trixie

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 
 -include .local.mk
 
-.PHONY: all install uninstall clean setup reconfigure test test-unit test-check test-signal test-integration test-orchestrator test-restart test-one-restart test-asan test-one test-visual test-one-visual test-ci test-fast build-test build-bench bench-run bench-run-live bench-json bench-baseline bench-compare bench-check bench-memory bench-flamegraph bench-diff bench-heaptrack profile profile-lua profile-save profile-diff
+.PHONY: all install uninstall clean setup reconfigure test test-unit test-lua-compat test-check test-signal test-integration test-orchestrator test-restart test-one-restart test-asan test-one test-visual test-one-visual test-ci test-fast build-test build-bench bench-run bench-run-live bench-json bench-baseline bench-compare bench-check bench-memory bench-flamegraph bench-diff bench-heaptrack profile profile-lua profile-save profile-diff
 
 # Default build: optimized release, no sanitizers
 all:
@@ -51,8 +51,12 @@ reconfigure:
 # Run all tests (fast, no ASAN)
 test: test-unit test-check test-signal test-orchestrator test-restart test-integration
 
+# Parse lua/ with every installed Lua version (no compositor needed)
+test-lua-compat:
+	@./tests/check-lua-compat.sh
+
 # Unit tests only (busted, no compositor needed)
-test-unit:
+test-unit: test-lua-compat
 	@./tests/run-unit.sh
 
 # Check mode tests (no compositor needed, tests somewm --check)

--- a/lua/naughty/dbus.lua
+++ b/lua/naughty/dbus.lua
@@ -14,7 +14,6 @@ local string = string
 local capi = { awesome = awesome }
 local gsurface = require("gears.surface")
 local gdebug  = require("gears.debug")
-local protected_call = require("gears.protected_call")
 local lgi = require("lgi")
 local cairo, Gio, GLib, GObject = lgi.cairo, lgi.Gio, lgi.GLib, lgi.GObject
 
@@ -23,6 +22,7 @@ local sbyte = string.byte
 local tcat = table.concat
 local tins = table.insert
 local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
+local traceback = debug.traceback
 local naughty = require("naughty.core")
 local cst     = require("naughty.constants")
 local nnotif = require("naughty.notification")
@@ -128,6 +128,10 @@ local function convert_icon(w, h, rowstride, channels, data)
     return res
 end
 
+local function reply_id(invocation, id)
+    invocation:return_value(GLib.Variant("(u)", { id }))
+end
+
 local notif_methods = {}
 
 function notif_methods.Notify(sender, object_path, interface, method, parameters, invocation)
@@ -144,8 +148,8 @@ function notif_methods.Notify(sender, object_path, interface, method, parameters
         if title ~= "" then
             args.message = title
         else
-            -- FIXME: We have to reply *something* to the DBus invocation.
-            -- Right now this leads to a memory leak, I think.
+            -- Nothing to display, but the invocation still needs a reply.
+            reply_id(invocation, nnotif._gen_next_id())
             return
         end
     end
@@ -352,11 +356,11 @@ function notif_methods.Notify(sender, object_path, interface, method, parameters
             notification:connect_signal("destroyed", function(_, r) args.destroy(r) end)
         end
 
-        invocation:return_value(GLib.Variant("(u)", { notification.id }))
+        reply_id(invocation, notification.id)
         return
     end
 
-    invocation:return_value(GLib.Variant("(u)", { nnotif._gen_next_id() }))
+    reply_id(invocation, nnotif._gen_next_id())
 end
 
 function notif_methods.CloseNotification(_, _, _, _, parameters, invocation)
@@ -381,17 +385,31 @@ function notif_methods.GetCapabilities(_, _, _, _, _, invocation)
 end
 
 local function method_call(_, sender, object_path, interface, method, parameters, invocation)
-    if not notif_methods[method] then return end
+    local handler = notif_methods[method]
+    if not handler then
+        invocation:return_error_literal(
+            Gio.DBusError.quark(),
+            Gio.DBusError.UNKNOWN_METHOD,
+            "Unknown method: " .. tostring(method)
+        )
+        return
+    end
 
-    protected_call(
-        notif_methods[method],
-        sender,
-        object_path,
-        interface,
-        method,
-        parameters,
-        invocation
-    )
+    -- An unanswered invocation freezes the sender until the D-Bus timeout
+    -- (~25s), so a handler error must still produce a reply.
+    local ok, err = xpcall(function()
+        handler(sender, object_path, interface, method, parameters, invocation)
+    end, traceback)
+    if not ok then
+        err = tostring(err)
+        gdebug.print_error("Error in org.freedesktop.Notifications."
+            .. tostring(method) .. ": " .. err)
+        invocation:return_error_literal(
+            Gio.DBusError.quark(),
+            Gio.DBusError.FAILED,
+            err:match("^[^\n]*")
+        )
+    end
 end
 
 local function on_bus_acquire(conn, _)

--- a/lua/somewm/layout_animation.lua
+++ b/lua/somewm/layout_animation.lua
@@ -101,6 +101,79 @@ end
 -- Signal handler
 ---------------------------------------------------------------------------
 
+local function arrange_client(c, enabled, grabbing)
+    local state = get_state(c)
+    local new_geo = c:geometry()
+    local prev_target = state.settled_geo
+    state.settled_geo = new_geo
+
+    -- When disabled or mouse is dragging: snap, no animation
+    if not enabled or grabbing then
+        stop_animation(state)
+        state.visual_geo = nil
+        return
+    end
+
+    -- Target unchanged and animation already running: re-snap to
+    -- current visual position (counteracts the non-silent
+    -- c:geometry(target) that triggered this arrange) and skip.
+    if state.anim_handle and prev_target
+            and not geos_differ(prev_target, new_geo) then
+        if state.visual_geo then
+            c:_set_geometry_silent(state.visual_geo)
+        end
+        return
+    end
+
+    -- Current visual position: mid-animation or last settled
+    local old_geo = state.visual_geo or prev_target
+
+    -- First arrange for this client: no old position, skip animation
+    if not old_geo then
+        return
+    end
+
+    -- Skip if delta is negligible
+    if not geos_differ(old_geo, new_geo) then
+        stop_animation(state)
+        state.visual_geo = nil
+        return
+    end
+
+    -- Cancel any running animation
+    stop_animation(state)
+
+    -- Snap back to old visual position (before compositor renders)
+    c:_set_geometry_silent(old_geo)
+
+    -- Animate toward new target
+    local from = old_geo
+    local target = new_geo
+    local duration = layout_animation.duration
+
+    if duration <= 0 then
+        c:_set_geometry_silent(target)
+        state.visual_geo = nil
+        return
+    end
+
+    state.anim_handle = capi.awesome.start_animation(
+        duration, layout_animation.easing,
+        function(progress)
+            if not c.valid then return end
+            local g = lerp_geo(from, target, progress)
+            state.visual_geo = g
+            c:_set_geometry_silent(g)
+        end,
+        function()
+            if c.valid then
+                c:_set_geometry_silent(target)
+            end
+            state.visual_geo = nil
+            state.anim_handle = nil
+        end)
+end
+
 capi.screen.connect_signal("arrange", function(s)
     local tiled = s.tiled_clients
     if not tiled then return end
@@ -109,78 +182,7 @@ capi.screen.connect_signal("arrange", function(s)
     local grabbing = capi.mousegrabber.isrunning()
 
     for _, c in ipairs(tiled) do
-        local state = get_state(c)
-        local new_geo = c:geometry()
-        local prev_target = state.settled_geo
-        state.settled_geo = new_geo
-
-        -- When disabled or mouse is dragging: snap, no animation
-        if not enabled or grabbing then
-            stop_animation(state)
-            state.visual_geo = nil
-            goto continue
-        end
-
-        -- Target unchanged and animation already running: re-snap to
-        -- current visual position (counteracts the non-silent
-        -- c:geometry(target) that triggered this arrange) and skip.
-        if state.anim_handle and prev_target
-                and not geos_differ(prev_target, new_geo) then
-            if state.visual_geo then
-                c:_set_geometry_silent(state.visual_geo)
-            end
-            goto continue
-        end
-
-        -- Current visual position: mid-animation or last settled
-        local old_geo = state.visual_geo or prev_target
-
-        -- First arrange for this client: no old position, skip animation
-        if not old_geo then
-            goto continue
-        end
-
-        -- Skip if delta is negligible
-        if not geos_differ(old_geo, new_geo) then
-            stop_animation(state)
-            state.visual_geo = nil
-            goto continue
-        end
-
-        -- Cancel any running animation
-        stop_animation(state)
-
-        -- Snap back to old visual position (before compositor renders)
-        c:_set_geometry_silent(old_geo)
-
-        -- Animate toward new target
-        local from = old_geo
-        local target = new_geo
-        local duration = layout_animation.duration
-
-        if duration <= 0 then
-            c:_set_geometry_silent(target)
-            state.visual_geo = nil
-            goto continue
-        end
-
-        state.anim_handle = capi.awesome.start_animation(
-            duration, layout_animation.easing,
-            function(progress)
-                if not c.valid then return end
-                local g = lerp_geo(from, target, progress)
-                state.visual_geo = g
-                c:_set_geometry_silent(g)
-            end,
-            function()
-                if c.valid then
-                    c:_set_geometry_silent(target)
-                end
-                state.visual_geo = nil
-                state.anim_handle = nil
-            end)
-
-        ::continue::
+        arrange_client(c, enabled, grabbing)
     end
 end)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,6 +12,13 @@ Unit tests test individual Lua modules in isolation using the busted framework. 
 **Framework**: busted
 **Runner**: `tests/run-unit.sh`
 
+### Lua Version Compatibility (`tests/check-lua-compat.sh`)
+
+Parses every file under `lua/` with each installed Lua interpreter (LuaJIT,
+5.1 through 5.5). Runs before the unit tests via `make test-unit`, or alone via
+`make test-lua-compat`. Missing interpreters are skipped unless listed in
+`LUA_COMPAT_REQUIRED` (CI requires the ones its images ship).
+
 ### Check Mode Tests (`tests/test-check-mode.sh`)
 
 Check mode tests validate `somewm --check` behavior by creating temporary config fixtures and verifying output and exit codes. These tests don't start the compositor — they invoke the binary directly as a CLI tool.

--- a/tests/check-lua-compat.sh
+++ b/tests/check-lua-compat.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Parse every file under lua/ with each installed Lua interpreter. The tree
+# must load on every supported version; a syntax error that only one version
+# rejects takes the whole config down at startup.
+#
+# A missing interpreter is skipped so local runs stay useful. Set
+# LUA_COMPAT_REQUIRED to a space-separated list that must be present (CI does),
+# so an absent interpreter cannot turn the check silently green.
+
+set -u
+cd "$(dirname "$0")/.."
+
+LUA_COMPAT_REQUIRED=${LUA_COMPAT_REQUIRED:-}
+
+files=$(find lua -name '*.lua')
+fail=0
+checked=0
+
+required() {
+    case " $LUA_COMPAT_REQUIRED " in
+        *" $1 "*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+for lua in luajit lua5.1 lua5.2 lua5.3 lua5.4 lua5.5; do
+    if ! command -v "$lua" >/dev/null 2>&1; then
+        if required "$lua"; then
+            echo "check-lua-compat: $lua required but not installed"
+            fail=1
+        else
+            echo "check-lua-compat: $lua not installed, skipping"
+        fi
+        continue
+    fi
+    if printf '%s\n' "$files" | "$lua" -e '
+        local bad = 0
+        for f in io.lines() do
+            local chunk, err = loadfile(f)
+            if not chunk then
+                io.stderr:write(err, "\n")
+                bad = bad + 1
+            end
+        end
+        os.exit(bad == 0 and 0 or 1)'; then
+        echo "check-lua-compat: $lua OK"
+    else
+        echo "check-lua-compat: $lua FAILED"
+        fail=1
+    fi
+    checked=1
+done
+
+if [ "$checked" = 0 ]; then
+    echo "check-lua-compat: no Lua interpreter found" >&2
+    exit 1
+fi
+exit $fail

--- a/tests/restart/README.md
+++ b/tests/restart/README.md
@@ -1,6 +1,9 @@
 # Restart / hot-reload tests
 
-Tests that assert on both sides of a real `awesome.restart()`.
+Tests that assert on both sides of a real `awesome.restart()`. The suite is
+also home to plain D-Bus tests (`notify-reply-paths.sh`): it is the only
+harness that gives each test a private session bus and drives a sandboxed
+instance from outside.
 
 ## Why this suite exists separately
 

--- a/tests/restart/lib.sh
+++ b/tests/restart/lib.sh
@@ -498,6 +498,17 @@ check_bus_owner() {
     check "$desc" "$owner" "$want"
 }
 
+# Skip unless the instance owns the bus name. dbus-run-session still honours
+# /usr/share/dbus-1/services, so an activated dunst/mako on the "private" bus
+# would answer every call and leave a test permanently green.
+skip_unless_bus_owner() {
+    local name="$1" busname="$2" owner inst
+    inst=$(sw_pid "$name")
+    owner=$(sw_bus_owner_pid "$busname") || skip "$busname has no owner"
+    [ "$owner" = "$inst" ] || skip "$busname owned by pid $owner, not the instance ($inst)"
+    pass "the instance owns $busname"
+}
+
 # Preflight for the tests that talk to the bus from outside the compositor.
 skip_unless_bus() {
     [ -z "${SOMEWM_NO_DBUS:-}" ] || skip "dbus-run-session not available"

--- a/tests/restart/notify-after-restart.sh
+++ b/tests/restart/notify-after-restart.sh
@@ -24,13 +24,7 @@ NOTIFY_PATH=/org/freedesktop/Notifications
 
 sw_start hr-notify --config "$RESTART_DIR/configs/rc-dbus.lua" || finish
 
-inst_pid=$(sw_pid hr-notify)
-
-# Without this, an activated dunst/mako on the private bus would answer every
-# Notify and make this regression test permanently green.
-owner_pid=$(sw_bus_owner_pid "$NOTIFY_NAME") || skip "$NOTIFY_NAME has no owner before the reload"
-[ "$owner_pid" = "$inst_pid" ] || skip "$NOTIFY_NAME owned by pid $owner_pid, not the instance ($inst_pid)"
-pass "the instance owns $NOTIFY_NAME before the reload"
+skip_unless_bus_owner hr-notify "$NOTIFY_NAME"
 
 notify() {
     sw_bus_call "$NOTIFY_NAME" "$NOTIFY_PATH" "$NOTIFY_NAME.Notify" \

--- a/tests/restart/notify-reply-paths.sh
+++ b/tests/restart/notify-reply-paths.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Every org.freedesktop.Notifications call must get a reply. An unanswered
+# invocation freezes the sender until the D-Bus timeout (~25s), which is how
+# issue 657 presented. Covers the paths that used to drop the invocation:
+# a Lua error inside a handler, an unknown method, and a Notify with nothing
+# to display.
+
+. "$(dirname "$0")/lib.sh"
+
+skip_unless_bus
+
+NOTIFY_NAME=org.freedesktop.Notifications
+NOTIFY_PATH=/org/freedesktop/Notifications
+
+sw_start notify-reply --config "$RESTART_DIR/configs/rc-dbus.lua" || finish
+
+skip_unless_bus_owner notify-reply "$NOTIFY_NAME"
+
+# notify-send-shaped call: urgency hint, no expiry.
+sw_bus_call "$NOTIFY_NAME" "$NOTIFY_PATH" "$NOTIFY_NAME.Notify" \
+    somewm-test 0 "" title body "[]" "{'urgency': <byte 1>}" -- -1
+check_match "Notify with hints returns an id" "$BUS_OUT" '^\(uint32 [0-9]+,\)$'
+check_eval notify-reply "notification reached this compositor" \
+    'return tostring(NOTIF_COUNT)' 1
+
+# Nothing to display, but the invocation still needs a reply.
+sw_bus_call "$NOTIFY_NAME" "$NOTIFY_PATH" "$NOTIFY_NAME.Notify" \
+    somewm-test 0 "" "" "" "[]" "{}" 2000
+check_match "empty Notify still returns an id" "$BUS_OUT" '^\(uint32 [0-9]+,\)$'
+check_eval notify-reply "empty Notify displays nothing" \
+    'return tostring(NOTIF_COUNT)' 1
+
+# Unknown method gets an error reply, not silence.
+sw_bus_call "$NOTIFY_NAME" "$NOTIFY_PATH" "$NOTIFY_NAME.NoSuchMethod" \
+    && fail "unknown method must not succeed" "$BUS_OUT"
+check_match "unknown method returns UnknownMethod" "$BUS_OUT" 'UnknownMethod'
+
+sw_check_log_clean notify-reply
+
+# A handler error must become an instant error reply. Injected last: the
+# traceback it prints would trip the log-clean check above.
+sw_eval notify-reply 'require("naughty").get_by_id = function() error("boom657") end; return "ok"' \
+    || fail "could not inject handler error" "$EVAL_ERROR"
+sw_bus_call "$NOTIFY_NAME" "$NOTIFY_PATH" "$NOTIFY_NAME.Notify" \
+    somewm-test 1 "" title body "[]" "{}" 2000 \
+    && fail "Notify with broken handler must not succeed" "$BUS_OUT"
+check_match "handler error returns a D-Bus error, not a timeout" "$BUS_OUT" 'boom657'
+
+finish


### PR DESCRIPTION
## Description
Notification D-Bus calls that hit a Lua error, an unknown method, or a Notify with nothing to display got no reply, freezing the sender until the ~25s D-Bus timeout. Every call now gets an instant reply or error reply. Also fixes a `goto` that Lua 5.1 rejects and adds a parse check of `lua/` across installed Lua versions to `make test-unit`.

## Test Plan
New `tests/restart/notify-reply-paths.sh` passes with the fix and fails against the old dispatcher. `make test-unit` (includes the new `check-lua-compat.sh`), full restart suite (32/32), and `make test-integration` (129/129) all green.

## Checklist
- [ ] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)