### PR TITLE
fix(tag): Prevent null tag->name crash

### DIFF
--- a/ewmh.c
+++ b/ewmh.c
@@ -631,7 +631,7 @@ ewmh_update_net_desktop_names(void)
     /* Build NULL-separated UTF8 string list (EWMH spec) */
     total_len = 0;
     foreach(tag, globalconf.tags)
-        total_len += strlen((*tag)->name) + 1;
+        total_len += a_strlen((*tag)->name) + 1;
 
     if (total_len == 0)
         return;
@@ -640,7 +640,7 @@ ewmh_update_net_desktop_names(void)
     p = names;
     foreach(tag, globalconf.tags)
     {
-        len = strlen((*tag)->name);
+        len = a_strlen((*tag)->name);
         memcpy(p, (*tag)->name, len);
         p += len;
         *p++ = '\0';

--- a/ewmh.c
+++ b/ewmh.c
@@ -641,7 +641,8 @@ ewmh_update_net_desktop_names(void)
     foreach(tag, globalconf.tags)
     {
         len = a_strlen((*tag)->name);
-        memcpy(p, (*tag)->name, len);
+        if (len)
+            memcpy(p, (*tag)->name, len);
         p += len;
         *p++ = '\0';
     }


### PR DESCRIPTION
## Description
Changes 2 `strlen` calls to null resistant `a_strlen` while walking `globalconf.tags`, which could be given null tag->name if tags with empty names (`""`, `nil`)already exist. Occurs after Xwayland is started and a new tag is added. Fixes #693.


## Test Plan
Tested with various tag creations with and without names.


## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
