### PR TITLE
fix(systray): size tray icons by base_size, not the source pixmap

### DIFF
--- a/lua/wibox/widget/systray_icon.lua
+++ b/lua/wibox/widget/systray_icon.lua
@@ -709,17 +709,10 @@ end
 -- @method fit
 -- @hidden
 function systray_icon:fit(context, width, height)
-    local item = self._private.item
+    -- Every icon gets the same base_size square; :draw scales the source
+    -- pixmap into it, so a large or non-square icon letterboxes instead of
+    -- widening its slot.
     local size = self._private.forced_size or 24
-
-    if item then
-        -- Use item's icon dimensions if available
-        local iw = item.icon_width
-        local ih = item.icon_height
-        if iw and iw > 0 and ih and ih > 0 then
-            size = math.max(iw, ih)
-        end
-    end
 
     -- Respect forced_width/height
     local w = self._private.forced_width or size

--- a/spec/wibox/widget/systray_icon_spec.lua
+++ b/spec/wibox/widget/systray_icon_spec.lua
@@ -1,0 +1,66 @@
+---------------------------------------------------------------------------
+-- @author somewm contributors
+-- @copyright 2026
+-- Tests for wibox.widget.systray_icon sizing
+---------------------------------------------------------------------------
+
+local systray_icon = require("wibox.widget.systray_icon")
+
+-- Build the widget state :fit reads, without the constructor: it lazily
+-- requires awful.tooltip, which needs the whole capi drawin chain.
+local function icon(private)
+    return setmetatable({ _private = private }, { __index = systray_icon })
+end
+
+-- A stand-in for the C systray_item, carrying the native pixmap dimensions a
+-- StatusNotifierItem reported over D-Bus.
+local function item(icon_width, icon_height)
+    return { icon_width = icon_width, icon_height = icon_height }
+end
+
+describe("wibox.widget.systray_icon", function()
+    describe("fit", function()
+        local context = {}
+
+        it("uses forced_size when the item has no icon", function()
+            local widget = icon { forced_size = 22 }
+
+            assert.is.same({22, 22}, {widget:fit(context, 1000, 1000)})
+        end)
+
+        it("ignores an oversized source pixmap", function()
+            local widget = icon { forced_size = 22, item = item(256, 256) }
+
+            assert.is.same({22, 22}, {widget:fit(context, 1000, 1000)})
+        end)
+
+        it("ignores a source pixmap smaller than forced_size", function()
+            local widget = icon { forced_size = 32, item = item(16, 16) }
+
+            assert.is.same({32, 32}, {widget:fit(context, 1000, 1000)})
+        end)
+
+        it("stays square for a non-square source pixmap", function()
+            local widget = icon { forced_size = 24, item = item(128, 32) }
+
+            assert.is.same({24, 24}, {widget:fit(context, 1000, 1000)})
+        end)
+
+        it("respects forced_width and forced_height", function()
+            local widget = icon {
+                forced_size = 24, forced_width = 40, forced_height = 12,
+                item = item(256, 256),
+            }
+
+            assert.is.same({40, 12}, {widget:fit(context, 1000, 1000)})
+        end)
+
+        it("never exceeds the available space", function()
+            local widget = icon { forced_size = 24, item = item(256, 256) }
+
+            assert.is.same({24, 10}, {widget:fit(context, 1000, 10)})
+        end)
+    end)
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
## Description

`systray_icon:fit` overwrote `forced_size` with `math.max(item.icon_width, item.icon_height)`, so a tray icon was sized by its source pixmap instead of `base_size`. Vesktop publishes a 64x64 `IconPixmap` and got a 64px wide slot holding a 24px icon; no `base_size` value could shrink it. Only affects apps that publish a raw pixmap rather than an `IconName`, and only the single-row tray.

Cherry-pick of the `release/1.4` fix in #708. The file is identical on both branches apart from the `fit` parameter name.

Fixes #587

## Test Plan

New `spec/wibox/widget/systray_icon_spec.lua`; 4 of its 6 cases fail on the unpatched file.

Measured on a live session (running the `release/1.4` build, same widget code), same three apps before and after:

| item | native pixmap | slot before | slot after |
| --- | --- | --- | --- |
| Slack | 22x22 | 22x26 | 24x26 |
| Discord | 24x24 | 24x26 | 24x26 |
| Vesktop | 64x64 | 64x26 | 24x26 |

`make test-unit` 762 passing, `make test-integration` 136 passing.

## Checklist
- [ ] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
