### PR TITLE
feat(input): add tablet and touch support for release/1.4

### DIFF
--- a/globalconf.h
+++ b/globalconf.h
@@ -126,6 +126,9 @@ typedef struct InputSettings {
      * is tablet tool-specific; map_to_output/map_to_region/map_from_region
      * are shared by both "tablet" and "touch" rule types. */
     char *tool_mode;                /* "absolute", "relative" */
+    int emulate_pointer;            /* touch-specific: synthesize wl_pointer
+                                      * clicks for clients that never bound
+                                      * wl_touch; 0=off, 1=on */
     char **map_to_output_list;      /* ordered candidates: "*", output name, or
                                       * make/model/serial identifier; first
                                       * connected candidate wins */

--- a/globalconf.h
+++ b/globalconf.h
@@ -122,7 +122,9 @@ typedef struct InputSettings {
     char *clickfinger_button_map;   /* "lrm", "lmr" */
     bool accel_speed_set;           /* true if accel_speed was explicitly set */
 
-    /* Tablet tool-specific rule properties (used by awful.input.rules) */
+    /* Tablet/touch rule properties (used by awful.input.rules). tool_mode
+     * is tablet tool-specific; map_to_output/map_to_region/map_from_region
+     * are shared by both "tablet" and "touch" rule types. */
     char *tool_mode;                /* "absolute", "relative" */
     char **map_to_output_list;      /* ordered candidates: "*", output name, or
                                       * make/model/serial identifier; first
@@ -146,7 +148,7 @@ typedef struct InputSettings {
 
 /** Per-device input rule (evaluated in order, last match wins per property) */
 typedef struct InputRule {
-    char *type;                     /* e.g. "touchpad", "pointer", "tablet", "tablet-tool-pen", "tablet-tool"; NULL=match any */
+    char *type;                     /* e.g. "touchpad", "pointer", "tablet", "tablet-tool-pen", "tablet-tool", "touch"; NULL=match any */
     char *name;                     /* device name substring, NULL=match any */
     InputSettings properties;
 } InputRule;

--- a/globalconf.h
+++ b/globalconf.h
@@ -122,7 +122,13 @@ typedef struct InputSettings {
     char *clickfinger_button_map;   /* "lrm", "lmr" */
     bool accel_speed_set;           /* true if accel_speed was explicitly set */
 
-    /* Tablet tool-specific rule properties (used by awful.input.rules) */
+    /* Tablet/touch rule properties (used by awful.input.rules). tool_mode
+     * is tablet tool-specific; map_to_output/map_to_region are shared by
+     * both "tablet" and "touch" rule types, but map_from_region only takes
+     * effect for tablet tools (see tablet_map_coords() in somewm.c) - a
+     * touchscreen's raw coordinates are already 1:1 with its physical
+     * surface, so cropping-then-stretching a sub-region would scale touch
+     * motion itself. */
     char *tool_mode;                /* "absolute", "relative" */
     char **map_to_output_list;      /* ordered candidates: "*", output name, or
                                       * make/model/serial identifier; first
@@ -146,7 +152,7 @@ typedef struct InputSettings {
 
 /** Per-device input rule (evaluated in order, last match wins per property) */
 typedef struct InputRule {
-    char *type;                     /* e.g. "touchpad", "pointer", "tablet", "tablet-tool-pen", "tablet-tool"; NULL=match any */
+    char *type;                     /* e.g. "touchpad", "pointer", "tablet", "tablet-tool-pen", "tablet-tool", "touch"; NULL=match any */
     char *name;                     /* device name substring, NULL=match any */
     InputSettings properties;
 } InputRule;

--- a/globalconf.h
+++ b/globalconf.h
@@ -130,6 +130,9 @@ typedef struct InputSettings {
      * surface, so cropping-then-stretching a sub-region would scale touch
      * motion itself. */
     char *tool_mode;                /* "absolute", "relative" */
+    int emulate_pointer;            /* touch-specific: synthesize wl_pointer
+                                      * clicks for clients that never bound
+                                      * wl_touch; 0=off, 1=on */
     char **map_to_output_list;      /* ordered candidates: "*", output name, or
                                       * make/model/serial identifier; first
                                       * connected candidate wins */

--- a/globalconf.h
+++ b/globalconf.h
@@ -121,11 +121,32 @@ typedef struct InputSettings {
     char *tap_button_map;           /* "lrm", "lmr" */
     char *clickfinger_button_map;   /* "lrm", "lmr" */
     bool accel_speed_set;           /* true if accel_speed was explicitly set */
+
+    /* Tablet tool-specific rule properties (used by awful.input.rules) */
+    char *tool_mode;                /* "absolute", "relative" */
+    char **map_to_output_list;      /* ordered candidates: "*", output name, or
+                                      * make/model/serial identifier; first
+                                      * connected candidate wins */
+    int map_to_output_count;
+    bool map_from_region_set;       /* true if region is explicitly set */
+    double map_from_region_x1;
+    double map_from_region_y1;
+    double map_from_region_x2;
+    double map_from_region_y2;
+
+    /* Absolute output-layout-pixel target rectangle; takes precedence over
+     * map_to_output_list when set (mirrors sway: an input is mapped to
+     * either an output or a region, not both). */
+    bool map_to_region_set;
+    double map_to_region_x1;
+    double map_to_region_y1;
+    double map_to_region_x2;
+    double map_to_region_y2;
 } InputSettings;
 
 /** Per-device input rule (evaluated in order, last match wins per property) */
 typedef struct InputRule {
-    char *type;                     /* "touchpad" or "pointer", NULL=match any */
+    char *type;                     /* e.g. "touchpad", "pointer", "tablet", "tablet-tool-pen", "tablet-tool"; NULL=match any */
     char *name;                     /* device name substring, NULL=match any */
     InputSettings properties;
 } InputRule;

--- a/luaa.c
+++ b/luaa.c
@@ -1067,6 +1067,7 @@ input_settings_init_unset(InputSettings *s)
 	s->tap_button_map = NULL;
 	s->accel_speed_set = false;
 	s->tool_mode = NULL;
+	s->emulate_pointer = -2;
 	s->map_to_output_list = NULL;
 	s->map_to_output_count = 0;
 	s->map_from_region_set = false;
@@ -1359,6 +1360,7 @@ luaA_awesome_set_input_rules(lua_State *L)
 			p->middle_button_emulation = input_rule_get_int(L, pidx, "middle_button_emulation", -2);
 			p->scroll_button = input_rule_get_int(L, pidx, "scroll_button", -2);
 			p->scroll_button_lock = input_rule_get_int(L, pidx, "scroll_button_lock", -2);
+			p->emulate_pointer = input_rule_get_int(L, pidx, "emulate_pointer", -2);
 
 			p->scroll_method = input_rule_get_string(L, pidx, "scroll_method");
 			p->click_method = input_rule_get_string(L, pidx, "click_method");

--- a/luaa.c
+++ b/luaa.c
@@ -1033,6 +1033,10 @@ input_rules_free(void)
 		free(r->properties.send_events_mode);
 		free(r->properties.accel_profile);
 		free(r->properties.tap_button_map);
+		free(r->properties.tool_mode);
+		for (int j = 0; j < r->properties.map_to_output_count; j++)
+			free(r->properties.map_to_output_list[j]);
+		free(r->properties.map_to_output_list);
 	}
 	free(globalconf.input_rules);
 	globalconf.input_rules = NULL;
@@ -1062,6 +1066,19 @@ input_settings_init_unset(InputSettings *s)
 	s->accel_speed = 0.0;
 	s->tap_button_map = NULL;
 	s->accel_speed_set = false;
+	s->tool_mode = NULL;
+	s->map_to_output_list = NULL;
+	s->map_to_output_count = 0;
+	s->map_from_region_set = false;
+	s->map_from_region_x1 = 0.0;
+	s->map_from_region_y1 = 0.0;
+	s->map_from_region_x2 = 0.0;
+	s->map_from_region_y2 = 0.0;
+	s->map_to_region_set = false;
+	s->map_to_region_x1 = 0.0;
+	s->map_to_region_y1 = 0.0;
+	s->map_to_region_x2 = 0.0;
+	s->map_to_region_y2 = 0.0;
 }
 
 /** Read an optional int field from a Lua table on the stack.
@@ -1087,6 +1104,168 @@ input_rule_get_string(lua_State *L, int idx, const char *field)
 		result = strdup(lua_tostring(L, -1));
 	lua_pop(L, 1);
 	return result;
+}
+
+/** Read and validate optional tool mode from a Lua table.
+ * Returns strdup'd value or NULL if field is absent. */
+static char *
+input_rule_get_tool_mode(lua_State *L, int idx, const char *field)
+{
+	char *result = NULL;
+	const char *val;
+
+	lua_getfield(L, idx, field);
+	if (!lua_isnil(L, -1)) {
+		val = luaL_checkstring(L, -1);
+		if (strcmp(val, "absolute") != 0 && strcmp(val, "relative") != 0) {
+			lua_pop(L, 1);
+			luaL_error(L,
+				"awful.input.rules: invalid properties.%s '%s' (expected 'absolute' or 'relative')",
+				field, val);
+			return NULL;
+		}
+		result = strdup(val);
+	}
+	lua_pop(L, 1);
+	return result;
+}
+
+/** Read and parse an optional two-corner region field from a Lua table.
+ * Used for both map_from_region (tablet-space, normalized/mm) and
+ * map_to_region (output-layout pixels) - the field itself carries no
+ * semantics here, just two corner points. Accepts either:
+ * - string: "X1xY1 X2xY2"
+ * - table: { x1 = <number>, y1 = <number>, x2 = <number>, y2 = <number> }
+ */
+static void
+input_rule_get_region(lua_State *L, int idx, const char *field,
+		bool *set, double *x1, double *y1, double *x2, double *y2)
+{
+	*set = false;
+
+	lua_getfield(L, idx, field);
+	if (lua_isnil(L, -1)) {
+		lua_pop(L, 1);
+		return;
+	}
+
+	if (lua_isstring(L, -1)) {
+		const char *raw = lua_tostring(L, -1);
+		double sx1, sy1, sx2, sy2;
+		int parsed = sscanf(raw, "%lfx%lf %lfx%lf", &sx1, &sy1, &sx2, &sy2);
+		if (parsed != 4) {
+			lua_pop(L, 1);
+			luaL_error(L,
+				"awful.input.rules: invalid properties.%s '%s' (expected 'X1xY1 X2xY2')",
+				field, raw);
+			return;
+		}
+		*x1 = sx1;
+		*y1 = sy1;
+		*x2 = sx2;
+		*y2 = sy2;
+		*set = true;
+		lua_pop(L, 1);
+		return;
+	}
+
+	if (lua_istable(L, -1)) {
+		double sx1, sy1, sx2, sy2;
+
+		lua_getfield(L, -1, "x1");
+		sx1 = luaL_checknumber(L, -1);
+		lua_pop(L, 1);
+
+		lua_getfield(L, -1, "y1");
+		sy1 = luaL_checknumber(L, -1);
+		lua_pop(L, 1);
+
+		lua_getfield(L, -1, "x2");
+		sx2 = luaL_checknumber(L, -1);
+		lua_pop(L, 1);
+
+		lua_getfield(L, -1, "y2");
+		sy2 = luaL_checknumber(L, -1);
+		lua_pop(L, 1);
+
+		*x1 = sx1;
+		*y1 = sy1;
+		*x2 = sx2;
+		*y2 = sy2;
+		*set = true;
+		lua_pop(L, 1);
+		return;
+	}
+
+	lua_pop(L, 1);
+	luaL_error(L,
+		"awful.input.rules: invalid properties.%s type (expected string or table)",
+		field);
+}
+
+/** Read the optional map_to_output field from a Lua table.
+ * Accepts either a single string or an ordered array of strings, tried in
+ * order with the first connected candidate winning. Returns a newly
+ * allocated array of strdup'd strings via *out_list (NULL if the field is
+ * absent), with element count via *out_count. */
+static void
+input_rule_get_map_to_output(lua_State *L, int idx, const char *field,
+		char ***out_list, int *out_count)
+{
+	*out_list = NULL;
+	*out_count = 0;
+
+	lua_getfield(L, idx, field);
+	if (lua_isnil(L, -1)) {
+		lua_pop(L, 1);
+		return;
+	}
+
+	if (lua_isstring(L, -1)) {
+		char **list = calloc(1, sizeof(char *));
+		list[0] = strdup(lua_tostring(L, -1));
+		*out_list = list;
+		*out_count = 1;
+		lua_pop(L, 1);
+		return;
+	}
+
+	if (lua_istable(L, -1)) {
+		int n = luaA_rawlen(L, -1);
+		char **list;
+
+		if (n == 0) {
+			lua_pop(L, 1);
+			return;
+		}
+
+		list = calloc(n, sizeof(char *));
+		for (int i = 0; i < n; i++) {
+			lua_rawgeti(L, -1, i + 1);
+			if (!lua_isstring(L, -1)) {
+				lua_pop(L, 2);
+				for (int j = 0; j < i; j++)
+					free(list[j]);
+				free(list);
+				luaL_error(L,
+					"awful.input.rules: invalid properties.%s[%d] (expected string)",
+					field, i + 1);
+				return;
+			}
+			list[i] = strdup(lua_tostring(L, -1));
+			lua_pop(L, 1);
+		}
+
+		*out_list = list;
+		*out_count = n;
+		lua_pop(L, 1);
+		return;
+	}
+
+	lua_pop(L, 1);
+	luaL_error(L,
+		"awful.input.rules: invalid properties.%s type (expected string or array of strings)",
+		field);
 }
 
 /** Set input rules from Lua.
@@ -1154,6 +1333,21 @@ luaA_awesome_set_input_rules(lua_State *L)
 			p->send_events_mode = input_rule_get_string(L, pidx, "send_events_mode");
 			p->accel_profile = input_rule_get_string(L, pidx, "accel_profile");
 			p->tap_button_map = input_rule_get_string(L, pidx, "tap_button_map");
+			p->tool_mode = input_rule_get_tool_mode(L, pidx, "tool_mode");
+			input_rule_get_map_to_output(L, pidx, "map_to_output",
+				&p->map_to_output_list, &p->map_to_output_count);
+			input_rule_get_region(L, pidx, "map_from_region",
+				&p->map_from_region_set,
+				&p->map_from_region_x1,
+				&p->map_from_region_y1,
+				&p->map_from_region_x2,
+				&p->map_from_region_y2);
+			input_rule_get_region(L, pidx, "map_to_region",
+				&p->map_to_region_set,
+				&p->map_to_region_x1,
+				&p->map_to_region_y1,
+				&p->map_to_region_x2,
+				&p->map_to_region_y2);
 
 			lua_getfield(L, pidx, "accel_speed");
 			if (!lua_isnil(L, -1)) {

--- a/luaa.c
+++ b/luaa.c
@@ -1067,6 +1067,7 @@ input_settings_init_unset(InputSettings *s)
 	s->tap_button_map = NULL;
 	s->accel_speed_set = false;
 	s->tool_mode = NULL;
+	s->emulate_pointer = -2;
 	s->map_to_output_list = NULL;
 	s->map_to_output_count = 0;
 	s->map_from_region_set = false;
@@ -1326,6 +1327,7 @@ luaA_awesome_set_input_rules(lua_State *L)
 			p->middle_button_emulation = input_rule_get_int(L, pidx, "middle_button_emulation", -2);
 			p->scroll_button = input_rule_get_int(L, pidx, "scroll_button", -2);
 			p->scroll_button_lock = input_rule_get_int(L, pidx, "scroll_button_lock", -2);
+			p->emulate_pointer = input_rule_get_int(L, pidx, "emulate_pointer", -2);
 
 			p->scroll_method = input_rule_get_string(L, pidx, "scroll_method");
 			p->click_method = input_rule_get_string(L, pidx, "click_method");

--- a/luaa.c
+++ b/luaa.c
@@ -1033,6 +1033,10 @@ input_rules_free(void)
 		free(r->properties.send_events_mode);
 		free(r->properties.accel_profile);
 		free(r->properties.tap_button_map);
+		free(r->properties.tool_mode);
+		for (int j = 0; j < r->properties.map_to_output_count; j++)
+			free(r->properties.map_to_output_list[j]);
+		free(r->properties.map_to_output_list);
 	}
 	free(globalconf.input_rules);
 	globalconf.input_rules = NULL;
@@ -1062,6 +1066,19 @@ input_settings_init_unset(InputSettings *s)
 	s->accel_speed = 0.0;
 	s->tap_button_map = NULL;
 	s->accel_speed_set = false;
+	s->tool_mode = NULL;
+	s->map_to_output_list = NULL;
+	s->map_to_output_count = 0;
+	s->map_from_region_set = false;
+	s->map_from_region_x1 = 0.0;
+	s->map_from_region_y1 = 0.0;
+	s->map_from_region_x2 = 0.0;
+	s->map_from_region_y2 = 0.0;
+	s->map_to_region_set = false;
+	s->map_to_region_x1 = 0.0;
+	s->map_to_region_y1 = 0.0;
+	s->map_to_region_x2 = 0.0;
+	s->map_to_region_y2 = 0.0;
 }
 
 /** Read an optional int field from a Lua table on the stack.
@@ -1087,6 +1104,201 @@ input_rule_get_string(lua_State *L, int idx, const char *field)
 		result = strdup(lua_tostring(L, -1));
 	lua_pop(L, 1);
 	return result;
+}
+
+/** Read and validate optional tool mode from a Lua table.
+ * Returns strdup'd value or NULL if field is absent. */
+static char *
+input_rule_get_tool_mode(lua_State *L, int idx, const char *field)
+{
+	char *result = NULL;
+	const char *val;
+
+	lua_getfield(L, idx, field);
+	if (!lua_isnil(L, -1)) {
+		val = luaL_checkstring(L, -1);
+		if (strcmp(val, "absolute") != 0 && strcmp(val, "relative") != 0) {
+			lua_pop(L, 1);
+			luaL_error(L,
+				"awful.input.rules: invalid properties.%s '%s' (expected 'absolute' or 'relative')",
+				field, val);
+			return NULL;
+		}
+		result = strdup(val);
+	}
+	lua_pop(L, 1);
+	return result;
+}
+
+/* Parses "NxM" into out_x/out_y. Special-cases a "0x" prefix the same way
+ * sway's own map_from_region parser does (sway/commands/input/map_from_region.c):
+ * strtod()/scanf's %f also accept C99 hex-float syntax, and glibc treats a
+ * bare "0x..." (no required 'p' exponent) as a complete hex-float literal -
+ * so a plain %lf silently swallows the "0x" of e.g. "0x0" as a hex-float
+ * lead-in instead of stopping at the intended 'x' separator, corrupting any
+ * region string whose first coordinate is 0 (the natural top-left corner,
+ * so the single most common value anyone would type). */
+static bool
+parse_coord_pair(const char *str, double *out_x, double *out_y)
+{
+	char *end;
+	const char *y_start;
+
+	if (str[0] == '0' && str[1] == 'x') {
+		*out_x = 0;
+		end = (char *)str + 1;
+	} else {
+		*out_x = strtod(str, &end);
+		if (end == str)
+			return false;
+	}
+	if (*end != 'x')
+		return false;
+
+	y_start = end + 1;
+	*out_y = strtod(y_start, &end);
+	return end != y_start && *end == '\0';
+}
+
+/** Read and parse an optional two-corner region field from a Lua table.
+ * Used for both map_from_region (tablet-space, normalized/mm) and
+ * map_to_region (output-layout pixels) - the field itself carries no
+ * semantics here, just two corner points. Accepts either:
+ * - string: "X1xY1 X2xY2"
+ * - table: { x1 = <number>, y1 = <number>, x2 = <number>, y2 = <number> }
+ */
+static void
+input_rule_get_region(lua_State *L, int idx, const char *field,
+		bool *set, double *x1, double *y1, double *x2, double *y2)
+{
+	*set = false;
+
+	lua_getfield(L, idx, field);
+	if (lua_isnil(L, -1)) {
+		lua_pop(L, 1);
+		return;
+	}
+
+	if (lua_isstring(L, -1)) {
+		const char *raw = lua_tostring(L, -1);
+		char first[64], second[64];
+		double sx1, sy1, sx2, sy2;
+		bool ok = sscanf(raw, "%63s %63s", first, second) == 2
+			&& parse_coord_pair(first, &sx1, &sy1)
+			&& parse_coord_pair(second, &sx2, &sy2);
+		if (!ok) {
+			lua_pop(L, 1);
+			luaL_error(L,
+				"awful.input.rules: invalid properties.%s '%s' (expected 'X1xY1 X2xY2')",
+				field, raw);
+			return;
+		}
+		*x1 = sx1;
+		*y1 = sy1;
+		*x2 = sx2;
+		*y2 = sy2;
+		*set = true;
+		lua_pop(L, 1);
+		return;
+	}
+
+	if (lua_istable(L, -1)) {
+		double sx1, sy1, sx2, sy2;
+
+		lua_getfield(L, -1, "x1");
+		sx1 = luaL_checknumber(L, -1);
+		lua_pop(L, 1);
+
+		lua_getfield(L, -1, "y1");
+		sy1 = luaL_checknumber(L, -1);
+		lua_pop(L, 1);
+
+		lua_getfield(L, -1, "x2");
+		sx2 = luaL_checknumber(L, -1);
+		lua_pop(L, 1);
+
+		lua_getfield(L, -1, "y2");
+		sy2 = luaL_checknumber(L, -1);
+		lua_pop(L, 1);
+
+		*x1 = sx1;
+		*y1 = sy1;
+		*x2 = sx2;
+		*y2 = sy2;
+		*set = true;
+		lua_pop(L, 1);
+		return;
+	}
+
+	lua_pop(L, 1);
+	luaL_error(L,
+		"awful.input.rules: invalid properties.%s type (expected string or table)",
+		field);
+}
+
+/** Read the optional map_to_output field from a Lua table.
+ * Accepts either a single string or an ordered array of strings, tried in
+ * order with the first connected candidate winning. Returns a newly
+ * allocated array of strdup'd strings via *out_list (NULL if the field is
+ * absent), with element count via *out_count. */
+static void
+input_rule_get_map_to_output(lua_State *L, int idx, const char *field,
+		char ***out_list, int *out_count)
+{
+	*out_list = NULL;
+	*out_count = 0;
+
+	lua_getfield(L, idx, field);
+	if (lua_isnil(L, -1)) {
+		lua_pop(L, 1);
+		return;
+	}
+
+	if (lua_isstring(L, -1)) {
+		char **list = calloc(1, sizeof(char *));
+		list[0] = strdup(lua_tostring(L, -1));
+		*out_list = list;
+		*out_count = 1;
+		lua_pop(L, 1);
+		return;
+	}
+
+	if (lua_istable(L, -1)) {
+		int n = luaA_rawlen(L, -1);
+		char **list;
+
+		if (n == 0) {
+			lua_pop(L, 1);
+			return;
+		}
+
+		list = calloc(n, sizeof(char *));
+		for (int i = 0; i < n; i++) {
+			lua_rawgeti(L, -1, i + 1);
+			if (!lua_isstring(L, -1)) {
+				lua_pop(L, 2);
+				for (int j = 0; j < i; j++)
+					free(list[j]);
+				free(list);
+				luaL_error(L,
+					"awful.input.rules: invalid properties.%s[%d] (expected string)",
+					field, i + 1);
+				return;
+			}
+			list[i] = strdup(lua_tostring(L, -1));
+			lua_pop(L, 1);
+		}
+
+		*out_list = list;
+		*out_count = n;
+		lua_pop(L, 1);
+		return;
+	}
+
+	lua_pop(L, 1);
+	luaL_error(L,
+		"awful.input.rules: invalid properties.%s type (expected string or array of strings)",
+		field);
 }
 
 /** Set input rules from Lua.
@@ -1154,6 +1366,21 @@ luaA_awesome_set_input_rules(lua_State *L)
 			p->send_events_mode = input_rule_get_string(L, pidx, "send_events_mode");
 			p->accel_profile = input_rule_get_string(L, pidx, "accel_profile");
 			p->tap_button_map = input_rule_get_string(L, pidx, "tap_button_map");
+			p->tool_mode = input_rule_get_tool_mode(L, pidx, "tool_mode");
+			input_rule_get_map_to_output(L, pidx, "map_to_output",
+				&p->map_to_output_list, &p->map_to_output_count);
+			input_rule_get_region(L, pidx, "map_from_region",
+				&p->map_from_region_set,
+				&p->map_from_region_x1,
+				&p->map_from_region_y1,
+				&p->map_from_region_x2,
+				&p->map_from_region_y2);
+			input_rule_get_region(L, pidx, "map_to_region",
+				&p->map_to_region_set,
+				&p->map_to_region_x1,
+				&p->map_to_region_y1,
+				&p->map_to_region_x2,
+				&p->map_to_region_y2);
 
 			lua_getfield(L, pidx, "accel_speed");
 			if (!lua_isnil(L, -1)) {

--- a/meson.build
+++ b/meson.build
@@ -225,6 +225,7 @@ protocols = [
   [wayland_protocols_dir / 'staging/cursor-shape/cursor-shape-v1.xml', 'enum-header'],
   [wayland_protocols_dir / 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml', 'enum-header'],
   [wayland_protocols_dir / 'stable/xdg-shell/xdg-shell.xml', 'server-header'],
+  [wayland_protocols_dir / 'stable/tablet/tablet-v2.xml', 'server-header'],
   # Local protocols
   ['protocols/wlr-layer-shell-unstable-v1.xml', 'enum-header'],
   ['protocols/wlr-output-power-management-unstable-v1.xml', 'server-header'],

--- a/meson.build
+++ b/meson.build
@@ -243,6 +243,7 @@ protocols = [
   [wayland_protocols_dir / 'staging/cursor-shape/cursor-shape-v1.xml', 'enum-header'],
   [wayland_protocols_dir / 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml', 'enum-header'],
   [wayland_protocols_dir / 'stable/xdg-shell/xdg-shell.xml', 'server-header'],
+  [wayland_protocols_dir / 'stable/tablet/tablet-v2.xml', 'server-header'],
   # Local protocols
   ['protocols/wlr-layer-shell-unstable-v1.xml', 'enum-header'],
   ['protocols/wlr-output-power-management-unstable-v1.xml', 'server-header'],

--- a/somewm.c
+++ b/somewm.c
@@ -3268,7 +3268,10 @@ inputdevice(struct wl_listener *listener, void *data)
 		createpointer(wlr_pointer_from_input_device(device));
 		break;
 	default:
-		/* TODO handle other input device types */
+		wlr_log(WLR_INFO,
+			"[input] ignoring unsupported device type=%d name=%s",
+			device->type,
+			device->name ? device->name : "(unknown)");
 		break;
 	}
 

--- a/somewm.c
+++ b/somewm.c
@@ -65,6 +65,9 @@
 #include <wlr/types/wlr_session_lock_v1.h>
 #include <wlr/types/wlr_single_pixel_buffer_v1.h>
 #include <wlr/types/wlr_subcompositor.h>
+#include <wlr/types/wlr_tablet_pad.h>
+#include <wlr/types/wlr_tablet_tool.h>
+#include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/types/wlr_viewporter.h>
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/types/wlr_virtual_pointer_v1.h>
@@ -147,6 +150,48 @@ typedef struct {
 	struct wl_list link;
 } TrackedPointer;
 
+/* Tracked tablet device for tool-event listeners and debug logging */
+typedef struct {
+	struct wlr_tablet *tablet;
+	struct wlr_tablet_v2_tablet *tablet_v2;
+	struct wl_listener axis;
+	struct wl_listener proximity;
+	struct wl_listener tip;
+	struct wl_listener button;
+	struct wl_listener destroy;
+	struct wl_list link;
+} TrackedTablet;
+
+/* Tracked tablet pad for debug logging in MVP phase */
+typedef struct {
+	struct wlr_tablet_pad *pad;
+	struct wlr_tablet_v2_tablet_pad *pad_v2;
+	struct wlr_tablet *attached_tablet;
+	struct wlr_surface *current_surface;
+	struct wl_listener button;
+	struct wl_listener ring;
+	struct wl_listener strip;
+	struct wl_listener attach_tablet;
+	struct wl_listener surface_destroy;
+	struct wl_listener destroy;
+	struct wl_list link;
+} TrackedTabletPad;
+
+typedef struct {
+	struct wlr_tablet_tool *tool;
+	struct wlr_tablet_v2_tablet_tool *tool_v2;
+	struct wlr_tablet *tablet;
+	/* Last known normalized (0..1) position and tilt, tracked per-tool so
+	 * a single-axis wlr_tablet_tool_axis_event (see tabletnotifyaxis())
+	 * can still resolve a full x/y or tilt_x/tilt_y pair. */
+	double last_x, last_y;
+	bool has_x, has_y;
+	double last_tilt_x, last_tilt_y;
+	bool has_tilt_x, has_tilt_y;
+	struct wl_listener destroy;
+	struct wl_list link;
+} TrackedTabletTool;
+
 /* function declarations */
 static void applybounds(Client *c, struct wlr_box *bbox);
 void arrange(Monitor *m);
@@ -179,6 +224,8 @@ static void createlocksurface(struct wl_listener *listener, void *data);
 static void createmon(struct wl_listener *listener, void *data);
 static void createnotify(struct wl_listener *listener, void *data);
 static void createpointer(struct wlr_pointer *pointer);
+static void createtablet(struct wlr_tablet *tablet);
+static void createtabletpad(struct wlr_tablet_pad *pad);
 static void createpointerconstraint(struct wl_listener *listener, void *data);
 static void createpopup(struct wl_listener *listener, void *data);
 void cursorconstrain(struct wlr_pointer_constraint_v1 *constraint);
@@ -196,6 +243,9 @@ static void destroypointerconstraint(struct wl_listener *listener, void *data);
 static void destroysessionlock(struct wl_listener *listener, void *data);
 static void destroykeyboardgroup(struct wl_listener *listener, void *data);
 static void destroytrackedpointer(struct wl_listener *listener, void *data);
+static void destroytrackedtablet(struct wl_listener *listener, void *data);
+static void destroytrackedtabletpad(struct wl_listener *listener, void *data);
+static void destroytrackedtablettool(struct wl_listener *listener, void *data);
 Monitor *dirtomon(enum wlr_direction dir);
 static void apply_input_settings_to_device(struct libinput_device *device);
 void focusclient(Client *c, int lift);
@@ -219,6 +269,15 @@ static void gestureholdend(struct wl_listener *listener, void *data);
 static void gpureset(struct wl_listener *listener, void *data);
 static void handlesig(int signo);
 static void inputdevice(struct wl_listener *listener, void *data);
+static void tabletnotifyaxis(struct wl_listener *listener, void *data);
+static void tabletnotifyproximity(struct wl_listener *listener, void *data);
+static void tabletnotifytip(struct wl_listener *listener, void *data);
+static void tabletnotifybutton(struct wl_listener *listener, void *data);
+static void tabletpadnotifybutton(struct wl_listener *listener, void *data);
+static void tabletpadnotifyring(struct wl_listener *listener, void *data);
+static void tabletpadnotifystrip(struct wl_listener *listener, void *data);
+static void tabletpadnotifyattach(struct wl_listener *listener, void *data);
+static void tabletpadnotifysurfacedestroy(struct wl_listener *listener, void *data);
 static int keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym);
 static void keypress(struct wl_listener *listener, void *data);
 static void keypressmod(struct wl_listener *listener, void *data);
@@ -341,6 +400,8 @@ struct wlr_pointer_constraints_v1 *pointer_constraints;
 static struct wlr_relative_pointer_manager_v1 *relative_pointer_mgr;
 static struct wlr_pointer_constraint_v1 *active_constraint;
 
+static struct wlr_tablet_manager_v2 *tablet_v2_mgr;
+
 struct wlr_cursor *cursor;
 /* Non-static so mousegrabber.c can access it */
 struct wlr_xcursor_manager *cursor_mgr;
@@ -361,6 +422,9 @@ struct wlr_output_layout *output_layout;
 static struct wlr_box sgeom;
 struct wl_list mons;
 static struct wl_list tracked_pointers; /* For runtime libinput config */
+static struct wl_list tracked_tablets;
+static struct wl_list tracked_tablet_pads;
+static struct wl_list tracked_tablet_tools;
 Monitor *selmon;
 static int in_updatemons;
 static int updatemons_pending;
@@ -1971,24 +2035,75 @@ get_input_device_type(struct libinput_device *device)
 		? "touchpad" : "pointer";
 }
 
-/* Resolve effective input settings for a device by overlaying matching rules
- * on top of the global defaults. String fields in the result are borrowed
- * pointers (not owned), so the caller must not free them. */
+static const char *
+tablet_tool_type_to_rule_type(enum wlr_tablet_tool_type type)
+{
+	switch (type) {
+	case WLR_TABLET_TOOL_TYPE_PEN:
+		return "tablet-tool-pen";
+	case WLR_TABLET_TOOL_TYPE_ERASER:
+		return "tablet-tool-eraser";
+	case WLR_TABLET_TOOL_TYPE_BRUSH:
+		return "tablet-tool-brush";
+	case WLR_TABLET_TOOL_TYPE_PENCIL:
+		return "tablet-tool-pencil";
+	case WLR_TABLET_TOOL_TYPE_AIRBRUSH:
+		return "tablet-tool-airbrush";
+	case WLR_TABLET_TOOL_TYPE_MOUSE:
+		return "tablet-tool-mouse";
+	case WLR_TABLET_TOOL_TYPE_LENS:
+		return "tablet-tool-lens";
+	case WLR_TABLET_TOOL_TYPE_TOTEM:
+		return "tablet-tool-totem";
+	default:
+		return NULL;
+	}
+}
+
+/* A rule's `type` can match on either of two independent axes: the device
+ * class (`primary`, e.g. "tablet") or, for tablets, which tool triggered
+ * the current event (`secondary`, e.g. "tablet-tool-pen"). Plain pointer/
+ * touchpad devices only have a `primary` axis (see resolve_input_settings());
+ * tablets pass both, since `primary` is always the constant "tablet" while
+ * `secondary` varies per event (see resolve_tablet_settings()) - so
+ * `{type="tablet"}` matches any tool on any tablet, `{type="tablet-tool-pen"}`
+ * matches a pen on any tablet, and both can be combined with `name` (always
+ * the tablet's own name, never the tool's) to narrow to one device. */
+static bool
+input_rule_type_matches(const char *rule_type, const char *primary, const char *secondary)
+{
+	if (!rule_type)
+		return true;
+
+	if (primary && strcmp(rule_type, primary) == 0)
+		return true;
+
+	if (secondary && strcmp(rule_type, secondary) == 0)
+		return true;
+
+	/* tablet-tool is a wildcard for any concrete tablet-tool-* type. */
+	if (secondary && strcmp(rule_type, "tablet-tool") == 0
+			&& strncmp(secondary, "tablet-tool-", strlen("tablet-tool-")) == 0)
+		return true;
+
+	return false;
+}
+
+/* Resolve effective input settings by overlaying matching rules on top of
+ * global defaults. String fields in the result are borrowed pointers
+ * (not owned), so the caller must not free them. */
 static void
-resolve_input_settings(struct libinput_device *device, struct InputSettings *out)
+resolve_input_settings_for_types(const char *type_primary,
+		const char *type_secondary, const char *dev_name,
+		struct InputSettings *out)
 {
 	/* Start with global defaults */
 	*out = globalconf.input;
-	/* String fields are borrowed from globalconf, not duplicated */
-
-	const char *dev_type = get_input_device_type(device);
-	const char *dev_name = libinput_device_get_name(device);
 
 	for (int i = 0; i < globalconf.input_rules_count; i++) {
 		struct InputRule *rule = &globalconf.input_rules[i];
 
-		/* Check type match */
-		if (rule->type && strcmp(rule->type, dev_type) != 0)
+		if (!input_rule_type_matches(rule->type, type_primary, type_secondary))
 			continue;
 		/* Check name match (substring) */
 		if (rule->name && (!dev_name || !strstr(dev_name, rule->name)))
@@ -2017,7 +2132,115 @@ resolve_input_settings(struct libinput_device *device, struct InputSettings *out
 			out->accel_speed = p->accel_speed;
 			out->accel_speed_set = true;
 		}
+		if (p->tool_mode) out->tool_mode = p->tool_mode;
+		if (p->map_to_output_count) {
+			out->map_to_output_list = p->map_to_output_list;
+			out->map_to_output_count = p->map_to_output_count;
+		}
+		if (p->map_from_region_set) {
+			out->map_from_region_set = true;
+			out->map_from_region_x1 = p->map_from_region_x1;
+			out->map_from_region_y1 = p->map_from_region_y1;
+			out->map_from_region_x2 = p->map_from_region_x2;
+			out->map_from_region_y2 = p->map_from_region_y2;
+		}
+		if (p->map_to_region_set) {
+			out->map_to_region_set = true;
+			out->map_to_region_x1 = p->map_to_region_x1;
+			out->map_to_region_y1 = p->map_to_region_y1;
+			out->map_to_region_x2 = p->map_to_region_x2;
+			out->map_to_region_y2 = p->map_to_region_y2;
+		}
 	}
+}
+/* Normalize tablet coordinates and map them into layout coordinates.
+ * Returns true if an explicit output mapping was successfully applied. */
+static bool
+tablet_map_coords(const struct InputSettings *s, double in_x, double in_y,
+		double *out_lx, double *out_ly)
+{
+	struct wlr_box box = {0};
+	Monitor *target = NULL;
+	double tx = in_x;
+	double ty = in_y;
+
+	/* First restrict input region to map_from_region setting and
+	 * remap-and-bound it to the unit square.*/
+	if (s->map_from_region_set) {
+		double w = s->map_from_region_x2 - s->map_from_region_x1;
+		double h = s->map_from_region_y2 - s->map_from_region_y1;
+
+		if (fabs(w) < 1e-9 || fabs(h) < 1e-9) {
+			wlr_log(WLR_ERROR,
+				"[tablet-map] invalid map_from_region: (%f,%f)-(%f,%f), falling back to raw coords",
+				s->map_from_region_x1, s->map_from_region_y1,
+				s->map_from_region_x2, s->map_from_region_y2);
+		} else {
+			tx = (in_x - s->map_from_region_x1) / w;
+			ty = (in_y - s->map_from_region_y1) / h;
+			tx = fmax(0.0, fmin(1.0, tx));
+			ty = fmax(0.0, fmin(1.0, ty));
+		}
+	}
+
+	/* An explicit target region takes precedence over map_to_output
+	 * (mirrors sway's mutually-exclusive output/region mapping). */
+	if (s->map_to_region_set) {
+		double w = s->map_to_region_x2 - s->map_to_region_x1;
+		double h = s->map_to_region_y2 - s->map_to_region_y1;
+
+		if (fabs(w) < 1e-9 || fabs(h) < 1e-9) {
+			wlr_log(WLR_ERROR,
+				"[tablet-map] invalid map_to_region: (%f,%f)-(%f,%f), falling back to map_to_output",
+				s->map_to_region_x1, s->map_to_region_y1,
+				s->map_to_region_x2, s->map_to_region_y2);
+		} else {
+			*out_lx = s->map_to_region_x1 + tx * w;
+			*out_ly = s->map_to_region_y1 + ty * h;
+			return true;
+		}
+	}
+
+	/* Map to a provided output monitor by identifying matching candidates
+	 * provided in map_to_output setting. */
+	for (int i = 0; i < s->map_to_output_count; i++) {
+		const char *candidate = s->map_to_output_list[i];
+
+		/* Map to entire layout, so stop mapping matching here. */
+		if (strcmp(candidate, "*") == 0)
+			break;
+
+		target = some_monitor_by_name(candidate);
+		if (target)
+			break;
+
+		wlr_log(WLR_INFO,
+			"[tablet-map] output '%s' not found, trying next candidate",
+			candidate);
+	}
+
+	/* Target output found. Map coordinates to it. */
+	if (target) {
+		*out_lx = target->m.x + tx * target->m.width;
+		*out_ly = target->m.y + ty * target->m.height;
+		return true;
+	}
+
+	wlr_output_layout_get_box(output_layout, NULL, &box);
+	*out_lx = box.x + tx * box.width;
+	*out_ly = box.y + ty * box.height;
+	return false;
+}
+
+/* Resolve effective input settings for a device by overlaying matching rules
+ * on top of the global defaults. String fields in the result are borrowed
+ * pointers (not owned), so the caller must not free them. */
+static void
+resolve_input_settings(struct libinput_device *device, struct InputSettings *out)
+{
+	const char *dev_type = get_input_device_type(device);
+	const char *dev_name = libinput_device_get_name(device);
+	resolve_input_settings_for_types(dev_type, NULL, dev_name, out);
 }
 
 /* Apply resolved input settings to a single libinput device */
@@ -2151,6 +2374,650 @@ apply_input_settings_to_all_devices(void)
 	TrackedPointer *tp;
 	wl_list_for_each(tp, &tracked_pointers, link) {
 		apply_input_settings_to_device(tp->libinput_dev);
+	}
+}
+
+/* primary is the constant "tablet" (see input_rule_type_matches()); only
+ * secondary (the active tool's type) varies per call. */
+static void
+resolve_tablet_settings(struct wlr_tablet *tablet, struct wlr_tablet_tool *tool,
+		struct InputSettings *out)
+{
+	const char *tool_type = tool ? tablet_tool_type_to_rule_type(tool->type) : NULL;
+	const char *dev_name = tablet && tablet->base.name ? tablet->base.name : NULL;
+
+	resolve_input_settings_for_types("tablet", tool_type, dev_name, out);
+
+	/* Puck-style tools have no fixed position on the tablet surface, so
+	 * absolute placement makes no sense for them; sway hardcodes this too
+	 * (sway-input(5): "Mouse and lens tools ignore this setting and are
+	 * always treated as relative") and doesn't let tool_mode rules override
+	 * it, so match that here. */
+	if (tool && (tool->type == WLR_TABLET_TOOL_TYPE_MOUSE
+			|| tool->type == WLR_TABLET_TOOL_TYPE_LENS))
+		out->tool_mode = "relative";
+}
+
+static TrackedTablet *
+find_tracked_tablet(struct wlr_tablet *tablet)
+{
+	TrackedTablet *tt;
+
+	wl_list_for_each(tt, &tracked_tablets, link) {
+		if (tt->tablet == tablet)
+			return tt;
+	}
+
+	return NULL;
+}
+
+static TrackedTablet *
+find_tracked_tablet_by_device(struct wlr_input_device *device)
+{
+	TrackedTablet *tt;
+
+	if (!device || device->type != WLR_INPUT_DEVICE_TABLET)
+		return NULL;
+
+	wl_list_for_each(tt, &tracked_tablets, link) {
+		if (&tt->tablet->base == device)
+			return tt;
+	}
+
+	return NULL;
+}
+
+/* Tracks a tool regardless of tablet-v2 support: axis position caching
+ * (tabletnotifyaxis()) needs this even when tablet_v2_mgr is unavailable. */
+static TrackedTabletTool *
+find_or_create_tracked_tablet_tool(struct wlr_tablet *tablet, struct wlr_tablet_tool *tool)
+{
+	TrackedTabletTool *ttt;
+
+	if (!tool)
+		return NULL;
+
+	wl_list_for_each(ttt, &tracked_tablet_tools, link) {
+		if (ttt->tool == tool) {
+			if (tablet)
+				ttt->tablet = tablet;
+			return ttt;
+		}
+	}
+
+	ttt = ecalloc(1, sizeof(*ttt));
+	ttt->tool = tool;
+	ttt->tablet = tablet;
+	wl_list_insert(&tracked_tablet_tools, &ttt->link);
+	LISTEN(&tool->events.destroy, &ttt->destroy, destroytrackedtablettool);
+
+	return ttt;
+}
+
+static struct wlr_tablet_v2_tablet_tool *
+get_or_create_tablet_v2_tool(struct wlr_tablet *tablet, struct wlr_tablet_tool *tool)
+{
+	TrackedTabletTool *ttt;
+
+	if (!tablet_v2_mgr)
+		return NULL;
+
+	ttt = find_or_create_tracked_tablet_tool(tablet, tool);
+	if (!ttt)
+		return NULL;
+
+	if (!ttt->tool_v2)
+		ttt->tool_v2 = wlr_tablet_tool_create(tablet_v2_mgr, seat, tool);
+
+	return ttt->tool_v2;
+}
+
+static TrackedTablet *
+find_tracked_tablet_by_tool(struct wlr_tablet_tool *tool)
+{
+	TrackedTabletTool *ttt;
+
+	if (!tool)
+		return NULL;
+
+	wl_list_for_each(ttt, &tracked_tablet_tools, link) {
+		if (ttt->tool == tool)
+			return find_tracked_tablet(ttt->tablet);
+	}
+
+	return NULL;
+}
+
+static TrackedTablet *
+find_tracked_tablet_by_attach_payload(void *payload)
+{
+	TrackedTablet *tt;
+	TrackedTablet *by_tool;
+
+	if (!payload)
+		return NULL;
+
+	/* libinput backends usually provide a wlr_tablet_tool payload. */
+	by_tool = find_tracked_tablet_by_tool((struct wlr_tablet_tool *)payload);
+	if (by_tool)
+		return by_tool;
+
+	/* Wayland backend can provide a wlr_input_device payload for the tablet. */
+	wl_list_for_each(tt, &tracked_tablets, link) {
+		if (&tt->tablet->base == payload)
+			return tt;
+	}
+
+	return NULL;
+}
+
+/* True if pad and tablet are libinput devices from the same physical
+ * hardware (e.g. the pad and pen halves of a single Wacom tablet), per
+ * libinput's device-group grouping. This is the authoritative way to pair
+ * a pad with its tablet; unlike the attach_tablet event, it doesn't depend
+ * on a backend actually emitting that signal. */
+static bool
+tablet_pad_shares_libinput_group(struct wlr_tablet_pad *pad, struct wlr_tablet *tablet)
+{
+	struct libinput_device *pad_dev, *tablet_dev;
+
+	if (!pad || !tablet
+			|| !wlr_input_device_is_libinput(&pad->base)
+			|| !wlr_input_device_is_libinput(&tablet->base))
+		return false;
+
+	pad_dev = wlr_libinput_get_device_handle(&pad->base);
+	tablet_dev = wlr_libinput_get_device_handle(&tablet->base);
+	if (!pad_dev || !tablet_dev)
+		return false;
+
+	return libinput_device_get_device_group(pad_dev)
+		== libinput_device_get_device_group(tablet_dev);
+}
+
+static void
+tabletpad_clear_focus(TrackedTabletPad *tp)
+{
+	if (!tp->current_surface)
+		return;
+
+	wlr_tablet_v2_tablet_pad_notify_leave(tp->pad_v2, tp->current_surface);
+	wl_list_remove(&tp->surface_destroy.link);
+	wl_list_init(&tp->surface_destroy.link);
+	tp->current_surface = NULL;
+}
+
+static void
+tabletpad_attach_tablet(TrackedTabletPad *tp, struct wlr_tablet *tablet)
+{
+	if (tp->attached_tablet == tablet)
+		return;
+
+	tabletpad_clear_focus(tp);
+	tp->attached_tablet = tablet;
+
+	wlr_log(WLR_INFO,
+		"[tablet-pad] attach device=%s mapped_tablet=%s",
+		tp->pad && tp->pad->base.name ? tp->pad->base.name : "(unknown)",
+		tablet && tablet->base.name ? tablet->base.name : "(unmapped)");
+}
+
+static void
+tabletpad_set_focus_for_cursor(TrackedTabletPad *tp)
+{
+	TrackedTablet *tt;
+	struct wlr_surface *surface = NULL;
+	double sx = 0.0, sy = 0.0;
+
+	if (!tp->pad_v2 || !tp->attached_tablet)
+		return;
+
+	tt = find_tracked_tablet(tp->attached_tablet);
+	if (!tt || !tt->tablet_v2)
+		return;
+
+	xytonode(cursor->x, cursor->y, &surface, NULL, NULL, NULL, NULL, &sx, &sy);
+	if (surface == tp->current_surface)
+		return;
+
+	tabletpad_clear_focus(tp);
+
+	if (!surface || !wlr_surface_accepts_tablet_v2(surface, tt->tablet_v2))
+		return;
+
+	wlr_tablet_v2_tablet_pad_notify_enter(tp->pad_v2, tt->tablet_v2, surface);
+	tp->current_surface = surface;
+	tp->surface_destroy.notify = tabletpadnotifysurfacedestroy;
+	wl_signal_add(&surface->events.destroy, &tp->surface_destroy);
+}
+
+static void
+tabletpadnotifysurfacedestroy(struct wl_listener *listener, void *data)
+{
+	TrackedTabletPad *tp = wl_container_of(listener, tp, surface_destroy);
+
+	(void)data;
+	tabletpad_clear_focus(tp);
+}
+
+static void
+tablet_notify_proximity_in_for_cursor(struct wlr_tablet *tablet,
+		struct wlr_tablet_tool *tool)
+{
+	TrackedTablet *tt;
+	struct wlr_tablet_v2_tablet_tool *tool_v2;
+	struct wlr_surface *surface = NULL;
+	double sx = 0.0, sy = 0.0;
+
+	if (!tablet_v2_mgr)
+		return;
+
+	tt = find_tracked_tablet(tablet);
+	if (!tt || !tt->tablet_v2)
+		return;
+
+	tool_v2 = get_or_create_tablet_v2_tool(tablet, tool);
+	if (!tool_v2)
+		return;
+
+	xytonode(cursor->x, cursor->y, &surface, NULL, NULL, NULL, NULL, &sx, &sy);
+	if (!surface)
+		return;
+
+	if (!wlr_surface_accepts_tablet_v2(surface, tt->tablet_v2))
+		return;
+
+	wlr_tablet_v2_tablet_tool_notify_proximity_in(tool_v2, tt->tablet_v2, surface);
+}
+
+static void
+tablet_apply_absolute_motion(struct wlr_tablet *tablet,
+		struct wlr_tablet_tool *tool, uint32_t time_msec,
+		double x, double y)
+{
+	struct InputSettings s;
+	double lx, ly, dx, dy;
+
+	resolve_tablet_settings(tablet, tool, &s);
+	tablet_map_coords(&s, x, y, &lx, &ly);
+	dx = lx - cursor->x;
+	dy = ly - cursor->y;
+
+	motionnotify(time_msec, &tablet->base, dx, dy, dx, dy);
+}
+
+static void
+tablet_apply_relative_motion(struct wlr_tablet *tablet,
+		struct wlr_tablet_tool *tool, uint32_t time_msec,
+		double dx, double dy)
+{
+	motionnotify(time_msec, &tablet->base, dx, dy, dx, dy);
+}
+
+static void
+tablet_apply_motion(struct wlr_tablet *tablet, struct wlr_tablet_tool *tool,
+		uint32_t time_msec, double x, double y, double dx, double dy)
+{
+	struct InputSettings s;
+	resolve_tablet_settings(tablet, tool, &s);
+	const char *tool_mode = s.tool_mode ? s.tool_mode : "absolute";
+
+	if (strcmp(tool_mode, "relative") == 0) {
+		tablet_apply_relative_motion(tablet, tool, time_msec, dx, dy);
+	} else {
+		if (strcmp(tool_mode, "absolute") != 0) {
+			wlr_log(WLR_INFO,
+					"[tablet] unknown tool_mode '%s', falling back to absolute",
+					tool_mode);
+		}
+
+		tablet_apply_absolute_motion(tablet, tool, time_msec, x, y);
+	}
+}
+
+static void
+tablet_apply_motion_absoluteonly(struct wlr_tablet *tablet,
+		struct wlr_tablet_tool *tool, uint32_t time_msec, double x, double y)
+{
+	struct InputSettings s;
+	resolve_tablet_settings(tablet, tool, &s);
+	const char *tool_mode = s.tool_mode ? s.tool_mode : "absolute";
+
+	if (strcmp(tool_mode, "relative") == 0) {
+		/* Nothing to do. */
+		return;
+	}
+
+	if (strcmp(tool_mode, "absolute") != 0) {
+		wlr_log(WLR_INFO,
+				"[tablet] unknown tool_mode '%s', falling back to absolute",
+				tool_mode);
+	}
+
+	tablet_apply_absolute_motion(tablet, tool, time_msec, x, y);
+}
+
+static void
+tabletnotifyaxis(struct wl_listener *listener, void *data)
+{
+	TrackedTablet *tt = wl_container_of(listener, tt, axis);
+	struct wlr_tablet_tool_axis_event *event = data;
+	struct wlr_tablet_v2_tablet_tool *tool_v2 = NULL;
+	TrackedTabletTool *ttt;
+	struct wlr_surface *surface = NULL;
+	double sx = 0.0, sy = 0.0;
+	double x, y, tilt_x, tilt_y;
+	bool updated_x, updated_y, has_xy;
+	bool updated_tilt_x, updated_tilt_y, has_tilt;
+
+	updated_x = event->updated_axes & WLR_TABLET_TOOL_AXIS_X;
+	updated_y = event->updated_axes & WLR_TABLET_TOOL_AXIS_Y;
+	updated_tilt_x = event->updated_axes & WLR_TABLET_TOOL_AXIS_TILT_X;
+	updated_tilt_y = event->updated_axes & WLR_TABLET_TOOL_AXIS_TILT_Y;
+
+	/* wlroots backends (e.g. libinput) only fill in x/y for the axes that
+	 * actually changed - a tool dragged along a single axis near the
+	 * tablet's edge is a normal, frequent event, not a malformed one, and
+	 * the other field is left at 0 rather than the tool's real position.
+	 * Track each tool's last known position so a single-axis update still
+	 * moves the cursor instead of being dropped, or worse, snapping to
+	 * (0, y)/(x, 0) if we trusted the unset field. */
+	ttt = find_or_create_tracked_tablet_tool(tt->tablet, event->tool);
+
+	x = (updated_x || !ttt) ? event->x : ttt->last_x;
+	y = (updated_y || !ttt) ? event->y : ttt->last_y;
+	has_xy = (updated_x || (ttt && ttt->has_x)) && (updated_y || (ttt && ttt->has_y));
+
+	/* Same reasoning applies to tilt: WLR_TABLET_TOOL_AXIS_TILT_X and
+	 * _TILT_Y are independent bits, so a report that only changed one of
+	 * them must not be treated as "no tilt update" nor have the other
+	 * axis read back as 0. */
+	tilt_x = (updated_tilt_x || !ttt) ? event->tilt_x : ttt->last_tilt_x;
+	tilt_y = (updated_tilt_y || !ttt) ? event->tilt_y : ttt->last_tilt_y;
+	has_tilt = (updated_tilt_x || (ttt && ttt->has_tilt_x))
+		&& (updated_tilt_y || (ttt && ttt->has_tilt_y));
+
+	if (ttt) {
+		if (updated_x) {
+			ttt->last_x = event->x;
+			ttt->has_x = true;
+		}
+		if (updated_y) {
+			ttt->last_y = event->y;
+			ttt->has_y = true;
+		}
+		if (updated_tilt_x) {
+			ttt->last_tilt_x = event->tilt_x;
+			ttt->has_tilt_x = true;
+		}
+		if (updated_tilt_y) {
+			ttt->last_tilt_y = event->tilt_y;
+			ttt->has_tilt_y = true;
+		}
+	}
+
+	if (has_xy) {
+		tablet_apply_motion(tt->tablet, event->tool, event->time_msec, x, y, event->dx, event->dy);
+	}
+
+	tool_v2 = get_or_create_tablet_v2_tool(tt->tablet, event->tool);
+	if (tool_v2) {
+		if (has_xy) {
+			tablet_notify_proximity_in_for_cursor(tt->tablet, event->tool);
+			xytonode(cursor->x, cursor->y, &surface, NULL, NULL, NULL, NULL, &sx, &sy);
+			if (surface && tt->tablet_v2
+					&& wlr_surface_accepts_tablet_v2(surface, tt->tablet_v2))
+				wlr_tablet_v2_tablet_tool_notify_motion(tool_v2, sx, sy);
+		}
+
+		if (event->updated_axes & WLR_TABLET_TOOL_AXIS_PRESSURE)
+			wlr_tablet_v2_tablet_tool_notify_pressure(tool_v2, event->pressure);
+		if (event->updated_axes & WLR_TABLET_TOOL_AXIS_DISTANCE)
+			wlr_tablet_v2_tablet_tool_notify_distance(tool_v2, event->distance);
+		if (has_tilt)
+			wlr_tablet_v2_tablet_tool_notify_tilt(tool_v2, tilt_x, tilt_y);
+		if (event->updated_axes & WLR_TABLET_TOOL_AXIS_ROTATION)
+			wlr_tablet_v2_tablet_tool_notify_rotation(tool_v2, event->rotation);
+		if (event->updated_axes & WLR_TABLET_TOOL_AXIS_SLIDER)
+			wlr_tablet_v2_tablet_tool_notify_slider(tool_v2, event->slider);
+		if (event->updated_axes & WLR_TABLET_TOOL_AXIS_WHEEL)
+			wlr_tablet_v2_tablet_tool_notify_wheel(tool_v2, event->wheel_delta, 0);
+	}
+	wlr_seat_pointer_notify_frame(seat);
+}
+
+static void
+tabletnotifyproximity(struct wl_listener *listener, void *data)
+{
+	TrackedTablet *tt = wl_container_of(listener, tt, proximity);
+	struct wlr_tablet_tool_proximity_event *event = data;
+	struct wlr_tablet_v2_tablet_tool *tool_v2;
+
+	tool_v2 = get_or_create_tablet_v2_tool(tt->tablet, event->tool);
+	if (!tool_v2)
+		return;
+
+	if (event->state == WLR_TABLET_TOOL_PROXIMITY_IN) {
+		tablet_apply_motion_absoluteonly(tt->tablet, event->tool, event->time_msec, event->x, event->y);
+		tablet_notify_proximity_in_for_cursor(tt->tablet, event->tool);
+	} else {
+		wlr_tablet_v2_tablet_tool_notify_proximity_out(tool_v2);
+		/* Refresh wl_pointer focus/cursor immediately after stylus leave. */
+		motionnotify(0, NULL, 0, 0, 0, 0);
+	}
+}
+
+static void
+tabletnotifytip(struct wl_listener *listener, void *data)
+{
+	TrackedTablet *tt = wl_container_of(listener, tt, tip);
+	struct wlr_tablet_tool_tip_event *event = data;
+	struct wlr_pointer_button_event button_event = {0};
+	struct wlr_tablet_v2_tablet_tool *tool_v2;
+
+	tablet_apply_motion_absoluteonly(tt->tablet, event->tool, event->time_msec, event->x, event->y);
+
+	button_event.time_msec = event->time_msec;
+	button_event.button = BTN_LEFT;
+	button_event.state = event->state == WLR_TABLET_TOOL_TIP_DOWN
+		? WL_POINTER_BUTTON_STATE_PRESSED
+		: WL_POINTER_BUTTON_STATE_RELEASED;
+
+	tool_v2 = get_or_create_tablet_v2_tool(tt->tablet, event->tool);
+	if (tool_v2) {
+		tablet_notify_proximity_in_for_cursor(tt->tablet, event->tool);
+		if (button_event.state == WL_POINTER_BUTTON_STATE_PRESSED)
+			wlr_tablet_v2_tablet_tool_notify_down(tool_v2);
+		else
+			wlr_tablet_v2_tablet_tool_notify_up(tool_v2);
+	}
+
+	/* Routed through buttonpress() rather than calling
+	 * wlr_seat_pointer_notify_button() directly: buttonpress() is where
+	 * Lua button-binding dispatch (click-to-focus/raise) happens. A tip
+	 * on an unfocused window must focus/raise it the same way a mouse
+	 * click would - a raw notify_button() call sends the client the click
+	 * but skips that dispatch entirely. The tablet tool already drives a
+	 * real, hovering cursor (tablet_apply_motion() always calls
+	 * motionnotify()), so tip down/up map directly onto press/release. */
+	buttonpress(NULL, &button_event);
+	wlr_seat_pointer_notify_frame(seat);
+	wlr_idle_notifier_v1_notify_activity(idle_notifier, seat);
+	some_notify_activity();
+}
+
+static void
+tabletnotifybutton(struct wl_listener *listener, void *data)
+{
+	TrackedTablet *tt = wl_container_of(listener, tt, button);
+	struct wlr_tablet_tool_button_event *event = data;
+	struct wlr_tablet_v2_tablet_tool *tool_v2;
+	enum zwp_tablet_pad_v2_button_state state;
+
+	tool_v2 = get_or_create_tablet_v2_tool(tt->tablet, event->tool);
+	if (!tool_v2)
+		return;
+
+	tablet_notify_proximity_in_for_cursor(tt->tablet, event->tool);
+	state = event->state == WLR_BUTTON_PRESSED
+		? ZWP_TABLET_PAD_V2_BUTTON_STATE_PRESSED
+		: ZWP_TABLET_PAD_V2_BUTTON_STATE_RELEASED;
+	wlr_tablet_v2_tablet_tool_notify_button(tool_v2, event->button, state);
+}
+
+static void
+tabletpadnotifybutton(struct wl_listener *listener, void *data)
+{
+	TrackedTabletPad *tp = wl_container_of(listener, tp, button);
+	struct wlr_tablet_pad_button_event *event = data;
+	enum zwp_tablet_pad_v2_button_state state;
+
+	if (!tp->pad_v2)
+		return;
+
+	tabletpad_set_focus_for_cursor(tp);
+	if (!tp->current_surface)
+		return;
+
+	state = event->state == WLR_BUTTON_PRESSED
+		? ZWP_TABLET_PAD_V2_BUTTON_STATE_PRESSED
+		: ZWP_TABLET_PAD_V2_BUTTON_STATE_RELEASED;
+	wlr_tablet_v2_tablet_pad_notify_mode(tp->pad_v2, event->group,
+		event->mode, event->time_msec);
+	wlr_tablet_v2_tablet_pad_notify_button(tp->pad_v2, event->button,
+		event->time_msec, state);
+}
+
+static void
+tabletpadnotifyring(struct wl_listener *listener, void *data)
+{
+	TrackedTabletPad *tp = wl_container_of(listener, tp, ring);
+	struct wlr_tablet_pad_ring_event *event = data;
+	bool finger;
+
+	if (!tp->pad_v2)
+		return;
+
+	tabletpad_set_focus_for_cursor(tp);
+	if (!tp->current_surface)
+		return;
+
+	finger = event->source == WLR_TABLET_PAD_RING_SOURCE_FINGER;
+	wlr_tablet_v2_tablet_pad_notify_ring(tp->pad_v2, event->ring,
+		event->position, finger, event->time_msec);
+}
+
+static void
+tabletpadnotifystrip(struct wl_listener *listener, void *data)
+{
+	TrackedTabletPad *tp = wl_container_of(listener, tp, strip);
+	struct wlr_tablet_pad_strip_event *event = data;
+	bool finger;
+
+	if (!tp->pad_v2)
+		return;
+
+	tabletpad_set_focus_for_cursor(tp);
+	if (!tp->current_surface)
+		return;
+
+	finger = event->source == WLR_TABLET_PAD_STRIP_SOURCE_FINGER;
+	wlr_tablet_v2_tablet_pad_notify_strip(tp->pad_v2, event->strip,
+		event->position, finger, event->time_msec);
+}
+
+static void
+tabletpadnotifyattach(struct wl_listener *listener, void *data)
+{
+	TrackedTabletPad *tp = wl_container_of(listener, tp, attach_tablet);
+	TrackedTablet *tt;
+
+	tt = find_tracked_tablet_by_attach_payload(data);
+	if (tt)
+		tabletpad_attach_tablet(tp, tt->tablet);
+	else
+		tabletpad_attach_tablet(tp, NULL);
+}
+
+static void
+createtablet(struct wlr_tablet *tablet)
+{
+	TrackedTablet *tt = ecalloc(1, sizeof(*tt));
+
+	tt->tablet = tablet;
+	tt->tablet_v2 = tablet_v2_mgr
+		? wlr_tablet_create(tablet_v2_mgr, seat, &tablet->base)
+		: NULL;
+	wl_list_insert(&tracked_tablets, &tt->link);
+
+	LISTEN(&tablet->events.axis, &tt->axis, tabletnotifyaxis);
+	LISTEN(&tablet->events.proximity, &tt->proximity, tabletnotifyproximity);
+	LISTEN(&tablet->events.tip, &tt->tip, tabletnotifytip);
+	LISTEN(&tablet->events.button, &tt->button, tabletnotifybutton);
+	LISTEN(&tablet->base.events.destroy, &tt->destroy, destroytrackedtablet);
+
+	wlr_cursor_attach_input_device(cursor, &tablet->base);
+
+	wlr_log(WLR_INFO,
+		"[tablet] new device name=%s size_mm=%.1fx%.1f vid=0x%04x pid=0x%04x",
+		tablet->base.name ? tablet->base.name : "(unknown)",
+		tablet->width_mm,
+		tablet->height_mm,
+		tablet->usb_vendor_id,
+		tablet->usb_product_id);
+
+	if (!tt->tablet_v2)
+		wlr_log(WLR_INFO, "[tablet] tablet-v2 registration unavailable for device=%s",
+			tablet->base.name ? tablet->base.name : "(unknown)");
+
+	/* Pair with any already-known pad from the same physical hardware. */
+	{
+		TrackedTabletPad *tp;
+		wl_list_for_each(tp, &tracked_tablet_pads, link) {
+			if (tablet_pad_shares_libinput_group(tp->pad, tablet))
+				tabletpad_attach_tablet(tp, tablet);
+		}
+	}
+}
+
+static void
+createtabletpad(struct wlr_tablet_pad *pad)
+{
+	TrackedTabletPad *tp = ecalloc(1, sizeof(*tp));
+
+	tp->pad = pad;
+	tp->pad_v2 = tablet_v2_mgr
+		? wlr_tablet_pad_create(tablet_v2_mgr, seat, &pad->base)
+		: NULL;
+	wl_list_insert(&tracked_tablet_pads, &tp->link);
+	wl_list_init(&tp->surface_destroy.link);
+
+	LISTEN(&pad->events.button, &tp->button, tabletpadnotifybutton);
+	LISTEN(&pad->events.ring, &tp->ring, tabletpadnotifyring);
+	LISTEN(&pad->events.strip, &tp->strip, tabletpadnotifystrip);
+	LISTEN(&pad->events.attach_tablet, &tp->attach_tablet, tabletpadnotifyattach);
+	LISTEN(&pad->base.events.destroy, &tp->destroy, destroytrackedtabletpad);
+
+	wlr_log(WLR_INFO,
+		"[tablet-pad] new device name=%s buttons=%zu rings=%zu strips=%zu",
+		pad->base.name ? pad->base.name : "(unknown)",
+		pad->button_count,
+		pad->ring_count,
+		pad->strip_count);
+
+	if (!tp->pad_v2)
+		wlr_log(WLR_INFO, "[tablet-pad] tablet-v2 registration unavailable for device=%s",
+			pad->base.name ? pad->base.name : "(unknown)");
+
+	/* Pair with any already-known tablet from the same physical hardware. */
+	{
+		TrackedTablet *tt;
+		wl_list_for_each(tt, &tracked_tablets, link) {
+			if (tablet_pad_shares_libinput_group(pad, tt->tablet)) {
+				tabletpad_attach_tablet(tp, tt->tablet);
+				break;
+			}
+		}
 	}
 }
 
@@ -2824,6 +3691,63 @@ destroytrackedpointer(struct wl_listener *listener, void *data)
 	free(tp);
 }
 
+static void
+destroytrackedtablet(struct wl_listener *listener, void *data)
+{
+	TrackedTablet *tt = wl_container_of(listener, tt, destroy);
+	TrackedTabletPad *tp;
+	TrackedTabletTool *ttt;
+
+	/* Other trackers keep raw struct wlr_tablet* back-references
+	 * (attached_tablet / tool->tablet) that wlroots has no signal for;
+	 * clear them here so they don't dangle once tt->tablet is freed. */
+	wl_list_for_each(tp, &tracked_tablet_pads, link) {
+		if (tp->attached_tablet == tt->tablet) {
+			tabletpad_clear_focus(tp);
+			tp->attached_tablet = NULL;
+		}
+	}
+
+	wl_list_for_each(ttt, &tracked_tablet_tools, link) {
+		if (ttt->tablet == tt->tablet)
+			ttt->tablet = NULL;
+	}
+
+	wl_list_remove(&tt->axis.link);
+	wl_list_remove(&tt->proximity.link);
+	wl_list_remove(&tt->tip.link);
+	wl_list_remove(&tt->button.link);
+	wl_list_remove(&tt->destroy.link);
+	wl_list_remove(&tt->link);
+	free(tt);
+}
+
+static void
+destroytrackedtabletpad(struct wl_listener *listener, void *data)
+{
+	TrackedTabletPad *tp = wl_container_of(listener, tp, destroy);
+
+	wl_list_remove(&tp->button.link);
+	wl_list_remove(&tp->ring.link);
+	wl_list_remove(&tp->strip.link);
+	wl_list_remove(&tp->attach_tablet.link);
+	wl_list_remove(&tp->surface_destroy.link);
+	wl_list_remove(&tp->destroy.link);
+	wl_list_remove(&tp->link);
+	free(tp);
+}
+
+static void
+destroytrackedtablettool(struct wl_listener *listener, void *data)
+{
+	TrackedTabletTool *ttt = wl_container_of(listener, ttt, destroy);
+
+	(void)data;
+	wl_list_remove(&ttt->destroy.link);
+	wl_list_remove(&ttt->link);
+	free(ttt);
+}
+
 void
 destroysessionlock(struct wl_listener *listener, void *data)
 {
@@ -3266,6 +4190,12 @@ inputdevice(struct wl_listener *listener, void *data)
 		break;
 	case WLR_INPUT_DEVICE_POINTER:
 		createpointer(wlr_pointer_from_input_device(device));
+		break;
+	case WLR_INPUT_DEVICE_TABLET:
+		createtablet(wlr_tablet_from_input_device(device));
+		break;
+	case WLR_INPUT_DEVICE_TABLET_PAD:
+		createtabletpad(wlr_tablet_pad_from_input_device(device));
 		break;
 	default:
 		wlr_log(WLR_INFO,
@@ -4352,6 +5282,24 @@ motionnotify(uint32_t time, struct wlr_input_device *device, double dx, double d
 			wlr_cursor_set_xcursor(cursor, cursor_mgr, hover_drawin->cursor);
 		else
 			wlr_cursor_set_xcursor(cursor, cursor_mgr, selected_root_cursor ? selected_root_cursor : "default");
+	}
+
+	/* Tablet-capable clients should receive stylus motion via tablet-v2 only.
+	 * Suppress wl_pointer motion emulation to avoid duplicate events in apps
+	 * like Krita's tablet tester. */
+	if (time && !seat->drag && device && device->type == WLR_INPUT_DEVICE_TABLET) {
+		TrackedTablet *tt = find_tracked_tablet_by_device(device);
+		struct wlr_surface *tablet_surface = NULL;
+		double tablet_sx = 0.0, tablet_sy = 0.0;
+
+		xytonode(cursor->x, cursor->y, &tablet_surface, NULL, NULL, NULL, NULL,
+				&tablet_sx, &tablet_sy);
+
+		if (tt && tt->tablet_v2 && tablet_surface
+				&& wlr_surface_accepts_tablet_v2(tablet_surface, tt->tablet_v2)) {
+			wlr_seat_pointer_notify_clear_focus(seat);
+			return;
+		}
 	}
 
 	pointerfocus(c, surface, sx, sy, time);
@@ -5770,6 +6718,9 @@ setup(void)
 	 * backend. */
 	wl_list_init(&mons);
 	wl_list_init(&tracked_pointers);
+	wl_list_init(&tracked_tablets);
+	wl_list_init(&tracked_tablet_pads);
+	wl_list_init(&tracked_tablet_tools);
 	wl_signal_add(&backend->events.new_output, &new_output);
 
 	/* Set up our client lists, the xdg-shell and the layer-shell. The xdg-shell is a
@@ -5883,6 +6834,7 @@ setup(void)
 	wl_signal_add(&seat->events.request_set_primary_selection, &request_set_psel);
 	wl_signal_add(&seat->events.request_start_drag, &request_start_drag);
 	wl_signal_add(&seat->events.start_drag, &start_drag);
+	tablet_v2_mgr = wlr_tablet_v2_create(dpy);
 
 	/* Initialize runtime configuration with C defaults (before Lua loads).
 	 * These defaults provide sane fallbacks if rc.lua doesn't set values.
@@ -5951,6 +6903,20 @@ setup(void)
 	globalconf.input.accel_speed = 0.0;
 	globalconf.input.tap_button_map = NULL;  /* String property - set via Lua */
 	globalconf.input.clickfinger_button_map = NULL;  /* String property - set via Lua */
+
+	globalconf.input.tool_mode = NULL;  /* Rule-only tablet tool property */
+	globalconf.input.map_to_output_list = NULL;  /* Rule-only tablet property */
+	globalconf.input.map_to_output_count = 0;
+	globalconf.input.map_from_region_set = false;
+	globalconf.input.map_from_region_x1 = 0.0;
+	globalconf.input.map_from_region_y1 = 0.0;
+	globalconf.input.map_from_region_x2 = 0.0;
+	globalconf.input.map_from_region_y2 = 0.0;
+	globalconf.input.map_to_region_set = false;
+	globalconf.input.map_to_region_x1 = 0.0;
+	globalconf.input.map_to_region_y1 = 0.0;
+	globalconf.input.map_to_region_x2 = 0.0;
+	globalconf.input.map_to_region_y2 = 0.0;
 
 	/* Logging defaults (only set if not already set by -d flag) */
 	if (globalconf.log_level == 0)

--- a/somewm.c
+++ b/somewm.c
@@ -68,6 +68,7 @@
 #include <wlr/types/wlr_tablet_pad.h>
 #include <wlr/types/wlr_tablet_tool.h>
 #include <wlr/types/wlr_tablet_v2.h>
+#include <wlr/types/wlr_touch.h>
 #include <wlr/types/wlr_viewporter.h>
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/types/wlr_virtual_pointer_v1.h>
@@ -192,6 +193,20 @@ typedef struct {
 	struct wl_list link;
 } TrackedTabletTool;
 
+/* Tracked touch device. wl_touch is core-protocol (gated by
+ * wl_seat.capabilities, not a separate extension manager like tablet-v2),
+ * so no "_v2" handle is needed here. */
+typedef struct {
+	struct wlr_touch *touch;
+	struct wl_listener down;
+	struct wl_listener up;
+	struct wl_listener motion;
+	struct wl_listener cancel;
+	struct wl_listener frame;
+	struct wl_listener destroy;
+	struct wl_list link;
+} TrackedTouch;
+
 /* function declarations */
 static void applybounds(Client *c, struct wlr_box *bbox);
 void arrange(Monitor *m);
@@ -226,6 +241,7 @@ static void createnotify(struct wl_listener *listener, void *data);
 static void createpointer(struct wlr_pointer *pointer);
 static void createtablet(struct wlr_tablet *tablet);
 static void createtabletpad(struct wlr_tablet_pad *pad);
+static void createtouch(struct wlr_touch *touch);
 static void createpointerconstraint(struct wl_listener *listener, void *data);
 static void createpopup(struct wl_listener *listener, void *data);
 void cursorconstrain(struct wlr_pointer_constraint_v1 *constraint);
@@ -246,6 +262,7 @@ static void destroytrackedpointer(struct wl_listener *listener, void *data);
 static void destroytrackedtablet(struct wl_listener *listener, void *data);
 static void destroytrackedtabletpad(struct wl_listener *listener, void *data);
 static void destroytrackedtablettool(struct wl_listener *listener, void *data);
+static void destroytrackedtouch(struct wl_listener *listener, void *data);
 Monitor *dirtomon(enum wlr_direction dir);
 static void apply_input_settings_to_device(struct libinput_device *device);
 void focusclient(Client *c, int lift);
@@ -278,6 +295,11 @@ static void tabletpadnotifyring(struct wl_listener *listener, void *data);
 static void tabletpadnotifystrip(struct wl_listener *listener, void *data);
 static void tabletpadnotifyattach(struct wl_listener *listener, void *data);
 static void tabletpadnotifysurfacedestroy(struct wl_listener *listener, void *data);
+static void touchnotifydown(struct wl_listener *listener, void *data);
+static void touchnotifymotion(struct wl_listener *listener, void *data);
+static void touchnotifyup(struct wl_listener *listener, void *data);
+static void touchnotifycancel(struct wl_listener *listener, void *data);
+static void touchnotifyframe(struct wl_listener *listener, void *data);
 static int keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym);
 static void keypress(struct wl_listener *listener, void *data);
 static void keypressmod(struct wl_listener *listener, void *data);
@@ -425,6 +447,7 @@ static struct wl_list tracked_pointers; /* For runtime libinput config */
 static struct wl_list tracked_tablets;
 static struct wl_list tracked_tablet_pads;
 static struct wl_list tracked_tablet_tools;
+static struct wl_list tracked_touches;
 Monitor *selmon;
 static int in_updatemons;
 static int updatemons_pending;
@@ -2153,35 +2176,40 @@ resolve_input_settings_for_types(const char *type_primary,
 		}
 	}
 }
-/* Normalize tablet coordinates and map them into layout coordinates.
+/* Find the single enabled output, if there is exactly one. Used as a
+ * zero-config default so an unconfigured tablet/touch device maps onto
+ * the one screen that exists instead of spanning the whole layout. Once
+ * a second output is enabled this no longer applies and callers fall
+ * back to whole-layout mapping unless an explicit map_to_output rule is
+ * set. */
+static Monitor *
+single_enabled_monitor(void)
+{
+	Monitor *m, *found = NULL;
+
+	wl_list_for_each(m, &mons, link) {
+		if (!m->wlr_output || !m->wlr_output->enabled)
+			continue;
+		if (found)
+			return NULL; /* more than one enabled output */
+		found = m;
+	}
+
+	return found;
+}
+
+/* Map already-normalized [0,1] device-space coordinates (tx,ty) into layout
+ * coordinates, honoring map_to_region / map_to_output / the single-enabled-
+ * output default. Shared by tablet and touch - tablet additionally crops
+ * via map_from_region before calling this (see tablet_map_coords() below);
+ * touch calls this directly since map_from_region doesn't apply to it.
  * Returns true if an explicit output mapping was successfully applied. */
 static bool
-tablet_map_coords(const struct InputSettings *s, double in_x, double in_y,
+input_map_coords(const struct InputSettings *s, double tx, double ty,
 		double *out_lx, double *out_ly)
 {
 	struct wlr_box box = {0};
 	Monitor *target = NULL;
-	double tx = in_x;
-	double ty = in_y;
-
-	/* First restrict input region to map_from_region setting and
-	 * remap-and-bound it to the unit square.*/
-	if (s->map_from_region_set) {
-		double w = s->map_from_region_x2 - s->map_from_region_x1;
-		double h = s->map_from_region_y2 - s->map_from_region_y1;
-
-		if (fabs(w) < 1e-9 || fabs(h) < 1e-9) {
-			wlr_log(WLR_ERROR,
-				"[tablet-map] invalid map_from_region: (%f,%f)-(%f,%f), falling back to raw coords",
-				s->map_from_region_x1, s->map_from_region_y1,
-				s->map_from_region_x2, s->map_from_region_y2);
-		} else {
-			tx = (in_x - s->map_from_region_x1) / w;
-			ty = (in_y - s->map_from_region_y1) / h;
-			tx = fmax(0.0, fmin(1.0, tx));
-			ty = fmax(0.0, fmin(1.0, ty));
-		}
-	}
 
 	/* An explicit target region takes precedence over map_to_output
 	 * (mirrors sway's mutually-exclusive output/region mapping). */
@@ -2191,7 +2219,7 @@ tablet_map_coords(const struct InputSettings *s, double in_x, double in_y,
 
 		if (fabs(w) < 1e-9 || fabs(h) < 1e-9) {
 			wlr_log(WLR_ERROR,
-				"[tablet-map] invalid map_to_region: (%f,%f)-(%f,%f), falling back to map_to_output",
+				"[input-map] invalid map_to_region: (%f,%f)-(%f,%f), falling back to map_to_output",
 				s->map_to_region_x1, s->map_to_region_y1,
 				s->map_to_region_x2, s->map_to_region_y2);
 		} else {
@@ -2215,9 +2243,14 @@ tablet_map_coords(const struct InputSettings *s, double in_x, double in_y,
 			break;
 
 		wlr_log(WLR_INFO,
-			"[tablet-map] output '%s' not found, trying next candidate",
+			"[input-map] output '%s' not found, trying next candidate",
 			candidate);
 	}
+
+	/* Zero-config default: if nothing matched above and there's exactly
+	 * one enabled output, use it instead of spanning the whole layout. */
+	if (!target)
+		target = single_enabled_monitor();
 
 	/* Target output found. Map coordinates to it. */
 	if (target) {
@@ -2230,6 +2263,39 @@ tablet_map_coords(const struct InputSettings *s, double in_x, double in_y,
 	*out_lx = box.x + tx * box.width;
 	*out_ly = box.y + ty * box.height;
 	return false;
+}
+
+/* Normalize tablet tool coordinates and map them into layout coordinates.
+ * map_from_region crops-then-stretches a sub-area of the tablet's native
+ * surface across the whole target (see input_map_coords() above for why
+ * this doesn't apply to touch), matching real sway: apply_mapping_from_region()
+ * in sway/input/cursor.c is only ever called from handle_tablet_tool_position().
+ * Returns true if an explicit output mapping was successfully applied. */
+static bool
+tablet_map_coords(const struct InputSettings *s, double in_x, double in_y,
+		double *out_lx, double *out_ly)
+{
+	double tx = in_x;
+	double ty = in_y;
+
+	if (s->map_from_region_set) {
+		double w = s->map_from_region_x2 - s->map_from_region_x1;
+		double h = s->map_from_region_y2 - s->map_from_region_y1;
+
+		if (fabs(w) < 1e-9 || fabs(h) < 1e-9) {
+			wlr_log(WLR_ERROR,
+				"[tablet-map] invalid map_from_region: (%f,%f)-(%f,%f), falling back to raw coords",
+				s->map_from_region_x1, s->map_from_region_y1,
+				s->map_from_region_x2, s->map_from_region_y2);
+		} else {
+			tx = (in_x - s->map_from_region_x1) / w;
+			ty = (in_y - s->map_from_region_y1) / h;
+			tx = fmax(0.0, fmin(1.0, tx));
+			ty = fmax(0.0, fmin(1.0, ty));
+		}
+	}
+
+	return input_map_coords(s, tx, ty, out_lx, out_ly);
 }
 
 /* Resolve effective input settings for a device by overlaying matching rules
@@ -2396,6 +2462,16 @@ resolve_tablet_settings(struct wlr_tablet *tablet, struct wlr_tablet_tool *tool,
 	if (tool && (tool->type == WLR_TABLET_TOOL_TYPE_MOUSE
 			|| tool->type == WLR_TABLET_TOOL_TYPE_LENS))
 		out->tool_mode = "relative";
+}
+
+/* primary is the constant "touch"; touch devices have no secondary/tool
+ * axis analogous to tablet tools. */
+static void
+resolve_touch_settings(struct wlr_touch *touch, struct InputSettings *out)
+{
+	const char *dev_name = touch && touch->base.name ? touch->base.name : NULL;
+
+	resolve_input_settings_for_types("touch", NULL, dev_name, out);
 }
 
 static TrackedTablet *
@@ -2598,6 +2674,96 @@ tabletpadnotifysurfacedestroy(struct wl_listener *listener, void *data)
 
 	(void)data;
 	tabletpad_clear_focus(tp);
+}
+
+/* Touch is inherently absolute and multi-point (keyed by touch_id), unlike
+ * tablet tools it doesn't move a shared cursor position via motionnotify();
+ * each point maps straight to layout coords and then surface-local coords. */
+static void
+touchnotifydown(struct wl_listener *listener, void *data)
+{
+	struct wlr_touch_down_event *event = data;
+	struct InputSettings s;
+	struct wlr_surface *surface = NULL;
+	double lx, ly, sx, sy;
+
+	(void)listener;
+	resolve_touch_settings(event->touch, &s);
+	input_map_coords(&s, event->x, event->y, &lx, &ly);
+	xytonode(lx, ly, &surface, NULL, NULL, NULL, NULL, &sx, &sy);
+
+	if (surface)
+		wlr_seat_touch_notify_down(seat, surface, event->time_msec,
+			event->touch_id, sx, sy);
+}
+
+static void
+touchnotifymotion(struct wl_listener *listener, void *data)
+{
+	struct wlr_touch_motion_event *event = data;
+	struct InputSettings s;
+	struct wlr_touch_point *point;
+	struct wlr_surface *surface;
+	Client *c = NULL;
+	LayerSurface *l = NULL;
+	double lx, ly, sx, sy;
+
+	(void)listener;
+
+	point = wlr_seat_touch_get_point(seat, event->touch_id);
+	if (!point)
+		return;
+
+	resolve_touch_settings(event->touch, &s);
+	input_map_coords(&s, event->x, event->y, &lx, &ly);
+
+	/* wlr_seat_touch_notify_motion() takes no surface argument - it always
+	 * delivers to the client of the touch point's original down surface.
+	 * Re-resolving the topmost surface under the finger here, the way the
+	 * down handler does, would compute sx/sy relative to a different
+	 * surface once the finger drags across a window boundary (wrong local
+	 * coords delivered to the down surface's client), and would drop the
+	 * event outright once the finger drags off any surface at all. Stay
+	 * pinned to point->surface instead and project lx/ly onto its origin -
+	 * mirrors how motionnotify() keeps a held mouse button pinned to its
+	 * focused surface while the cursor roams elsewhere. */
+	surface = point->surface;
+	if (!surface || toplevel_from_wlr_surface(surface, &c, &l) < 0)
+		return;
+
+	sx = lx - (l ? l->scene->node.x : c->geometry.x);
+	sy = ly - (l ? l->scene->node.y : c->geometry.y);
+
+	wlr_seat_touch_notify_motion(seat, event->time_msec, event->touch_id, sx, sy);
+}
+
+static void
+touchnotifyup(struct wl_listener *listener, void *data)
+{
+	struct wlr_touch_up_event *event = data;
+
+	(void)listener;
+	wlr_seat_touch_notify_up(seat, event->time_msec, event->touch_id);
+}
+
+static void
+touchnotifycancel(struct wl_listener *listener, void *data)
+{
+	struct wlr_touch_cancel_event *event = data;
+	struct wlr_touch_point *point;
+
+	(void)listener;
+	point = wlr_seat_touch_get_point(seat, event->touch_id);
+	if (point)
+		wlr_seat_touch_notify_cancel(seat, point->client);
+}
+
+static void
+touchnotifyframe(struct wl_listener *listener, void *data)
+{
+	(void)listener;
+	(void)data;
+	wlr_seat_touch_notify_frame(seat);
 }
 
 static void
@@ -3019,6 +3185,27 @@ createtabletpad(struct wlr_tablet_pad *pad)
 			}
 		}
 	}
+}
+
+static void
+createtouch(struct wlr_touch *touch)
+{
+	TrackedTouch *tc = ecalloc(1, sizeof(*tc));
+
+	tc->touch = touch;
+	wl_list_insert(&tracked_touches, &tc->link);
+
+	LISTEN(&touch->events.down, &tc->down, touchnotifydown);
+	LISTEN(&touch->events.up, &tc->up, touchnotifyup);
+	LISTEN(&touch->events.motion, &tc->motion, touchnotifymotion);
+	LISTEN(&touch->events.cancel, &tc->cancel, touchnotifycancel);
+	LISTEN(&touch->events.frame, &tc->frame, touchnotifyframe);
+	LISTEN(&touch->base.events.destroy, &tc->destroy, destroytrackedtouch);
+
+	wlr_cursor_attach_input_device(cursor, &touch->base);
+
+	wlr_log(WLR_INFO, "[touch] new device name=%s",
+		touch->base.name ? touch->base.name : "(unknown)");
 }
 
 void
@@ -3748,6 +3935,22 @@ destroytrackedtablettool(struct wl_listener *listener, void *data)
 	free(ttt);
 }
 
+static void
+destroytrackedtouch(struct wl_listener *listener, void *data)
+{
+	TrackedTouch *tc = wl_container_of(listener, tc, destroy);
+
+	(void)data;
+	wl_list_remove(&tc->down.link);
+	wl_list_remove(&tc->up.link);
+	wl_list_remove(&tc->motion.link);
+	wl_list_remove(&tc->cancel.link);
+	wl_list_remove(&tc->frame.link);
+	wl_list_remove(&tc->destroy.link);
+	wl_list_remove(&tc->link);
+	free(tc);
+}
+
 void
 destroysessionlock(struct wl_listener *listener, void *data)
 {
@@ -4196,6 +4399,9 @@ inputdevice(struct wl_listener *listener, void *data)
 		break;
 	case WLR_INPUT_DEVICE_TABLET_PAD:
 		createtabletpad(wlr_tablet_pad_from_input_device(device));
+		break;
+	case WLR_INPUT_DEVICE_TOUCH:
+		createtouch(wlr_touch_from_input_device(device));
 		break;
 	default:
 		wlr_log(WLR_INFO,
@@ -6721,6 +6927,7 @@ setup(void)
 	wl_list_init(&tracked_tablets);
 	wl_list_init(&tracked_tablet_pads);
 	wl_list_init(&tracked_tablet_tools);
+	wl_list_init(&tracked_touches);
 	wl_signal_add(&backend->events.new_output, &new_output);
 
 	/* Set up our client lists, the xdg-shell and the layer-shell. The xdg-shell is a
@@ -6928,9 +7135,12 @@ setup(void)
 	/* The cursor and the group keyboard exist regardless of physical devices,
 	 * so advertise both capabilities once here. Waiting for a device event
 	 * leaves them at zero on headless backends and clients can bind neither
-	 * wl_pointer nor wl_keyboard. */
+	 * wl_pointer nor wl_keyboard. Touch is advertised unconditionally too,
+	 * for the same reason (a bound wl_touch that never fires costs nothing,
+	 * but toggling capabilities at runtime is fragile). */
 	wlr_seat_set_capabilities(seat,
-		WL_SEAT_CAPABILITY_POINTER | WL_SEAT_CAPABILITY_KEYBOARD);
+		WL_SEAT_CAPABILITY_POINTER | WL_SEAT_CAPABILITY_KEYBOARD
+		| WL_SEAT_CAPABILITY_TOUCH);
 
 	output_mgr = wlr_output_manager_v1_create(dpy);
 	wl_signal_add(&output_mgr->events.apply, &output_mgr_apply);

--- a/somewm.c
+++ b/somewm.c
@@ -68,6 +68,7 @@
 #include <wlr/types/wlr_tablet_pad.h>
 #include <wlr/types/wlr_tablet_tool.h>
 #include <wlr/types/wlr_tablet_v2.h>
+#include <wlr/types/wlr_touch.h>
 #include <wlr/types/wlr_viewporter.h>
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/types/wlr_virtual_pointer_v1.h>
@@ -192,6 +193,20 @@ typedef struct {
 	struct wl_list link;
 } TrackedTabletTool;
 
+/* Tracked touch device. wl_touch is core-protocol (gated by
+ * wl_seat.capabilities, not a separate extension manager like tablet-v2),
+ * so no "_v2" handle is needed here. */
+typedef struct {
+	struct wlr_touch *touch;
+	struct wl_listener down;
+	struct wl_listener up;
+	struct wl_listener motion;
+	struct wl_listener cancel;
+	struct wl_listener frame;
+	struct wl_listener destroy;
+	struct wl_list link;
+} TrackedTouch;
+
 /* function declarations */
 static void applybounds(Client *c, struct wlr_box *bbox);
 void arrange(Monitor *m);
@@ -226,6 +241,7 @@ static void createnotify(struct wl_listener *listener, void *data);
 static void createpointer(struct wlr_pointer *pointer);
 static void createtablet(struct wlr_tablet *tablet);
 static void createtabletpad(struct wlr_tablet_pad *pad);
+static void createtouch(struct wlr_touch *touch);
 static void createpointerconstraint(struct wl_listener *listener, void *data);
 static void createpopup(struct wl_listener *listener, void *data);
 void cursorconstrain(struct wlr_pointer_constraint_v1 *constraint);
@@ -246,6 +262,7 @@ static void destroytrackedpointer(struct wl_listener *listener, void *data);
 static void destroytrackedtablet(struct wl_listener *listener, void *data);
 static void destroytrackedtabletpad(struct wl_listener *listener, void *data);
 static void destroytrackedtablettool(struct wl_listener *listener, void *data);
+static void destroytrackedtouch(struct wl_listener *listener, void *data);
 Monitor *dirtomon(enum wlr_direction dir);
 static void apply_input_settings_to_device(struct libinput_device *device);
 void focusclient(Client *c, int lift);
@@ -278,6 +295,11 @@ static void tabletpadnotifyring(struct wl_listener *listener, void *data);
 static void tabletpadnotifystrip(struct wl_listener *listener, void *data);
 static void tabletpadnotifyattach(struct wl_listener *listener, void *data);
 static void tabletpadnotifysurfacedestroy(struct wl_listener *listener, void *data);
+static void touchnotifydown(struct wl_listener *listener, void *data);
+static void touchnotifymotion(struct wl_listener *listener, void *data);
+static void touchnotifyup(struct wl_listener *listener, void *data);
+static void touchnotifycancel(struct wl_listener *listener, void *data);
+static void touchnotifyframe(struct wl_listener *listener, void *data);
 static int keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym);
 static void keypress(struct wl_listener *listener, void *data);
 static void keypressmod(struct wl_listener *listener, void *data);
@@ -425,6 +447,7 @@ static struct wl_list tracked_pointers; /* For runtime libinput config */
 static struct wl_list tracked_tablets;
 static struct wl_list tracked_tablet_pads;
 static struct wl_list tracked_tablet_tools;
+static struct wl_list tracked_touches;
 Monitor *selmon;
 static int in_updatemons;
 static int updatemons_pending;
@@ -2153,10 +2176,33 @@ resolve_input_settings_for_types(const char *type_primary,
 		}
 	}
 }
-/* Normalize tablet coordinates and map them into layout coordinates.
- * Returns true if an explicit output mapping was successfully applied. */
+/* Find the single enabled output, if there is exactly one. Used as a
+ * zero-config default so an unconfigured tablet/touch device maps onto
+ * the one screen that exists instead of spanning the whole layout. Once
+ * a second output is enabled this no longer applies and callers fall
+ * back to whole-layout mapping unless an explicit map_to_output rule is
+ * set (see feat-touch-support.md / #707 for the reasoning). */
+static Monitor *
+single_enabled_monitor(void)
+{
+	Monitor *m, *found = NULL;
+
+	wl_list_for_each(m, &mons, link) {
+		if (!m->wlr_output || !m->wlr_output->enabled)
+			continue;
+		if (found)
+			return NULL; /* more than one enabled output */
+		found = m;
+	}
+
+	return found;
+}
+
+/* Normalize tablet/touch device coordinates and map them into layout
+ * coordinates. Returns true if an explicit output mapping was successfully
+ * applied. */
 static bool
-tablet_map_coords(const struct InputSettings *s, double in_x, double in_y,
+input_map_coords(const struct InputSettings *s, double in_x, double in_y,
 		double *out_lx, double *out_ly)
 {
 	struct wlr_box box = {0};
@@ -2218,6 +2264,11 @@ tablet_map_coords(const struct InputSettings *s, double in_x, double in_y,
 			"[tablet-map] output '%s' not found, trying next candidate",
 			candidate);
 	}
+
+	/* Zero-config default: if nothing matched above and there's exactly
+	 * one enabled output, use it instead of spanning the whole layout. */
+	if (!target)
+		target = single_enabled_monitor();
 
 	/* Target output found. Map coordinates to it. */
 	if (target) {
@@ -2396,6 +2447,16 @@ resolve_tablet_settings(struct wlr_tablet *tablet, struct wlr_tablet_tool *tool,
 	if (tool && (tool->type == WLR_TABLET_TOOL_TYPE_MOUSE
 			|| tool->type == WLR_TABLET_TOOL_TYPE_LENS))
 		out->tool_mode = "relative";
+}
+
+/* primary is the constant "touch"; touch devices have no secondary/tool
+ * axis analogous to tablet tools. */
+static void
+resolve_touch_settings(struct wlr_touch *touch, struct InputSettings *out)
+{
+	const char *dev_name = touch && touch->base.name ? touch->base.name : NULL;
+
+	resolve_input_settings_for_types("touch", NULL, dev_name, out);
 }
 
 static TrackedTablet *
@@ -2600,6 +2661,96 @@ tabletpadnotifysurfacedestroy(struct wl_listener *listener, void *data)
 	tabletpad_clear_focus(tp);
 }
 
+/* Touch is inherently absolute and multi-point (keyed by touch_id), unlike
+ * tablet tools it doesn't move a shared cursor position via motionnotify();
+ * each point maps straight to layout coords and then surface-local coords. */
+static void
+touchnotifydown(struct wl_listener *listener, void *data)
+{
+	struct wlr_touch_down_event *event = data;
+	struct InputSettings s;
+	struct wlr_surface *surface = NULL;
+	double lx, ly, sx, sy;
+
+	(void)listener;
+	resolve_touch_settings(event->touch, &s);
+	input_map_coords(&s, event->x, event->y, &lx, &ly);
+	xytonode(lx, ly, &surface, NULL, NULL, NULL, NULL, &sx, &sy);
+
+	if (surface)
+		wlr_seat_touch_notify_down(seat, surface, event->time_msec,
+			event->touch_id, sx, sy);
+}
+
+static void
+touchnotifymotion(struct wl_listener *listener, void *data)
+{
+	struct wlr_touch_motion_event *event = data;
+	struct InputSettings s;
+	struct wlr_touch_point *point;
+	struct wlr_surface *surface;
+	Client *c = NULL;
+	LayerSurface *l = NULL;
+	double lx, ly, sx, sy;
+
+	(void)listener;
+
+	point = wlr_seat_touch_get_point(seat, event->touch_id);
+	if (!point)
+		return;
+
+	resolve_touch_settings(event->touch, &s);
+	input_map_coords(&s, event->x, event->y, &lx, &ly);
+
+	/* wlr_seat_touch_notify_motion() takes no surface argument - it always
+	 * delivers to the client of the touch point's original down surface.
+	 * Re-resolving the topmost surface under the finger here, the way the
+	 * down handler does, would compute sx/sy relative to a different
+	 * surface once the finger drags across a window boundary (wrong local
+	 * coords delivered to the down surface's client), and would drop the
+	 * event outright once the finger drags off any surface at all. Stay
+	 * pinned to point->surface instead and project lx/ly onto its origin -
+	 * mirrors how motionnotify() keeps a held mouse button pinned to its
+	 * focused surface while the cursor roams elsewhere. */
+	surface = point->surface;
+	if (!surface || toplevel_from_wlr_surface(surface, &c, &l) < 0)
+		return;
+
+	sx = lx - (l ? l->scene->node.x : c->geometry.x);
+	sy = ly - (l ? l->scene->node.y : c->geometry.y);
+
+	wlr_seat_touch_notify_motion(seat, event->time_msec, event->touch_id, sx, sy);
+}
+
+static void
+touchnotifyup(struct wl_listener *listener, void *data)
+{
+	struct wlr_touch_up_event *event = data;
+
+	(void)listener;
+	wlr_seat_touch_notify_up(seat, event->time_msec, event->touch_id);
+}
+
+static void
+touchnotifycancel(struct wl_listener *listener, void *data)
+{
+	struct wlr_touch_cancel_event *event = data;
+	struct wlr_touch_point *point;
+
+	(void)listener;
+	point = wlr_seat_touch_get_point(seat, event->touch_id);
+	if (point)
+		wlr_seat_touch_notify_cancel(seat, point->client);
+}
+
+static void
+touchnotifyframe(struct wl_listener *listener, void *data)
+{
+	(void)listener;
+	(void)data;
+	wlr_seat_touch_notify_frame(seat);
+}
+
 static void
 tablet_notify_proximity_in_for_cursor(struct wlr_tablet *tablet,
 		struct wlr_tablet_tool *tool)
@@ -2639,7 +2790,7 @@ tablet_apply_absolute_motion(struct wlr_tablet *tablet,
 	double lx, ly, dx, dy;
 
 	resolve_tablet_settings(tablet, tool, &s);
-	tablet_map_coords(&s, x, y, &lx, &ly);
+	input_map_coords(&s, x, y, &lx, &ly);
 	dx = lx - cursor->x;
 	dy = ly - cursor->y;
 
@@ -3019,6 +3170,27 @@ createtabletpad(struct wlr_tablet_pad *pad)
 			}
 		}
 	}
+}
+
+static void
+createtouch(struct wlr_touch *touch)
+{
+	TrackedTouch *tc = ecalloc(1, sizeof(*tc));
+
+	tc->touch = touch;
+	wl_list_insert(&tracked_touches, &tc->link);
+
+	LISTEN(&touch->events.down, &tc->down, touchnotifydown);
+	LISTEN(&touch->events.up, &tc->up, touchnotifyup);
+	LISTEN(&touch->events.motion, &tc->motion, touchnotifymotion);
+	LISTEN(&touch->events.cancel, &tc->cancel, touchnotifycancel);
+	LISTEN(&touch->events.frame, &tc->frame, touchnotifyframe);
+	LISTEN(&touch->base.events.destroy, &tc->destroy, destroytrackedtouch);
+
+	wlr_cursor_attach_input_device(cursor, &touch->base);
+
+	wlr_log(WLR_INFO, "[touch] new device name=%s",
+		touch->base.name ? touch->base.name : "(unknown)");
 }
 
 void
@@ -3748,6 +3920,22 @@ destroytrackedtablettool(struct wl_listener *listener, void *data)
 	free(ttt);
 }
 
+static void
+destroytrackedtouch(struct wl_listener *listener, void *data)
+{
+	TrackedTouch *tc = wl_container_of(listener, tc, destroy);
+
+	(void)data;
+	wl_list_remove(&tc->down.link);
+	wl_list_remove(&tc->up.link);
+	wl_list_remove(&tc->motion.link);
+	wl_list_remove(&tc->cancel.link);
+	wl_list_remove(&tc->frame.link);
+	wl_list_remove(&tc->destroy.link);
+	wl_list_remove(&tc->link);
+	free(tc);
+}
+
 void
 destroysessionlock(struct wl_listener *listener, void *data)
 {
@@ -4196,6 +4384,9 @@ inputdevice(struct wl_listener *listener, void *data)
 		break;
 	case WLR_INPUT_DEVICE_TABLET_PAD:
 		createtabletpad(wlr_tablet_pad_from_input_device(device));
+		break;
+	case WLR_INPUT_DEVICE_TOUCH:
+		createtouch(wlr_touch_from_input_device(device));
 		break;
 	default:
 		wlr_log(WLR_INFO,
@@ -6721,6 +6912,7 @@ setup(void)
 	wl_list_init(&tracked_tablets);
 	wl_list_init(&tracked_tablet_pads);
 	wl_list_init(&tracked_tablet_tools);
+	wl_list_init(&tracked_touches);
 	wl_signal_add(&backend->events.new_output, &new_output);
 
 	/* Set up our client lists, the xdg-shell and the layer-shell. The xdg-shell is a
@@ -6928,9 +7120,12 @@ setup(void)
 	/* The cursor and the group keyboard exist regardless of physical devices,
 	 * so advertise both capabilities once here. Waiting for a device event
 	 * leaves them at zero on headless backends and clients can bind neither
-	 * wl_pointer nor wl_keyboard. */
+	 * wl_pointer nor wl_keyboard. Touch is advertised unconditionally too,
+	 * for the same reason (a bound wl_touch that never fires costs nothing,
+	 * but toggling capabilities at runtime is fragile). */
 	wlr_seat_set_capabilities(seat,
-		WL_SEAT_CAPABILITY_POINTER | WL_SEAT_CAPABILITY_KEYBOARD);
+		WL_SEAT_CAPABILITY_POINTER | WL_SEAT_CAPABILITY_KEYBOARD
+		| WL_SEAT_CAPABILITY_TOUCH);
 
 	output_mgr = wlr_output_manager_v1_create(dpy);
 	wl_signal_add(&output_mgr->events.apply, &output_mgr_apply);

--- a/somewm.c
+++ b/somewm.c
@@ -2145,6 +2145,7 @@ resolve_input_settings_for_types(const char *type_primary,
 		if (p->middle_button_emulation != -2) out->middle_button_emulation = p->middle_button_emulation;
 		if (p->scroll_button != -2) out->scroll_button = p->scroll_button;
 		if (p->scroll_button_lock != -2) out->scroll_button_lock = p->scroll_button_lock;
+		if (p->emulate_pointer != -2) out->emulate_pointer = p->emulate_pointer;
 		if (p->scroll_method) out->scroll_method = p->scroll_method;
 		if (p->click_method) out->click_method = p->click_method;
 		if (p->clickfinger_button_map) out->clickfinger_button_map = p->clickfinger_button_map;
@@ -2676,6 +2677,69 @@ tabletpadnotifysurfacedestroy(struct wl_listener *listener, void *data)
 	tabletpad_clear_focus(tp);
 }
 
+/* A client that never bound wl_touch (e.g. it only understands wl_pointer,
+ * or - for XWayland - Xwayland itself handles touch internally and may or
+ * may not forward a click) needs a synthesized click to be usable by touch
+ * at all. Touch-aware clients (they bound wl_touch) are untouched: this
+ * check is what keeps emulation from ever firing double input for them. */
+static bool
+touch_client_needs_pointer_emulation(struct wlr_surface *surface)
+{
+	struct wlr_seat_client *sc = wlr_seat_client_for_wl_client(seat,
+		wl_resource_get_client(surface->resource));
+	return !sc || wl_list_empty(&sc->touches);
+}
+
+/* Synthesizes an atomic left-click (press+release, no separate touch_id
+ * tracking needed) via buttonpress() so Lua button-binding dispatch and
+ * click-to-focus/raise run normally. Only for clients with no wl_touch
+ * binding - touch-aware clients get real touch instead, see touchnotifydown(). */
+static void
+touch_emulate_click(struct wlr_touch *touch, double lx, double ly, uint32_t time_msec)
+{
+	struct wlr_pointer_button_event press = {0};
+	struct wlr_pointer_button_event release = {0};
+
+	motionnotify(time_msec, &touch->base, lx - cursor->x, ly - cursor->y,
+		lx - cursor->x, ly - cursor->y);
+
+	press.time_msec = time_msec;
+	press.button = BTN_LEFT;
+	press.state = WL_POINTER_BUTTON_STATE_PRESSED;
+	buttonpress(NULL, &press);
+	wlr_seat_pointer_notify_frame(seat);
+
+	release.time_msec = time_msec;
+	release.button = BTN_LEFT;
+	release.state = WL_POINTER_BUTTON_STATE_RELEASED;
+	buttonpress(NULL, &release);
+	wlr_seat_pointer_notify_frame(seat);
+
+	/* Real touch has no hover state; clear synthetic pointer focus so the
+	 * tapped surface doesn't get stuck showing a hover highlight with no
+	 * real mouse-leave ever following. */
+	wlr_seat_pointer_notify_clear_focus(seat);
+}
+
+/* Whether some other surface already has an active touch point right now.
+ * Gates focus-stealing in touchnotifydown(): touching a second, different
+ * window while a touch is still down elsewhere (e.g. drawing on an
+ * unfocused canvas on one screen while touch-scrolling a document on
+ * another) must not disturb whichever window currently has focus.
+ * Concurrent touches on the *same* surface (a two-finger gesture) don't
+ * count as "elsewhere" and don't block focus. */
+static bool
+touch_point_active_elsewhere(struct wlr_surface *surface)
+{
+	struct wlr_touch_point *point;
+
+	wl_list_for_each(point, &seat->touch_state.touch_points, link) {
+		if (point->surface && point->surface != surface)
+			return true;
+	}
+	return false;
+}
+
 /* Touch is inherently absolute and multi-point (keyed by touch_id), unlike
  * tablet tools it doesn't move a shared cursor position via motionnotify();
  * each point maps straight to layout coords and then surface-local coords. */
@@ -2685,16 +2749,42 @@ touchnotifydown(struct wl_listener *listener, void *data)
 	struct wlr_touch_down_event *event = data;
 	struct InputSettings s;
 	struct wlr_surface *surface = NULL;
+	Client *c = NULL;
 	double lx, ly, sx, sy;
 
 	(void)listener;
 	resolve_touch_settings(event->touch, &s);
 	input_map_coords(&s, event->x, event->y, &lx, &ly);
-	xytonode(lx, ly, &surface, NULL, NULL, NULL, NULL, &sx, &sy);
+	xytonode(lx, ly, &surface, &c, NULL, NULL, NULL, &sx, &sy);
 
-	if (surface)
+	if (!surface)
+		return;
+
+	/* wlroots itself refuses to create a touch point (logged as an ERROR)
+	 * for a client with no bound wl_touch resource, so only forward the
+	 * raw event to clients that can actually use it. Everyone else gets
+	 * an emulated click instead, if enabled. */
+	if (!touch_client_needs_pointer_emulation(surface)) {
+		/* Touch-aware clients get real, raw touch - no synthetic
+		 * wl_pointer click (see touch_emulate_click()'s comment for
+		 * why). They still deserve focus/raise on a deliberate tap
+		 * though, the same way a mouse click gets it: go through the
+		 * same rc.lua button-binding dispatch buttonpress() uses,
+		 * just without the final wl_pointer delivery to the client. */
+		if (c && (!client_is_unmanaged(c) || client_wants_focus(c))
+				&& !touch_point_active_elsewhere(surface)) {
+			struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat);
+			uint32_t mods = keyboard ? wlr_keyboard_get_modifiers(keyboard) : 0;
+			int rel_x = (int)lx - c->geometry.x;
+			int rel_y = (int)ly - c->geometry.y;
+
+			luaA_client_button_check(c, rel_x, rel_y, BTN_LEFT,
+			                        CLEANMASK(mods), true);
+		}
 		wlr_seat_touch_notify_down(seat, surface, event->time_msec,
 			event->touch_id, sx, sy);
+	} else if (s.emulate_pointer)
+		touch_emulate_click(event->touch, lx, ly, event->time_msec);
 }
 
 static void
@@ -2710,6 +2800,10 @@ touchnotifymotion(struct wl_listener *listener, void *data)
 
 	(void)listener;
 
+	/* No point was ever created for this touch_id if the down event was
+	 * emulated instead of forwarded (see touchnotifydown()) - skip, same
+	 * guard touchnotifycancel() already uses, avoids another wlroots
+	 * "unknown touch point" ERROR log. */
 	point = wlr_seat_touch_get_point(seat, event->touch_id);
 	if (!point)
 		return;
@@ -2743,7 +2837,8 @@ touchnotifyup(struct wl_listener *listener, void *data)
 	struct wlr_touch_up_event *event = data;
 
 	(void)listener;
-	wlr_seat_touch_notify_up(seat, event->time_msec, event->touch_id);
+	if (wlr_seat_touch_get_point(seat, event->touch_id))
+		wlr_seat_touch_notify_up(seat, event->time_msec, event->touch_id);
 }
 
 static void
@@ -7112,6 +7207,8 @@ setup(void)
 	globalconf.input.clickfinger_button_map = NULL;  /* String property - set via Lua */
 
 	globalconf.input.tool_mode = NULL;  /* Rule-only tablet tool property */
+	globalconf.input.emulate_pointer = 1;  /* touch: synthesize pointer clicks for
+	                                         * clients that never bound wl_touch */
 	globalconf.input.map_to_output_list = NULL;  /* Rule-only tablet property */
 	globalconf.input.map_to_output_count = 0;
 	globalconf.input.map_from_region_set = false;

--- a/somewm.c
+++ b/somewm.c
@@ -2145,6 +2145,7 @@ resolve_input_settings_for_types(const char *type_primary,
 		if (p->middle_button_emulation != -2) out->middle_button_emulation = p->middle_button_emulation;
 		if (p->scroll_button != -2) out->scroll_button = p->scroll_button;
 		if (p->scroll_button_lock != -2) out->scroll_button_lock = p->scroll_button_lock;
+		if (p->emulate_pointer != -2) out->emulate_pointer = p->emulate_pointer;
 		if (p->scroll_method) out->scroll_method = p->scroll_method;
 		if (p->click_method) out->click_method = p->click_method;
 		if (p->clickfinger_button_map) out->clickfinger_button_map = p->clickfinger_button_map;
@@ -2661,6 +2662,81 @@ tabletpadnotifysurfacedestroy(struct wl_listener *listener, void *data)
 	tabletpad_clear_focus(tp);
 }
 
+/* A client that never bound wl_touch (e.g. it only understands wl_pointer,
+ * or - for XWayland - Xwayland itself handles touch internally and may or
+ * may not forward a click) needs a synthesized click to be usable by touch
+ * at all. Touch-aware clients (they bound wl_touch) are untouched: this
+ * check is what keeps emulation from ever firing double input for them. */
+static bool
+touch_client_needs_pointer_emulation(struct wlr_surface *surface)
+{
+	struct wlr_seat_client *sc = wlr_seat_client_for_wl_client(seat,
+		wl_resource_get_client(surface->resource));
+	return !sc || wl_list_empty(&sc->touches);
+}
+
+/* Synthesize a single left-click (press+release together, not press-on-down/
+ * release-on-up) at the touch-down point. Deliberately atomic: real touch
+ * has no hover/drag state to preserve, and firing both here means no
+ * touch_id needs to be tracked across motion/up/cancel for this to work.
+ *
+ * Routed through buttonpress() rather than calling
+ * wlr_seat_pointer_notify_button() directly: buttonpress() is also where
+ * Lua button-binding dispatch happens (luaA_client_button_check() /
+ * luaA_root_button_check()), which is where click-to-focus/raise actually
+ * lives (an rc.lua-configured behavior, not hardcoded C). A direct
+ * notify_button() call sends the client a raw click but skips that dispatch
+ * entirely, so tapping an unfocused window never focused/raised it. Real
+ * touch on touch-aware clients (Krita, GIMP, ...) is intentionally NOT
+ * routed through here - a synthetic wl_pointer click on top of their real
+ * wl_touch input would be double input. See touchnotifydown() for how those
+ * clients still get focus/raise on a plain tap, without the click. */
+static void
+touch_emulate_click(struct wlr_touch *touch, double lx, double ly, uint32_t time_msec)
+{
+	struct wlr_pointer_button_event press = {0};
+	struct wlr_pointer_button_event release = {0};
+
+	motionnotify(time_msec, &touch->base, lx - cursor->x, ly - cursor->y,
+		lx - cursor->x, ly - cursor->y);
+
+	press.time_msec = time_msec;
+	press.button = BTN_LEFT;
+	press.state = WL_POINTER_BUTTON_STATE_PRESSED;
+	buttonpress(NULL, &press);
+	wlr_seat_pointer_notify_frame(seat);
+
+	release.time_msec = time_msec;
+	release.button = BTN_LEFT;
+	release.state = WL_POINTER_BUTTON_STATE_RELEASED;
+	buttonpress(NULL, &release);
+	wlr_seat_pointer_notify_frame(seat);
+
+	/* Real touch has no hover state; clear synthetic pointer focus so the
+	 * tapped surface doesn't get stuck showing a hover highlight with no
+	 * real mouse-leave ever following. */
+	wlr_seat_pointer_notify_clear_focus(seat);
+}
+
+/* Whether some other surface already has an active touch point right now.
+ * Gates focus-stealing in touchnotifydown(): touching a second, different
+ * window while a touch is still down elsewhere (e.g. drawing on an
+ * unfocused canvas on one screen while touch-scrolling a document on
+ * another) must not disturb whichever window currently has focus - see
+ * #612. Concurrent touches on the *same* surface (a two-finger gesture)
+ * don't count as "elsewhere" and don't block focus. */
+static bool
+touch_point_active_elsewhere(struct wlr_surface *surface)
+{
+	struct wlr_touch_point *point;
+
+	wl_list_for_each(point, &seat->touch_state.touch_points, link) {
+		if (point->surface && point->surface != surface)
+			return true;
+	}
+	return false;
+}
+
 /* Touch is inherently absolute and multi-point (keyed by touch_id), unlike
  * tablet tools it doesn't move a shared cursor position via motionnotify();
  * each point maps straight to layout coords and then surface-local coords. */
@@ -2670,16 +2746,42 @@ touchnotifydown(struct wl_listener *listener, void *data)
 	struct wlr_touch_down_event *event = data;
 	struct InputSettings s;
 	struct wlr_surface *surface = NULL;
+	Client *c = NULL;
 	double lx, ly, sx, sy;
 
 	(void)listener;
 	resolve_touch_settings(event->touch, &s);
 	input_map_coords(&s, event->x, event->y, &lx, &ly);
-	xytonode(lx, ly, &surface, NULL, NULL, NULL, NULL, &sx, &sy);
+	xytonode(lx, ly, &surface, &c, NULL, NULL, NULL, &sx, &sy);
 
-	if (surface)
+	if (!surface)
+		return;
+
+	/* wlroots itself refuses to create a touch point (logged as an ERROR)
+	 * for a client with no bound wl_touch resource, so only forward the
+	 * raw event to clients that can actually use it. Everyone else gets
+	 * an emulated click instead, if enabled. */
+	if (!touch_client_needs_pointer_emulation(surface)) {
+		/* Touch-aware clients get real, raw touch - no synthetic
+		 * wl_pointer click (see touch_emulate_click()'s comment for
+		 * why). They still deserve focus/raise on a deliberate tap
+		 * though, the same way a mouse click gets it: go through the
+		 * same rc.lua button-binding dispatch buttonpress() uses,
+		 * just without the final wl_pointer delivery to the client. */
+		if (c && (!client_is_unmanaged(c) || client_wants_focus(c))
+				&& !touch_point_active_elsewhere(surface)) {
+			struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat);
+			uint32_t mods = keyboard ? wlr_keyboard_get_modifiers(keyboard) : 0;
+			int rel_x = (int)lx - c->geometry.x;
+			int rel_y = (int)ly - c->geometry.y;
+
+			luaA_client_button_check(c, rel_x, rel_y, BTN_LEFT,
+			                        CLEANMASK(mods), true);
+		}
 		wlr_seat_touch_notify_down(seat, surface, event->time_msec,
 			event->touch_id, sx, sy);
+	} else if (s.emulate_pointer)
+		touch_emulate_click(event->touch, lx, ly, event->time_msec);
 }
 
 static void
@@ -2695,6 +2797,10 @@ touchnotifymotion(struct wl_listener *listener, void *data)
 
 	(void)listener;
 
+	/* No point was ever created for this touch_id if the down event was
+	 * emulated instead of forwarded (see touchnotifydown()) - skip, same
+	 * guard touchnotifycancel() already uses, avoids another wlroots
+	 * "unknown touch point" ERROR log. */
 	point = wlr_seat_touch_get_point(seat, event->touch_id);
 	if (!point)
 		return;
@@ -2728,7 +2834,8 @@ touchnotifyup(struct wl_listener *listener, void *data)
 	struct wlr_touch_up_event *event = data;
 
 	(void)listener;
-	wlr_seat_touch_notify_up(seat, event->time_msec, event->touch_id);
+	if (wlr_seat_touch_get_point(seat, event->touch_id))
+		wlr_seat_touch_notify_up(seat, event->time_msec, event->touch_id);
 }
 
 static void
@@ -7097,6 +7204,8 @@ setup(void)
 	globalconf.input.clickfinger_button_map = NULL;  /* String property - set via Lua */
 
 	globalconf.input.tool_mode = NULL;  /* Rule-only tablet tool property */
+	globalconf.input.emulate_pointer = 1;  /* touch: synthesize pointer clicks for
+	                                         * clients that never bound wl_touch */
 	globalconf.input.map_to_output_list = NULL;  /* Rule-only tablet property */
 	globalconf.input.map_to_output_count = 0;
 	globalconf.input.map_from_region_set = false;

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -1385,6 +1385,25 @@ some_monitor_at_cursor(void)
 }
 
 /*
+ * Find monitor by output name (e.g., "HDMI-A-1", "eDP-1")
+ */
+Monitor *
+some_monitor_by_name(const char *name)
+{
+	Monitor *m;
+
+	if (!name)
+		return NULL;
+
+	wl_list_for_each(m, &mons, link) {
+		if (m->wlr_output && m->wlr_output->name && strcmp(m->wlr_output->name, name) == 0)
+			return m;
+	}
+
+	return NULL;
+}
+
+/*
  * Get current cursor position
  */
 void

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -1385,7 +1385,22 @@ some_monitor_at_cursor(void)
 }
 
 /*
- * Find monitor by output name (e.g., "HDMI-A-1", "eDP-1")
+ * Build the "make model serial" output identifier (same convention as sway
+ * and wlr-randr). Unlike the connector name (e.g. "DP-8"), this stays
+ * stable across DRM connector renumbering on replug/redock.
+ */
+static void
+monitor_output_identifier(struct wlr_output *output, char *buf, size_t len)
+{
+	snprintf(buf, len, "%s %s %s",
+		output->make ? output->make : "Unknown",
+		output->model ? output->model : "Unknown",
+		output->serial ? output->serial : "Unknown");
+}
+
+/*
+ * Find monitor by output name (e.g., "HDMI-A-1", "eDP-1") or, failing that,
+ * by its make/model/serial identifier (e.g. "Dell Inc. DELL U2415 ABC123").
  */
 Monitor *
 some_monitor_by_name(const char *name)
@@ -1397,6 +1412,17 @@ some_monitor_by_name(const char *name)
 
 	wl_list_for_each(m, &mons, link) {
 		if (m->wlr_output && m->wlr_output->name && strcmp(m->wlr_output->name, name) == 0)
+			return m;
+	}
+
+	wl_list_for_each(m, &mons, link) {
+		char id[256];
+
+		if (!m->wlr_output)
+			continue;
+
+		monitor_output_identifier(m->wlr_output, id, sizeof(id));
+		if (strcmp(id, name) == 0)
 			return m;
 	}
 

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -126,6 +126,7 @@ Monitor *some_get_focused_monitor(void);
 struct wl_list *some_get_monitors(void);
 Monitor *some_monitor_at(double lx, double ly);
 Monitor *some_monitor_from_direction(Monitor *from, enum wlr_direction dir);
+Monitor *some_monitor_by_name(const char *name);
 void some_focus_monitor(Monitor *m);
 void some_focus_monitor_direction(enum wlr_direction dir);
 void some_move_client_to_monitor_direction(enum wlr_direction dir);

--- a/spec/awful/input_spec.lua
+++ b/spec/awful/input_spec.lua
@@ -371,6 +371,27 @@ describe("awful.input", function()
             assert.is.equal(3, #input.rules)
             assert.is.same(rules, input.rules)
         end)
+
+        it("rules accept tablet properties", function()
+            local rules = {
+                { rule = { type = "tablet" },
+                  properties = {
+                      map_to_output = "*",
+                                            tool_mode = "absolute",
+                      map_from_region = "0x0 100x100",
+                  } },
+                                { rule = { type = "tablet-tool-pen", name = "Wacom Intuos S Pen" },
+                  properties = {
+                                            tool_mode = "relative",
+                      map_to_output = "DP-1",
+                      map_from_region = { x1 = 1, y1 = 2, x2 = 3, y2 = 4 },
+                  } },
+            }
+
+            input.rules = rules
+            assert.is.same(rules, input.rules)
+            assert.is.equal(1, #input_rules_calls)
+        end)
     end)
 
     describe("realistic usage scenarios", function()

--- a/spec/awful/input_spec.lua
+++ b/spec/awful/input_spec.lua
@@ -400,6 +400,7 @@ describe("awful.input", function()
                 { rule = { type = "touch", name = "Wacom HID 1234 Finger" },
                   properties = {
                       map_to_output = { "eDP-1", "AOC U27E3U ZX3QBHA000360" },
+                      emulate_pointer = false,
                   } },
             }
 

--- a/spec/awful/input_spec.lua
+++ b/spec/awful/input_spec.lua
@@ -392,6 +392,21 @@ describe("awful.input", function()
             assert.is.same(rules, input.rules)
             assert.is.equal(1, #input_rules_calls)
         end)
+
+        it("rules accept touch properties", function()
+            local rules = {
+                { rule = { type = "touch" },
+                  properties = { map_to_output = "*" } },
+                { rule = { type = "touch", name = "Wacom HID 1234 Finger" },
+                  properties = {
+                      map_to_output = { "eDP-1", "AOC U27E3U ZX3QBHA000360" },
+                  } },
+            }
+
+            input.rules = rules
+            assert.is.same(rules, input.rules)
+            assert.is.equal(1, #input_rules_calls)
+        end)
     end)
 
     describe("realistic usage scenarios", function()

--- a/tests/test-input-rules-region-parsing.lua
+++ b/tests/test-input-rules-region-parsing.lua
@@ -1,0 +1,64 @@
+--- Test that a "0"-leading map_from_region/map_to_region string parses.
+--
+-- input_rule_get_region() parsed "X1xY1 X2xY2" strings with
+-- sscanf(raw, "%lfx%lf %lfx%lf", ...). glibc's %lf conversion also accepts
+-- C99 hex-float syntax, and permissively treats a bare "0x0" (no required
+-- 'p' exponent) as the complete value 0.0 - so the first %lf silently
+-- swallowed the "0x" of a "0x0 ..." string as a hex-float lead-in instead
+-- of stopping at the intended 'x' separator, breaking any region string
+-- whose first coordinate is 0 - the natural top-left corner, so the single
+-- most common value anyone would type (#692).
+
+local input = require("awful.input")
+
+local steps = {}
+
+table.insert(steps, function()
+    local ok, err = pcall(function()
+        input.rules = {
+            { rule = { type = "tablet" },
+              properties = { map_from_region = "0x0 0.5x0.5" } },
+        }
+    end)
+
+    assert(ok, "regression: a '0x0 ...' map_from_region string raised an "
+        .. "error: " .. tostring(err))
+
+    return true
+end)
+
+table.insert(steps, function()
+    -- map_to_region shares the same parser - same coverage.
+    local ok, err = pcall(function()
+        input.rules = {
+            { rule = { type = "tablet" },
+              properties = { map_to_region = "0x0 100x100" } },
+        }
+    end)
+
+    assert(ok, "regression: a '0x0 ...' map_to_region string raised an "
+        .. "error: " .. tostring(err))
+
+    return true
+end)
+
+table.insert(steps, function()
+    -- The parser should still reject genuinely malformed strings.
+    local ok = pcall(function()
+        input.rules = {
+            { rule = { type = "tablet" },
+              properties = { map_from_region = "garbage" } },
+        }
+    end)
+
+    assert(not ok, "malformed map_from_region string should still error")
+
+    -- Clear the rule so it doesn't leak into later tests.
+    input.rules = {}
+
+    return true
+end)
+
+require("_runner").run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
## Description

It adds tablet support as described in feature issue #663 and touch support as described in feature issue #707.

The following developments could naturally follow up on this PR:
 - Adding support for input rule management of somewem-client.

## Test Plan

Only little test code coverage. Mainly manual tests.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
