### PR TITLE
fix(input): skip root button bindings for clicks on a wibar

### DIFF
--- a/input.c
+++ b/input.c
@@ -587,8 +587,11 @@ buttonpress(struct wl_listener *listener, void *data)
 			}
 		}
 
-		/* Check root button bindings (ONLY for empty space, not client clicks) */
-		if (!c && !l) {
+		/* Check root button bindings (only over empty desktop). A click on a
+		 * wibar belongs to that wibar whether or not a widget consumed it:
+		 * AwesomeWM grabs root buttons on the root window, which a wibox click
+		 * never reaches. */
+		if (!c && !l && !drawin) {
 			lua_State *L = globalconf_get_lua_State();
 
 			/* Check root button bindings */

--- a/tests/test-root-button-wibar.lua
+++ b/tests/test-root-button-wibar.lua
@@ -1,0 +1,68 @@
+---------------------------------------------------------------------------
+--- Regression test: a right click on a wibar must not fire root bindings.
+---
+--- buttonpress() ran the root button check whenever no client and no layer
+--- surface was under the cursor, and a wibar click sets neither: the root
+--- binding (the main menu in the default config) fired on top of whatever
+--- the wibar itself did with the click.
+---
+--- The click is injected with test-virtual-pointer-client so it traverses the
+--- real buttonpress() path (root.fake_input bypasses it).
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local async  = require("_async")
+local awful  = require("awful")
+
+local VPOINTER = "./build-test/test-virtual-pointer-client"
+
+local f = io.open(VPOINTER, "r")
+if not f then
+    io.stderr:write("SKIP: " .. VPOINTER .. " not found (run meson compile first)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+f:close()
+
+runner.run_async(function()
+    local s  = screen[1]
+    local sg = s.geometry
+
+    local bar = awful.wibar { position = "top", screen = s, height = 20 }
+    local bar_presses = 0
+    bar:connect_signal("button::press", function() bar_presses = bar_presses + 1 end)
+
+    local root_presses = 0
+    awful.mouse.append_global_mousebindings({
+        awful.button({ }, 3, function() root_presses = root_presses + 1 end),
+    })
+    async.sleep(0.2)
+
+    local bg = bar:geometry()
+    assert(bg.height > 0, "wibar has no geometry")
+
+    local function right_click(x, y)
+        awful.spawn(string.format("%s click %d %d %d %d right",
+                                  VPOINTER, x, y, sg.width, sg.height))
+        async.sleep(1)
+    end
+
+    -- Right click on the wibar: the wibar sees it, the root binding must not.
+    right_click(bg.x + math.floor(bg.width / 2), bg.y + math.floor(bg.height / 2))
+    assert(bar_presses > 0, "click never reached the wibar")
+    assert(root_presses == 0,
+        "root button binding fired for a click on the wibar (" .. root_presses .. ")")
+
+    -- Right click on empty desktop: the root binding still works.
+    right_click(sg.x + math.floor(sg.width / 2), sg.y + math.floor(sg.height / 2))
+    assert(root_presses == 1,
+        "root button binding did not fire on empty desktop (" .. root_presses .. ")")
+
+    io.stderr:write("[ALL TESTS] PASS\n")
+
+    bar.visible = false
+    runner.done()
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-virtual-pointer-client.c
+++ b/tests/test-virtual-pointer-client.c
@@ -7,10 +7,12 @@
  * path: mousegrabber routing, client button bindings, and seat notification.
  *
  * Usage: test-virtual-pointer-client <move|click> <x> <y> <x_extent> <y_extent>
+ *                                     [left|middle|right]
  *
  * x/y are layout coordinates; x_extent/y_extent the layout size (normally the
  * screen geometry). "move" only positions the cursor; "click" also presses and
- * releases BTN_LEFT. Exits after the events are flushed.
+ * releases the given button (left by default). Exits after the events are
+ * flushed.
  */
 
 #include <linux/input-event-codes.h>
@@ -55,10 +57,24 @@ static const struct wl_registry_listener registry_listener = {
     .global_remove = registry_global_remove,
 };
 
+static uint32_t button_code(const char *name) {
+    if (strcmp(name, "left") == 0) return BTN_LEFT;
+    if (strcmp(name, "middle") == 0) return BTN_MIDDLE;
+    if (strcmp(name, "right") == 0) return BTN_RIGHT;
+    return 0;
+}
+
 int main(int argc, char *argv[]) {
-    if (argc != 6 || (strcmp(argv[1], "move") != 0 && strcmp(argv[1], "click") != 0)) {
-        fprintf(stderr, "Usage: %s <move|click> <x> <y> <x_extent> <y_extent>\n",
-                argv[0]);
+    if ((argc != 6 && argc != 7)
+            || (strcmp(argv[1], "move") != 0 && strcmp(argv[1], "click") != 0)) {
+        fprintf(stderr, "Usage: %s <move|click> <x> <y> <x_extent> <y_extent> "
+                "[left|middle|right]\n", argv[0]);
+        return 1;
+    }
+    uint32_t btn = argc == 7 ? button_code(argv[6]) : BTN_LEFT;
+    if (!btn) {
+        fprintf(stderr, "Unknown button: %s (expected left, middle or right)\n",
+                argv[6]);
         return 1;
     }
     int click = strcmp(argv[1], "click") == 0;
@@ -98,12 +114,12 @@ int main(int argc, char *argv[]) {
 
     if (click) {
         sleep_ms(50);
-        zwlr_virtual_pointer_v1_button(pointer, now_ms(), BTN_LEFT,
+        zwlr_virtual_pointer_v1_button(pointer, now_ms(), btn,
                                        WL_POINTER_BUTTON_STATE_PRESSED);
         zwlr_virtual_pointer_v1_frame(pointer);
         wl_display_roundtrip(display);
         sleep_ms(50);
-        zwlr_virtual_pointer_v1_button(pointer, now_ms(), BTN_LEFT,
+        zwlr_virtual_pointer_v1_button(pointer, now_ms(), btn,
                                        WL_POINTER_BUTTON_STATE_RELEASED);
         zwlr_virtual_pointer_v1_frame(pointer);
         wl_display_roundtrip(display);


### PR DESCRIPTION
## Description

Cherry-picks #700 onto main. The block lives in `input.c` here.

## Test Plan

`tests/test-root-button-wibar.lua` fails on the parent commit, passes here.
`make test-unit` and the integration suite pass.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified**
- [x] Tests pass (`make test-unit && make test-integration`)