### PR TITLE
fix(input): deliver scroll ticks to the mousegrabber as buttons 4/5

### DIFF
--- a/event.c
+++ b/event.c
@@ -14,6 +14,7 @@
 #include "globalconf.h"
 #include "objects/button.h"
 #include "objects/mousegrabber.h"
+#include "somewm_api.h"
 #include "luaa.h"
 #include "common/luaobject.h"
 #include "common/util.h"
@@ -139,27 +140,26 @@ event_emit_button(lua_State *L, button_event_t *ev)
 /** Handle event with mousegrabber if active
  * Ported from AwesomeWM's event_handle_mousegrabber()
  *
+ * The mask passed to the grabber is built from the tracked button state;
+ * extra_mask bits are ORed in. Scroll buttons (4-7) are synthesized from
+ * axis events and never held, so they only ever arrive via extra_mask.
+ *
  * \param x Mouse X coordinate
  * \param y Mouse Y coordinate
- * \param button_states Array of 5 button states
+ * \param extra_mask X11-style button mask bits to add to the tracked state
  * \return true if event consumed by mousegrabber
  */
-static bool __attribute__((unused))
-event_handle_mousegrabber(double x, double y, int button_states[5])
+bool
+event_handle_mousegrabber(double x, double y, uint16_t extra_mask)
 {
     lua_State *L;
-    uint16_t mask = 0;
+    uint16_t mask;
 
     if (!mousegrabber_isrunning())
         return false;
 
     L = globalconf_get_lua_State();
-
-    /* Convert button_states array to X11-style mask */
-    for (int i = 0; i < 5; i++) {
-        if (button_states[i])
-            mask |= (1 << (8 + i));
-    }
+    mask = extra_mask | some_button_state_mask();
 
     /* Push coords table to stack */
     mousegrabber_handleevent(L, (int)x, (int)y, mask);
@@ -188,6 +188,30 @@ event_handle_mousegrabber(double x, double y, int button_states[5])
 
     lua_pop(L, 1);  /* Pop coords table */
     return true;
+}
+
+/** Deliver scroll ticks to the mousegrabber as X11-style button events.
+ *
+ * X11 delivers each tick as a press+release pair: the button's state mask
+ * bit set, then cleared. Only buttons 1-5 have a state mask bit, so
+ * horizontal ticks (buttons 6/7) set no flag, matching upstream.
+ *
+ * \param x Mouse X coordinate
+ * \param y Mouse Y coordinate
+ * \param button X11 button number (4-7)
+ * \param ticks Number of full scroll ticks to deliver
+ */
+void
+event_handle_mousegrabber_scroll(double x, double y, uint32_t button, int ticks)
+{
+    uint16_t press_mask = button <= 5 ? 1 << (7 + button) : 0;
+
+    for (int tick = 0; tick < ticks; tick++) {
+        if (!event_handle_mousegrabber(x, y, press_mask))
+            break;
+        if (!event_handle_mousegrabber(x, y, 0))
+            break;
+    }
 }
 
 /** Record that the given drawable contains the pointer.

--- a/event.h
+++ b/event.h
@@ -36,4 +36,13 @@ void event_button_callback(button_event_t *ev, button_array_t *arr,
  */
 void event_drawable_under_mouse(lua_State *L, int ud);
 
+/** Route an input event to the mousegrabber if one is active.
+ * \return true if the event was consumed by the mousegrabber.
+ */
+bool event_handle_mousegrabber(double x, double y, uint16_t extra_mask);
+
+/** Deliver scroll ticks to an active mousegrabber as press+release pairs. */
+void event_handle_mousegrabber_scroll(double x, double y, uint32_t button,
+                                      int ticks);
+
 #endif /* SOMEWM_EVENT_H */

--- a/globalconf.h
+++ b/globalconf.h
@@ -225,7 +225,8 @@ typedef struct
      * This is the Wayland equivalent of X11's passive button grab state.
      */
     struct {
-        bool buttons[5];  /* Button 1-5 pressed states (true = pressed) */
+        bool buttons[5];  /* X11 button 1-5 pressed states; only 1-3 are
+                           * ever set (4/5 mean scroll, never held) */
     } button_state;
 
     /** The exit code that main() will return with */

--- a/mouse.c
+++ b/mouse.c
@@ -79,21 +79,13 @@ bool
 mouse_query_pointer(int16_t *x, int16_t *y, uint16_t *mask)
 {
     double dx, dy;
-    int button_states[5];
 
     some_get_cursor_position(&dx, &dy);
     *x = (int16_t)dx;
     *y = (int16_t)dy;
 
-    if (mask) {
-        some_get_button_states(button_states);
-        /* Convert button array to X11-style mask for API compatibility */
-        *mask = 0;
-        for (int i = 0; i < 5; i++) {
-            if (button_states[i])
-                *mask |= (1 << (8 + i)); /* XCB_BUTTON_MASK_1 = 1<<8, etc. */
-        }
-    }
+    if (mask)
+        *mask = some_button_state_mask();
 
     return true;
 }

--- a/somewm.c
+++ b/somewm.c
@@ -797,53 +797,8 @@ axisnotify(struct wl_listener *listener, void *data)
 	wlr_idle_notifier_v1_notify_activity(idle_notifier, seat);
 	some_notify_activity();
 
-	/* If mousegrabber is active, route event to Lua callback */
-	if (mousegrabber_isrunning()) {
-		lua_State *L = globalconf_get_lua_State();
-		int button_states[5];
-		uint16_t mask = 0;
-
-		/* Get current button states */
-		some_get_button_states(button_states);
-
-		/* Convert button_states array to X11-style mask */
-		for (int i = 0; i < 5; i++) {
-			if (button_states[i])
-				mask |= (1 << (8 + i));
-		}
-
-		/* Push coords table to Lua stack */
-		mousegrabber_handleevent(L, cursor->x, cursor->y, mask);
-
-		/* Get the callback from registry */
-		lua_rawgeti(L, LUA_REGISTRYINDEX, globalconf.mousegrabber);
-
-		/* Push coords table as argument */
-		lua_pushvalue(L, -2);
-
-		/* Call callback(coords) */
-		if (lua_pcall(L, 1, 1, 0) == 0) {
-			/* Check return value */
-			int continue_grab = lua_toboolean(L, -1);
-			lua_pop(L, 1); /* Pop return value */
-
-			if (!continue_grab) {
-				/* Callback returned false, stop grabbing */
-				luaA_mousegrabber_stop(L);
-			}
-		} else {
-			/* Error in callback */
-			fprintf(stderr, "somewm: mousegrabber callback error: %s\n",
-				lua_tostring(L, -1));
-			lua_pop(L, 1);
-			luaA_mousegrabber_stop(L);
-		}
-
-		lua_pop(L, 1); /* Pop coords table */
-		return; /* Don't process event further */
-	}
-
-	/* Handle scroll wheel for mousebindings (AwesomeWM compatibility)
+	/* Handle scroll wheel for mousebindings and the mousegrabber
+	 * (AwesomeWM compatibility).
 	 * Convert axis events to X11-style button 4/5/6/7 press+release events.
 	 * In X11, each scroll tick generates a button press+release pair.
 	 *
@@ -858,6 +813,7 @@ axisnotify(struct wl_listener *listener, void *data)
 		static int32_t scroll_acc_h = 0;
 		int32_t *acc;
 		int ticks = 0;
+		uint32_t button;
 
 		acc = (event->orientation == WL_POINTER_AXIS_VERTICAL_SCROLL)
 			? &scroll_acc_v : &scroll_acc_h;
@@ -878,6 +834,18 @@ axisnotify(struct wl_listener *listener, void *data)
 		if ((event->delta > 0 && *acc < 0) || (event->delta < 0 && *acc > 0))
 			*acc = 0;
 
+		/* Determine button number based on axis orientation and direction */
+		if (event->orientation == WL_POINTER_AXIS_VERTICAL_SCROLL)
+			button = (event->delta < 0) ? 4 : 5;
+		else
+			button = (event->delta < 0) ? 6 : 7;
+
+		if (mousegrabber_isrunning()) {
+			event_handle_mousegrabber_scroll(cursor->x, cursor->y,
+					button, ticks);
+			return; /* Don't process event further */
+		}
+
 		for (int tick = 0; tick < ticks; tick++) {
 			lua_State *L = globalconf_get_lua_State();
 			struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat);
@@ -885,15 +853,7 @@ axisnotify(struct wl_listener *listener, void *data)
 			Client *c = NULL;
 			drawin_t *drawin = NULL;
 			drawable_t *titlebar_drawable = NULL;
-			uint32_t button;
 			int rel_x, rel_y;
-
-			/* Determine button number based on axis orientation and direction */
-			if (event->orientation == WL_POINTER_AXIS_VERTICAL_SCROLL) {
-				button = (event->delta < 0) ? 4 : 5;
-			} else {
-				button = (event->delta < 0) ? 6 : 7;
-			}
 
 			/* Find what's under the cursor */
 			xytonode(cursor->x, cursor->y, NULL, &c, NULL, &drawin, &titlebar_drawable, NULL, NULL);
@@ -930,6 +890,12 @@ axisnotify(struct wl_listener *listener, void *data)
 		}
 	}
 
+	/* An active grabber consumes the remaining axis events: axis-stop
+	 * (delta == 0) frames, and a grab started inside a scroll-binding
+	 * callback above (matching the equivalent buttonpress check). */
+	if (mousegrabber_isrunning())
+		return;
+
 	/* Notify the client with pointer focus of the axis event. */
 	wlr_seat_pointer_notify_axis(seat,
 			event->time_msec, event->orientation, event->delta,
@@ -949,7 +915,9 @@ buttonpress(struct wl_listener *listener, void *data)
 
 	/* Update globalconf button state tracking FIRST, before any early returns.
 	 * This ensures mousegrabber callbacks receive accurate button states.
-	 * Map wlroots button codes (BTN_LEFT=0x110, etc.) to indices 0-4.
+	 * Only buttons 1-3 have a slot: slots 4/5 of the X11 state mask mean
+	 * scroll up/down (synthesized from axis events, never held), and
+	 * BTN_SIDE/BTN_EXTRA are X11 buttons 8/9, which have no state mask bit.
 	 */
 	{
 		int idx = -1;
@@ -957,8 +925,6 @@ buttonpress(struct wl_listener *listener, void *data)
 		case 0x110: idx = 0; break;  /* BTN_LEFT -> button 1 */
 		case 0x112: idx = 1; break;  /* BTN_MIDDLE -> button 2 */
 		case 0x111: idx = 2; break;  /* BTN_RIGHT -> button 3 */
-		case 0x113: idx = 3; break;  /* BTN_SIDE -> button 4 */
-		case 0x114: idx = 4; break;  /* BTN_EXTRA -> button 5 */
 		}
 		if (idx >= 0) {
 			globalconf.button_state.buttons[idx] =
@@ -967,50 +933,8 @@ buttonpress(struct wl_listener *listener, void *data)
 	}
 
 	/* If mousegrabber is active, route event to Lua callback */
-	if (mousegrabber_isrunning()) {
-		lua_State *L = globalconf_get_lua_State();
-		int button_states[5];
-		uint16_t mask = 0;
-
-		/* Get current button states */
-		some_get_button_states(button_states);
-
-		/* Convert button_states array to X11-style mask */
-		for (int i = 0; i < 5; i++) {
-			if (button_states[i])
-				mask |= (1 << (8 + i));
-		}
-
-		/* Push coords table to Lua stack */
-		mousegrabber_handleevent(L, cursor->x, cursor->y, mask);
-
-		/* Get the callback from registry */
-		lua_rawgeti(L, LUA_REGISTRYINDEX, globalconf.mousegrabber);
-
-		/* Push coords table as argument */
-		lua_pushvalue(L, -2);
-
-		/* Call callback(coords) */
-		if (lua_pcall(L, 1, 1, 0) == 0) {
-			/* Check return value */
-			int continue_grab = lua_toboolean(L, -1);
-			lua_pop(L, 1); /* Pop return value */
-
-			if (!continue_grab) {
-				/* Callback returned false, stop grabbing */
-				luaA_mousegrabber_stop(L);
-			}
-		} else {
-			/* Error in callback */
-			fprintf(stderr, "somewm: mousegrabber callback error: %s\n",
-				lua_tostring(L, -1));
-			lua_pop(L, 1);
-			luaA_mousegrabber_stop(L);
-		}
-
-		lua_pop(L, 1); /* Pop coords table */
+	if (event_handle_mousegrabber(cursor->x, cursor->y, 0))
 		return; /* Don't process event further */
-	}
 
 	switch (event->state) {
 	case WL_POINTER_BUTTON_STATE_PRESSED: {
@@ -4298,50 +4222,8 @@ motionnotify(uint32_t time, struct wlr_input_device *device, double dx, double d
 
 	/* If mousegrabber is active, route event to Lua callback (AwesomeWM behavior:
 	 * check mousegrabber BEFORE enter/leave signals to filter them during grabs) */
-	if (mousegrabber_isrunning()) {
-		lua_State *L = globalconf_get_lua_State();
-		int button_states[5];
-		uint16_t mask = 0;
-
-		/* Get current button states */
-		some_get_button_states(button_states);
-
-		/* Convert button_states array to X11-style mask */
-		for (int i = 0; i < 5; i++) {
-			if (button_states[i])
-				mask |= (1 << (8 + i));
-		}
-
-		/* Push coords table to Lua stack */
-		mousegrabber_handleevent(L, cursor->x, cursor->y, mask);
-
-		/* Get the callback from registry */
-		lua_rawgeti(L, LUA_REGISTRYINDEX, globalconf.mousegrabber);
-
-		/* Push coords table as argument */
-		lua_pushvalue(L, -2);
-
-		/* Call callback(coords) */
-		if (lua_pcall(L, 1, 1, 0) == 0) {
-			/* Check return value */
-			int continue_grab = lua_toboolean(L, -1);
-			lua_pop(L, 1); /* Pop return value */
-
-			if (!continue_grab) {
-				/* Callback returned false, stop grabbing */
-				luaA_mousegrabber_stop(L);
-			}
-		} else {
-			/* Error in callback */
-			fprintf(stderr, "somewm: mousegrabber callback error: %s\n",
-				lua_tostring(L, -1));
-			lua_pop(L, 1);
-			luaA_mousegrabber_stop(L);
-		}
-
-		lua_pop(L, 1); /* Pop coords table */
+	if (event_handle_mousegrabber(cursor->x, cursor->y, 0))
 		return; /* Don't process event further (skip enter/leave signals, pointerfocus) */
-	}
 
 	/* Track which object is under the cursor and emit enter/leave/move signals
 	 * (only when mousegrabber is NOT active - filtered above) */

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -1464,9 +1464,9 @@ some_fake_motion(double dx, double dy)
 }
 
 /*
- * Get mouse button states
- * Returns pressed state for buttons 1-5 (left, middle, right, side1, side2)
- * Button mapping: BTN_LEFT=1, BTN_MIDDLE=2, BTN_RIGHT=3, BTN_SIDE=4, BTN_EXTRA=5
+ * Get the X11-style 5-button state mask (Button1Mask = 1<<8, etc.).
+ * Only buttons 1-3 (left, middle, right) are ever tracked: bits 4/5 mean
+ * scroll up/down, which is synthesized from axis events and never held.
  *
  * NOTE: We use globalconf.button_state which is tracked in buttonpress(),
  * NOT seat->pointer_state. This is critical for mousegrabber to work correctly.
@@ -1474,17 +1474,15 @@ some_fake_motion(double dx, double dy)
  * but during compositor-level grabs (like window move/resize) there may be
  * no focused surface. globalconf.button_state is always accurate.
  */
-void
-some_get_button_states(int states[5])
+uint16_t
+some_button_state_mask(void)
 {
-	int i;
+	uint16_t mask = 0;
 
-	if (!states)
-		return;
-
-	/* Read from globalconf.button_state which is updated in buttonpress() */
-	for (i = 0; i < 5; i++)
-		states[i] = globalconf.button_state.buttons[i] ? 1 : 0;
+	for (int i = 0; i < 5; i++)
+		if (globalconf.button_state.buttons[i])
+			mask |= 1 << (8 + i);
+	return mask;
 }
 
 /*

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -184,7 +184,7 @@ uint32_t some_get_cursor_size(void);
 void some_update_cursor_theme(const char *theme_name, uint32_t size);
 void some_get_cursor_position(double *x, double *y);
 void some_set_cursor_position(double x, double y, int silent);
-void some_get_button_states(int states[5]);
+uint16_t some_button_state_mask(void);
 Client *some_object_under_cursor(void);
 drawin_t *some_drawin_under_cursor(void);
 void some_warp_cursor_to_monitor(Monitor *m);

--- a/tests/_utils.lua
+++ b/tests/_utils.lua
@@ -156,6 +156,23 @@ function utils.is_headless()
     return os.getenv("WLR_BACKENDS") == "headless"
 end
 
+--- Require a compiled test helper binary, skipping the test if missing.
+-- On a miss this prints the SKIP markers and quits; the caller must then
+-- return from its chunk.
+-- @tparam string path Path to the binary
+-- @treturn string|nil The path if it exists, nil after skipping
+function utils.binary_or_skip(path)
+    local f = io.open(path, "r")
+    if f then
+        f:close()
+        return path
+    end
+    io.stderr:write("SKIP: " .. path .. " not found (run meson compile first)\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return nil
+end
+
 ---------------------------------------------------------------------------
 --- Debug helpers for focus history, signals, and stacking order
 -- @section debug_helpers

--- a/tests/test-mousegrabber-scroll.lua
+++ b/tests/test-mousegrabber-scroll.lua
@@ -1,0 +1,81 @@
+---------------------------------------------------------------------------
+--- Scroll wheel and side buttons during mousegrabber (parity with X11).
+---
+--- A scroll tick must reach the grabber callback as X11 buttons 4/5: a
+--- press call with the flag set, immediately followed by a release call
+--- with it cleared. BTN_SIDE/BTN_EXTRA are X11 buttons 8/9 and must not
+--- fake the scroll flags (they used to be tracked in slots 4/5).
+---
+--- Input is injected with test-virtual-pointer-client so it traverses the
+--- real axisnotify()/buttonpress() paths (root.fake_input bypasses them).
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local async  = require("_async")
+local awful  = require("awful")
+local utils  = require("_utils")
+
+local VPOINTER = utils.binary_or_skip("./build-test/test-virtual-pointer-client")
+if not VPOINTER then return end
+
+runner.run_async(function()
+    local sg = screen[1].geometry
+    local cx = sg.x + math.floor(sg.width / 2)
+    local cy = sg.y + math.floor(sg.height / 2)
+
+    local records = {}
+    mousegrabber.run(function(m)
+        records[#records + 1] = { b4 = m.buttons[4], b5 = m.buttons[5] }
+        return true
+    end, nil)
+    assert(mousegrabber.isrunning(), "mousegrabber did not start")
+
+    local function inject(action, arg)
+        records = {}
+        awful.spawn(string.format("%s %s %d %d %d %d %s",
+                                  VPOINTER, action, cx, cy, sg.width, sg.height, arg))
+        -- 2 motion callbacks (client double-sends the move) + press + release
+        async.wait_for_condition(function() return #records >= 4 end, 5)
+        return records
+    end
+
+    -- One scroll tick: press call with the flag set, then a release call.
+    local function assert_tick(recs, flag, label)
+        local press
+        for i, r in ipairs(recs) do
+            if r[flag] then press = i break end
+        end
+        assert(press, label .. ": grabber never saw " .. flag .. " pressed")
+        local rel = recs[press + 1]
+        assert(rel and not rel[flag],
+            label .. ": no release call after the " .. flag .. " press")
+    end
+
+    local recs = inject("scroll", "down")
+    assert_tick(recs, "b5", "scroll down")
+    for _, r in ipairs(recs) do
+        assert(not r.b4, "scroll down: buttons[4] flagged")
+    end
+
+    recs = inject("scroll", "up")
+    assert_tick(recs, "b4", "scroll up")
+    for _, r in ipairs(recs) do
+        assert(not r.b5, "scroll up: buttons[5] flagged")
+    end
+
+    -- BTN_SIDE (X11 button 8) must not appear as scroll (regression: it was
+    -- tracked in slot 4).
+    recs = inject("click", "side")
+    assert(#recs > 0, "side click: grabber saw no events")
+    for _, r in ipairs(recs) do
+        assert(not r.b4 and not r.b5, "side click: flagged as scroll")
+    end
+
+    mousegrabber.stop()
+    assert(not mousegrabber.isrunning(), "mousegrabber did not stop")
+
+    io.stderr:write("[ALL TESTS] PASS\n")
+    runner.done()
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-root-button-wibar.lua
+++ b/tests/test-root-button-wibar.lua
@@ -13,17 +13,10 @@
 local runner = require("_runner")
 local async  = require("_async")
 local awful  = require("awful")
+local utils  = require("_utils")
 
-local VPOINTER = "./build-test/test-virtual-pointer-client"
-
-local f = io.open(VPOINTER, "r")
-if not f then
-    io.stderr:write("SKIP: " .. VPOINTER .. " not found (run meson compile first)\n")
-    io.stderr:write("Test finished successfully.\n")
-    awesome.quit()
-    return
-end
-f:close()
+local VPOINTER = utils.binary_or_skip("./build-test/test-virtual-pointer-client")
+if not VPOINTER then return end
 
 runner.run_async(function()
     local s  = screen[1]

--- a/tests/test-virtual-pointer-client.c
+++ b/tests/test-virtual-pointer-client.c
@@ -1,18 +1,20 @@
 /**
  * test-virtual-pointer-client - Inject pointer input via zwlr_virtual_pointer_v1.
  *
- * Moves the cursor to an absolute layout position and performs one left click.
- * Unlike root.fake_input("button_press"), the injected events arrive through a
- * real wlr_input_device, so they traverse the compositor's full buttonpress()
- * path: mousegrabber routing, client button bindings, and seat notification.
+ * Moves the cursor to an absolute layout position and performs one left click
+ * or scroll tick. Unlike root.fake_input("button_press"), the injected events
+ * arrive through a real wlr_input_device, so they traverse the compositor's
+ * full buttonpress()/axisnotify() path: mousegrabber routing, client button
+ * bindings, and seat notification.
  *
- * Usage: test-virtual-pointer-client <move|click> <x> <y> <x_extent> <y_extent>
- *                                     [left|middle|right]
+ * Usage: test-virtual-pointer-client <move|click|scroll> <x> <y>
+ *                                     <x_extent> <y_extent>
+ *                                     [left|middle|right|side|extra|up|down]
  *
  * x/y are layout coordinates; x_extent/y_extent the layout size (normally the
  * screen geometry). "move" only positions the cursor; "click" also presses and
- * releases the given button (left by default). Exits after the events are
- * flushed.
+ * releases the given button (left by default); "scroll" sends one discrete
+ * vertical wheel tick (down by default). Exits after the events are flushed.
  */
 
 #include <linux/input-event-codes.h>
@@ -61,23 +63,41 @@ static uint32_t button_code(const char *name) {
     if (strcmp(name, "left") == 0) return BTN_LEFT;
     if (strcmp(name, "middle") == 0) return BTN_MIDDLE;
     if (strcmp(name, "right") == 0) return BTN_RIGHT;
+    if (strcmp(name, "side") == 0) return BTN_SIDE;
+    if (strcmp(name, "extra") == 0) return BTN_EXTRA;
     return 0;
 }
 
 int main(int argc, char *argv[]) {
     if ((argc != 6 && argc != 7)
-            || (strcmp(argv[1], "move") != 0 && strcmp(argv[1], "click") != 0)) {
-        fprintf(stderr, "Usage: %s <move|click> <x> <y> <x_extent> <y_extent> "
-                "[left|middle|right]\n", argv[0]);
-        return 1;
-    }
-    uint32_t btn = argc == 7 ? button_code(argv[6]) : BTN_LEFT;
-    if (!btn) {
-        fprintf(stderr, "Unknown button: %s (expected left, middle or right)\n",
-                argv[6]);
+            || (strcmp(argv[1], "move") != 0 && strcmp(argv[1], "click") != 0
+                && strcmp(argv[1], "scroll") != 0)) {
+        fprintf(stderr, "Usage: %s <move|click|scroll> <x> <y> <x_extent> "
+                "<y_extent> [left|middle|right|side|extra|up|down]\n", argv[0]);
         return 1;
     }
     int click = strcmp(argv[1], "click") == 0;
+    int scroll = strcmp(argv[1], "scroll") == 0;
+    uint32_t btn = BTN_LEFT;
+    int32_t scroll_dir = 1; /* wl_pointer convention: positive = down */
+    if (argc == 7) {
+        if (scroll) {
+            if (strcmp(argv[6], "up") == 0) {
+                scroll_dir = -1;
+            } else if (strcmp(argv[6], "down") != 0) {
+                fprintf(stderr, "Unknown direction: %s (expected up or down)\n",
+                        argv[6]);
+                return 1;
+            }
+        } else {
+            btn = button_code(argv[6]);
+            if (!btn) {
+                fprintf(stderr, "Unknown button: %s (expected left, middle, "
+                        "right, side or extra)\n", argv[6]);
+                return 1;
+            }
+        }
+    }
     uint32_t x = (uint32_t)strtoul(argv[2], NULL, 10);
     uint32_t y = (uint32_t)strtoul(argv[3], NULL, 10);
     uint32_t x_extent = (uint32_t)strtoul(argv[4], NULL, 10);
@@ -121,6 +141,14 @@ int main(int argc, char *argv[]) {
         sleep_ms(50);
         zwlr_virtual_pointer_v1_button(pointer, now_ms(), btn,
                                        WL_POINTER_BUTTON_STATE_RELEASED);
+        zwlr_virtual_pointer_v1_frame(pointer);
+        wl_display_roundtrip(display);
+    } else if (scroll) {
+        sleep_ms(50);
+        /* One discrete wheel click; wlroots scales discrete to value120 */
+        zwlr_virtual_pointer_v1_axis_discrete(pointer, now_ms(),
+                WL_POINTER_AXIS_VERTICAL_SCROLL,
+                wl_fixed_from_int(scroll_dir * 15), scroll_dir);
         zwlr_virtual_pointer_v1_frame(pointer);
         wl_display_roundtrip(display);
     }


### PR DESCRIPTION
## Description
During mousegrabber, scroll wheel ticks never appeared as buttons 4/5, and BTN_SIDE/BTN_EXTRA wrongly did. Axis events now reach the grabber as X11-style press+release pairs, and side/extra are no longer tracked in the scroll slots. Fixes #690.

## Test Plan
New integration test injects scroll and side-button input through the virtual pointer path; it fails without the fix. Full unit and integration suites pass.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
