### PR TITLE
fix(csd): honor xdg-shell maximize and minimize requests

### DIFF
--- a/DEVIATIONS.md
+++ b/DEVIATIONS.md
@@ -13,6 +13,7 @@ This document tracks all known differences between somewm and AwesomeWM. These e
 | GTK theme detection | Creates GTK widgets, queries `GtkStyleContext` | Parses `gtk-3.0/settings.ini` and `gtk-4.0/settings.ini` | Creating GTK windows inside a compositor is unsafe |
 | Xresources | Queries `xrdb` server | Parses `~/.Xresources` file directly | No `xrdb` server on Wayland |
 | Wibox shape surfaces | 1-bit (`cairo.Format.A1`) | Full ARGB32 with anti-aliasing | Enables anti-aliased rounded corners and HiDPI scaling |
+| Client-drawn titlebar buttons | No equivalent (X11 apps ask via `_NET_WM_STATE`) | `xdg_toplevel.set_maximized` / `set_minimized` set `c.maximized` / `c.minimized` | GTK and Chromium draw their own titlebars; the requests go through the same `request::geometry` path `awful.permissions` already governs |
 | Config/cache paths | `~/.config/awesome/`, `~/.cache/awesome/` | `~/.config/somewm/`, `~/.cache/somewm/` | Rebranded |
 
 ### Detailed Explanations

--- a/meson.build
+++ b/meson.build
@@ -536,6 +536,15 @@ test_fullscreen_client = executable(
   install: false,
 )
 
+# Test XDG client that drives CSD maximize/minimize requests
+test_csd_state_client = executable(
+  'test-csd-state-client',
+  ['tests/test-csd-state-client.c', xdg_shell_client_code],
+  xdg_shell_client_header,
+  dependencies: [wayland_client],
+  install: false,
+)
+
 # Test XDG client that renders a 4-quadrant pattern at the preferred buffer
 # scale, used by test-client-content-pattern.lua to verify HiDPI c.content.
 test_content_pattern_client = executable(

--- a/objects/client.c
+++ b/objects/client.c
@@ -2833,8 +2833,23 @@ client_set_minimized(lua_State *L, int cidx, bool s)
          * The C arrange() also sets this, but runs asynchronously via
          * timer.delayed_call. Set it immediately so the client can start
          * rendering at the new size before the deferred arrange fires. */
-        if(c->client_type == XDGShell)
+        if(c->client_type == XDGShell) {
             wlr_xdg_toplevel_set_suspended(c->surface.xdg->toplevel, s);
+
+            /* On restore (s == false), force a fresh configure so the
+             * client resumes with the compositor's current maximized
+             * state + geometry. Without this, Firefox/GTK CSD can wake
+             * from suspended with stale hit regions and turn the next
+             * titlebar click into an xdg_toplevel.resize request — see
+             * log: after wibar unminimize the subsequent max-button
+             * click triggers mousegrabber_run + top_left_corner. */
+            if(!s && c->surface.xdg->initialized && c->scene
+                    && c->surface.xdg->surface
+                    && c->surface.xdg->surface->mapped) {
+                wlr_xdg_toplevel_set_maximized(c->surface.xdg->toplevel, c->maximized);
+                apply_geometry_to_wlroots(c);
+            }
+        }
 
         if(c->toplevel_handle)
             wlr_foreign_toplevel_handle_v1_set_minimized(c->toplevel_handle, s);

--- a/objects/client.c
+++ b/objects/client.c
@@ -3012,6 +3012,14 @@ client_set_maximized_common(lua_State *L, int cidx, bool s, const char* type, co
             luaA_object_emit_signal(L, abs_cidx, "property::maximized", 0);
             if(c->toplevel_handle)
                 wlr_foreign_toplevel_handle_v1_set_maximized(c->toplevel_handle, c->maximized);
+            /* Inform the xdg-shell client of its new maximized state.
+             * Without this, CSD buttons in Gtk/Qt apps render stale state
+             * when maximize is toggled via Lua (c.maximized = true) or via
+             * the foreign-toplevel protocol (wibar tasklist click). The xdg
+             * protocol path calls this directly in the request handler to
+             * also cover redundant requests where next==current. */
+            if(c->client_type == XDGShell && c->surface.xdg && c->surface.xdg->initialized)
+                wlr_xdg_toplevel_set_maximized(c->surface.xdg->toplevel, c->maximized);
         }
 
         stack_windows();

--- a/objects/client.c
+++ b/objects/client.c
@@ -2829,27 +2829,17 @@ client_set_minimized(lua_State *L, int cidx, bool s)
         if(c->scene)
             wlr_scene_node_set_enabled(&c->scene->node, !s);
 
-        /* Wayland: Sync suspended state with minimized state.
-         * The C arrange() also sets this, but runs asynchronously via
-         * timer.delayed_call. Set it immediately so the client can start
-         * rendering at the new size before the deferred arrange fires. */
-        if(c->client_type == XDGShell) {
-            wlr_xdg_toplevel_set_suspended(c->surface.xdg->toplevel, s);
-
-            /* On restore (s == false), force a fresh configure so the
-             * client resumes with the compositor's current maximized
-             * state + geometry. Without this, Firefox/GTK CSD can wake
-             * from suspended with stale hit regions and turn the next
-             * titlebar click into an xdg_toplevel.resize request — see
-             * log: after wibar unminimize the subsequent max-button
-             * click triggers mousegrabber_run + top_left_corner. */
-            if(!s && c->surface.xdg->initialized && c->scene
-                    && c->surface.xdg->surface
-                    && c->surface.xdg->surface->mapped) {
-                wlr_xdg_toplevel_set_maximized(c->surface.xdg->toplevel, c->maximized);
-                apply_geometry_to_wlroots(c);
-            }
-        }
+        /* NOTE: xdg-shell state (suspended, maximized, size) is NOT driven
+         * from here. The property::minimized signal below triggers
+         * awful.layout.arrange() → window.c arrange() which calls
+         * client_set_suspended(c, !client_isvisible(c)). wlroots batches
+         * the pending toplevel state (size, maximized, activated, suspended)
+         * into a single coherent configure, matching KWin's pattern
+         * (xdgshellwindow.cpp:873 doSetActive → scheduleConfigure). Earlier
+         * versions called set_suspended + set_maximized + apply_geometry
+         * here directly, which fired three separate events at different
+         * layers and left Firefox/Chrome CSD with stale hit regions after
+         * restore-from-minimize. */
 
         if(c->toplevel_handle)
             wlr_foreign_toplevel_handle_v1_set_minimized(c->toplevel_handle, s);

--- a/objects/client.c
+++ b/objects/client.c
@@ -2829,17 +2829,10 @@ client_set_minimized(lua_State *L, int cidx, bool s)
         if(c->scene)
             wlr_scene_node_set_enabled(&c->scene->node, !s);
 
-        /* NOTE: xdg-shell state (suspended, maximized, size) is NOT driven
-         * from here. The property::minimized signal below triggers
-         * awful.layout.arrange() → window.c arrange() which calls
-         * client_set_suspended(c, !client_isvisible(c)). wlroots batches
-         * the pending toplevel state (size, maximized, activated, suspended)
-         * into a single coherent configure, matching KWin's pattern
-         * (xdgshellwindow.cpp:873 doSetActive → scheduleConfigure). Earlier
-         * versions called set_suspended + set_maximized + apply_geometry
-         * here directly, which fired three separate events at different
-         * layers and left Firefox/Chrome CSD with stale hit regions after
-         * restore-from-minimize. */
+        /* xdg state is not set here. property::minimized below reaches
+         * arrange(), which calls client_set_suspended() - one configure
+         * carrying suspended and the new size together, instead of a bare
+         * suspended change a frame ahead of the size. */
 
         if(c->toplevel_handle)
             wlr_foreign_toplevel_handle_v1_set_minimized(c->toplevel_handle, s);
@@ -3017,14 +3010,9 @@ client_set_maximized_common(lua_State *L, int cidx, bool s, const char* type, co
             luaA_object_emit_signal(L, abs_cidx, "property::maximized", 0);
             if(c->toplevel_handle)
                 wlr_foreign_toplevel_handle_v1_set_maximized(c->toplevel_handle, c->maximized);
-            /* Inform the xdg-shell client of its new maximized state.
-             * Without this, CSD buttons in Gtk/Qt apps render stale state
-             * when maximize is toggled via Lua (c.maximized = true) or via
-             * the foreign-toplevel protocol (wibar tasklist click). The xdg
-             * protocol path calls this directly in the request handler to
-             * also cover redundant requests where next==current. */
-            if(c->client_type == XDGShell && c->surface.xdg && c->surface.xdg->initialized)
-                wlr_xdg_toplevel_set_maximized(c->surface.xdg->toplevel, c->maximized);
+            /* xdg-shell state is not written here. apply_geometry_to_wlroots()
+             * reconciles it, so it batches into the same configure as the
+             * size change (same as fullscreen). */
         }
 
         stack_windows();
@@ -4570,6 +4558,16 @@ luaA_client_get_xdg_fullscreen(lua_State *L, client_t *c)
     return 1;
 }
 
+static int
+luaA_client_get_xdg_maximized(lua_State *L, client_t *c)
+{
+    if (c->client_type == XDGShell && c->surface.xdg && c->surface.xdg->toplevel)
+        lua_pushboolean(L, c->surface.xdg->toplevel->scheduled.maximized);
+    else
+        lua_pushboolean(L, c->maximized);
+    return 1;
+}
+
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, modal, lua_pushboolean)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, ontop, lua_pushboolean)
 LUA_OBJECT_EXPORT_PROPERTY(client, client_t, urgent, lua_pushboolean)
@@ -5376,6 +5374,7 @@ client_class_setup(lua_State *L)
         { "urgent", (lua_class_propfunc_t) luaA_client_set_urgent, (lua_class_propfunc_t) luaA_client_get_urgent, (lua_class_propfunc_t) luaA_client_set_urgent },
         { "window", NULL, (lua_class_propfunc_t) luaA_client_get_window, NULL },
         { "xdg_fullscreen", NULL, (lua_class_propfunc_t) luaA_client_get_xdg_fullscreen, NULL },
+        { "xdg_maximized", NULL, (lua_class_propfunc_t) luaA_client_get_xdg_maximized, NULL },
     };
     luaA_class_add_properties(&client_class, properties, countof(properties));
     /* _buttons is a method (in client_meta), not a property - matches AwesomeWM */

--- a/objects/client.h
+++ b/objects/client.h
@@ -169,6 +169,7 @@ struct client_t
     struct wl_listener commit;         /* For subsequent commits after scene surface exists */
     struct wl_listener map;
     struct wl_listener maximize;
+    struct wl_listener minimize;
     struct wl_listener unmap;
     struct wl_listener destroy;
     struct wl_listener set_title;

--- a/tests/test-csd-maximize-request.lua
+++ b/tests/test-csd-maximize-request.lua
@@ -1,0 +1,136 @@
+---------------------------------------------------------------------------
+-- Test: xdg-shell CSD maximize/minimize requests reach Lua and the client.
+--
+-- GTK and Chromium draw their own titlebar buttons and drive window state
+-- with xdg_toplevel.set_maximized / unset_maximized / set_minimized.
+--
+-- c.xdg_maximized reads the state scheduled on the toplevel, which is what
+-- separates "Lua thinks it is maximized" from "the client was told".
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local utils = require("_utils")
+local awful = require("awful")
+
+local TEST_CSD_CLIENT = "./build-test/test-csd-state-client"
+
+local function is_test_client_available()
+    local f = io.open(TEST_CSD_CLIENT, "r")
+    if f then
+        f:close()
+        return true
+    end
+    return false
+end
+
+if not is_test_client_available() then
+    io.stderr:write("SKIP: test-csd-state-client not found (run make build-test)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local SIGUSR1, SIGUSR2, SIGHUP = 10, 12, 1
+
+local c_test
+local proc_pid
+local floating_geo
+
+local steps = {
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning test-csd-state-client\n")
+            proc_pid = awful.spawn(TEST_CSD_CLIENT)
+        end
+        c_test = utils.find_client_by_class("csd_test")
+        if c_test then
+            io.stderr:write("[TEST] Client appeared\n")
+            return true
+        end
+    end,
+
+    -- Let placement settle, then record the pre-maximize rect.
+    function(count)
+        if count < 5 then return nil end
+        assert(not c_test.maximized, "client should start unmaximized")
+        assert(not c_test.xdg_maximized, "toplevel should start unmaximized")
+        floating_geo = c_test:geometry()
+        io.stderr:write(string.format("[TEST] Floating geometry %dx%d+%d+%d\n",
+            floating_geo.width, floating_geo.height, floating_geo.x, floating_geo.y))
+        return true
+    end,
+
+    -- CSD maximize button.
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Sending SIGUSR1 (xdg set_maximized)\n")
+            awesome.kill(proc_pid, SIGUSR1)
+        end
+        if not c_test.maximized then return nil end
+        if count < 5 then return nil end
+
+        assert(c_test.xdg_maximized,
+            "toplevel must be told it is maximized (wlr_xdg_toplevel_set_maximized)")
+
+        local wa = utils.get_workarea()
+        utils.assert_geometry(c_test:geometry(),
+            { width = wa.width, height = wa.height }, 2 * c_test.border_width)
+
+        io.stderr:write("[TEST] PASS: CSD maximize applied and acked\n")
+        return true
+    end,
+
+    -- CSD restore button.
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Sending SIGUSR2 (xdg unset_maximized)\n")
+            awesome.kill(proc_pid, SIGUSR2)
+        end
+        if c_test.maximized then return nil end
+        if count < 5 then return nil end
+
+        assert(not c_test.xdg_maximized,
+            "toplevel must be told it is no longer maximized")
+        utils.assert_geometry(c_test:geometry(), floating_geo, 2)
+
+        io.stderr:write("[TEST] PASS: CSD unmaximize restored the floating rect\n")
+        return true
+    end,
+
+    -- CSD minimize button. xdg-shell has no unset_minimized, so this is
+    -- one-way; unminimize is a Lua-side concern.
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Sending SIGHUP (xdg set_minimized)\n")
+            awesome.kill(proc_pid, SIGHUP)
+        end
+        if not c_test.minimized then return nil end
+        io.stderr:write("[TEST] PASS: CSD minimize applied\n")
+        return true
+    end,
+
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Cleanup\n")
+            if proc_pid then
+                awful.spawn("kill " .. proc_pid)
+            end
+        end
+
+        if #client.get() == 0 then
+            io.stderr:write("[TEST] Cleanup: done\n")
+            return true
+        end
+
+        if count >= 10 then
+            io.stderr:write("[TEST] Cleanup: force killing\n")
+            if proc_pid then
+                os.execute("kill -9 " .. proc_pid .. " 2>/dev/null")
+            end
+            os.execute("pkill -9 test-csd-state-client 2>/dev/null")
+            return true
+        end
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })

--- a/tests/test-csd-state-client.c
+++ b/tests/test-csd-state-client.c
@@ -1,0 +1,293 @@
+/**
+ * test-csd-state-client - Minimal XDG shell client for CSD maximize/minimize tests
+ *
+ * Stands in for the client-side decoration buttons Gtk/Chromium draw
+ * themselves, so Lua tests can verify the compositor honors
+ * xdg_toplevel.set_maximized / unset_maximized / set_minimized.
+ *
+ * - Starts with one XDG toplevel (app_id: "csd_test")
+ * - On SIGUSR1: xdg_toplevel_set_maximized()
+ * - On SIGUSR2: xdg_toplevel_unset_maximized()
+ * - On SIGHUP:  xdg_toplevel_set_minimized()
+ * - On SIGTERM: clean shutdown
+ *
+ * Usage: test-csd-state-client
+ */
+
+#include <errno.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <wayland-client.h>
+#include "xdg-shell-client-protocol.h"
+
+/* Globals */
+static struct wl_display *g_display;
+static struct wl_registry *g_registry;
+static struct wl_compositor *g_compositor;
+static struct wl_shm *g_shm;
+static struct xdg_wm_base *g_xdg_wm_base;
+
+static bool g_running = true;
+/* Which state request to send on the next loop pass, as a signal number. */
+static volatile sig_atomic_t g_pending;
+
+/* Toplevel */
+static struct wl_surface *g_surface;
+static struct xdg_surface *g_xdg_surface;
+static struct xdg_toplevel *g_toplevel;
+
+static uint32_t g_width = 200, g_height = 200;
+
+/* Signal handlers */
+static void handle_sigterm(int sig) {
+    (void)sig;
+    g_running = false;
+}
+
+static void handle_state_sig(int sig) {
+    g_pending = sig;
+}
+
+/* Create a simple shared memory buffer */
+static struct wl_buffer *create_buffer(uint32_t w, uint32_t h, uint32_t color) {
+    int stride = w * 4;
+    int size = stride * h;
+
+    char name[] = "/tmp/test-csd-state-XXXXXX";
+    int fd = mkstemp(name);
+    if (fd < 0) {
+        perror("mkstemp");
+        return NULL;
+    }
+    unlink(name);
+
+    if (ftruncate(fd, size) < 0) {
+        perror("ftruncate");
+        close(fd);
+        return NULL;
+    }
+
+    uint32_t *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (data == MAP_FAILED) {
+        perror("mmap");
+        close(fd);
+        return NULL;
+    }
+
+    for (int i = 0; i < (int)(w * h); i++)
+        data[i] = color;
+    munmap(data, size);
+
+    struct wl_shm_pool *pool = wl_shm_create_pool(g_shm, fd, size);
+    struct wl_buffer *buffer = wl_shm_pool_create_buffer(
+        pool, 0, w, h, stride, WL_SHM_FORMAT_ARGB8888);
+    wl_shm_pool_destroy(pool);
+    close(fd);
+
+    return buffer;
+}
+
+/* xdg_surface callbacks */
+static void xdg_surface_configure(void *data,
+        struct xdg_surface *xdg_surface, uint32_t serial) {
+    (void)data;
+    xdg_surface_ack_configure(xdg_surface, serial);
+
+    struct wl_buffer *buffer = create_buffer(g_width, g_height, 0xFF996633);
+    if (buffer) {
+        wl_surface_attach(g_surface, buffer, 0, 0);
+        wl_surface_commit(g_surface);
+    }
+}
+
+static const struct xdg_surface_listener xdg_surface_listener = {
+    .configure = xdg_surface_configure,
+};
+
+/* xdg_toplevel callbacks */
+static void toplevel_configure(void *data, struct xdg_toplevel *toplevel,
+        int32_t w, int32_t h, struct wl_array *states) {
+    (void)data; (void)toplevel; (void)states;
+    if (w > 0) g_width = w;
+    if (h > 0) g_height = h;
+}
+
+static void toplevel_close(void *data, struct xdg_toplevel *toplevel) {
+    (void)data; (void)toplevel;
+    g_running = false;
+}
+
+static void toplevel_configure_bounds(void *data,
+        struct xdg_toplevel *toplevel, int32_t w, int32_t h) {
+    (void)data; (void)toplevel; (void)w; (void)h;
+}
+
+static void toplevel_wm_capabilities(void *data,
+        struct xdg_toplevel *toplevel, struct wl_array *caps) {
+    (void)data; (void)toplevel; (void)caps;
+}
+
+static const struct xdg_toplevel_listener toplevel_listener = {
+    .configure = toplevel_configure,
+    .close = toplevel_close,
+    .configure_bounds = toplevel_configure_bounds,
+    .wm_capabilities = toplevel_wm_capabilities,
+};
+
+/* xdg_wm_base callbacks */
+static void xdg_wm_base_ping(void *data, struct xdg_wm_base *wm_base,
+        uint32_t serial) {
+    (void)data;
+    xdg_wm_base_pong(wm_base, serial);
+}
+
+static const struct xdg_wm_base_listener xdg_wm_base_listener = {
+    .ping = xdg_wm_base_ping,
+};
+
+/* Registry callbacks */
+static void registry_global(void *data, struct wl_registry *reg,
+        uint32_t name, const char *interface, uint32_t version) {
+    (void)data; (void)version;
+
+    if (strcmp(interface, wl_compositor_interface.name) == 0) {
+        g_compositor = wl_registry_bind(reg, name,
+            &wl_compositor_interface, 4);
+    } else if (strcmp(interface, wl_shm_interface.name) == 0) {
+        g_shm = wl_registry_bind(reg, name, &wl_shm_interface, 1);
+    } else if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
+        g_xdg_wm_base = wl_registry_bind(reg, name,
+            &xdg_wm_base_interface, 5);
+        xdg_wm_base_add_listener(g_xdg_wm_base, &xdg_wm_base_listener, NULL);
+    }
+}
+
+static void registry_global_remove(void *data, struct wl_registry *reg,
+        uint32_t name) {
+    (void)data; (void)reg; (void)name;
+}
+
+static const struct wl_registry_listener registry_listener = {
+    .global = registry_global,
+    .global_remove = registry_global_remove,
+};
+
+int main(int argc, char *argv[]) {
+    (void)argc; (void)argv;
+
+    /* Setup signal handlers.
+     * No SA_RESTART, so poll() returns EINTR and we act on the request
+     * immediately instead of up to 100ms later. */
+    struct sigaction sa_term = { .sa_handler = handle_sigterm };
+    struct sigaction sa_state = { .sa_handler = handle_state_sig };
+    sigaction(SIGTERM, &sa_term, NULL);
+    sigaction(SIGINT, &sa_term, NULL);
+    sigaction(SIGUSR1, &sa_state, NULL);
+    sigaction(SIGUSR2, &sa_state, NULL);
+    sigaction(SIGHUP, &sa_state, NULL);
+
+    /* Connect to Wayland */
+    g_display = wl_display_connect(NULL);
+    if (!g_display) {
+        fprintf(stderr, "Failed to connect to Wayland display\n");
+        return 1;
+    }
+
+    g_registry = wl_display_get_registry(g_display);
+    wl_registry_add_listener(g_registry, &registry_listener, NULL);
+    wl_display_roundtrip(g_display);
+
+    if (!g_compositor || !g_shm || !g_xdg_wm_base) {
+        fprintf(stderr, "Missing required Wayland globals\n");
+        return 1;
+    }
+
+    /* Create surface + xdg toplevel */
+    g_surface = wl_compositor_create_surface(g_compositor);
+
+    g_xdg_surface = xdg_wm_base_get_xdg_surface(g_xdg_wm_base, g_surface);
+    xdg_surface_add_listener(g_xdg_surface, &xdg_surface_listener, NULL);
+
+    g_toplevel = xdg_surface_get_toplevel(g_xdg_surface);
+    xdg_toplevel_add_listener(g_toplevel, &toplevel_listener, NULL);
+    xdg_toplevel_set_app_id(g_toplevel, "csd_test");
+    xdg_toplevel_set_title(g_toplevel, "CSD State Test");
+
+    /* Initial commit to get configure event */
+    wl_surface_commit(g_surface);
+    wl_display_roundtrip(g_display);
+
+    fprintf(stderr, "[test-csd-state-client] running (pid=%d)\n", getpid());
+
+    /* Event loop using poll with timeout */
+    while (g_running) {
+        if (g_pending) {
+            int sig = g_pending;
+            g_pending = 0;
+            switch (sig) {
+            case SIGUSR1:
+                fprintf(stderr, "[test-csd-state-client] requesting maximize\n");
+                xdg_toplevel_set_maximized(g_toplevel);
+                break;
+            case SIGUSR2:
+                fprintf(stderr, "[test-csd-state-client] requesting unmaximize\n");
+                xdg_toplevel_unset_maximized(g_toplevel);
+                break;
+            case SIGHUP:
+                fprintf(stderr, "[test-csd-state-client] requesting minimize\n");
+                xdg_toplevel_set_minimized(g_toplevel);
+                break;
+            }
+            wl_surface_commit(g_surface);
+            wl_display_flush(g_display);
+        }
+
+        /* Dispatch any pending events first */
+        if (wl_display_dispatch_pending(g_display) == -1)
+            break;
+
+        /* Flush outgoing requests */
+        if (wl_display_flush(g_display) == -1 && errno != EAGAIN)
+            break;
+
+        /* Prepare to read, dispatch pending if another thread beat us */
+        while (wl_display_prepare_read(g_display) != 0) {
+            if (wl_display_dispatch_pending(g_display) == -1)
+                goto done;
+        }
+
+        /* Poll with 100ms timeout so we can check signal flags */
+        struct pollfd pfd = {
+            .fd = wl_display_get_fd(g_display),
+            .events = POLLIN,
+        };
+        int ret = poll(&pfd, 1, 100);
+
+        if (ret > 0) {
+            wl_display_read_events(g_display);
+        } else {
+            wl_display_cancel_read(g_display);
+        }
+    }
+done:
+
+    fprintf(stderr, "[test-csd-state-client] shutting down\n");
+
+    /* Cleanup */
+    if (g_toplevel) xdg_toplevel_destroy(g_toplevel);
+    if (g_xdg_surface) xdg_surface_destroy(g_xdg_surface);
+    if (g_surface) wl_surface_destroy(g_surface);
+    if (g_xdg_wm_base) xdg_wm_base_destroy(g_xdg_wm_base);
+    if (g_shm) wl_shm_destroy(g_shm);
+    if (g_compositor) wl_compositor_destroy(g_compositor);
+    if (g_registry) wl_registry_destroy(g_registry);
+    wl_display_disconnect(g_display);
+
+    return 0;
+}

--- a/tests/test-fullscreen-noop-restore.lua
+++ b/tests/test-fullscreen-noop-restore.lua
@@ -1,0 +1,108 @@
+---------------------------------------------------------------------------
+-- Test: unset_fullscreen on a client that was never fullscreen is a no-op.
+--
+-- c->prev is the pre-fullscreen restore point. It used to hold the map-time
+-- rect for every client, so a redundant unset_fullscreen threw away every
+-- geometry change made since.
+--
+-- The client must move after map for this to be visible: if the map-time
+-- rect and the current rect are the same, restoring to the stale memento
+-- looks like a no-op.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local utils = require("_utils")
+local awful = require("awful")
+
+local TEST_FULLSCREEN_CLIENT = "./build-test/test-fullscreen-client"
+
+local function is_test_client_available()
+    local f = io.open(TEST_FULLSCREEN_CLIENT, "r")
+    if f then
+        f:close()
+        return true
+    end
+    return false
+end
+
+if not is_test_client_available() then
+    io.stderr:write("SKIP: test-fullscreen-client not found (run make build-test)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local SIGUSR2 = 12
+
+local MOVED = { x = 120, y = 90, width = 640, height = 480 }
+
+local c_test
+local proc_pid
+
+local steps = {
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning test-fullscreen-client\n")
+            proc_pid = awful.spawn(TEST_FULLSCREEN_CLIENT)
+        end
+        c_test = utils.find_client_by_class("fullscreen_test")
+        if c_test then
+            io.stderr:write("[TEST] Client appeared\n")
+            return true
+        end
+    end,
+
+    -- Move away from the map-time rect so a stale-memento restore is visible.
+    function(count)
+        if count == 1 then
+            assert(not c_test.fullscreen, "client should start non-fullscreen")
+            c_test.floating = true
+            c_test:geometry(MOVED)
+            io.stderr:write("[TEST] Moved client off its map-time rect\n")
+        end
+        if count < 5 then return nil end
+
+        utils.assert_geometry(c_test:geometry(), MOVED, 2)
+        io.stderr:write("[TEST] Client sits on its new rect\n")
+        return true
+    end,
+
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Sending SIGUSR2 (redundant unset_fullscreen)\n")
+            awesome.kill(proc_pid, SIGUSR2)
+        end
+        if count < 5 then return nil end
+
+        assert(not c_test.fullscreen, "client must still be non-fullscreen")
+        utils.assert_geometry(c_test:geometry(), MOVED, 2)
+
+        io.stderr:write("[TEST] PASS: redundant unset_fullscreen left geometry alone\n")
+        return true
+    end,
+
+    function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Cleanup\n")
+            if proc_pid then
+                awful.spawn("kill " .. proc_pid)
+            end
+        end
+
+        if #client.get() == 0 then
+            io.stderr:write("[TEST] Cleanup: done\n")
+            return true
+        end
+
+        if count >= 10 then
+            io.stderr:write("[TEST] Cleanup: force killing\n")
+            if proc_pid then
+                os.execute("kill -9 " .. proc_pid .. " 2>/dev/null")
+            end
+            os.execute("pkill -9 test-fullscreen-client 2>/dev/null")
+            return true
+        end
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })

--- a/window.c
+++ b/window.c
@@ -252,14 +252,9 @@ initialcommitnotify(struct wl_listener *listener, void *data)
 			WLR_XDG_TOPLEVEL_WM_CAPABILITIES_MAXIMIZE |
 			WLR_XDG_TOPLEVEL_WM_CAPABILITIES_MINIMIZE);
 
-	/* Honor state requests that arrived before the initial commit so Gtk/Qt
-	 * clients start maximized when they ask for it (e.g. via
-	 * xdg_toplevel.set_maximized before the first ack_configure). We cannot
-	 * call wlr_xdg_toplevel_set_maximized() in maximizenotify() before the
-	 * surface is initialized, so we fold the pending request into the first
-	 * configure here. Minimize is handled via Lua state only — no xdg reply. */
-	if (c->surface.xdg->toplevel->requested.maximized)
-		wlr_xdg_toplevel_set_maximized(c->surface.xdg->toplevel, true);
+	/* A set_maximized that arrived before this commit already ran through
+	 * maximizenotify() into c->maximized; apply_geometry_to_wlroots() puts
+	 * it on the wire once the client is mapped. Nothing to fold in here. */
 
 	if (c->decoration)
 		requestdecorationmode(&c->set_decoration_mode, c->decoration);
@@ -1213,88 +1208,46 @@ unset_fullscreen:
 void
 maximizenotify(struct wl_listener *listener, void *data)
 {
-	/* Emitted when a client clicks its own CSD maximize button or calls
-	 * xdg_toplevel.{set,unset}_maximized. Routes through the same Lua API
-	 * as protocols.c:foreign_toplevel_request_maximize, so both entry
-	 * points (CSD button + wibar tasklist) behave identically.
+	/* CSD maximize button, or xdg_toplevel.{set,unset}_maximized. Routes
+	 * through the same Lua setter as the foreign-toplevel path, so a
+	 * titlebar button and a tasklist click behave identically.
 	 *
-	 * Ordering matters: we MUST let Lua apply the maximized geometry
-	 * (awful arrangers resize c to the full screen rect) BEFORE we ack
-	 * the xdg maximize state. If we send set_maximized(true) first, the
-	 * next configure carries maximized=true at the OLD floating size;
-	 * Firefox/GTK computes its CSD hit regions against that stale size
-	 * and — especially after a suspend/resume cycle — can end up treating
-	 * the next pointer press as a resize drag. Letting Lua arrange first
-	 * means the only configure the client sees is
-	 * (maximized=true, full-screen size) in one coherent message.
-	 *
-	 * Protocol compliance: xdg-shell requires a configure after every
-	 * set_maximized / unset_maximized, even for redundant or policy-
-	 * ignored requests. client_set_maximized_common() emits one via
-	 * wlr_xdg_toplevel_set_maximized when the state actually changes;
-	 * if Lua short-circuits (already in the requested state), we emit a
-	 * trailing redundant-ack below. */
+	 * set_maximized while fullscreen has no effect (xdg-shell.xml:1049). */
 	Client *c = wl_container_of(listener, c, maximize);
-	struct wlr_xdg_toplevel *toplevel;
-	bool wants, before;
-	lua_State *L;
+	lua_State *L = globalconf_get_lua_State();
+	bool before;
 
 	if (!c->surface.xdg || !c->surface.xdg->toplevel)
 		return;
-	toplevel = c->surface.xdg->toplevel;
-	wants = toplevel->requested.maximized;
-
-	/* xdg-shell: set_maximized while fullscreen has no direct effect
-	 * (see xdg-shell.xml:1049). Keep our fullscreen/maximized mutual
-	 * exclusion and just ack the request with the current state. */
-	if (c->fullscreen) {
-		if (c->surface.xdg->initialized)
-			wlr_xdg_toplevel_set_maximized(toplevel, c->maximized);
-		return;
-	}
-
-	L = globalconf_get_lua_State();
-	if (!L) {
-		/* No Lua VM — still owe the client a configure. */
-		if (c->surface.xdg->initialized)
-			wlr_xdg_toplevel_set_maximized(toplevel, wants);
-		return;
-	}
 
 	before = c->maximized;
-	luaA_object_push(L, c);
-	client_set_maximized(L, -1, wants);
-	lua_pop(L, 1);
+	if (L && !c->fullscreen) {
+		luaA_object_push(L, c);
+		client_set_maximized(L, -1, c->surface.xdg->toplevel->requested.maximized);
+		lua_pop(L, 1);
+	}
 
-	/* Redundant request ack: Lua short-circuited because we were already
-	 * in the requested state, so client_set_maximized_common didn't fire
-	 * its own set_maximized. xdg-shell still requires a configure. */
-	if (c->surface.xdg->initialized && before == c->maximized)
-		wlr_xdg_toplevel_set_maximized(toplevel, c->maximized);
+	/* xdg-shell owes a configure for every request. When the state changed,
+	 * apply_geometry_to_wlroots() sends one next frame carrying the new
+	 * maximized flag and the new size together; acking here too would land
+	 * first, with stale state. So only ack what we ignored or no-opped. */
+	if (c->surface.xdg->initialized && before == (bool)c->maximized)
+		wlr_xdg_surface_schedule_configure(c->surface.xdg);
 }
 
 void
 minimizenotify(struct wl_listener *listener, void *data)
 {
-	/* Emitted when a client clicks its own CSD minimize button or calls
-	 * xdg_toplevel.set_minimized. Unlike maximize, xdg-shell has no
-	 * unset_minimized — the request is always "minimize me" (xdg-shell.xml:
-	 * 1132). Unminimize happens via Lua: wibar tasklist click
-	 * (rc.lua: c:activate { action="toggle_minimization" }) or the
-	 * Super+Ctrl+n keybind.
-	 *
-	 * The xdg protocol does not require a configure reply for minimize,
-	 * so unlike maximize we don't need to guarantee a wlroots call. We
-	 * just route the event through to Lua. */
+	/* CSD minimize button, or xdg_toplevel.set_minimized. xdg-shell has no
+	 * unset_minimized (xdg-shell.xml:1132), so the request is always
+	 * "minimize me" and unminimize stays a Lua-side concern. No configure
+	 * is owed for it either. */
 	Client *c = wl_container_of(listener, c, minimize);
 	lua_State *L;
 
 	if (!c->surface.xdg || !c->surface.xdg->toplevel)
 		return;
-	/* client_set_minimized calls wlr_xdg_toplevel_set_suspended which
-	 * needs an initialized surface. Pre-initial requests are vanishingly
-	 * rare for CSD button clicks (surface is already mapped), but guard
-	 * anyway — the banning flag isn't meaningful before map either. */
+	/* Nothing to hide before the client has committed a surface. */
 	if (!c->surface.xdg->initialized)
 		return;
 
@@ -1424,6 +1377,11 @@ apply_geometry_to_wlroots(Client *c)
 				&& c->surface.xwayland->fullscreen != c->fullscreen)
 			client_set_fullscreen_internal(c, c->fullscreen);
 #endif
+		/* Same for maximized: GTK and Chromium draw their own titlebar
+		 * button from it, and it must arrive with the matching size. */
+		if (c->client_type == XDGShell && c->surface.xdg && c->surface.xdg->toplevel
+				&& c->surface.xdg->toplevel->scheduled.maximized != !!c->maximized)
+			wlr_xdg_toplevel_set_maximized(c->surface.xdg->toplevel, !!c->maximized);
 		if (c->fullscreen) {
 			/* Fullscreen: no titlebars (and bw is 0), client gets the full geometry */
 			c->resize = client_set_size(c, c->geometry.width, c->geometry.height);
@@ -1609,18 +1567,6 @@ setfullscreen(Client *c, int fullscreen)
 	if (!c->mon || !client_surface(c)->mapped)
 		return;
 
-	/* Same-value non-fullscreen transition is a no-op. Without this early
-	 * return, the exit branch below runs resize(c, c->prev, 0), which for
-	 * a client that has never been fullscreen restores to a stale memento
-	 * (e.g. the 254x306 initial-configure rect GTK CSD clients ship with
-	 * before placement rules run) — the visible bug is Firefox/Chrome
-	 * snapping to a tiny corner after any idempotent unfullscreen notify.
-	 * The FS → FS path is intentionally allowed to fall through: setmon()
-	 * re-invokes setfullscreen(c, c->fullscreen) after a monitor move to
-	 * re-expand the client onto the new workarea. */
-	if (!fullscreen && !was_fullscreen)
-		return;
-
 	/* Fullscreen is mutually exclusive with maximized states */
 	if (fullscreen && (c->maximized || c->maximized_horizontal || c->maximized_vertical)) {
 		c->maximized = 0;
@@ -1632,20 +1578,21 @@ setfullscreen(Client *c, int fullscreen)
 	}
 
 	c->bw = fullscreen ? 0 : get_border_width();
-	client_set_fullscreen_internal(c, fullscreen);
+	/* Only on the edge: wlroots does not dedupe, so an unconditional call
+	 * would send a fullscreen configure to every client setmon() touches. */
+	if (was_fullscreen != fullscreen)
+		client_set_fullscreen_internal(c, fullscreen);
 	wlr_scene_node_reparent(&c->scene->node, layers[c->fullscreen ? LyrFS : LyrTile]);
 
+	/* c->prev is the pre-fullscreen restore point: capture only on the
+	 * non-FS -> FS edge, consume only on FS -> non-FS. setmon() and
+	 * fullscreennotify() both re-call with the current value, and running
+	 * either edge on a no-op corrupts the memento. */
 	if (fullscreen) {
-		/* Only capture pre-fullscreen geometry on the non-FS → FS
-		 * transition. Redundant enter-FS calls (setmon() re-applies
-		 * setfullscreen(c, c->fullscreen) after a monitor move, and
-		 * xdg-shell fullscreennotify() can fire while already fullscreen)
-		 * would otherwise overwrite c->prev with the current fullscreen
-		 * rect — losing the original restore point. */
 		if (!was_fullscreen)
 			c->prev = c->geometry;
 		resize(c, c->mon->m, 0);
-	} else {
+	} else if (was_fullscreen) {
 		/* restore previous size instead of arrange for floating windows since
 		 * client positions are set by the user and cannot be recalculated */
 		resize(c, c->prev, 0);
@@ -1685,14 +1632,7 @@ setmon(Client *c, Monitor *m, uint32_t newtags)
 	old_screen = c->screen;  /* Capture before update */
 
 	c->mon = m;
-	/* NOTE: do not write c->prev here. c->prev is a restore-memento owned
-	 * by setfullscreen() (and, for future maximize work, by the maximize
-	 * transition). Monitor assignment must not touch it — at map time
-	 * c->geometry still holds the initial-configure rect (e.g. GTK CSD
-	 * clients arrive with 254x306 before placement rules run), so writing
-	 * c->prev = c->geometry here poisons the memento with a stub rect and
-	 * the next same-value setfullscreen(c, 0) restores to it. Restore
-	 * points belong to their owning transition, not to setmon. */
+	/* c->prev belongs to setfullscreen(); do not write it here. */
 
 	/* Update c->screen to match c->mon for Lua property access */
 	c->screen = luaA_screen_get_by_monitor(L, m);

--- a/window.c
+++ b/window.c
@@ -248,7 +248,19 @@ initialcommitnotify(struct wl_listener *listener, void *data)
 	}
 
 	wlr_xdg_toplevel_set_wm_capabilities(c->surface.xdg->toplevel,
-			WLR_XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN);
+			WLR_XDG_TOPLEVEL_WM_CAPABILITIES_FULLSCREEN |
+			WLR_XDG_TOPLEVEL_WM_CAPABILITIES_MAXIMIZE |
+			WLR_XDG_TOPLEVEL_WM_CAPABILITIES_MINIMIZE);
+
+	/* Honor state requests that arrived before the initial commit so Gtk/Qt
+	 * clients start maximized when they ask for it (e.g. via
+	 * xdg_toplevel.set_maximized before the first ack_configure). We cannot
+	 * call wlr_xdg_toplevel_set_maximized() in maximizenotify() before the
+	 * surface is initialized, so we fold the pending request into the first
+	 * configure here. Minimize is handled via Lua state only — no xdg reply. */
+	if (c->surface.xdg->toplevel->requested.maximized)
+		wlr_xdg_toplevel_set_maximized(c->surface.xdg->toplevel, true);
+
 	if (c->decoration)
 		requestdecorationmode(&c->set_decoration_mode, c->decoration);
 	/* Send the workarea as a bounds hint and let the client pick its own
@@ -456,6 +468,7 @@ createnotify(struct wl_listener *listener, void *data)
 	LISTEN(&toplevel->events.destroy, &c->destroy, destroynotify);
 	LISTEN(&toplevel->events.request_fullscreen, &c->request_fullscreen, fullscreennotify);
 	LISTEN(&toplevel->events.request_maximize, &c->maximize, maximizenotify);
+	LISTEN(&toplevel->events.request_minimize, &c->minimize, minimizenotify);
 	LISTEN(&toplevel->events.set_title, &c->set_title, updatetitle);
 
 	/* Note: property_register_wayland_listeners() is called in mapnotify() after
@@ -540,6 +553,7 @@ client_remove_all_listeners(client_t *c)
 		wl_list_remove(&c->map.link);
 		wl_list_remove(&c->unmap.link);
 		wl_list_remove(&c->maximize.link);
+		wl_list_remove(&c->minimize.link);
 	}
 	/* Clean up foreign toplevel handle if not already done by unmapnotify */
 	if (c->toplevel_handle) {
@@ -599,6 +613,7 @@ client_reregister_listeners(client_t *c)
 		LISTEN(&toplevel->events.destroy, &c->destroy, destroynotify);
 		LISTEN(&toplevel->events.request_fullscreen, &c->request_fullscreen, fullscreennotify);
 		LISTEN(&toplevel->events.request_maximize, &c->maximize, maximizenotify);
+		LISTEN(&toplevel->events.request_minimize, &c->minimize, minimizenotify);
 		LISTEN(&toplevel->events.set_title, &c->set_title, updatetitle);
 
 		if (c->scene) {
@@ -1198,19 +1213,87 @@ unset_fullscreen:
 void
 maximizenotify(struct wl_listener *listener, void *data)
 {
-	/* This event is raised when a client would like to maximize itself,
-	 * typically because the user clicked on the maximize button on
-	 * client-side decorations. somewm doesn't support maximization, but
-	 * to conform to xdg-shell protocol we still must send a configure.
-	 * Since xdg-shell protocol v5 we should ignore request of unsupported
-	 * capabilities, just schedule a empty configure when the client uses <5
-	 * protocol version
-	 * wlr_xdg_surface_schedule_configure() is used to send an empty reply. */
+	/* Emitted when a client clicks its own CSD maximize button or calls
+	 * xdg_toplevel.{set,unset}_maximized. Routes through the same Lua API
+	 * as the foreign-toplevel protocol path in
+	 * protocols.c:foreign_toplevel_request_maximize, so both entry points
+	 * (CSD button and wibar tasklist) behave identically.
+	 *
+	 * xdg-shell requires a configure after every set_maximized /
+	 * unset_maximized, even when the state is unchanged or the request is
+	 * policy-ignored. We therefore always call wlr_xdg_toplevel_set_maximized()
+	 * (which folds the state into the next configure and schedules one if
+	 * needed) regardless of whether client_set_maximized_common() short-
+	 * circuits on current==next.
+	 *
+	 * Safety ordering: do the protocol reply first (cannot depend on Lua
+	 * availability without violating the protocol), then call into Lua. */
 	Client *c = wl_container_of(listener, c, maximize);
-	if (c->surface.xdg->initialized
-			&& wl_resource_get_version(c->surface.xdg->toplevel->resource)
-					< XDG_TOPLEVEL_WM_CAPABILITIES_SINCE_VERSION)
-		wlr_xdg_surface_schedule_configure(c->surface.xdg);
+	struct wlr_xdg_toplevel *toplevel;
+	bool wants;
+	lua_State *L;
+
+	if (!c->surface.xdg || !c->surface.xdg->toplevel)
+		return;
+	toplevel = c->surface.xdg->toplevel;
+	wants = toplevel->requested.maximized;
+
+	/* xdg-shell: set_maximized while fullscreen has no direct effect
+	 * (see xdg-shell.xml:1049). Keep our fullscreen/maximized mutual
+	 * exclusion and just ack the request with the current state. */
+	if (c->fullscreen) {
+		if (c->surface.xdg->initialized)
+			wlr_xdg_toplevel_set_maximized(toplevel, c->maximized);
+		return;
+	}
+
+	/* Protocol configure, independent of Lua — fires even for redundant
+	 * requests (current==next) that client_set_maximized_common skips. */
+	if (c->surface.xdg->initialized)
+		wlr_xdg_toplevel_set_maximized(toplevel, wants);
+
+	/* Update Awesome-side state (floating/tiled transition + Lua signals).
+	 * client_set_maximized_common also re-sends set_maximized on state
+	 * change, but that is idempotent with the call above. */
+	L = globalconf_get_lua_State();
+	if (!L)
+		return;
+	luaA_object_push(L, c);
+	client_set_maximized(L, -1, wants);
+	lua_pop(L, 1);
+}
+
+void
+minimizenotify(struct wl_listener *listener, void *data)
+{
+	/* Emitted when a client clicks its own CSD minimize button or calls
+	 * xdg_toplevel.set_minimized. Unlike maximize, xdg-shell has no
+	 * unset_minimized — the request is always "minimize me" (xdg-shell.xml:
+	 * 1132). Unminimize happens via Lua: wibar tasklist click
+	 * (rc.lua: c:activate { action="toggle_minimization" }) or the
+	 * Super+Ctrl+n keybind.
+	 *
+	 * The xdg protocol does not require a configure reply for minimize,
+	 * so unlike maximize we don't need to guarantee a wlroots call. We
+	 * just route the event through to Lua. */
+	Client *c = wl_container_of(listener, c, minimize);
+	lua_State *L;
+
+	if (!c->surface.xdg || !c->surface.xdg->toplevel)
+		return;
+	/* client_set_minimized calls wlr_xdg_toplevel_set_suspended which
+	 * needs an initialized surface. Pre-initial requests are vanishingly
+	 * rare for CSD button clicks (surface is already mapped), but guard
+	 * anyway — the banning flag isn't meaningful before map either. */
+	if (!c->surface.xdg->initialized)
+		return;
+
+	L = globalconf_get_lua_State();
+	if (!L)
+		return;
+	luaA_object_push(L, c);
+	client_set_minimized(L, -1, true);
+	lua_pop(L, 1);
 }
 
 void

--- a/window.c
+++ b/window.c
@@ -1603,8 +1603,22 @@ resize(Client *c, struct wlr_box geo, int interact)
 void
 setfullscreen(Client *c, int fullscreen)
 {
+	int was_fullscreen = c->fullscreen;
+
 	c->fullscreen = fullscreen;
 	if (!c->mon || !client_surface(c)->mapped)
+		return;
+
+	/* Same-value non-fullscreen transition is a no-op. Without this early
+	 * return, the exit branch below runs resize(c, c->prev, 0), which for
+	 * a client that has never been fullscreen restores to a stale memento
+	 * (e.g. the 254x306 initial-configure rect GTK CSD clients ship with
+	 * before placement rules run) — the visible bug is Firefox/Chrome
+	 * snapping to a tiny corner after any idempotent unfullscreen notify.
+	 * The FS → FS path is intentionally allowed to fall through: setmon()
+	 * re-invokes setfullscreen(c, c->fullscreen) after a monitor move to
+	 * re-expand the client onto the new workarea. */
+	if (!fullscreen && !was_fullscreen)
 		return;
 
 	/* Fullscreen is mutually exclusive with maximized states */
@@ -1622,7 +1636,14 @@ setfullscreen(Client *c, int fullscreen)
 	wlr_scene_node_reparent(&c->scene->node, layers[c->fullscreen ? LyrFS : LyrTile]);
 
 	if (fullscreen) {
-		c->prev = c->geometry;
+		/* Only capture pre-fullscreen geometry on the non-FS → FS
+		 * transition. Redundant enter-FS calls (setmon() re-applies
+		 * setfullscreen(c, c->fullscreen) after a monitor move, and
+		 * xdg-shell fullscreennotify() can fire while already fullscreen)
+		 * would otherwise overwrite c->prev with the current fullscreen
+		 * rect — losing the original restore point. */
+		if (!was_fullscreen)
+			c->prev = c->geometry;
 		resize(c, c->mon->m, 0);
 	} else {
 		/* restore previous size instead of arrange for floating windows since
@@ -1664,7 +1685,14 @@ setmon(Client *c, Monitor *m, uint32_t newtags)
 	old_screen = c->screen;  /* Capture before update */
 
 	c->mon = m;
-	c->prev = c->geometry;
+	/* NOTE: do not write c->prev here. c->prev is a restore-memento owned
+	 * by setfullscreen() (and, for future maximize work, by the maximize
+	 * transition). Monitor assignment must not touch it — at map time
+	 * c->geometry still holds the initial-configure rect (e.g. GTK CSD
+	 * clients arrive with 254x306 before placement rules run), so writing
+	 * c->prev = c->geometry here poisons the memento with a stub rect and
+	 * the next same-value setfullscreen(c, 0) restores to it. Restore
+	 * points belong to their owning transition, not to setmon. */
 
 	/* Update c->screen to match c->mon for Lua property access */
 	c->screen = luaA_screen_get_by_monitor(L, m);

--- a/window.c
+++ b/window.c
@@ -1215,22 +1215,28 @@ maximizenotify(struct wl_listener *listener, void *data)
 {
 	/* Emitted when a client clicks its own CSD maximize button or calls
 	 * xdg_toplevel.{set,unset}_maximized. Routes through the same Lua API
-	 * as the foreign-toplevel protocol path in
-	 * protocols.c:foreign_toplevel_request_maximize, so both entry points
-	 * (CSD button and wibar tasklist) behave identically.
+	 * as protocols.c:foreign_toplevel_request_maximize, so both entry
+	 * points (CSD button + wibar tasklist) behave identically.
 	 *
-	 * xdg-shell requires a configure after every set_maximized /
-	 * unset_maximized, even when the state is unchanged or the request is
-	 * policy-ignored. We therefore always call wlr_xdg_toplevel_set_maximized()
-	 * (which folds the state into the next configure and schedules one if
-	 * needed) regardless of whether client_set_maximized_common() short-
-	 * circuits on current==next.
+	 * Ordering matters: we MUST let Lua apply the maximized geometry
+	 * (awful arrangers resize c to the full screen rect) BEFORE we ack
+	 * the xdg maximize state. If we send set_maximized(true) first, the
+	 * next configure carries maximized=true at the OLD floating size;
+	 * Firefox/GTK computes its CSD hit regions against that stale size
+	 * and — especially after a suspend/resume cycle — can end up treating
+	 * the next pointer press as a resize drag. Letting Lua arrange first
+	 * means the only configure the client sees is
+	 * (maximized=true, full-screen size) in one coherent message.
 	 *
-	 * Safety ordering: do the protocol reply first (cannot depend on Lua
-	 * availability without violating the protocol), then call into Lua. */
+	 * Protocol compliance: xdg-shell requires a configure after every
+	 * set_maximized / unset_maximized, even for redundant or policy-
+	 * ignored requests. client_set_maximized_common() emits one via
+	 * wlr_xdg_toplevel_set_maximized when the state actually changes;
+	 * if Lua short-circuits (already in the requested state), we emit a
+	 * trailing redundant-ack below. */
 	Client *c = wl_container_of(listener, c, maximize);
 	struct wlr_xdg_toplevel *toplevel;
-	bool wants;
+	bool wants, before;
 	lua_State *L;
 
 	if (!c->surface.xdg || !c->surface.xdg->toplevel)
@@ -1247,20 +1253,24 @@ maximizenotify(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	/* Protocol configure, independent of Lua — fires even for redundant
-	 * requests (current==next) that client_set_maximized_common skips. */
-	if (c->surface.xdg->initialized)
-		wlr_xdg_toplevel_set_maximized(toplevel, wants);
-
-	/* Update Awesome-side state (floating/tiled transition + Lua signals).
-	 * client_set_maximized_common also re-sends set_maximized on state
-	 * change, but that is idempotent with the call above. */
 	L = globalconf_get_lua_State();
-	if (!L)
+	if (!L) {
+		/* No Lua VM — still owe the client a configure. */
+		if (c->surface.xdg->initialized)
+			wlr_xdg_toplevel_set_maximized(toplevel, wants);
 		return;
+	}
+
+	before = c->maximized;
 	luaA_object_push(L, c);
 	client_set_maximized(L, -1, wants);
 	lua_pop(L, 1);
+
+	/* Redundant request ack: Lua short-circuited because we were already
+	 * in the requested state, so client_set_maximized_common didn't fire
+	 * its own set_maximized. xdg-shell still requires a configure. */
+	if (c->surface.xdg->initialized && before == c->maximized)
+		wlr_xdg_toplevel_set_maximized(toplevel, c->maximized);
 }
 
 void

--- a/window.h
+++ b/window.h
@@ -31,6 +31,7 @@ void unmapnotify(struct wl_listener *listener, void *data);
 void destroynotify(struct wl_listener *listener, void *data);
 void updatetitle(struct wl_listener *listener, void *data);
 void maximizenotify(struct wl_listener *listener, void *data);
+void minimizenotify(struct wl_listener *listener, void *data);
 void fullscreennotify(struct wl_listener *listener, void *data);
 
 /* Geometry */


### PR DESCRIPTION
## Description

Closes #483.

GTK and Chromium drive window state with `xdg_toplevel.set_maximized` and
`set_minimized`; somewm advertised neither capability and dropped both
requests. Separately `setmon()` overwrote the `c->prev` fullscreen restore
point, so a redundant unset_fullscreen restored a client to its map-time rect.

First four commits are raven2cz's. The fifth reconciles xdg maximized state in
`apply_geometry_to_wlroots()` next to the fullscreen flag, guards `c->prev` on
the transition edge, and adds read-only `c.xdg_maximized` plus two regression
tests.

## Test Plan

`make test-unit` and `make test-integration` pass; both new tests fail on `main`.

Manually on two monitors: the five-step chain from the issue ends at the full
workarea, a non-fullscreen client re-tiles after a monitor move, and a
fullscreen client re-expands and restores.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
