### PR TITLE
fix(idle): defer inhibitor-destroy recompute until wlroots unlinks it

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -335,6 +335,21 @@ virtual_pointer_client_code = custom_target(
   command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
 )
 
+# idle-inhibit client protocol (header + code) for the idle-inhibitor test client
+idle_inhibit_client_header = custom_target(
+  'idle-inhibit-unstable-v1-client-protocol.h',
+  input: wayland_protocols_dir / 'unstable/idle-inhibit/idle-inhibit-unstable-v1.xml',
+  output: 'idle-inhibit-unstable-v1-client-protocol.h',
+  command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+)
+
+idle_inhibit_client_code = custom_target(
+  'idle-inhibit-unstable-v1-client-protocol.c',
+  input: wayland_protocols_dir / 'unstable/idle-inhibit/idle-inhibit-unstable-v1.xml',
+  output: 'idle-inhibit-unstable-v1-client-protocol.c',
+  command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
+)
+
 # ==============================================================================
 # Compiler Flags
 # ==============================================================================
@@ -527,6 +542,16 @@ test_fullscreen_client = executable(
   'test-fullscreen-client',
   ['tests/test-fullscreen-client.c', xdg_shell_client_code],
   xdg_shell_client_header,
+  dependencies: [wayland_client],
+  install: false,
+)
+
+# Test client that creates an idle inhibitor and destroys it in either order
+# (inhibitor first while staying mapped, or surface first)
+test_idle_inhibit_client = executable(
+  'test-idle-inhibit-client',
+  ['tests/test-idle-inhibit-client.c', xdg_shell_client_code, idle_inhibit_client_code],
+  [xdg_shell_client_header, idle_inhibit_client_header],
   dependencies: [wayland_client],
   install: false,
 )

--- a/somewm.c
+++ b/somewm.c
@@ -2358,10 +2358,26 @@ destroydragicon(struct wl_listener *listener, void *data)
 	free(listener);
 }
 
+/* wlroots emits the inhibitor destroy signal before unlinking it from
+ * idle_inhibit_mgr->inhibitors, so a recompute here would still count the
+ * dying inhibitor and, if its surface is still mapped, latch idle timers
+ * off with nothing left to ever recompute. Defer to the end of the current
+ * dispatch (same pattern as pending_flush_source, see #530). */
+static struct wl_event_source *pending_idle_recompute;
+
+static void
+recompute_idle_inhibit_idle(void *data)
+{
+	pending_idle_recompute = NULL;
+	some_recompute_idle_inhibit();
+}
+
 void
 destroyidleinhibitor(struct wl_listener *listener, void *data)
 {
-	some_recompute_idle_inhibit();
+	if (!pending_idle_recompute)
+		pending_idle_recompute = wl_event_loop_add_idle(event_loop,
+			recompute_idle_inhibit_idle, NULL);
 
 	wl_list_remove(&listener->link);
 	free(listener);
@@ -2607,12 +2623,8 @@ some_is_idle_inhibited()
 		return false;
 
 	wl_list_for_each(inhibitor, &idle_inhibit_mgr->inhibitors, link) {
-
-		// Attention: When some_is_idle_inhibited() is called during
-		// destroyidleinhibitor() signal handler then
-		// idle_inhibit_mgr->inhibitors still contains the respective
-		// inhibitor, however, the below scene tree is already teared down and
-		// wlr_scene_node_coords() cannot be called.
+		/* An unmapped surface must not inhibit, and its scene tree may
+		 * already be gone (the !tree case below counts as inhibited). */
 		if (!inhibitor->surface->mapped)
 			continue;
 

--- a/tests/test-idle-inhibit-client.c
+++ b/tests/test-idle-inhibit-client.c
@@ -1,0 +1,317 @@
+/**
+ * test-idle-inhibit-client - XDG client that creates and drops an idle inhibitor
+ *
+ * Maps a toplevel and immediately creates a zwp_idle_inhibitor_v1 on it.
+ * Lets Lua tests verify the compositor recomputes idle inhibition when the
+ * inhibitor dies, in both orders a real client can produce:
+ *
+ * - Starts with one XDG toplevel (app_id: "idle_inhibit_test")
+ * - On SIGUSR1: destroys ONLY the inhibitor; the surface stays mapped and the
+ *   client keeps running (mpv-on-pause order)
+ * - On SIGUSR2: destroys toplevel, xdg_surface, then wl_surface in order while
+ *   keeping the inhibitor resource and the connection alive, so the surface is
+ *   unmapped before the inhibitor dies server-side
+ * - On SIGTERM: clean shutdown
+ *
+ * Usage: test-idle-inhibit-client
+ */
+
+#include <errno.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <wayland-client.h>
+#include "xdg-shell-client-protocol.h"
+#include "idle-inhibit-unstable-v1-client-protocol.h"
+
+/* Globals */
+static struct wl_display *g_display;
+static struct wl_registry *g_registry;
+static struct wl_compositor *g_compositor;
+static struct wl_shm *g_shm;
+static struct xdg_wm_base *g_xdg_wm_base;
+static struct zwp_idle_inhibit_manager_v1 *g_inhibit_mgr;
+
+static bool g_running = true;
+static volatile sig_atomic_t g_drop_inhibitor = 0;
+static volatile sig_atomic_t g_drop_surface = 0;
+
+/* Toplevel */
+static struct wl_surface *g_surface;
+static struct xdg_surface *g_xdg_surface;
+static struct xdg_toplevel *g_toplevel;
+static struct zwp_idle_inhibitor_v1 *g_inhibitor;
+
+static uint32_t g_width = 200, g_height = 200;
+
+/* Signal handlers */
+static void handle_sigterm(int sig) {
+    (void)sig;
+    g_running = false;
+}
+
+static void handle_sigusr1(int sig) {
+    (void)sig;
+    g_drop_inhibitor = 1;
+}
+
+static void handle_sigusr2(int sig) {
+    (void)sig;
+    g_drop_surface = 1;
+}
+
+/* Create a simple shared memory buffer */
+static struct wl_buffer *create_buffer(uint32_t w, uint32_t h, uint32_t color) {
+    int stride = w * 4;
+    int size = stride * h;
+
+    char name[] = "/tmp/test-idle-inhibit-XXXXXX";
+    int fd = mkstemp(name);
+    if (fd < 0) {
+        perror("mkstemp");
+        return NULL;
+    }
+    unlink(name);
+
+    if (ftruncate(fd, size) < 0) {
+        perror("ftruncate");
+        close(fd);
+        return NULL;
+    }
+
+    uint32_t *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (data == MAP_FAILED) {
+        perror("mmap");
+        close(fd);
+        return NULL;
+    }
+
+    for (int i = 0; i < (int)(w * h); i++)
+        data[i] = color;
+    munmap(data, size);
+
+    struct wl_shm_pool *pool = wl_shm_create_pool(g_shm, fd, size);
+    struct wl_buffer *buffer = wl_shm_pool_create_buffer(
+        pool, 0, w, h, stride, WL_SHM_FORMAT_ARGB8888);
+    wl_shm_pool_destroy(pool);
+    close(fd);
+
+    return buffer;
+}
+
+/* xdg_surface callbacks */
+static void xdg_surface_configure(void *data,
+        struct xdg_surface *xdg_surface, uint32_t serial) {
+    (void)data;
+    xdg_surface_ack_configure(xdg_surface, serial);
+
+    struct wl_buffer *buffer = create_buffer(g_width, g_height, 0xFF993366);
+    if (buffer) {
+        wl_surface_attach(g_surface, buffer, 0, 0);
+        wl_surface_commit(g_surface);
+    }
+}
+
+static const struct xdg_surface_listener xdg_surface_listener = {
+    .configure = xdg_surface_configure,
+};
+
+/* xdg_toplevel callbacks */
+static void toplevel_configure(void *data, struct xdg_toplevel *toplevel,
+        int32_t w, int32_t h, struct wl_array *states) {
+    (void)data; (void)toplevel; (void)states;
+    if (w > 0) g_width = w;
+    if (h > 0) g_height = h;
+}
+
+static void toplevel_close(void *data, struct xdg_toplevel *toplevel) {
+    (void)data; (void)toplevel;
+    g_running = false;
+}
+
+static void toplevel_configure_bounds(void *data,
+        struct xdg_toplevel *toplevel, int32_t w, int32_t h) {
+    (void)data; (void)toplevel; (void)w; (void)h;
+}
+
+static void toplevel_wm_capabilities(void *data,
+        struct xdg_toplevel *toplevel, struct wl_array *caps) {
+    (void)data; (void)toplevel; (void)caps;
+}
+
+static const struct xdg_toplevel_listener toplevel_listener = {
+    .configure = toplevel_configure,
+    .close = toplevel_close,
+    .configure_bounds = toplevel_configure_bounds,
+    .wm_capabilities = toplevel_wm_capabilities,
+};
+
+/* xdg_wm_base callbacks */
+static void xdg_wm_base_ping(void *data, struct xdg_wm_base *wm_base,
+        uint32_t serial) {
+    (void)data;
+    xdg_wm_base_pong(wm_base, serial);
+}
+
+static const struct xdg_wm_base_listener xdg_wm_base_listener = {
+    .ping = xdg_wm_base_ping,
+};
+
+/* Registry callbacks */
+static void registry_global(void *data, struct wl_registry *reg,
+        uint32_t name, const char *interface, uint32_t version) {
+    (void)data; (void)version;
+
+    if (strcmp(interface, wl_compositor_interface.name) == 0) {
+        g_compositor = wl_registry_bind(reg, name,
+            &wl_compositor_interface, 4);
+    } else if (strcmp(interface, wl_shm_interface.name) == 0) {
+        g_shm = wl_registry_bind(reg, name, &wl_shm_interface, 1);
+    } else if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
+        g_xdg_wm_base = wl_registry_bind(reg, name,
+            &xdg_wm_base_interface, 5);
+        xdg_wm_base_add_listener(g_xdg_wm_base, &xdg_wm_base_listener, NULL);
+    } else if (strcmp(interface, zwp_idle_inhibit_manager_v1_interface.name) == 0) {
+        g_inhibit_mgr = wl_registry_bind(reg, name,
+            &zwp_idle_inhibit_manager_v1_interface, 1);
+    }
+}
+
+static void registry_global_remove(void *data, struct wl_registry *reg,
+        uint32_t name) {
+    (void)data; (void)reg; (void)name;
+}
+
+static const struct wl_registry_listener registry_listener = {
+    .global = registry_global,
+    .global_remove = registry_global_remove,
+};
+
+int main(int argc, char *argv[]) {
+    (void)argc; (void)argv;
+
+    /* Setup signal handlers.
+     * Use sigaction WITHOUT SA_RESTART so that wl_display_dispatch() returns
+     * EINTR when a signal arrives. */
+    struct sigaction sa_term = { .sa_handler = handle_sigterm };
+    struct sigaction sa_usr1 = { .sa_handler = handle_sigusr1 };
+    struct sigaction sa_usr2 = { .sa_handler = handle_sigusr2 };
+    sigaction(SIGTERM, &sa_term, NULL);
+    sigaction(SIGINT, &sa_term, NULL);
+    sigaction(SIGUSR1, &sa_usr1, NULL);
+    sigaction(SIGUSR2, &sa_usr2, NULL);
+
+    /* Connect to Wayland */
+    g_display = wl_display_connect(NULL);
+    if (!g_display) {
+        fprintf(stderr, "Failed to connect to Wayland display\n");
+        return 1;
+    }
+
+    g_registry = wl_display_get_registry(g_display);
+    wl_registry_add_listener(g_registry, &registry_listener, NULL);
+    wl_display_roundtrip(g_display);
+
+    if (!g_compositor || !g_shm || !g_xdg_wm_base || !g_inhibit_mgr) {
+        fprintf(stderr, "Missing required Wayland globals\n");
+        return 1;
+    }
+
+    /* Create surface + xdg toplevel */
+    g_surface = wl_compositor_create_surface(g_compositor);
+
+    g_xdg_surface = xdg_wm_base_get_xdg_surface(g_xdg_wm_base, g_surface);
+    xdg_surface_add_listener(g_xdg_surface, &xdg_surface_listener, NULL);
+
+    g_toplevel = xdg_surface_get_toplevel(g_xdg_surface);
+    xdg_toplevel_add_listener(g_toplevel, &toplevel_listener, NULL);
+    xdg_toplevel_set_app_id(g_toplevel, "idle_inhibit_test");
+    xdg_toplevel_set_title(g_toplevel, "Idle Inhibit Test");
+
+    /* Initial commit to get configure event; the configure handler attaches
+     * a buffer, so after this roundtrip the surface is mapped. */
+    wl_surface_commit(g_surface);
+    wl_display_roundtrip(g_display);
+
+    g_inhibitor = zwp_idle_inhibit_manager_v1_create_inhibitor(
+        g_inhibit_mgr, g_surface);
+    wl_display_flush(g_display);
+
+    fprintf(stderr, "[test-idle-inhibit-client] running (pid=%d)\n", getpid());
+
+    /* Event loop using poll with timeout */
+    while (g_running) {
+        if (g_drop_inhibitor) {
+            g_drop_inhibitor = 0;
+            if (g_inhibitor) {
+                fprintf(stderr, "[test-idle-inhibit-client] destroying inhibitor, staying mapped\n");
+                zwp_idle_inhibitor_v1_destroy(g_inhibitor);
+                g_inhibitor = NULL;
+                wl_display_flush(g_display);
+            }
+        }
+
+        if (g_drop_surface) {
+            g_drop_surface = 0;
+            if (g_surface) {
+                fprintf(stderr, "[test-idle-inhibit-client] destroying surface, keeping inhibitor\n");
+                xdg_toplevel_destroy(g_toplevel);
+                xdg_surface_destroy(g_xdg_surface);
+                wl_surface_destroy(g_surface);
+                g_toplevel = NULL;
+                g_xdg_surface = NULL;
+                g_surface = NULL;
+                wl_display_flush(g_display);
+            }
+        }
+
+        /* Dispatch any pending events first */
+        if (wl_display_dispatch_pending(g_display) == -1)
+            break;
+
+        /* Flush outgoing requests */
+        if (wl_display_flush(g_display) == -1 && errno != EAGAIN)
+            break;
+
+        /* Prepare to read, dispatch pending if another thread beat us */
+        while (wl_display_prepare_read(g_display) != 0) {
+            if (wl_display_dispatch_pending(g_display) == -1)
+                goto done;
+        }
+
+        /* Poll with 100ms timeout so we can check signal flags */
+        struct pollfd pfd = {
+            .fd = wl_display_get_fd(g_display),
+            .events = POLLIN,
+        };
+        int ret = poll(&pfd, 1, 100);
+
+        if (ret > 0) {
+            wl_display_read_events(g_display);
+        } else {
+            wl_display_cancel_read(g_display);
+        }
+    }
+done:
+
+    fprintf(stderr, "[test-idle-inhibit-client] shutting down\n");
+
+    /* Cleanup */
+    if (g_inhibitor) zwp_idle_inhibitor_v1_destroy(g_inhibitor);
+    if (g_toplevel) xdg_toplevel_destroy(g_toplevel);
+    if (g_xdg_surface) xdg_surface_destroy(g_xdg_surface);
+    if (g_surface) wl_surface_destroy(g_surface);
+    if (g_inhibit_mgr) zwp_idle_inhibit_manager_v1_destroy(g_inhibit_mgr);
+    if (g_xdg_wm_base) xdg_wm_base_destroy(g_xdg_wm_base);
+    if (g_shm) wl_shm_destroy(g_shm);
+    if (g_compositor) wl_compositor_destroy(g_compositor);
+    if (g_registry) wl_registry_destroy(g_registry);
+    wl_display_disconnect(g_display);
+
+    return 0;
+}

--- a/tests/test-idle-inhibit-protocol.lua
+++ b/tests/test-idle-inhibit-protocol.lua
@@ -1,0 +1,125 @@
+---------------------------------------------------------------------------
+--- Test: idle timers recover when a protocol idle inhibitor is destroyed
+--
+-- A zwp_idle_inhibitor_v1 dying must re-enable awesome.set_idle_timeout()
+-- timers. Two destroy orders, driven by test-idle-inhibit-client:
+--
+-- Mode B (SIGUSR2): surface destroyed first, inhibitor dies unmapped.
+-- Mode A (SIGUSR1): inhibitor destroyed while the surface stays mapped
+--   (mpv-on-pause order). Without the fix the compositor counts the dying
+--   inhibitor during its destroy signal, latches idle timers off, and no
+--   later event ever recomputes.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local awful = require("awful")
+
+local TEST_CLIENT = "./build-test/test-idle-inhibit-client"
+
+local function is_test_client_available()
+    local f = io.open(TEST_CLIENT, "r")
+    if f then
+        f:close()
+        return true
+    end
+    return false
+end
+
+if not is_test_client_available() then
+    io.stderr:write("SKIP: test-idle-inhibit-client not found (run make build-test)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local fired = {}
+local proc_pid
+
+-- Spawn a client (SIGTERMing the previous one first) and wait for its
+-- inhibitor to take effect
+local function spawn_and_wait(label)
+    return function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] Spawning " .. label .. "\n")
+            if proc_pid then
+                awesome.kill(proc_pid, 15)
+            end
+            proc_pid = awful.spawn(TEST_CLIENT)
+        end
+        if awesome.inhibitor_count == 1 and awesome.idle_inhibited then
+            return true
+        end
+        if count > 30 then
+            error(label .. " inhibitor never registered")
+        end
+    end
+end
+
+-- Signal the client and wait for its inhibitor to go away
+local function kill_and_wait_gone(sig, label)
+    return function(count)
+        if count == 1 then
+            io.stderr:write("[TEST] " .. label .. "\n")
+            awesome.kill(proc_pid, sig)
+        end
+        if awesome.inhibitor_count == 0 and not awesome.idle_inhibited then
+            return true
+        end
+        if count > 30 then
+            error("inhibitor never went away: " .. label)
+        end
+    end
+end
+
+-- Arm a 1s idle timeout and wait for it to fire
+local function timers_alive(key, msg)
+    return function(count)
+        if count == 1 then
+            awesome.set_idle_timeout(key, 1, function()
+                fired[key] = true
+            end)
+        end
+        if fired[key] then
+            awesome.clear_idle_timeout(key)
+            return true
+        end
+        if count > 30 then
+            error("idle timeout dead " .. msg)
+        end
+    end
+end
+
+local steps = {
+    -- Baseline separates "idle timers don't run in this environment" from a
+    -- recompute regression in the failure log
+    timers_alive("baseline", "with no inhibitor ever created"),
+
+    spawn_and_wait("client #1"),
+    kill_and_wait_gone(12, "mode B: SIGUSR2 (surface destroyed first)"),
+    timers_alive("after_b", "after mode B (surface-first destroy)"),
+
+    spawn_and_wait("client #2"),
+    kill_and_wait_gone(10, "mode A: SIGUSR1 (inhibitor destroyed, client stays mapped)"),
+    timers_alive("after_a", "after mode A (inhibitor destroyed while mapped)"),
+
+    -- Cleanup
+    function(count)
+        if count == 1 then
+            awesome.clear_all_idle_timeouts()
+            if proc_pid then
+                awesome.kill(proc_pid, 15)
+            end
+        end
+        if #client.get() == 0 then
+            return true
+        end
+        if count >= 10 then
+            os.execute("pkill -9 test-idle-inhibit-client 2>/dev/null")
+            return true
+        end
+    end,
+}
+
+runner.run_steps(steps, { wait_per_step = 5, kill_clients = false })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
## Description
Destroying a protocol idle inhibitor while its window stayed mapped (mpv on pause) left `awesome.set_idle_timeout()` timers permanently disarmed. wlroots emits the inhibitor destroy signal before unlinking it, so the recompute still counted the dying inhibitor. The recompute now runs at the end of the current dispatch.

Fixes #684

## Test Plan
New integration test (`tests/test-idle-inhibit-protocol.lua` + C client) covers both destroy orders; it fails on HEAD at the inhibitor-destroyed-while-mapped step and passes with the fix. Full unit and integration suites pass.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)