### PR TITLE
fix(focus): keep X11 pointer grabs across same-surface refocus

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -316,6 +316,22 @@ keyboard_shortcuts_inhibit_client_code = custom_target(
   command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
 )
 
+# wlr-virtual-pointer client protocol (header + code) for the input-injection
+# test client
+virtual_pointer_client_header = custom_target(
+  'wlr-virtual-pointer-unstable-v1-client-protocol.h',
+  input: 'protocols/wlr-virtual-pointer-unstable-v1.xml',
+  output: 'wlr-virtual-pointer-unstable-v1-client-protocol.h',
+  command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+)
+
+virtual_pointer_client_code = custom_target(
+  'wlr-virtual-pointer-unstable-v1-client-protocol.c',
+  input: 'protocols/wlr-virtual-pointer-unstable-v1.xml',
+  output: 'wlr-virtual-pointer-unstable-v1-client-protocol.c',
+  command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
+)
+
 # ==============================================================================
 # Compiler Flags
 # ==============================================================================
@@ -568,6 +584,29 @@ test_disconnect_mid_map_client = executable(
   dependencies: [wayland_client],
   install: false,
 )
+
+# Test client that injects pointer motion and clicks through
+# zwlr_virtual_pointer_v1, driving the compositor's real buttonpress() path
+# (root.fake_input bypasses it). Used by test-xwayland-pointer-grab-click.lua.
+test_virtual_pointer_client = executable(
+  'test-virtual-pointer-client',
+  ['tests/test-virtual-pointer-client.c', virtual_pointer_client_code],
+  virtual_pointer_client_header,
+  dependencies: [wayland_client],
+  install: false,
+)
+
+# X11 client that grabs the pointer like a game (confined grab, blank cursor)
+# and logs focus/button events to a marker file. Used by
+# test-xwayland-pointer-grab-click.lua.
+if have_xwayland
+  test_x11_grab_client = executable(
+    'test-x11-grab-client',
+    'tests/test-x11-grab-client.c',
+    dependencies: [xcb],
+    install: false,
+  )
+endif
 # ==============================================================================
 # Install Data
 # ==============================================================================

--- a/protocols/wlr-virtual-pointer-unstable-v1.xml
+++ b/protocols/wlr-virtual-pointer-unstable-v1.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_virtual_pointer_unstable_v1">
+  <copyright>
+    Copyright © 2019 Josef Gajdusek
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_virtual_pointer_v1" version="2">
+    <description summary="virtual pointer">
+      This protocol allows clients to emulate a physical pointer device. The
+      requests are mostly mirror opposites of those specified in wl_pointer.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_axis" value="0"
+        summary="client sent invalid axis enumeration value" />
+      <entry name="invalid_axis_source" value="1"
+        summary="client sent invalid axis source enumeration value" />
+    </enum>
+
+    <request name="motion">
+      <description summary="pointer relative motion event">
+        The pointer has moved by a relative amount to the previous request.
+
+        Values are in the global compositor space.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="dx" type="fixed" summary="displacement on the x-axis"/>
+      <arg name="dy" type="fixed" summary="displacement on the y-axis"/>
+    </request>
+
+    <request name="motion_absolute">
+      <description summary="pointer absolute motion event">
+        The pointer has moved in an absolute coordinate frame.
+
+        Value of x can range from 0 to x_extent, value of y can range from 0
+        to y_extent.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="x" type="uint" summary="position on the x-axis"/>
+      <arg name="y" type="uint" summary="position on the y-axis"/>
+      <arg name="x_extent" type="uint" summary="extent of the x-axis"/>
+      <arg name="y_extent" type="uint" summary="extent of the y-axis"/>
+    </request>
+
+    <request name="button">
+      <description summary="button event">
+        A button was pressed or released.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="button" type="uint" summary="button that produced the event"/>
+      <arg name="state" type="uint" enum="wl_pointer.button_state" summary="physical state of the button"/>
+    </request>
+
+    <request name="axis">
+      <description summary="axis event">
+        Scroll and other axis requests.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="axis type"/>
+      <arg name="value" type="fixed" summary="length of vector in touchpad coordinates"/>
+    </request>
+
+    <request name="frame">
+      <description summary="end of a pointer event sequence">
+        Indicates the set of events that logically belong together.
+      </description>
+    </request>
+
+    <request name="axis_source">
+      <description summary="axis source event">
+        Source information for scroll and other axis.
+      </description>
+      <arg name="axis_source" type="uint" enum="wl_pointer.axis_source" summary="source of the axis event"/>
+    </request>
+
+    <request name="axis_stop">
+      <description summary="axis stop event">
+        Stop notification for scroll and other axes.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="the axis stopped with this event"/>
+    </request>
+
+    <request name="axis_discrete">
+      <description summary="axis click event">
+        Discrete step information for scroll and other axes.
+
+        This event allows the client to extend data normally sent using the axis
+        event with discrete value.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="axis type"/>
+      <arg name="value" type="fixed" summary="length of vector in touchpad coordinates"/>
+      <arg name="discrete" type="int" summary="number of steps"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual pointer object"/>
+    </request>
+  </interface>
+
+  <interface name="zwlr_virtual_pointer_manager_v1" version="2">
+    <description summary="virtual pointer manager">
+      This object allows clients to create individual virtual pointer objects.
+    </description>
+
+    <request name="create_virtual_pointer">
+      <description summary="Create a new virtual pointer">
+        Creates a new virtual pointer. The optional seat is a suggestion to the
+        compositor.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"/>
+      <arg name="id" type="new_id" interface="zwlr_virtual_pointer_v1"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual pointer manager"/>
+    </request>
+
+    <!-- Version 2 additions -->
+    <request name="create_virtual_pointer_with_output" since="2">
+      <description summary="Create a new virtual pointer">
+        Creates a new virtual pointer. The seat and the output arguments are
+        optional. If the seat argument is set, the compositor should assign the
+        input device to the requested seat. If the output argument is set, the
+        compositor should map the input device to the requested output.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"/>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+      <arg name="id" type="new_id" interface="zwlr_virtual_pointer_v1"/>
+    </request>
+  </interface>
+</protocol>

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -12,6 +12,7 @@
 #include <glib.h>
 #include <wlr/types/wlr_fractional_scale_v1.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
+#include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_keyboard_group.h>
 #include <wlr/interfaces/wlr_keyboard.h>
@@ -407,6 +408,18 @@ some_set_seat_keyboard_focus(Client *c)
 	if (seat->keyboard_state.focused_surface == surface) {
 #ifdef XWAYLAND
 		if (c->client_type == X11) {
+			struct wlr_pointer_constraint_v1 *constraint =
+				wlr_pointer_constraints_v1_constraint_for_surface(
+					pointer_constraints, surface, seat);
+			if (constraint) {
+				/* A constraint-backed X11 pointer grab is in progress
+				 * (games): the clear/re-enter cycle below becomes
+				 * FocusOut in X11 and Xwayland tears the grab down,
+				 * destroying the constraint. Focus is demonstrably
+				 * working; just make sure the constraint is active. */
+				cursorconstrain(constraint);
+				return;
+			}
 			/* KWin pattern: force focus re-delivery for X11 clients.
 			 * wlroots skips re-entry to the same surface, so we must
 			 * deactivate→clear→re-enter to deliver a new FocusIn event.
@@ -508,6 +521,12 @@ some_set_seat_keyboard_focus(Client *c)
 	if (c->client_type == X11)
 		client_activate_surface(surface, 1);
 #endif
+
+	/* Update pointer constraint for the newly focused surface, mirroring
+	 * focusclient(). Without this a constraint created around a Lua-path
+	 * focus change is never activated. */
+	cursorconstrain(wlr_pointer_constraints_v1_constraint_for_surface(
+		pointer_constraints, surface, seat));
 }
 
 /** Find the Client* that owns a given wlr_surface.

--- a/tests/test-virtual-pointer-client.c
+++ b/tests/test-virtual-pointer-client.c
@@ -1,0 +1,118 @@
+/**
+ * test-virtual-pointer-client - Inject pointer input via zwlr_virtual_pointer_v1.
+ *
+ * Moves the cursor to an absolute layout position and performs one left click.
+ * Unlike root.fake_input("button_press"), the injected events arrive through a
+ * real wlr_input_device, so they traverse the compositor's full buttonpress()
+ * path: mousegrabber routing, client button bindings, and seat notification.
+ *
+ * Usage: test-virtual-pointer-client <move|click> <x> <y> <x_extent> <y_extent>
+ *
+ * x/y are layout coordinates; x_extent/y_extent the layout size (normally the
+ * screen geometry). "move" only positions the cursor; "click" also presses and
+ * releases BTN_LEFT. Exits after the events are flushed.
+ */
+
+#include <linux/input-event-codes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <wayland-client.h>
+#include "wlr-virtual-pointer-unstable-v1-client-protocol.h"
+
+static struct wl_seat *g_seat;
+static struct zwlr_virtual_pointer_manager_v1 *g_manager;
+
+static uint32_t now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint32_t)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
+}
+
+static void sleep_ms(long ms) {
+    struct timespec ts = { .tv_sec = 0, .tv_nsec = ms * 1000000 };
+    nanosleep(&ts, NULL);
+}
+
+static void registry_global(void *data, struct wl_registry *reg,
+        uint32_t name, const char *interface, uint32_t version) {
+    (void)data; (void)version;
+    if (strcmp(interface, wl_seat_interface.name) == 0) {
+        g_seat = wl_registry_bind(reg, name, &wl_seat_interface, 1);
+    } else if (strcmp(interface, zwlr_virtual_pointer_manager_v1_interface.name) == 0) {
+        g_manager = wl_registry_bind(reg, name,
+            &zwlr_virtual_pointer_manager_v1_interface, 1);
+    }
+}
+
+static void registry_global_remove(void *data, struct wl_registry *reg, uint32_t name) {
+    (void)data; (void)reg; (void)name;
+}
+
+static const struct wl_registry_listener registry_listener = {
+    .global = registry_global,
+    .global_remove = registry_global_remove,
+};
+
+int main(int argc, char *argv[]) {
+    if (argc != 6 || (strcmp(argv[1], "move") != 0 && strcmp(argv[1], "click") != 0)) {
+        fprintf(stderr, "Usage: %s <move|click> <x> <y> <x_extent> <y_extent>\n",
+                argv[0]);
+        return 1;
+    }
+    int click = strcmp(argv[1], "click") == 0;
+    uint32_t x = (uint32_t)strtoul(argv[2], NULL, 10);
+    uint32_t y = (uint32_t)strtoul(argv[3], NULL, 10);
+    uint32_t x_extent = (uint32_t)strtoul(argv[4], NULL, 10);
+    uint32_t y_extent = (uint32_t)strtoul(argv[5], NULL, 10);
+
+    struct wl_display *display = wl_display_connect(NULL);
+    if (!display) {
+        fprintf(stderr, "Failed to connect to Wayland display\n");
+        return 1;
+    }
+
+    struct wl_registry *registry = wl_display_get_registry(display);
+    wl_registry_add_listener(registry, &registry_listener, NULL);
+    wl_display_roundtrip(display);
+
+    if (!g_seat || !g_manager) {
+        fprintf(stderr, "Missing wl_seat or zwlr_virtual_pointer_manager_v1\n");
+        return 1;
+    }
+
+    struct zwlr_virtual_pointer_v1 *pointer =
+        zwlr_virtual_pointer_manager_v1_create_virtual_pointer(g_manager, g_seat);
+
+    /* Workaround, sent twice: motionnotify hit-tests at the pre-move cursor
+     * position, so pointer focus catches up one event late. Drop the second
+     * send once hit-testing follows the move (input.c motionnotify). */
+    for (int i = 0; i < 2; i++) {
+        zwlr_virtual_pointer_v1_motion_absolute(pointer, now_ms(), x, y,
+                                                x_extent, y_extent);
+        zwlr_virtual_pointer_v1_frame(pointer);
+        wl_display_roundtrip(display);
+        sleep_ms(30);
+    }
+
+    if (click) {
+        sleep_ms(50);
+        zwlr_virtual_pointer_v1_button(pointer, now_ms(), BTN_LEFT,
+                                       WL_POINTER_BUTTON_STATE_PRESSED);
+        zwlr_virtual_pointer_v1_frame(pointer);
+        wl_display_roundtrip(display);
+        sleep_ms(50);
+        zwlr_virtual_pointer_v1_button(pointer, now_ms(), BTN_LEFT,
+                                       WL_POINTER_BUTTON_STATE_RELEASED);
+        zwlr_virtual_pointer_v1_frame(pointer);
+        wl_display_roundtrip(display);
+    }
+
+    zwlr_virtual_pointer_v1_destroy(pointer);
+    zwlr_virtual_pointer_manager_v1_destroy(g_manager);
+    wl_seat_destroy(g_seat);
+    wl_registry_destroy(registry);
+    wl_display_disconnect(display);
+    return 0;
+}

--- a/tests/test-x11-grab-client.c
+++ b/tests/test-x11-grab-client.c
@@ -1,0 +1,180 @@
+/**
+ * test-x11-grab-client - X11 client that grabs the pointer like a game.
+ *
+ * Maps a window and, when the pointer enters it, issues an active XGrabPointer
+ * confined to the window with a blank cursor (the classic game capture
+ * pattern; Xwayland translates it into a pointer constraint). Appends one line
+ * per event to a marker file:
+ *
+ *     GRAB <status>          0 = success (xcb_grab_status_t otherwise)
+ *     ENTER
+ *     FOCUS_IN mode=M detail=D
+ *     FOCUS_OUT mode=M detail=D
+ *     BUTTON press|release
+ *
+ * Used by test-xwayland-pointer-grab-click.lua: a left click on the grabbing
+ * window must not produce FOCUS_OUT, which is what makes Xwayland tear the
+ * grab down.
+ *
+ * Usage: test-x11-grab-client <marker-path> <wm-class> <x> <y> <w> <h>
+ *
+ * The window is created at the given box. It must match where the compositor
+ * places the client and avoid the X pointer's resting position: a window that
+ * maps under the pointer delivers EnterNotify (and grabs) immediately.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <xcb/xcb.h>
+
+static const char *g_marker;
+
+static void log_line(const char *fmt, ...) {
+    FILE *f = fopen(g_marker, "a");
+    if (!f)
+        return;
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(f, fmt, ap);
+    va_end(ap);
+    fputc('\n', f);
+    fclose(f);
+}
+
+/* Grab like a game entering mouse capture: on pointer enter, so the cursor
+ * is inside the window when the grab (and any pointer constraint Xwayland
+ * derives from it) takes effect. Retried until it succeeds. */
+static int try_grab(xcb_connection_t *conn, xcb_window_t win,
+                    xcb_cursor_t cursor) {
+    xcb_grab_pointer_reply_t *reply = xcb_grab_pointer_reply(conn,
+        xcb_grab_pointer(conn, 1, win,
+            XCB_EVENT_MASK_BUTTON_PRESS | XCB_EVENT_MASK_BUTTON_RELEASE
+                | XCB_EVENT_MASK_POINTER_MOTION,
+            XCB_GRAB_MODE_ASYNC, XCB_GRAB_MODE_ASYNC,
+            win, cursor, XCB_CURRENT_TIME),
+        NULL);
+    uint8_t status = reply ? reply->status : 0xff;
+    free(reply);
+    log_line("GRAB %u", status);
+    return status == XCB_GRAB_STATUS_SUCCESS;
+}
+
+/* 1x1 empty-pixmap cursor: hides the pointer for the grab's duration. */
+static xcb_cursor_t blank_cursor(xcb_connection_t *conn, xcb_screen_t *screen) {
+    xcb_pixmap_t pixmap = xcb_generate_id(conn);
+    xcb_create_pixmap(conn, 1, pixmap, screen->root, 1, 1);
+    xcb_cursor_t cursor = xcb_generate_id(conn);
+    xcb_create_cursor(conn, cursor, pixmap, pixmap, 0, 0, 0, 0, 0, 0, 0, 0);
+    xcb_free_pixmap(conn, pixmap);
+    return cursor;
+}
+
+int main(int argc, char *argv[]) {
+    if (argc != 7) {
+        fprintf(stderr, "Usage: %s <marker-path> <wm-class> <x> <y> <w> <h>\n",
+                argv[0]);
+        return 1;
+    }
+    g_marker = argv[1];
+    const char *wm_class = argv[2];
+    int16_t x = (int16_t)atoi(argv[3]);
+    int16_t y = (int16_t)atoi(argv[4]);
+    uint16_t w = (uint16_t)atoi(argv[5]);
+    uint16_t h = (uint16_t)atoi(argv[6]);
+
+    xcb_connection_t *conn = xcb_connect(NULL, NULL);
+    if (xcb_connection_has_error(conn)) {
+        fprintf(stderr, "Failed to connect to X display\n");
+        return 1;
+    }
+    xcb_screen_t *screen =
+        xcb_setup_roots_iterator(xcb_get_setup(conn)).data;
+
+    xcb_window_t win = xcb_generate_id(conn);
+    uint32_t values[] = {
+        screen->white_pixel,
+        XCB_EVENT_MASK_EXPOSURE | XCB_EVENT_MASK_STRUCTURE_NOTIFY
+            | XCB_EVENT_MASK_FOCUS_CHANGE | XCB_EVENT_MASK_BUTTON_PRESS
+            | XCB_EVENT_MASK_BUTTON_RELEASE | XCB_EVENT_MASK_ENTER_WINDOW,
+    };
+    xcb_create_window(conn, XCB_COPY_FROM_PARENT, win, screen->root,
+                      x, y, w, h, 0, XCB_WINDOW_CLASS_INPUT_OUTPUT,
+                      screen->root_visual,
+                      XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK, values);
+
+    /* WM_CLASS is "instance\0class\0"; the test finds the client by class. */
+    char class_prop[256];
+    size_t len = strlen(wm_class) + 1;
+    if (2 * len > sizeof(class_prop)) {
+        fprintf(stderr, "wm-class too long\n");
+        return 1;
+    }
+    memcpy(class_prop, wm_class, len);
+    memcpy(class_prop + len, wm_class, len);
+    xcb_change_property(conn, XCB_PROP_MODE_REPLACE, win, XCB_ATOM_WM_CLASS,
+                        XCB_ATOM_STRING, 8, 2 * len, class_prop);
+    xcb_change_property(conn, XCB_PROP_MODE_REPLACE, win, XCB_ATOM_WM_NAME,
+                        XCB_ATOM_STRING, 8, strlen(wm_class), wm_class);
+
+    /* WM_HINTS: input = True, initial_state = NormalState. */
+    uint32_t wm_hints[9] = { (1 << 0) | (1 << 1), 1, 1, 0, 0, 0, 0, 0, 0 };
+    xcb_change_property(conn, XCB_PROP_MODE_REPLACE, win, XCB_ATOM_WM_HINTS,
+                        XCB_ATOM_WM_HINTS, 32, 9, wm_hints);
+    /* WM_NORMAL_HINTS: PPosition | PSize. */
+    uint32_t size_hints[18] = { (1 << 2) | (1 << 3) };
+    size_hints[1] = (uint32_t)x; size_hints[2] = (uint32_t)y;
+    size_hints[3] = w; size_hints[4] = h;
+    xcb_change_property(conn, XCB_PROP_MODE_REPLACE, win,
+                        XCB_ATOM_WM_NORMAL_HINTS, XCB_ATOM_WM_SIZE_HINTS,
+                        32, 18, size_hints);
+
+    xcb_gcontext_t gc = xcb_generate_id(conn);
+    uint32_t gc_values[] = { screen->white_pixel };
+    xcb_create_gc(conn, gc, win, XCB_GC_FOREGROUND, gc_values);
+
+    xcb_map_window(conn, win);
+    xcb_flush(conn);
+
+    xcb_cursor_t cursor = blank_cursor(conn, screen);
+    int grabbed = 0;
+    xcb_generic_event_t *ev;
+    while ((ev = xcb_wait_for_event(conn))) {
+        switch (ev->response_type & ~0x80) {
+        case XCB_EXPOSE: {
+            /* Paint the window: Xwayland only maps a Wayland buffer for
+             * windows with rendered content. */
+            xcb_rectangle_t rect = { 0, 0, w, h };
+            xcb_poly_fill_rectangle(conn, win, gc, 1, &rect);
+            break;
+        }
+        case XCB_ENTER_NOTIFY:
+            log_line("ENTER");
+            if (!grabbed)
+                grabbed = try_grab(conn, win, cursor);
+            break;
+        case XCB_FOCUS_IN: {
+            xcb_focus_in_event_t *fe = (xcb_focus_in_event_t *)ev;
+            log_line("FOCUS_IN mode=%u detail=%u", fe->mode, fe->detail);
+            break;
+        }
+        case XCB_FOCUS_OUT: {
+            xcb_focus_out_event_t *fe = (xcb_focus_out_event_t *)ev;
+            log_line("FOCUS_OUT mode=%u detail=%u", fe->mode, fe->detail);
+            break;
+        }
+        case XCB_BUTTON_PRESS:
+            log_line("BUTTON press");
+            break;
+        case XCB_BUTTON_RELEASE:
+            log_line("BUTTON release");
+            break;
+        }
+        free(ev);
+        xcb_flush(conn);
+    }
+
+    xcb_disconnect(conn);
+    return 0;
+}

--- a/tests/test-xwayland-pointer-grab-click.lua
+++ b/tests/test-xwayland-pointer-grab-click.lua
@@ -1,0 +1,187 @@
+---------------------------------------------------------------------------
+--- Regression test: left click must not break an XWayland pointer grab.
+---
+--- A game grabs the pointer (test-x11-grab-client: confined grab, blank
+--- cursor). Clicking inside the window runs the default mouse binding,
+--- c:activate { context = "mouse_click" }, whose redundant client.focus = c
+--- used to drive a deactivate/clear/re-enter cycle for X11 clients. Xwayland
+--- turns that into FocusOut, tears the grab down, and destroys its pointer
+--- constraint: capture lost on every click (issue reproduced by this test).
+---
+--- The click is injected with test-virtual-pointer-client so it traverses
+--- the real buttonpress() path (root.fake_input bypasses it). Assertions:
+--- the click reaches the grabbing client (BUTTON press) and produces no
+--- FOCUS_OUT after the grab was established.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local async  = require("_async")
+local awful  = require("awful")
+local ruled  = require("ruled")
+
+local GRAB_CLIENT = "./build-test/test-x11-grab-client"
+local VPOINTER    = "./build-test/test-virtual-pointer-client"
+local CLASS       = "grab_click"
+
+if os.getenv("WLR_BACKENDS") == "headless" then
+    io.stderr:write("SKIP: XWayland tests require visual mode (HEADLESS=0)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local function file_exists(path)
+    local f = io.open(path, "r"); if not f then return false end
+    f:close(); return true
+end
+
+for _, bin in ipairs({ GRAB_CLIENT, VPOINTER }) do
+    if not file_exists(bin) then
+        io.stderr:write("SKIP: " .. bin .. " not found (run meson compile first)\n")
+        io.stderr:write("Test finished successfully.\n")
+        awesome.quit()
+        return
+    end
+end
+
+local marker = string.format("/tmp/somewm-grab-click-%d.log",
+                             os.time() * 1000 + math.random(0, 999))
+os.remove(marker)
+
+local function read_lines()
+    local f = io.open(marker, "r"); if not f then return {} end
+    local out = {}
+    for line in f:lines() do out[#out + 1] = line end
+    f:close()
+    return out
+end
+
+local function grab_index(lines)
+    for i, line in ipairs(lines) do
+        if line == "GRAB 0" then return i end
+    end
+    return nil
+end
+
+-- Counts lines starting with the given prefix (FOCUS lines carry mode/detail).
+local function count_after(lines, from, want)
+    local n = 0
+    for i = from, #lines do
+        if lines[i]:find(want, 1, true) == 1 then n = n + 1 end
+    end
+    return n
+end
+
+runner.run_async(function()
+    -- The somewmrc default left-click binding; tests/rc.lua has none.
+    awful.mouse.append_client_mousebindings({
+        awful.button({ }, 1, function(c)
+            c:activate { context = "mouse_click" }
+        end),
+    })
+
+    -- Workaround for a compositor defect: the first X client after the lazy
+    -- XWayland start races its map against xwaylandready() and never maps
+    -- compositor-side (fast minimal clients lose; xterm-sized ones win).
+    -- Spawn and discard one client so the real one maps reliably; matched by
+    -- name because the racy client never gets its class. Remove once the
+    -- first-X11-client map race is fixed.
+    do
+        local warm = awful.spawn(string.format("%s /dev/null warmup_x11 0 0 50 50",
+                                               GRAB_CLIENT))
+        assert(type(warm) == "number", "warm-up spawn failed: " .. tostring(warm))
+        local wc
+        async.wait_for_condition(function()
+            for _, cc in ipairs(client.get()) do
+                if cc.name == "warmup_x11" then wc = cc; return true end
+            end
+        end, 10)
+        assert(wc, "warm-up X client did not appear")
+        os.execute("kill -9 " .. warm .. " 2>/dev/null")
+        async.wait_for_condition(function() return not wc.valid end, 5)
+        async.sleep(0.2)
+    end
+
+    -- The client grabs on pointer enter, so it must spawn floating in a box
+    -- containing neither the compositor cursor's startup position (100, 100)
+    -- nor Xwayland's X-side pointer resting position (the screen center);
+    -- either one delivers EnterNotify at map and the grab fires early.
+    local box = { x = 350, y = 40, width = 200, height = 150 }
+    ruled.client.append_rule {
+        rule = { class = CLASS },
+        properties = { floating = true, x = box.x, y = box.y,
+                       width = box.width, height = box.height },
+    }
+
+    local grab_pid = awful.spawn(string.format("%s %s %s %d %d %d %d",
+        GRAB_CLIENT, marker, CLASS, box.x, box.y, box.width, box.height))
+    assert(type(grab_pid) == "number", "spawn returned: " .. tostring(grab_pid))
+
+    local c = async.wait_for_client(CLASS, 10)
+    assert(c, "X11 grab client did not appear")
+    assert(c.window and c.window > 0, "client is not an XWayland client")
+
+    assert(async.wait_for_focus(CLASS, 5), "X11 grab client did not receive focus")
+    assert(grab_index(read_lines()) == nil,
+        "grab fired before the cursor entered the window; marker: ["
+        .. table.concat(read_lines(), " | ") .. "]")
+
+    local g = c:geometry()
+    local cx = math.floor(g.x + g.width / 2)
+    local cy = math.floor(g.y + g.height / 2)
+    local sg = c.screen.geometry
+
+    local function inject(mode)
+        awful.spawn(string.format("%s %s %d %d %d %d", VPOINTER, mode, cx, cy,
+                                  sg.width, sg.height))
+    end
+
+    -- Move the cursor into the window first; the client grabs on pointer
+    -- enter, like a game entering mouse capture.
+    inject("move")
+
+    local gi
+    async.wait_for_condition(function()
+        gi = grab_index(read_lines())
+        return gi ~= nil
+    end, 5)
+    assert(gi, "pointer grab did not succeed; marker: ["
+        .. table.concat(read_lines(), " | ") .. "]")
+    io.stderr:write("[TEST] pointer grab established\n")
+
+    inject("click")
+    local clicked = async.wait_for_condition(function()
+        return count_after(read_lines(), gi, "BUTTON press") >= 1
+    end, 5)
+    assert(clicked, "click did not reach the grabbing client; marker: ["
+        .. table.concat(read_lines(), " | ") .. "]")
+
+    -- Give any focus fallout time to reach the client before asserting.
+    async.sleep(0.5)
+
+    local lines = read_lines()
+    assert(count_after(lines, gi, "FOCUS_OUT") == 0,
+        "left click broke the pointer grab (FocusOut delivered); marker: ["
+        .. table.concat(lines, " | ") .. "]")
+    assert(client.focus == c, "client lost compositor focus after click")
+
+    -- The grab must still be operative: a second click still lands.
+    inject("click")
+    local clicked_again = async.wait_for_condition(function()
+        return count_after(read_lines(), gi, "BUTTON press") >= 2
+    end, 5)
+    assert(clicked_again, "second click did not reach the grabbing client")
+    async.sleep(0.3)
+    assert(count_after(read_lines(), gi, "FOCUS_OUT") == 0,
+        "second click broke the pointer grab (FocusOut delivered)")
+
+    io.stderr:write("[ALL TESTS] PASS\n")
+
+    if c.valid then c:kill() end
+    os.execute("kill -9 " .. grab_pid .. " 2>/dev/null")
+    async.wait_for_no_clients(5)
+    os.remove(marker)
+    runner.done()
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
## Description
Clicking an already-focused XWayland client re-delivers keyboard focus. Xwayland sees FocusOut and drops the client's pointer grab, so games lose mouse capture on every click. Skip the re-delivery while the surface holds a pointer constraint. Fixes #475.

## Test Plan
New test `tests/test-xwayland-pointer-grab-click.lua`: a virtual-pointer click into a grabbing X11 client. Fails on main, passes here. Unit 756 pass, integration 130 pass.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified**
- [x] Tests pass (`make test-unit && make test-integration`)