### PR TITLE
fix(monitor): detach scene output before Lua removal work in cleanupmon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to somewm will be documented in this file.
 
 ### Added
 
+- `awesome._test_remove_output` test helper - destroys a headless output by name, driving the real unplug path
+
 ### Fixed
+
+- Output unplug no longer crashes when clients are relocated off the removed screen
 
 ### Changed
 

--- a/lua/naughty/init.lua
+++ b/lua/naughty/init.lua
@@ -22,41 +22,19 @@ naughty.container = require("naughty.container")
 naughty.action = require("naughty.action")
 naughty.notification = require("naughty.notification")
 
--- Attempt to handle early errors when using the manual screen mode.
+-- An error this early has no screen to display a notification on, so log it
+-- and skip the popup.
 --
--- Creating a notification popup before the screens are added won't work. To
--- work around this, the code below initializes some screens. One potential
--- problem is that it could emit enough signal to cause even more errors and
--- lose the original error.
---
--- For example, the following error can be displayed using this fallback:
---
---    screen.connect_signal("scanned", function() foobar() end)
---
-local function screen_fallback()
-    -- capi.screen.count() is not enough: after a config timeout the Lua state
-    -- is rebuilt while the screen refs still point at the closed one, so the
-    -- compositor reports screens that no notification can be placed on.
-    if capi.screen.count() == 0 or not ascreen.focused() then
-        gdebug.print_warning("An error occurred before a screen was added")
-
-        -- Private API to scan for screens now.
-        if #screen._viewports() == 0 then
-            screen._scan_quiet()
-        end
-
-        local viewports = screen._viewports()
-
-        if #viewports > 0 then
-            for _, viewport in ipairs(viewports) do
-                local geo = viewport.geometry
-                local s = capi.screen.fake_add(geo.x, geo.y, geo.width, geo.height)
-                s.outputs = viewport.outputs
-            end
-        else
-            capi.screen.fake_add(0, 0, 640, 480)
-        end
+-- capi.screen.count() is not enough: after a config timeout the Lua state
+-- is rebuilt while the screen refs still point at the closed one, so the
+-- compositor reports screens that no notification can be placed on.
+local function can_display()
+    if capi.screen.count() > 0 and ascreen.focused() then
+        return true
     end
+
+    gdebug.print_warning("An error occurred before a screen was added")
+    return false
 end
 
 -- Handle runtime errors during startup
@@ -66,7 +44,10 @@ if capi.awesome.startup_errors then
     -- Otherwise nothing is handling them (yet).
     client.connect_signal("scanning", function()
         -- A lot of things have to go wrong for this to happen, but it can.
-        screen_fallback()
+        if not can_display() then
+            gdebug.print_error(capi.awesome.startup_errors)
+            return
+        end
 
         naughty.emit_signal(
             "request::display_error", capi.awesome.startup_errors, true
@@ -84,9 +65,11 @@ do
 
         in_error = true
 
-        screen_fallback()
-
-        naughty.emit_signal("request::display_error", tostring(err), false)
+        if can_display() then
+            naughty.emit_signal("request::display_error", tostring(err), false)
+        else
+            gdebug.print_error(err)
+        end
 
         in_error = false
     end)

--- a/luaa.c
+++ b/luaa.c
@@ -1262,6 +1262,19 @@ luaA_awesome_test_add_output(lua_State *L)
 	return 1;
 }
 
+/** awesome._test_remove_output: Destroy a headless test output by name.
+ * Drives the real output-destroy → cleanupmon() code path.
+ * \param name Output name as returned by _test_add_output
+ * \return true if the output was found and destroyed
+ */
+static int
+luaA_awesome_test_remove_output(lua_State *L)
+{
+	const char *name = luaL_checkstring(L, 1);
+	lua_pushboolean(L, some_test_remove_output(name));
+	return 1;
+}
+
 /** Reload shadow settings from beautiful theme.
  * Call this after changing beautiful.shadow_* values to apply them.
  * Regenerates shadow textures and updates all existing shadows.
@@ -2116,6 +2129,7 @@ const luaL_Reg awesome_methods[] = {
 	{ "restart", luaA_restart },
 	{ "shadow_reload", luaA_awesome_shadow_reload },
 	{ "_test_add_output", luaA_awesome_test_add_output },
+	{ "_test_remove_output", luaA_awesome_test_remove_output },
 	/* Lock API methods */
 	{ "lock", luaA_awesome_lock },
 	{ "unlock", luaA_awesome_unlock },

--- a/monitor.c
+++ b/monitor.c
@@ -82,6 +82,25 @@ cleanupmon(struct wl_listener *listener, void *data)
 	wlr_log(WLR_ERROR, "[HOTPLUG] cleanupmon: %s remaining_mons=%d",
 		m->wlr_output->name, wl_list_length(&mons) - 1);
 
+	/* Block updatemons() for the whole teardown. The monitor stays on `mons`
+	 * with a NULL scene_output until it is unlinked below, and updatemons()
+	 * has no guard for that: it would re-add the still-enabled output to the
+	 * layout and deref the NULL scene_output. The Lua removal work below can
+	 * reach updatemons() (output setters call it directly, and any output
+	 * commit gets there via layout::change), so the flag has to outlive it.
+	 * The pending replay at the end runs it once, after `m` is gone. */
+	in_updatemons = 1;
+
+	/* Destroy the scene output and detach from the layout before any Lua
+	 * removal work runs. Relocating clients off the removed screen moves
+	 * scene nodes, and with the scene output still alive the scene can
+	 * re-send surface enter on the dying output. Listeners registered
+	 * during the destroy emission are never invoked, so the surface's
+	 * bind listener would survive and trip the wlr_output_finish assert. */
+	wlr_scene_output_destroy(m->scene_output);
+	m->scene_output = NULL;
+	wlr_output_layout_remove(output_layout, m->wlr_output);
+
 	/* Find and remove screen BEFORE destroying monitor data (AwesomeWM pattern)
 	 * This emits instance-level "removed" signal and relocates clients.
 	 * Also emit viewports and primary_changed signals as needed. */
@@ -133,19 +152,12 @@ cleanupmon(struct wl_listener *listener, void *data)
 	if (m->lock_surface)
 		destroylocksurface(&m->destroy_lock_surface, NULL);
 	m->wlr_output->data = NULL;
-	/* Block updatemons() during output cleanup. wlr_output_layout_remove
-	 * emits layout::change which triggers updatemons(). If updatemons runs,
-	 * it does arrange/focus work that can indirectly add commit listeners
-	 * (e.g. presentation_time, gamma) to the output being destroyed, causing
-	 * wlr_output_finish() assertion failure. */
-	in_updatemons = 1;
-	wlr_scene_output_destroy(m->scene_output);
-	wlr_output_layout_remove(output_layout, m->wlr_output);
-	in_updatemons = 0;
 
 	closemon(m);
 	wlr_scene_node_destroy(&m->fullscreen_bg->node);
 	free(m);
+
+	in_updatemons = 0;
 
 	if (updatemons_pending) {
 		updatemons_pending = 0;

--- a/somewm.c
+++ b/somewm.c
@@ -1748,6 +1748,29 @@ some_test_add_output(unsigned int width, unsigned int height)
 	return output->name;
 }
 
+bool
+some_test_remove_output(const char *name)
+{
+	Monitor *m;
+
+	/* Only a headless output, and never the last one, so a test cannot leave
+	 * the compositor without a screen. Under WLR_BACKENDS=headless the
+	 * harness's own output is headless too, so the count check is what
+	 * actually protects it there. */
+	if (wl_list_length(&mons) <= 1)
+		return false;
+
+	wl_list_for_each(m, &mons, link) {
+		if (!strcmp(m->wlr_output->name, name)
+				&& wlr_output_is_headless(m->wlr_output)) {
+			wlr_output_destroy(m->wlr_output);
+			return true;
+		}
+	}
+
+	return false;
+}
+
 /** Find liblgi_closure_guard.so by searching multiple paths.
  * Returns a pointer to a static buffer containing the path, or NULL. */
 static const char *

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -269,5 +269,6 @@ void somewm_pin_lgi_libs(void);
  * Test helpers - headless output hotplug simulation
  */
 const char *some_test_add_output(unsigned int width, unsigned int height);
+bool some_test_remove_output(const char *name);
 
 #endif /* SOMEWM_API_H */

--- a/tests/restart/README.md
+++ b/tests/restart/README.md
@@ -203,7 +203,7 @@ the fallback loads):
 - `screens-after-config-timeout`: the retried config gets real screens. The
   abort closes the state, so every screen userdata is freed while the C-side
   ref arrays live on; without the rebuild, naughty's startup-error fallback
-  fake_adds a phantom screen.
+  finds no screen to display the error on.
 - `class-signals-after-config-timeout`: class signal handlers connected by the
   aborted config do not dispatch into the closed state. Class signal arrays
   live on the C-side `lua_class_t`, so they outlive the `lua_close()` the

--- a/tests/restart/screens-after-config-timeout.sh
+++ b/tests/restart/screens-after-config-timeout.sh
@@ -6,9 +6,8 @@
 # userdata. The Monitor structs and the C-side ref arrays survive, so without a
 # rebuild the fresh state holds registry ints into a closed state: screen.primary
 # reads nil, pushing a stale ref warns "Trying to emit signal ... on non-object",
-# and naughty's startup-error fallback concludes no screen exists and fake_adds a
-# phantom one. The instance then runs with one more screen than it has outputs,
-# and awful.screen.focused() returns the phantom.
+# and naughty's startup-error fallback concludes no screen exists and the
+# startup error notification is silently lost.
 #
 # The counts assume the harness default of a single headless output.
 
@@ -20,7 +19,7 @@ check_eval hr-scr "one screen per output, and it is a real one" \
     'return "count=" .. screen.count() .. "|outputs=" .. #screen._viewports()' \
     'count=1|outputs=1'
 
-check_eval hr-scr "the screen came from C, not from a fake_add fallback" \
+check_eval hr-scr "the screen came from C" \
     'return tostring(screen[1]._managed)' C
 
 check_eval hr-scr "there is a primary screen" \

--- a/tests/test-fullscreen-wibar-cross-screen.lua
+++ b/tests/test-fullscreen-wibar-cross-screen.lua
@@ -24,22 +24,28 @@ if not test_client.is_available() then
     return
 end
 
-local fake_screen
+local out_name
+local second_screen
 local c_fs, c_other
 local wibar_s2
 
 local steps = {
-    -- Step 1: Add a fake second screen and create a wibar on it
+    -- Step 1: Hotplug a second screen and create a wibar on it.
+    -- _test_add_output is synchronous, so the screen exists on return.
     function()
-        fake_screen = screen.fake_add(1400, 0, 400, 300)
-        assert(fake_screen and fake_screen.valid, "screen.fake_add failed")
+        out_name = assert(awesome._test_add_output(400, 300),
+            "_test_add_output failed")
+        second_screen = assert(output.get_by_name(out_name),
+            "no output named " .. out_name).screen
+        assert(second_screen and second_screen.valid,
+            "hotplugged screen should be valid")
         assert(screen.count() >= 2, "Need at least 2 screens")
 
         -- Create a dock-type wibar on screen 2 (goes to LyrTop)
-        wibar_s2 = awful.wibar({ position = "top", screen = fake_screen })
+        wibar_s2 = awful.wibar({ position = "top", screen = second_screen })
         assert(wibar_s2 and wibar_s2.visible, "Wibar should be visible")
 
-        io.stderr:write("[TEST] Fake screen and wibar created\n")
+        io.stderr:write("[TEST] Second screen and wibar created\n")
         return true
     end,
 
@@ -57,12 +63,12 @@ local steps = {
     -- Step 3: Move client to screen 2 and make it fullscreen
     function(count)
         if count == 1 then
-            c_fs:move_to_screen(fake_screen)
+            c_fs:move_to_screen(second_screen)
             c_fs.fullscreen = true
             c_fs:emit_signal("request::activate", "test", { raise = true })
         end
         if not c_fs.fullscreen then return nil end
-        if c_fs.screen ~= fake_screen then return nil end
+        if c_fs.screen ~= second_screen then return nil end
         if client.focus ~= c_fs then return nil end
         io.stderr:write("[TEST] Client is fullscreen on screen 2 with focus\n")
         return true
@@ -104,7 +110,7 @@ local steps = {
         assert(c_fs.valid, "Fullscreen client should still be valid")
         assert(c_fs.fullscreen,
             "Client should still be fullscreen after cross-screen focus change")
-        assert(c_fs.screen == fake_screen,
+        assert(c_fs.screen == second_screen,
             "Client should still be on screen 2")
         assert(client.focus ~= c_fs,
             "Fullscreen client should NOT have focus")
@@ -116,16 +122,26 @@ local steps = {
         return true
     end,
 
-    -- Step 7: Verify same-screen behavior is preserved: focusing another
+    -- Step 7: Move the other client onto the fullscreen client's screen.
+    -- The move itself refocuses the top-of-stack fullscreen client, so focus
+    -- is expected to land on c_fs here.
+    function(count)
+        if count == 1 then
+            c_other:move_to_screen(second_screen)
+        end
+        if c_other.screen ~= c_fs.screen then return nil end
+        io.stderr:write("[TEST] Other client moved to screen 2\n")
+        return true
+    end,
+
+    -- Step 8: Verify same-screen behavior is preserved: focusing another
     -- client on the SAME screen should still demote the fullscreen client
     -- (matching AwesomeWM behavior).
     function(count)
         if count == 1 then
-            c_other:move_to_screen(fake_screen)
             c_other:emit_signal("request::activate", "test", { raise = true })
         end
         if client.focus ~= c_other then return nil end
-        if c_other.screen ~= c_fs.screen then return nil end
         assert(c_fs.fullscreen,
             "Fullscreen property should still be set")
         io.stderr:write("[TEST] PASS: same-screen focus correctly allows " ..
@@ -133,30 +149,28 @@ local steps = {
         return true
     end,
 
-    -- Step 8: Cleanup
+    -- Step 9: Kill the clients
     function(count)
         if count == 1 then
             if wibar_s2 then wibar_s2.visible = false end
             if c_fs and c_fs.valid then c_fs:kill() end
             if c_other and c_other.valid then c_other:kill() end
         end
-        if #client.get() == 0 then
-            if fake_screen and fake_screen.valid then
-                fake_screen:fake_remove()
-            end
-            return true
-        end
+        if #client.get() == 0 then return true end
         if count >= 15 then
-            local pids = test_client.get_spawned_pids()
-            for _, pid in ipairs(pids) do
+            for _, pid in ipairs(test_client.get_spawned_pids()) do
                 os.execute("kill -9 " .. pid .. " 2>/dev/null")
-            end
-            if fake_screen and fake_screen.valid then
-                fake_screen:fake_remove()
             end
             return true
         end
         return nil
+    end,
+
+    -- Step 10: Remove the hotplugged output so persistent runs stay clean
+    function()
+        assert(awesome._test_remove_output(out_name),
+            "_test_remove_output failed for " .. out_name)
+        return true
     end,
 }
 

--- a/tests/test-lock-multiscreen.lua
+++ b/tests/test-lock-multiscreen.lua
@@ -1,10 +1,7 @@
 ---------------------------------------------------------------------------
 -- Test: Lock multi-screen support
 --
--- Covers: MULTI-1 through MULTI-5, MULTI-7, cover API integration
---
--- Note: MULTI-6 (interactive screen removal while locked) requires
--- _test_remove_output which doesn't exist yet. Skipped.
+-- Covers: MULTI-1 through MULTI-7, cover API integration
 ---------------------------------------------------------------------------
 
 local runner = require("_runner")
@@ -22,12 +19,13 @@ end
 
 local initial_screen_count = screen.count()
 local interactive_wb, cover_wbs
+local out2_name, out3_name
 
 runner.run_steps({
     -- Step 1: Add a second headless output
     function()
-        local name = awesome._test_add_output(800, 600)
-        assert(name, "_test_add_output returned nil")
+        out2_name = awesome._test_add_output(800, 600)
+        assert(out2_name, "_test_add_output returned nil")
         return true
     end,
 
@@ -80,8 +78,8 @@ runner.run_steps({
 
     -- Step 5: Add third output while locked - create cover for it
     function()
-        local name = awesome._test_add_output(640, 480)
-        assert(name, "failed to add third output")
+        out3_name = awesome._test_add_output(640, 480)
+        assert(out3_name, "failed to add third output")
         return true
     end,
 
@@ -100,7 +98,18 @@ runner.run_steps({
         return true
     end,
 
-    -- Step 7: Authenticate and unlock - verify surfaces hidden
+    -- Step 7: Remove third output while locked (MULTI-6).
+    -- _test_remove_output is synchronous, so the screen is gone on return.
+    function()
+        assert(awesome._test_remove_output(out3_name),
+            "_test_remove_output failed for " .. out3_name)
+        assert(screen.count() == initial_screen_count + 1,
+            "expected " .. (initial_screen_count + 1) .. " screens after removal")
+        assert(awesome.locked, "should still be locked after screen removal")
+        return true
+    end,
+
+    -- Step 8: Authenticate and unlock - verify surfaces hidden
     function()
         awesome.authenticate(lock.TEST_PASSWORD)
         awesome.unlock()
@@ -113,8 +122,12 @@ runner.run_steps({
         return true
     end,
 
-    -- Cleanup
+    -- Cleanup: remove the added output so persistent runs stay clean
     function()
+        assert(awesome._test_remove_output(out2_name),
+            "_test_remove_output failed for " .. out2_name)
+        assert(screen.count() == initial_screen_count,
+            "screen count should return to " .. initial_screen_count)
         lock.teardown()
         return true
     end,

--- a/tests/test-naughty-screen-add-ordering.lua
+++ b/tests/test-naughty-screen-add-ordering.lua
@@ -10,9 +10,10 @@
 -- Fix: screen_added() is now emitted synchronously (6ca11b1), matching
 -- AwesomeWM's screen_refresh() pattern.
 --
--- Test strategy: fake_add triggers screen_added() synchronously (screen.c uses
--- the same path). Immediately emitting property::geometry on the new screen
--- must not trigger a debug::error. Without the fix, this crashes.
+-- Test strategy: hotplug a headless output, which drives the real createmon()
+-- -> updatemons() path synchronously. When _test_add_output returns, naughty's
+-- init_screen() must already have run, so emitting property::geometry on the
+-- new screen must not trigger a debug::error. Without the fix, this crashes.
 
 local runner = require("_runner")
 
@@ -25,29 +26,34 @@ awesome.connect_signal("debug::error", function(err)
     table.insert(errors_seen, tostring(err))
 end)
 
-local fake_screen = nil
+local out_name = nil
+local hot_screen = nil
 
 local steps = {
-    -- Step 1: Add a fake screen.
-    -- screen_added() fires synchronously (same path as hotplug createmon()).
-    -- naughty's init_screen() runs immediately via connect_for_each_screen,
-    -- so by_position[fake_screen] is populated before this step returns.
+    -- Step 1: Hotplug an output.
+    -- screen_added() fires synchronously inside createmon()/updatemons(), and
+    -- naughty's init_screen() runs immediately via connect_for_each_screen, so
+    -- by_position[hot_screen] is populated before this returns.
     function()
-        fake_screen = screen.fake_add(1400, 0, 400, 300)
-        assert(fake_screen and fake_screen.valid, "screen.fake_add failed")
+        out_name = assert(awesome._test_add_output(400, 300),
+            "_test_add_output failed")
+        hot_screen = assert(output.get_by_name(out_name),
+            "no output named " .. out_name).screen
+        assert(hot_screen and hot_screen.valid,
+            "hotplugged screen should be valid")
         return true
     end,
 
     -- Step 2: Immediately emit property::geometry on the new screen.
-    -- With the fix: by_position[fake_screen] is already populated -> no crash.
-    -- Without the fix: by_position[fake_screen] could be nil -> debug::error
+    -- With the fix: by_position[hot_screen] is already populated -> no crash.
+    -- Without the fix: by_position[hot_screen] could be nil -> debug::error
     --   "bad argument #1 to 'pairs' (table expected, got nil)".
     --
     -- Pass old_geom to match the C emission pattern in screen.c:510-513;
     -- awful/layout/init.lua:426 expects this argument and crashes without it.
     function()
-        local geom = fake_screen.geometry
-        fake_screen:emit_signal("property::geometry", geom)
+        local geom = hot_screen.geometry
+        hot_screen:emit_signal("property::geometry", geom)
         return true
     end,
 
@@ -61,9 +67,11 @@ local steps = {
         return true
     end,
 
-    -- Step 4: Clean up the fake screen.
+    -- Step 4: Clean up the hotplugged output.
     function()
-        fake_screen:fake_remove()
+        assert(awesome._test_remove_output(out_name),
+            "_test_remove_output failed for " .. out_name)
+        assert(not hot_screen.valid, "screen should be invalid after removal")
         return true
     end,
 }

--- a/tests/test-output-retroactive.lua
+++ b/tests/test-output-retroactive.lua
@@ -1,30 +1,36 @@
 ---------------------------------------------------------------------------
 -- Tests for output "added::connected" retroactive signal delivery:
---   1. Create an output (via fake_add), then connect handler afterward
+--   1. Create an output, then connect handler afterward
 --   2. Verify handler fires retroactively for all existing outputs
 --   3. Verify handler receives correct output properties
 --   4. Verify hotplug still works (new output after handler connected)
 --   5. Verify a second handler also gets retroactive delivery
+--
+-- _test_add_output/_test_remove_output are synchronous (wlroots emits
+-- new_output/destroy inline), so these steps assert directly.
 ---------------------------------------------------------------------------
 
 local runner = require("_runner")
 
 print("TEST: Starting output-retroactive test")
 
-local fake_screen1 = nil
+local out1_name = nil
+local out2_name = nil
 local retroactive_outputs = {}
 local post_connect_outputs = {}
 local handler_connected = false
 
 local steps = {
-    -- Step 1: Create a fake screen BEFORE connecting the handler
+    -- Step 1: Create an output BEFORE connecting the handler
     function()
         print("TEST: Step 1 - Create output before handler is connected")
-        fake_screen1 = screen.fake_add(0, 0, 800, 600)
-        assert(fake_screen1, "fake_add should return a screen")
-        assert(fake_screen1.output, "fake screen should have an output")
-        assert(fake_screen1.output.valid, "output should be valid")
-        print("TEST:   created output: " .. fake_screen1.output.name)
+        out1_name = assert(awesome._test_add_output(800, 600),
+            "_test_add_output should return a name")
+        local o = assert(output.get_by_name(out1_name),
+            "no output named " .. out1_name)
+        assert(o.valid, "output should be valid")
+        assert(o.screen, "output should have a screen")
+        print("TEST:   created output: " .. out1_name)
         return true
     end,
 
@@ -60,44 +66,45 @@ local steps = {
         return true
     end,
 
-    -- Step 3: Verify our fake output was among the retroactive deliveries
+    -- Step 3: Verify our output was among the retroactive deliveries
     function()
-        print("TEST: Step 3 - Verify fake output in retroactive deliveries")
+        print("TEST: Step 3 - Verify output in retroactive deliveries")
         local found = false
+        local out1_screen = output.get_by_name(out1_name).screen
         for _, info in ipairs(retroactive_outputs) do
-            if info.name == fake_screen1.output.name then
+            if info.name == out1_name then
                 found = true
                 assert(info.valid == true,
                     "retroactive output should be valid")
-                assert(info.screen == fake_screen1,
+                assert(info.screen == out1_screen,
                     "retroactive output should reference its screen")
                 print("TEST:   found " .. info.name
                     .. " valid=" .. tostring(info.valid) .. " screen=OK")
             end
         end
         assert(found,
-            "fake output " .. fake_screen1.output.name
+            "output " .. out1_name
             .. " should be among retroactive deliveries")
         return true
     end,
 
-    -- Step 4: Hotplug - add new screen AFTER handler connected
+    -- Step 4: Hotplug - add new output AFTER handler connected
     function()
         print("TEST: Step 4 - Hotplug: add new output after handler connected")
-        local before = #post_connect_outputs
-        local fake_screen2 = screen.fake_add(800, 0, 400, 300)
-        assert(fake_screen2, "second fake_add should succeed")
+        out2_name = assert(awesome._test_add_output(400, 300),
+            "second _test_add_output should succeed")
 
-        local new_deliveries = #post_connect_outputs - before
-        assert(new_deliveries == 1,
-            "handler should fire once for hotplugged output, got "
-            .. new_deliveries)
-        assert(post_connect_outputs[#post_connect_outputs].valid == true,
+        local delivered = nil
+        for _, info in ipairs(post_connect_outputs) do
+            if info.name == out2_name then delivered = info end
+        end
+        assert(delivered, "handler should fire for hotplugged output")
+        assert(delivered.valid == true,
             "hotplugged output should be valid")
         print("TEST:   hotplug delivery OK")
 
-        -- Cleanup
-        fake_screen2:fake_remove()
+        assert(awesome._test_remove_output(out2_name),
+            "_test_remove_output failed for " .. out2_name)
         return true
     end,
 
@@ -120,8 +127,8 @@ local steps = {
 
     -- Step 6: Cleanup
     function()
-        print("TEST: Step 6 - Cleanup")
-        fake_screen1:fake_remove()
+        assert(awesome._test_remove_output(out1_name),
+            "_test_remove_output failed for " .. out1_name)
         print("TEST:   cleanup done")
         return true
     end,

--- a/tests/test-output-signals.lua
+++ b/tests/test-output-signals.lua
@@ -1,19 +1,23 @@
 ---------------------------------------------------------------------------
--- Tests for output class-level signals and virtual get_by_name:
---   1. output "added" fires during fake_add()
+-- Tests for output class-level signals and get_by_name:
+--   1. output "added" fires when an output is hotplugged
 --   2. o.screen is accessible inside "added" handler
---   3. get_by_name() finds virtual output by name
---   4. output "removed" fires during fake_remove()
+--   3. get_by_name() finds the output by name
+--   4. output "removed" fires when the output is destroyed
 --   5. o.valid == true and o.name accessible inside "removed" handler
 --   6. After removal: output invalidated, get_by_name returns nil
+--
+-- _test_add_output/_test_remove_output are synchronous (wlroots emits
+-- new_output/destroy inline), so the signals have already fired when they
+-- return and these steps assert directly instead of polling.
 ---------------------------------------------------------------------------
 
 local runner = require("_runner")
 
 print("TEST: Starting output-signals test")
 
-local fake_screen = nil
-local fake_output = nil
+local out_name = nil
+local hot_output = nil
 
 -- Capture tables for signal handler assertions
 local added_info = nil
@@ -24,7 +28,6 @@ local function on_added(o)
     added_info = {
         name = o.name,
         valid = o.valid,
-        virtual = o.virtual,
         screen = o.screen,
     }
     print("TEST:   [signal] added: " .. tostring(o.name)
@@ -35,26 +38,27 @@ local function on_removed(o)
     removed_info = {
         name = o.name,
         valid = o.valid,
-        virtual = o.virtual,
     }
     print("TEST:   [signal] removed: " .. tostring(o.name)
         .. " valid=" .. tostring(o.valid))
 end
 
--- Connect class-level signals before any fake_add
+-- Connect class-level signals before the hotplug
 output.connect_signal("added", on_added)
 output.connect_signal("removed", on_removed)
 
 local steps = {
-    -- Step 1: Create fake screen — "added" signal fires synchronously
+    -- Step 1: Hotplug an output - "added" signal fires
     function()
-        print("TEST: Step 1 - fake_add triggers output 'added' signal")
-        fake_screen = screen.fake_add(1400, 0, 400, 300)
-        fake_output = fake_screen.output
-
-        -- Signal fired synchronously during fake_add
-        assert(added_info ~= nil,
-            "output 'added' signal did not fire during fake_add()")
+        print("TEST: Step 1 - hotplug triggers output 'added' signal")
+        out_name = assert(awesome._test_add_output(400, 300),
+            "_test_add_output returned nil")
+        assert(added_info, "output 'added' signal did not fire")
+        assert(added_info.name == out_name,
+            "added signal fired for " .. tostring(added_info.name)
+            .. ", expected " .. out_name)
+        hot_output = assert(output.get_by_name(out_name),
+            "get_by_name should find the new output")
         print("TEST:   added signal fired OK")
         return true
     end,
@@ -66,45 +70,37 @@ local steps = {
         -- Gap 12: signal fired with the output object
         assert(added_info.valid == true,
             "output should be valid in added handler")
-        assert(added_info.virtual == true,
-            "output should be virtual in added handler")
         assert(type(added_info.name) == "string" and #added_info.name > 0,
             "output should have a name in added handler")
 
         -- Gap 9: o.screen accessible inside added handler
         assert(added_info.screen ~= nil,
             "output.screen should not be nil in added handler")
-        assert(added_info.screen == fake_screen,
-            "output.screen should reference the fake screen in added handler")
-        print("TEST:   o.screen == fake_screen in added handler OK")
+        assert(added_info.screen == hot_output.screen,
+            "output.screen should reference the new screen in added handler")
+        print("TEST:   o.screen accessible in added handler OK")
 
         return true
     end,
 
-    -- Step 3: get_by_name() finds virtual output
+    -- Step 3: get_by_name() finds the output
     function()
-        print("TEST: Step 3 - get_by_name finds virtual output")
-        local name = fake_output.name
-        local found = output.get_by_name(name)
+        print("TEST: Step 3 - get_by_name finds output")
+        local found = output.get_by_name(out_name)
         assert(found ~= nil,
-            "get_by_name('" .. name .. "') returned nil for virtual output")
-        assert(found.name == name,
+            "get_by_name('" .. out_name .. "') returned nil")
+        assert(found.name == out_name,
             "get_by_name returned wrong output")
-        assert(found.virtual == true,
-            "get_by_name result should be virtual")
-        print("TEST:   get_by_name('" .. name .. "') found virtual OK")
+        print("TEST:   get_by_name('" .. out_name .. "') found OK")
         return true
     end,
 
-    -- Step 4: fake_remove triggers "removed" signal
+    -- Step 4: Output destroy triggers "removed" signal
     function()
-        print("TEST: Step 4 - fake_remove triggers output 'removed' signal")
-        local output_name = fake_output.name
-        fake_screen:fake_remove()
-
-        -- Signal fired synchronously during fake_remove
-        assert(removed_info ~= nil,
-            "output 'removed' signal did not fire during fake_remove()")
+        print("TEST: Step 4 - destroy triggers output 'removed' signal")
+        assert(awesome._test_remove_output(out_name),
+            "_test_remove_output failed for " .. out_name)
+        assert(removed_info, "output 'removed' signal did not fire")
         print("TEST:   removed signal fired OK")
 
         -- Gap 10: o.valid == true inside "removed" handler (before invalidation)
@@ -114,28 +110,28 @@ local steps = {
         print("TEST:   o.valid == true inside removed handler OK")
 
         -- Gap 10: o.name accessible inside "removed" handler
-        assert(removed_info.name == output_name,
+        assert(removed_info.name == out_name,
             "output name should match in removed handler, expected '"
-            .. output_name .. "' got '" .. tostring(removed_info.name) .. "'")
+            .. out_name .. "' got '" .. tostring(removed_info.name) .. "'")
         print("TEST:   o.name accessible inside removed handler OK")
 
         return true
     end,
 
-    -- Step 5: After removal — output invalidated, get_by_name returns nil
+    -- Step 5: After removal - output invalidated, get_by_name returns nil
     function()
         print("TEST: Step 5 - Post-removal state")
 
-        -- Gap 10: after fake_remove, output is invalidated
-        assert(fake_output.valid == false,
-            "output should be invalid after fake_remove, got "
-            .. tostring(fake_output.valid))
+        -- Gap 10: after removal, output is invalidated
+        assert(hot_output.valid == false,
+            "output should be invalid after removal, got "
+            .. tostring(hot_output.valid))
         print("TEST:   output.valid == false after removal OK")
 
-        -- get_by_name returns nil for removed virtual output
-        local found = output.get_by_name(removed_info.name)
+        -- get_by_name returns nil for removed output
+        local found = output.get_by_name(out_name)
         assert(found == nil,
-            "get_by_name should return nil for removed virtual output")
+            "get_by_name should return nil for removed output")
         print("TEST:   get_by_name returns nil after removal OK")
 
         return true

--- a/tests/test-screen-hotplug-lifecycle.lua
+++ b/tests/test-screen-hotplug-lifecycle.lua
@@ -1,0 +1,143 @@
+---------------------------------------------------------------------------
+-- Tests for hotplugged screen full lifecycle:
+--   1. A hotplugged output creates a valid screen with tags
+--   2. Signals fire correctly during hotplug
+--   3. Output removal invalidates the screen
+--   4. Layoutlist widget survives screen removal (PR #391 regression)
+--   5. Multiple add/remove cycles don't leak or crash
+--
+-- _test_add_output and _test_remove_output are synchronous: wlroots emits
+-- new_output/destroy inline, and createmon/cleanupmon build and tear down the
+-- screen before the helper returns. So these steps assert directly instead of
+-- polling.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local awful = require("awful")
+
+print("TEST: Starting screen-hotplug-lifecycle test")
+
+local initial_count = screen.count()
+local out_name = nil
+local hot_screen = nil
+local added_screens = {}
+local removed_screens = {}
+local errors = {}
+
+-- Capture errors that would normally become notifications
+awesome.connect_signal("debug::error", function(err)
+    table.insert(errors, tostring(err))
+end)
+
+-- Track added/removed signals (connect before hotplug)
+screen.connect_signal("added", function(s)
+    table.insert(added_screens, s)
+end)
+screen.connect_signal("removed", function(s)
+    table.insert(removed_screens, s)
+end)
+
+local steps = {
+    -- Step 1: hotplug creates a valid screen
+    function()
+        print("TEST: Step 1 - hotplug creates valid screen")
+        out_name = assert(awesome._test_add_output(1920, 1080),
+            "_test_add_output returned nil")
+        hot_screen = assert(output.get_by_name(out_name),
+            "no output named " .. out_name).screen
+        assert(hot_screen, "hotplugged output has no screen")
+        assert(hot_screen.valid, "hotplugged screen not valid")
+        assert(screen.count() == initial_count + 1,
+            "screen count should increment, got " .. screen.count())
+        print("TEST:   screen count: " .. screen.count())
+        return true
+    end,
+
+    -- Step 2: Screen has tags and signals fired
+    function()
+        print("TEST: Step 2 - Screen has tags, signals fired")
+        assert(#hot_screen.tags > 0,
+            "hotplugged screen has no tags, desktop_decoration handler didn't run")
+        print("TEST:   tags: " .. #hot_screen.tags)
+
+        -- Check added signal fired for our screen
+        local found = false
+        for _, s in ipairs(added_screens) do
+            if s == hot_screen then found = true; break end
+        end
+        assert(found, "added signal did not fire for hotplugged screen")
+        print("TEST:   added signal fired OK")
+        return true
+    end,
+
+    -- Step 3: Layoutlist widget bound to the new screen works
+    function()
+        print("TEST: Step 3 - Layoutlist on hotplugged screen")
+        local layouts = awful.widget.layoutlist.source.for_screen(hot_screen)
+        assert(type(layouts) == "table", "for_screen should return table")
+        assert(#layouts > 0, "for_screen should return layouts")
+        print("TEST:   layouts: " .. #layouts)
+        return true
+    end,
+
+    -- Step 4: Output removal invalidates the screen
+    function()
+        print("TEST: Step 4 - remove output")
+        assert(awesome._test_remove_output(out_name),
+            "_test_remove_output failed for " .. out_name)
+        assert(not hot_screen.valid, "screen should be invalid after removal")
+        assert(screen.count() == initial_count,
+            "screen count should return to initial, got " .. screen.count())
+        print("TEST:   screen count back to " .. screen.count())
+
+        -- Check removed signal fired for our screen
+        local found = false
+        for _, s in ipairs(removed_screens) do
+            if s == hot_screen then found = true; break end
+        end
+        assert(found, "removed signal did not fire for hotplugged screen")
+        return true
+    end,
+
+    -- Step 5: Layoutlist gracefully handles removed screen (PR #391)
+    function()
+        print("TEST: Step 5 - Layoutlist handles removed screen")
+        local ok, result = pcall(awful.widget.layoutlist.source.for_screen,
+            hot_screen)
+        assert(ok, "for_screen should not error on invalid screen: "
+            .. tostring(result))
+        assert(type(result) == "table", "should return table")
+        assert(#result == 0, "should return empty table for invalid screen")
+        print("TEST:   graceful empty return OK")
+        return true
+    end,
+}
+
+-- Step 6 and on: each add/remove cycle is its own step
+for i = 1, 3 do
+    steps[#steps + 1] = function()
+        local name = assert(awesome._test_add_output(800, 600),
+            "cycle " .. i .. ": _test_add_output failed")
+        local s = assert(output.get_by_name(name), "cycle " .. i
+            .. ": no output named " .. name).screen
+        assert(s and s.valid, "cycle " .. i .. ": screen not valid")
+        assert(awesome._test_remove_output(name),
+            "cycle " .. i .. ": _test_remove_output failed")
+        assert(not s.valid, "cycle " .. i .. ": still valid after remove")
+        assert(screen.count() == initial_count,
+            "cycle " .. i .. ": screen count not restored")
+        print("TEST:   cycle " .. i .. " OK, count = " .. screen.count())
+        return true
+    end
+end
+
+-- Final step: no errors accumulated
+steps[#steps + 1] = function()
+    print("TEST: No errors during test")
+    assert(#errors == 0,
+        "Errors during test:\n" .. table.concat(errors, "\n"))
+    print("TEST:   0 errors OK")
+    return true
+end
+
+runner.run_steps(steps)


### PR DESCRIPTION
## Description
Fixes a crash on output unplug. Relocating clients off the removed screen re-sent
surface enter on the dying output while its scene output was still alive, leaving a
bind listener that tripped the `wlr_output_finish` assert. Also adds
`awesome._test_remove_output` and moves the multi-screen tests onto real headless
output hotplug, which is what exposed the crash.

## Test Plan
`make test` passes (unit, check, signal, orchestrator, restart, integration).
The migrated multi-screen tests also pass under `HEADLESS=1`.

## Checklist
- [ ] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
