### PR TITLE
fix(drawin): read shape masks in whichever format they arrive in

### DIFF
--- a/DEVIATIONS.md
+++ b/DEVIATIONS.md
@@ -262,7 +262,7 @@ These modifications to AwesomeWM's Lua libraries were necessary for Wayland comp
 |------|--------|--------|
 | `wibox/widget/systray.lua` | Complete rewrite | SNI D-Bus protocol replaces X11 XEmbed |
 | `beautiful/gtk.lua` | Complete rewrite | File parsing replaces live GTK widget queries |
-| `wibox/init.lua` | ARGB32 shapes, HiDPI scaling, surface lifetime, `shape_border` | Wayland scene graph and compositing model |
+| `wibox/init.lua` | ARGB32 shape masks (AwesomeWM uses A1), HiDPI scaling, surface lifetime, `shape_border` | Wayland scene graph and compositing model; ARGB32 gives anti-aliased edges on curved shapes. The rendering path accepts either format, so a config may still assign A1 masks. |
 | `wibox/drawable.lua` | HiDPI scale-change handler | Recreates surfaces when `screen.scale` changes |
 | `awful/client.lua` | `c.type or "normal"` fallback | Native Wayland clients may not set window type |
 | `awful/permissions/init.lua` | Layer surface keyboard focus handlers | Wayland layer-shell has no X11 equivalent |

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -249,29 +249,58 @@ drawin_update_drawing(lua_State *L, int widx)
 /** Refresh callback for drawable - called when drawable content should be displayed
  * This updates the scene graph buffer with new Cairo-rendered content
  */
-/** Apply shape_bounding mask to a drawable surface.
- * Creates a copy of the surface with alpha zeroed where shape is 0.
- * Returns a new cairo_surface_t that the caller must destroy.
- * Returns NULL if no shape or allocation fails.
- */
-static cairo_surface_t *
-drawin_apply_shape_mask(drawable_t *d, cairo_surface_t *shape)
+
+/* Read one pixel from a CAIRO_FORMAT_A1 surface row. Cairo packs A1
+ * into native-endian 32-bit words; on little-endian the leftmost
+ * pixel is bit (x & 31) of word (x >> 5). Caller ensures bounds. */
+static inline int
+shape_a1_get(const unsigned char *data, int stride, int x, int y)
 {
-	cairo_surface_t *src, *dst;
+	const uint32_t *row = (const uint32_t *)(data + y * stride);
+	uint32_t word = row[x >> 5];
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+	return (word >> (31 - (x & 31))) & 1u;
+#else
+	return (word >> (x & 31)) & 1u;
+#endif
+}
+
+/** Apply a shape mask to a cairo surface.
+ * Returns a copy of src with each pixel scaled by the shape's coverage,
+ * or NULL if either surface is unusable or the shape is neither A1 nor
+ * ARGB32. Caller must destroy the returned surface.
+ *
+ * Both mask formats are in use: gears.surface.apply_shape_bounding and
+ * AwesomeWM's wibox:_apply_shape produce A1, while somewm's own
+ * _apply_shape and awful.mouse.snap produce ARGB32 for anti-aliased
+ * edges. Reading one as the other walks off the end of the buffer,
+ * since A1 rows are ~32x smaller.
+ */
+cairo_surface_t *
+drawin_apply_shape_mask(cairo_surface_t *src, cairo_surface_t *shape)
+{
+	cairo_surface_t *dst;
+	cairo_format_t shape_format;
 	unsigned char *src_data, *dst_data, *shape_data;
 	int src_stride, dst_stride, shape_stride;
 	int width, height, shape_width, shape_height;
 	int x, y;
 
-	if (!d || !d->surface || !shape)
+	if (!src || !shape)
 		return NULL;
 
 	/* Check if surfaces are still valid (not finished by GC) */
-	if (cairo_surface_status(d->surface) != CAIRO_STATUS_SUCCESS ||
+	if (cairo_surface_status(src) != CAIRO_STATUS_SUCCESS ||
 	    cairo_surface_status(shape) != CAIRO_STATUS_SUCCESS)
 		return NULL;
 
-	src = d->surface;
+	shape_format = cairo_image_surface_get_format(shape);
+	if (shape_format != CAIRO_FORMAT_A1 && shape_format != CAIRO_FORMAT_ARGB32) {
+		warn("drawin: ignoring shape mask in unsupported cairo format %d",
+		     shape_format);
+		return NULL;
+	}
+
 	cairo_surface_flush(src);
 	cairo_surface_flush(shape);
 
@@ -280,7 +309,6 @@ drawin_apply_shape_mask(drawable_t *d, cairo_surface_t *shape)
 	shape_width = cairo_image_surface_get_width(shape);
 	shape_height = cairo_image_surface_get_height(shape);
 
-	/* Create a copy of the surface */
 	dst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
 	if (cairo_surface_status(dst) != CAIRO_STATUS_SUCCESS) {
 		cairo_surface_destroy(dst);
@@ -302,7 +330,6 @@ drawin_apply_shape_mask(drawable_t *d, cairo_surface_t *shape)
 	shape_stride = cairo_image_surface_get_stride(shape);
 
 	/* Copy pixels, applying shape alpha mask.
-	 * Shape surface is ARGB32 with anti-aliased edges.
 	 * Note: The shape surface may be at logical scale while the source
 	 * surface is at physical (HiDPI) scale. We need to scale coordinates
 	 * when looking up shape alpha. */
@@ -319,19 +346,26 @@ drawin_apply_shape_mask(drawable_t *d, cairo_surface_t *shape)
 			/* Map physical x to logical shape x */
 			int shape_x = (shape_width > 0) ? (x * shape_width / width) : 0;
 
-			/* Check if this pixel is within shape bounds */
+			/* Check if this pixel is within shape bounds.
+			 * Outside shape bounds = alpha 0 (transparent) */
 			if (shape_x < shape_width && shape_y < shape_height) {
-				/* ARGB32 format: 4 bytes per pixel, alpha is byte 3 (on little-endian) */
-				int pixel_offset = (shape_y * shape_stride) + (shape_x * 4);
-				shape_alpha = shape_data[pixel_offset + 3];
+				if (shape_format == CAIRO_FORMAT_A1) {
+					/* 1 bit per pixel, fully in or fully out */
+					shape_alpha = shape_a1_get(shape_data, shape_stride,
+								   shape_x, shape_y) ? 255 : 0;
+				} else {
+					/* ARGB32: 4 bytes per pixel, alpha is byte 3 (on little-endian) */
+					int pixel_offset = (shape_y * shape_stride) + (shape_x * 4);
+					shape_alpha = shape_data[pixel_offset + 3];
+				}
 			}
-			/* Outside shape bounds = alpha 0 (transparent) */
 
 			if (shape_alpha == 255) {
 				/* Fully opaque - copy directly */
 				dst_row[x] = src_row[x];
 			} else if (shape_alpha == 0) {
-				/* Fully transparent */
+				/* Fully transparent. Cairo uses premultiplied
+				 * alpha, so RGB must be zeroed too. */
 				dst_row[x] = 0;
 			} else {
 				/* Partial alpha - blend (premultiplied alpha) */
@@ -342,100 +376,6 @@ drawin_apply_shape_mask(drawable_t *d, cairo_surface_t *shape)
 				uint8_t a = (pixel >> 24) & 0xFF;
 
 				/* Multiply all channels by shape_alpha/255 */
-				b = (b * shape_alpha) / 255;
-				g = (g * shape_alpha) / 255;
-				r = (r * shape_alpha) / 255;
-				a = (a * shape_alpha) / 255;
-
-				dst_row[x] = ((uint32_t)a << 24) | (r << 16) | (g << 8) | b;
-			}
-		}
-	}
-
-	cairo_surface_mark_dirty(dst);
-	return dst;
-}
-
-/** Apply shape mask to a cairo surface (exported for screenshot support).
- * Returns a new cairo_surface_t with alpha applied from ARGB32 shape mask.
- * Caller must destroy the returned surface.
- * Returns NULL if no shape or allocation fails.
- */
-cairo_surface_t *
-drawin_apply_shape_mask_for_screenshot(cairo_surface_t *src, cairo_surface_t *shape)
-{
-	cairo_surface_t *dst;
-	unsigned char *src_data, *dst_data, *shape_data;
-	int src_stride, dst_stride, shape_stride;
-	int width, height, shape_width, shape_height;
-	int x, y;
-
-	if (!src || !shape)
-		return NULL;
-
-	if (cairo_surface_status(src) != CAIRO_STATUS_SUCCESS ||
-	    cairo_surface_status(shape) != CAIRO_STATUS_SUCCESS)
-		return NULL;
-
-	cairo_surface_flush(src);
-	cairo_surface_flush(shape);
-
-	width = cairo_image_surface_get_width(src);
-	height = cairo_image_surface_get_height(src);
-	shape_width = cairo_image_surface_get_width(shape);
-	shape_height = cairo_image_surface_get_height(shape);
-
-	dst = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
-	if (cairo_surface_status(dst) != CAIRO_STATUS_SUCCESS) {
-		cairo_surface_destroy(dst);
-		return NULL;
-	}
-
-	src_data = cairo_image_surface_get_data(src);
-	dst_data = cairo_image_surface_get_data(dst);
-	shape_data = cairo_image_surface_get_data(shape);
-
-	if (!src_data || !dst_data || !shape_data) {
-		cairo_surface_destroy(dst);
-		return NULL;
-	}
-
-	src_stride = cairo_image_surface_get_stride(src);
-	dst_stride = cairo_image_surface_get_stride(dst);
-	shape_stride = cairo_image_surface_get_stride(shape);
-
-	/* Copy pixels, applying shape alpha mask.
-	 * Shape surface is ARGB32 with anti-aliased edges.
-	 * Note: Cairo uses premultiplied alpha, so when alpha=0, RGB must also be 0. */
-	for (y = 0; y < height; y++) {
-		uint32_t *src_row = (uint32_t *)(src_data + y * src_stride);
-		uint32_t *dst_row = (uint32_t *)(dst_data + y * dst_stride);
-
-		int shape_y = (shape_height > 0) ? (y * shape_height / height) : 0;
-
-		for (x = 0; x < width; x++) {
-			uint8_t shape_alpha = 0;
-
-			int shape_x = (shape_width > 0) ? (x * shape_width / width) : 0;
-
-			if (shape_x < shape_width && shape_y < shape_height) {
-				/* ARGB32 format: 4 bytes per pixel, alpha is byte 3 */
-				int pixel_offset = (shape_y * shape_stride) + (shape_x * 4);
-				shape_alpha = shape_data[pixel_offset + 3];
-			}
-
-			if (shape_alpha == 255) {
-				dst_row[x] = src_row[x];
-			} else if (shape_alpha == 0) {
-				dst_row[x] = 0;
-			} else {
-				/* Partial alpha - blend (premultiplied alpha) */
-				uint32_t pixel = src_row[x];
-				uint8_t b = (pixel >> 0) & 0xFF;
-				uint8_t g = (pixel >> 8) & 0xFF;
-				uint8_t r = (pixel >> 16) & 0xFF;
-				uint8_t a = (pixel >> 24) & 0xFF;
-
 				b = (b * shape_alpha) / 255;
 				g = (g * shape_alpha) / 255;
 				r = (r * shape_alpha) / 255;
@@ -487,23 +427,15 @@ drawin_refresh_drawable(drawin_t *drawin)
 	/* Apply shape_clip first (clips the drawable content area)
 	 * In AwesomeWM, shape_clip restricts what's visible within the content area */
 	if (drawin->shape_clip) {
-		clipped_surface = drawin_apply_shape_mask(d, drawin->shape_clip);
+		clipped_surface = drawin_apply_shape_mask(work_surface, drawin->shape_clip);
 		if (clipped_surface)
 			work_surface = clipped_surface;
 	}
 
 	/* Apply shape_bounding mask (clips the whole window including border)
-	 * This is applied after shape_clip */
+	 * This is applied after shape_clip, chaining off its result if any */
 	if (drawin->shape_bounding) {
-		/* If we already have a clipped surface, use that as the source */
-		if (clipped_surface) {
-			/* Create a temporary drawable struct to pass to apply_shape_mask */
-			drawable_t temp_d = *d;
-			temp_d.surface = clipped_surface;
-			masked_surface = drawin_apply_shape_mask(&temp_d, drawin->shape_bounding);
-		} else {
-			masked_surface = drawin_apply_shape_mask(d, drawin->shape_bounding);
-		}
+		masked_surface = drawin_apply_shape_mask(work_surface, drawin->shape_bounding);
 		if (masked_surface)
 			work_surface = masked_surface;
 	}

--- a/objects/drawin.h
+++ b/objects/drawin.h
@@ -71,7 +71,8 @@ typedef struct drawin_t {
 	shadow_nodes_t shadow;                  /* Shadow scene nodes */
 
 	/* Shape properties (AwesomeWM compatibility)
-	 * These are cairo_surface_t* in A1 format (1-bit alpha mask).
+	 * These are cairo_surface_t* alpha masks, either A1 (AwesomeWM's
+	 * format) or ARGB32 (somewm's, for anti-aliased edges).
 	 * NULL means no custom shape (full rectangle). */
 	cairo_surface_t *shape_bounding;        /* Visual bounding shape (rounded corners, etc.) */
 	cairo_surface_t *shape_clip;            /* Drawing clip region */
@@ -115,11 +116,11 @@ void luaA_drawin_apply_geometry(drawin_t *drawin);
 /* Drawin refresh cycle (called from main event loop) */
 void drawin_refresh(void);
 
-/* Apply shape mask to a drawable surface (for screenshot support).
- * Returns a new surface with alpha zeroed where shape bit is 0.
+/* Apply an A1 or ARGB32 shape mask to a surface.
+ * Returns a new surface scaled by the mask's coverage.
  * Caller must destroy the returned surface.
- * Returns NULL if no shape or allocation fails. */
-cairo_surface_t *drawin_apply_shape_mask_for_screenshot(
+ * Returns NULL if no shape, an unsupported format, or allocation fails. */
+cairo_surface_t *drawin_apply_shape_mask(
     cairo_surface_t *src, cairo_surface_t *shape);
 
 /* Object signal support

--- a/root.c
+++ b/root.c
@@ -1542,7 +1542,7 @@ composite_widgets_directly(cairo_t *cr, bool ontop_only)
 			/* Apply shape_bounding mask if set (for rounded corners etc.) */
 			if (drawin->shape_bounding &&
 			    cairo_surface_status(drawin->shape_bounding) == CAIRO_STATUS_SUCCESS) {
-				masked_surface = drawin_apply_shape_mask_for_screenshot(
+				masked_surface = drawin_apply_shape_mask(
 					drawin->drawable->surface, drawin->shape_bounding);
 				if (masked_surface)
 					surface_to_composite = masked_surface;

--- a/tests/test-wibox-shape-mask-formats.lua
+++ b/tests/test-wibox-shape-mask-formats.lua
@@ -1,0 +1,109 @@
+---------------------------------------------------------------------------
+-- Test: drawin shape masks accept both A1 and ARGB32 surfaces.
+--
+-- somewm's own wibox:_apply_shape and awful.mouse.snap build masks in
+-- cairo.Format.ARGB32 for anti-aliased edges, while AwesomeWM's
+-- _apply_shape and gears.surface.apply_shape_bounding build them in
+-- cairo.Format.A1. A1 rows are ~32x smaller, so reading one as the
+-- other walks off the end of the buffer.
+--
+-- Under ASAN a reader that assumes a single format aborts here; a
+-- format-aware one survives every producer.
+---------------------------------------------------------------------------
+
+local runner   = require("_runner")
+local awful    = require("awful")
+local wibox    = require("wibox")
+local gears    = require("gears")
+local gsurface = require("gears.surface")
+local cairo    = require("lgi").cairo
+
+local test_wibox
+
+local function build_a1(width, height)
+    local img = cairo.ImageSurface.create(cairo.Format.A1, width, height)
+    local cr  = cairo.Context.create(img)
+    cr:set_source_rgba(1, 1, 1, 1)
+    gears.shape.rounded_rect(cr, width, height, 20)
+    cr:set_operator(cairo.Operator.SOURCE)
+    cr:fill()
+    return img
+end
+
+-- Give the compositor a few frames to run the mask reader, then check the
+-- wibox came through it. Under ASAN a mis-read mask aborts before this.
+local function settle(msg)
+    return function(count)
+        if count >= 3 then
+            assert(test_wibox.valid, msg)
+            return true
+        end
+    end
+end
+
+local steps = {
+    -- Step 1: a shaped wibox. somewm's _apply_shape builds ARGB32 masks,
+    -- so this covers the anti-aliased path.
+    function()
+        test_wibox = wibox {
+            x = 50, y = 50,
+            width = 200, height = 100,
+            bg = "#335588",
+            visible = true,
+            screen = awful.screen.focused(),
+            shape = function(cr, w, h)
+                gears.shape.rounded_rect(cr, w, h, 20)
+            end,
+        }
+        return true
+    end,
+
+    settle("wibox should survive ARGB32 shape masks"),
+
+    -- Step 2: gears.surface.apply_shape_bounding is public API and builds
+    -- an A1 surface, so it reaches the C reader without any override.
+    function()
+        gsurface.apply_shape_bounding(test_wibox, function(cr, w, h)
+            gears.shape.rounded_rect(cr, w, h, 20)
+        end)
+        return true
+    end,
+
+    settle("wibox should survive gears.surface.apply_shape_bounding (A1)"),
+
+    -- Step 3: A1 assigned straight to shape_bounding / shape_clip, as a
+    -- config overriding _apply_shape with AwesomeWM's version would.
+    function()
+        local bw  = test_wibox.border_width or 0
+        local geo = test_wibox:geometry()
+
+        test_wibox.shape_bounding =
+            build_a1(geo.width + 2 * bw, geo.height + 2 * bw)._native
+        test_wibox.shape_clip = build_a1(geo.width, geo.height)._native
+        return true
+    end,
+
+    settle("wibox should survive directly assigned A1 shape masks"),
+
+    -- Step 4: clearing after real A1 surfaces were held catches lifetime
+    -- regressions in the nil path of the shape setters.
+    function()
+        test_wibox.shape_bounding = nil
+        test_wibox.shape_clip = nil
+        return true
+    end,
+
+    settle("wibox should survive clearing shape masks"),
+
+    function()
+        if test_wibox then
+            test_wibox.visible = false
+            test_wibox = nil
+        end
+        return true
+    end,
+}
+
+runner.run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
## Description

`drawin_apply_shape_mask()` and its screenshot twin both assumed shape masks were
ARGB32. `gears.surface.apply_shape_bounding()` builds A1, whose rows are ~32x smaller,
so reading one as the other runs off the end of the buffer. A 300px-wide drawin reads at
byte ~1203 of a 40-byte row.

Both formats are legitimately in use: `gears.surface.apply_shape_bounding` and
AwesomeWM's `wibox:_apply_shape` produce A1, while somewm's own `_apply_shape` and
`awful.mouse.snap` produce ARGB32 for anti-aliased edges. So the reader dispatches on
the format rather than picking one, and unsupported formats now `warn()` instead of
silently leaving the drawin unshaped.

This also fixes issue #472's crash for configs that override `_apply_shape` with the
upstream version.

The two readers were byte-identical apart from where the source surface came from, so
they collapse into one worker. That pays for the new format path and then some:
`objects/drawin.c` is net -68 lines, and a per-frame `drawable_t` struct copy in
`drawin_refresh_drawable()` goes with it.

No Lua changes. Anti-aliased shaped wibox edges are unaffected.

Known gap, not fixed here: `drawin_accepts_input_at()` (`input.c`) reads the same
`shape_bounding` field hardcoded as A1. It stays in bounds so it does not crash, but it
stretches the mask ~32x horizontally, making shaped drawins click-through in their top
and bottom bands. That is a separate correctness fix and belongs with the other
`input.c` work in #472.

## Test Plan

New `tests/test-wibox-shape-mask-formats.lua` covers all three producers: ARGB32 via a
shaped wibox, A1 via `gears.surface.apply_shape_bounding`, and A1 assigned directly to
`shape_bounding`/`shape_clip`. Under ASAN it aborts with a heap-buffer-overflow before
this change and passes after. It is an ASAN guard by nature - the overread is in-bounds
enough that a plain build reads adjacent heap and returns normally.

- `make test-unit` - 756 passed, 0 failed
- `make test-integration` - 134 passed, 0 failed
- `make test-asan` on the new test plus `test-snap-preview-shape` and
  `test-shape-input-gc` - all pass

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
