### PR TITLE
docs: add AI usage policy and PR disclosure section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,10 @@
 <!-- How did you verify this works? -->
 
 
+## AI Usage
+<!-- Per AI_POLICY.md: state the tool used and how much of the work was AI-assisted, or "None". -->
+
+
 ## Checklist
 - [ ] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
 - [ ] Tests pass (`make test-unit && make test-integration`)

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,24 @@
+# AI Usage Policy
+
+somewm has rules for AI usage in contributions. This policy is adapted from the
+[Ghostty AI usage policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md).
+
+- **All AI usage must be disclosed.** State the tool you used (e.g. Claude Code, Cursor, Copilot) and how much of the work was AI-assisted.
+
+- **You must fully understand your code.** If you can't explain what your changes do and how they interact with the rest of the compositor without help from an AI tool, do not submit them.
+
+- **Issues and discussions can use AI assistance, but a human must review and edit the text first.** AI output tends to be verbose and padded with noise. Do your own research and trim it down before posting.
+
+- **No AI-generated media (art, images, videos, audio).** Text and code are the only acceptable AI-generated content, under the other rules in this policy.
+
+Contributions that break these rules will be closed without detailed review. Repeat offenders may be blocked.
+
+These rules apply to outside contributions. Maintainers are exempt and may use AI tools at their discretion.
+
+## There Are Humans Here
+
+Every issue, discussion, and pull request here is read by a human. Submitting low-effort, unqualified work puts the whole burden of validation on the maintainer. That is rude, whether or not AI wrote it.
+
+## AI Is Welcome Here
+
+somewm is written with plenty of AI assistance, and this policy is not anti-AI. The problem it addresses is unqualified people submitting AI output they don't understand. It's the people, not the tools.


### PR DESCRIPTION
## Description
Adds AI_POLICY.md, adapted from Ghostty's AI usage policy, and an AI Usage disclosure section to the PR template.

## Test Plan
Docs only.

## AI Usage
Written with Claude Code, reviewed and edited by the maintainer.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)