### PR TITLE
fix(systemd): use command -v instead of hash for POSIX compliance

### DIFF
--- a/contrib/systemd/somewm-session.sh
+++ b/contrib/systemd/somewm-session.sh
@@ -26,7 +26,7 @@ if [ -n "${MANAGERPID:-}" ] && [ "${SYSTEMD_EXEC_PID:-}" = "$$" ]; then
 fi
 
 # Make sure systemd is available
-if ! hash systemctl >/dev/null 2>&1; then
+if ! command -v systemctl >/dev/null 2>&1; then
     echo "systemd not found. Run somewm directly instead." >&2
     exit 1
 fi
@@ -59,7 +59,7 @@ systemctl --user set-environment \
     XDG_SESSION_TYPE=wayland
 
 # D-Bus activation environment is independent from systemd
-if hash dbus-update-activation-environment 2>/dev/null; then
+if command -v dbus-update-activation-environment 2>/dev/null; then
     dbus-update-activation-environment --all
 fi
 


### PR DESCRIPTION
hash is a bashism and not guaranteed in POSIX sh (dash etc.). command -v is the POSIX-standard way to check for command existence, fixes ShellCheck SC2143.

## AI Usage
<!-- Per AI_POLICY.md: state the tool used and how much of the work was AI-assisted, or "None". -->

It could be a good philosophical discussion: where is the border between “normal” tools (e.g., I used `checkbashism`) and what we call now AI tools. What’s the difference?

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
