### PR TITLE
fix(placement): round margins and offsets to whole pixels

### DIFF
--- a/UPSTREAM_PORTS.md
+++ b/UPSTREAM_PORTS.md
@@ -8,6 +8,7 @@ Since SomeWM is not a direct git fork, we manually port relevant changes from up
 
 | AwesomeWM PR | Description | Notes |
 |--------------|-------------|-------|
+| [#4122](https://github.com/awesomeWM/awesome/pull/4122) | Round placement margins and offsets to whole pixels | Ported here ahead of the upstream merge (somewm issue #715). Revisit if the AwesomeWM maintainers change the fix. |
 | [#4077](https://github.com/awesomeWM/awesome/pull/4077) | Decouple fullscreen stacking layer from focus | C-side (stack.c). Needs adaptation: somewm keeps the fullscreen layer when the focused client is on another screen, so the top-of-stack check must be per-screen. somewm also forces stack_windows() on focus change (somewm.c), which may already mask the upstream bug. |
 
 ## Ported PRs

--- a/lua/awful/placement.lua
+++ b/lua/awful/placement.lua
@@ -39,7 +39,8 @@
 --
 -- **margins** (*number* or *table*):
 --
---  A table with left, right, top, bottom keys or a number
+--  A table with left, right, top, bottom keys or a number. Fractional values
+--  are rounded to a whole number of pixels.
 --
 -- **parent** (client, wibox, mouse or screen):
 --
@@ -58,7 +59,8 @@
 --
 -- **offset** (*table or number*):
 --
--- The offset(s) to apply to the new geometry.
+-- The offset(s) to apply to the new geometry. Fractional values are rounded
+-- to a whole number of pixels.
 --
 -- **store_geometry** (*boolean*):
 --
@@ -348,7 +350,22 @@ local function get_decoration(args)
         top  = args.margins or 0 , bottom = args.margins or 0
     }
 
-    return m, offset
+    -- The margins and offsets are added to the geometry when it is read and
+    -- removed again when it is written back, but the C code rounds the drawin
+    -- geometry to whole pixels. Fractional values, such as half of an odd
+    -- theme size, would make that round trip grow the drawable by one pixel on
+    -- every pass of an attached placement, until the C stack overflows (#4121).
+    return {
+        left   = gmath.round(m.left   or 0),
+        right  = gmath.round(m.right  or 0),
+        top    = gmath.round(m.top    or 0),
+        bottom = gmath.round(m.bottom or 0),
+    }, {
+        x      = gmath.round(offset.x      or 0),
+        y      = gmath.round(offset.y      or 0),
+        width  = gmath.round(offset.width  or 0),
+        height = gmath.round(offset.height or 0),
+    }
 end
 
 --- Apply some modifications before applying the new geometry.

--- a/tests/test-wibar-margins.lua
+++ b/tests/test-wibar-margins.lua
@@ -1,0 +1,71 @@
+--- Test that fractional margins do not make a wibar grow.
+--
+-- The placement code adds the margins to the geometry it reads and removes
+-- them from the geometry it writes. The drawin geometry is rounded to whole
+-- pixels, so a fractional margin used to make the wibar one pixel taller every
+-- time the attached placement ran, until the C stack overflowed (#4121).
+
+local wibar = require("awful.wibar")
+
+local steps = {}
+
+-- A fractional margin, as half of an odd theme size gives. It is rounded to 11.
+local margin, rounded = 10.5, 11
+
+local height = 24
+local sgeo   = screen.primary.geometry
+
+local expected = {
+    x      = sgeo.x + rounded,
+    y      = sgeo.y + rounded,
+    width  = sgeo.width - 2 * rounded,
+    height = height,
+}
+
+local w
+
+-- The top and bottom margins are on the same axis as the height of a top
+-- wibar. Only the top one is set, so their sum is fractional.
+table.insert(steps, function()
+    -- Without the fix, this alone overflows the C stack.
+    w = wibar {
+        position = "top",
+        screen   = screen.primary,
+        height   = height,
+        margins  = { top = margin, left = margin, right = margin },
+    }
+
+    return true
+end)
+
+-- The placement is re-applied every time the size changes, so keep checking
+-- the geometry for a while to make sure it stays put.
+for _=1, 3 do
+    table.insert(steps, function()
+        local geo = w:geometry()
+
+        for _, key in ipairs {"x", "y", "width", "height"} do
+            assert(geo[key] == expected[key], string.format(
+                "regression: fractional margins changed the %s to %d, "..
+                "expected %d", key, geo[key], expected[key]
+            ))
+        end
+
+        return true
+    end)
+end
+
+table.insert(steps, function()
+    -- The strut covers the wibar and the margin above it.
+    local expected_y = expected.y + expected.height
+
+    assert(screen.primary.workarea.y == expected_y, string.format(
+        "regression: the workarea starts at %d, expected %d",
+        screen.primary.workarea.y, expected_y))
+
+    return true
+end)
+
+require("_runner").run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
## Description

Fixes #715.  
Port of awesomeWM/awesome#4122, which is still open

### Cause
When awful.placement reads a drawable's geometry, it adds the margins to it, and when it writes the result back, it subtracts them again. The C setter stored only whole pixels though. So if the margins on an axis do not sum to a whole number, the add and subtract don't "cancel out."

With the issue's numbers (a top wibar of height 24, margins.top = 10.5):

    Read: d:geometry() returns 24, margins are added: 34.5
    align() does math.ceil(34.5) = 35
    Write back: 35 - 10.5 = 24.5, which the C setter rounds up to 25

Both roundings go up, so the drawable gains a pixel.
The problem is that, for an attached placement this recurses.

    C setter emits property::height
    attach tracker re-runs the placement inside the signal
    grows by 1 pixel per pass until the C stack overflows.


### Fix
Round the margins and offsets to whole pixels in get_decoration(), and document that fractional values are rounded.

IMO, fractional margins could never be rendered exactly anyway, since drawin geometry is integer at the protocol level, so something has to round somewhere. Rounding at the input means every consumer of the margins (the placement math, the delta path, the struts) sees the same whole numbers, and the read/write round trip cancels exactly


## AI Usage
none


## Checklist
- [ ] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)
