### PR TITLE
Fix -Wsign-compare warning/error on 32-bit architectures

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -1223,7 +1223,7 @@ static int
 luaA_awesome_set_preferred_icon_size(lua_State *L)
 {
 	lua_Integer size = luaL_checkinteger(L, 1);
-	if (size < 0 || size > UINT32_MAX) {
+	if (size < 0 || (uint64_t)size > UINT32_MAX) {
 		return luaL_error(L, "icon size must be between 0 and %u", UINT32_MAX);
 	}
 	globalconf.preferred_icon_size = (uint32_t)size;


### PR DESCRIPTION
On 32-bit platforms, `lua_Integer` is typically defined as a 32-bit signed `int`. Comparing it directly with `UINT32_MAX` (which is unsigned 32-bit) triggers a `-Wsign-compare` compiler warning/error:

    ../luaa.c:1225:30: error: comparison of integer expressions of
    different signedness: ‘lua_Integer’ {aka ‘int’} and ‘unsigned int’

On 64-bit systems, `lua_Integer` is signed 64-bit, so `UINT32_MAX` is promoted to signed 64-bit and no warning is emitted. On 32-bit platforms, however, comparing signed and unsigned 32-bit integers forces conversion of the signed operand to unsigned, raising the warning.

Fix this by casting `size` to `uint64_t` after validating that it is non-negative (`size < 0` is handled first). This is fully portable, preserves the bounds check, and is warning-free on all architectures.

Yes, this nine-letter change was generated by LLM.

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
