### PR TITLE
fix(ewmh): prevent null tag->name crash in _NET_DESKTOP_NAMES

### DIFF
--- a/ewmh.c
+++ b/ewmh.c
@@ -426,7 +426,8 @@ ewmh_update_net_desktop_names(void)
     foreach(tag, globalconf.tags)
     {
         len = a_strlen((*tag)->name);
-        memcpy(p, (*tag)->name, len);
+        if (len)
+            memcpy(p, (*tag)->name, len);
         p += len;
         *p++ = '\0';
     }

--- a/ewmh.c
+++ b/ewmh.c
@@ -416,7 +416,7 @@ ewmh_update_net_desktop_names(void)
     /* Build NULL-separated UTF8 string list (EWMH spec) */
     total_len = 0;
     foreach(tag, globalconf.tags)
-        total_len += strlen((*tag)->name) + 1;
+        total_len += a_strlen((*tag)->name) + 1;
 
     if (total_len == 0)
         return;
@@ -425,7 +425,7 @@ ewmh_update_net_desktop_names(void)
     p = names;
     foreach(tag, globalconf.tags)
     {
-        len = strlen((*tag)->name);
+        len = a_strlen((*tag)->name);
         memcpy(p, (*tag)->name, len);
         p += len;
         *p++ = '\0';


### PR DESCRIPTION
## Description
Cherry-picks #696 forward. `ewmh_update_net_desktop_names()` called `strlen()` on
`tag->name`, which is NULL for a tag with no name or an empty one. Adding a tag
after XWayland starts then crashed the compositor.

## Test Plan
`make test-unit` and `make test-integration` on this branch.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
