### PR TITLE
render: vendor clay.h and port the Clay renderer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 
 -include .local.mk
 
-.PHONY: all install uninstall clean setup reconfigure test test-unit test-lua-compat test-check test-signal test-integration test-orchestrator test-restart test-one-restart test-asan test-one test-visual test-one-visual test-ci test-fast build-test build-bench bench-run bench-run-live bench-json bench-baseline bench-compare bench-check bench-memory bench-flamegraph bench-diff bench-heaptrack profile profile-lua profile-save profile-diff
+.PHONY: all install uninstall clean setup setup-test reconfigure test test-unit test-render test-lua-compat test-check test-signal test-integration test-orchestrator test-restart test-one-restart test-asan test-one test-visual test-one-visual test-ci test-fast build-test build-bench bench-run bench-run-live bench-json bench-baseline bench-compare bench-check bench-memory bench-flamegraph bench-diff bench-heaptrack profile profile-lua profile-save profile-diff
 
 # Default build: optimized release, no sanitizers
 all:
@@ -21,9 +21,12 @@ asan:
 	@test -d build-asan || meson setup build-asan -Db_sanitize=address,undefined $(if $(LUA_PKG),-Dlua_pkg=$(LUA_PKG),) $(MESON_OPTS)
 	ninja -C build-asan
 
-# Build for tests: NO ASAN (fast) - explicitly disable sanitizers, enable test PAM stub
-build-test:
+# Configure the test build dir without building anything in it
+setup-test:
 	@test -d build-test || meson setup build-test -Db_sanitize=none -Dtest_pam=true $(if $(LUA_PKG),-Dlua_pkg=$(LUA_PKG),) $(MESON_OPTS)
+
+# Build for tests: NO ASAN (fast) - explicitly disable sanitizers, enable test PAM stub
+build-test: setup-test
 	ninja -C build-test
 
 install:
@@ -55,9 +58,16 @@ test: test-unit test-check test-signal test-orchestrator test-restart test-integ
 test-lua-compat:
 	@./tests/check-lua-compat.sh
 
-# Unit tests only (busted, no compositor needed)
-test-unit: test-lua-compat
+# Unit tests only (busted and the C renderer test; no compositor needed)
+test-unit: test-lua-compat test-render
 	@./tests/run-unit.sh
+
+# C unit tests (meson): the Clay reconciler against hand-built command arrays.
+# Builds the one test binary rather than the whole compositor, so test-unit
+# stays the cheap target.
+test-render: setup-test
+	@ninja -C build-test test-render
+	@meson test -C build-test --suite unit --print-errorlogs --no-rebuild
 
 # Check mode tests (no compositor needed, tests somewm --check)
 test-check: build-test
@@ -91,8 +101,10 @@ endif
 test-integration: build-test
 	@SOMEWM=./build-test/somewm SOMEWM_CLIENT=./build-test/somewm-client ./tests/run-integration.sh
 
-# Integration tests with ASAN (slower, catches memory bugs)
+# Integration tests with ASAN (slower, catches memory bugs). The C unit tests
+# run here too, since the ASAN build is where they are worth the most.
 test-asan: asan
+	@meson test -C build-asan --suite unit --print-errorlogs
 	@SOMEWM=./build-asan/somewm SOMEWM_CLIENT=./build-asan/somewm-client ./tests/run-integration.sh
 
 # CI mode: headless (for automated testing environments)

--- a/clay_impl.c
+++ b/clay_impl.c
@@ -1,0 +1,6 @@
+/* The single translation unit that compiles Clay itself. Clay is a
+ * header-only library: every other file includes clay.h for the
+ * declarations, and CLAY_IMPLEMENTATION is defined here and nowhere else. */
+
+#define CLAY_IMPLEMENTATION
+#include "clay.h"

--- a/licenses/LICENSE.clay
+++ b/licenses/LICENSE.clay
@@ -1,0 +1,23 @@
+LICENSE
+zlib/libpng license
+
+Copyright (c) 2024 Nic Barker
+
+This software is provided 'as-is', without any express or implied warranty.
+In no event will the authors be held liable for any damages arising from the
+use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+    claim that you wrote the original software. If you use this software in a
+    product, an acknowledgment in the product documentation would be
+    appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not
+    be misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source
+    distribution.

--- a/meson.build
+++ b/meson.build
@@ -49,6 +49,14 @@ endif
 
 cc = meson.get_compiler('c')
 
+# third_party holds vendored headers; clay.h is included as <clay.h> by the
+# renderer and compiled once by clay_impl.c below.
+somewm_inc = include_directories('.', 'third_party')
+
+# The renderer, named once: the compositor links it and the C unit test compiles
+# it again with the verifier forced on.
+render_sources = files('render.c', 'render_text.c', 'render_image.c')
+
 # Math library (for round(), etc.)
 m_dep = cc.find_library('m', required: false)
 
@@ -385,6 +393,23 @@ if get_option('bench')
   add_project_arguments('-DSOMEWM_BENCH', language: 'c')
 endif
 
+# The Clay tree==scene verifier. Derived from the build directory's own options
+# rather than passed in by the Makefile, so a dir that was configured before this
+# option existed still gets the right answer, and reconfiguring a dir to use a
+# sanitizer turns the verifier on with it. b_sanitize is a string in older meson
+# and an array in newer, hence the format.
+render_verify = get_option('render_verify')
+if render_verify.auto()
+  sanitizers = '@0@'.format(get_option('b_sanitize'))
+  render_verify_on = sanitizers.contains('address') or \
+    sanitizers.contains('undefined') or get_option('test_pam')
+else
+  render_verify_on = render_verify.enabled()
+endif
+if render_verify_on
+  add_project_arguments('-DSOMEWM_RENDER_VERIFY', language: 'c')
+endif
+
 # Development flags
 add_project_arguments(
   '-Wno-unused-parameter',
@@ -496,14 +521,27 @@ if have_pam
   all_deps += [pam_dep]
 endif
 
+# Clay is header-only; clay_impl.c is the single translation unit that compiles
+# it. Its own static library so -w applies to the vendored code and nothing else:
+# clay.h is not ours to keep clean against this project's warning set.
+clay_lib = static_library(
+  'clay',
+  'clay_impl.c',
+  include_directories: somewm_inc,
+  c_args: ['-w'],
+  dependencies: [m_dep],
+)
+
 somewm_exe = executable(
   'somewm',
   somewm_sources,
+  render_sources,
   protocol_headers,
   keyboard_shortcuts_inhibit_client_header,
   keyboard_shortcuts_inhibit_client_code,
   dependencies: all_deps,
-  include_directories: include_directories('.'),
+  include_directories: somewm_inc,
+  link_with: clay_lib,
   install: true,
 )
 
@@ -524,6 +562,26 @@ somewm_client = executable(
   'somewm-client.c',
   'test_orchestrator.c',
   install: true,
+)
+
+# The Clay reconciler's unit test: hand-built command arrays in, wlr_scene out.
+# It compiles the renderer itself rather than linking the compositor, so the
+# tree==scene verifier is on here whatever -Drender_verify says for the build.
+test_render = executable(
+  'test-render',
+  ['tests/test-render.c', render_sources],
+  include_directories: somewm_inc,
+  link_with: clay_lib,
+  dependencies: [wlroots, wayland_server, cairo, pangocairo, gdk_pixbuf, m_dep],
+  c_args: ['-DSOMEWM_RENDER_VERIFY'],
+  install: false,
+)
+
+# The suppressions keep an ASAN run of this test reporting only allocations the
+# renderer owns; fontconfig and pango cache fonts process-wide and never free.
+test('render', test_render, suite: 'unit',
+  env: {'LSAN_OPTIONS': 'suppressions=' +
+    meson.current_source_dir() / 'tests/lsan-suppressions.txt'},
 )
 
 # Test layer-shell client for deterministic integration tests

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -47,3 +47,10 @@ option(
   value: '',
   description: 'Force a specific Lua pkg-config name (e.g. lua5.5, luajit). Empty = autodetect (LuaJIT > 5.5 > 5.4 > ... > 5.1).',
 )
+
+option(
+  'render_verify',
+  type: 'feature',
+  value: 'auto',
+  description: 'Compile the Clay tree==scene verifier into the renderer. It walks every retained node after each reconcile and aborts on divergence. auto = on for a sanitizer or test build, off otherwise.',
+)

--- a/render.c
+++ b/render.c
@@ -1,0 +1,1646 @@
+/* The renderer: reconciles Clay's sorted render command array into wlr_scene,
+ * retained and keyed by (command id, command type). Square rectangles and
+ * borders become scene rects; text, images, and rounded rectangles and borders
+ * rasterize with cairo into a wlr_buffer (wlr_scene has no rounded or
+ * non-rectangular primitive). Unchanged commands cause zero scene mutations;
+ * ids that vanish are swept.
+ *
+ * Ported from kiln, the reference compositor this was proven in. The tree==scene
+ * verifier at the tail of every pass is compiled in only under
+ * SOMEWM_RENDER_VERIFY (the asan and test builds), never in release. */
+
+#include <assert.h>
+#include <drm_fourcc.h>
+#include <inttypes.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <cairo.h>
+#include <pango/pangocairo.h>
+#include <wlr/interfaces/wlr_buffer.h>
+#include <wlr/types/wlr_scene.h>
+#include <wlr/util/log.h>
+
+#include "common/util.h"
+#include "render.h"
+#include "render_image.h"
+#include "render_text.h"
+
+/* Max SCISSOR nesting the clip stack holds; deeper scopes reuse the innermost
+ * bound (degenerate, and far past any real chrome). CLIP_INF stands in for an
+ * unclipped axis: outputs are at most a few thousand px, so it never clamps. */
+#define CLIP_STACK_MAX 64
+#define CLIP_INF 1.0e6f
+
+/* A wlr_buffer backed by a cairo image surface, for rasterized text. */
+struct cairo_buffer {
+	struct wlr_buffer base;
+	cairo_surface_t *surface;
+};
+
+static void cairo_buffer_destroy(struct wlr_buffer *buffer) {
+	struct cairo_buffer *cb = wl_container_of(buffer, cb, base);
+	cairo_surface_destroy(cb->surface);
+	free(cb);
+}
+
+static bool cairo_buffer_begin_data_ptr_access(struct wlr_buffer *buffer,
+		uint32_t flags, void **data, uint32_t *format, size_t *stride) {
+	struct cairo_buffer *cb = wl_container_of(buffer, cb, base);
+	if (flags & WLR_BUFFER_DATA_PTR_ACCESS_WRITE) {
+		return false;
+	}
+	unsigned char *pixels = cairo_image_surface_get_data(cb->surface);
+	if (pixels == NULL) {
+		return false;
+	}
+	*data = pixels;
+	*format = DRM_FORMAT_ARGB8888;
+	*stride = cairo_image_surface_get_stride(cb->surface);
+	return true;
+}
+
+static void cairo_buffer_end_data_ptr_access(struct wlr_buffer *buffer) {
+}
+
+static const struct wlr_buffer_impl cairo_buffer_impl = {
+	.destroy = cairo_buffer_destroy,
+	.begin_data_ptr_access = cairo_buffer_begin_data_ptr_access,
+	.end_data_ptr_access = cairo_buffer_end_data_ptr_access,
+};
+
+/* NULL when the surface could not be created. Cairo hands back a nil surface
+ * rather than crashing when a dimension exceeds its limits, and a nil surface's
+ * data pointer is NULL, so an unchecked buffer reaches wlroots as a scene
+ * buffer that reports data access succeeded and yields no pixels. Every caller
+ * treats NULL as "no raster this frame". */
+static struct cairo_buffer *cairo_buffer_create(int width, int height) {
+	struct cairo_buffer *cb = calloc(1, sizeof(*cb));
+	if (cb == NULL) {
+		return NULL;
+	}
+	cb->surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
+		width, height);
+	if (cairo_surface_status(cb->surface) != CAIRO_STATUS_SUCCESS) {
+		cairo_surface_destroy(cb->surface);
+		free(cb);
+		return NULL;
+	}
+	wlr_buffer_init(&cb->base, &cairo_buffer_impl, width, height);
+	return cb;
+}
+
+/* One retained record per (command id, command type). */
+struct rnode {
+	uint64_t key;
+	/* box is Clay's solved box; rbox is the realized box after clipping to
+	 * the active SCISSOR scope (equal to box when no clip applies). box
+	 * drives raster/content diffs; rbox drives node position, size, and the
+	 * tree==scene verifier. */
+	Clay_BoundingBox box;
+	Clay_BoundingBox rbox;
+	/* The active SCISSOR clip scope this node was realized against (the
+	 * infinite box when unclipped or exempt), retained so the verifier can
+	 * assert rbox stays inside it: rbox = box_intersect(box, clip) by
+	 * construction, so a green check proves no path skipped the clip. */
+	Clay_BoundingBox clip;
+	Clay_RenderData data;
+	char *text;
+	int32_t text_len;
+	/* RECTANGLE: a scene rect. TEXT: a scene buffer. BORDER: a tree
+	 * holding four scene rects (top, right, bottom, left). CUSTOM: a
+	 * client scene tree the renderer borrowed, never owned. */
+	struct wlr_scene_node *node;
+	/* BORDER: a tree of four straight edge rects plus, for a rounded border,
+	 * up to four corner arc buffers (tiny tiles, not a full-box buffer).
+	 * border_sides holds the edges; border_corners the arcs (NULL/disabled where
+	 * a corner radius is zero). */
+	struct wlr_scene_rect *border_sides[4];
+	struct wlr_scene_buffer *border_corners[4];
+	/* Whether each corner's last raster produced a tile. The scene buffer
+	 * pointer cannot answer this: the scene frees a dropped raster buffer
+	 * after texture upload, so it reads NULL for a corner that still renders. */
+	bool border_tile[4];
+	/* IMAGE: the decode generation last rasterized, so a reload re-rasters. */
+	uint64_t img_gen;
+	/* The scale this node's raster was drawn at: the fourth raster cache key
+	 * (content, font, size, scale). Clay solves logical, so a scale change alone
+	 * leaves the box identical; without this a runtime set_scale would keep the
+	 * old-density buffer. Rects and square borders carry no raster, so it stays 0. */
+	float raster_scale;
+	/* TEXT: the device-pixel bound this node's raster was truncated to, 0 for an
+	 * untouched run. A fifth raster key, and the only one not derivable from the
+	 * command: it comes from the clip, which can move while the command does not. */
+	int text_ellipsis;
+	/* Bytes of the cairo raster this node holds in the scene (0 for rects,
+	 * trees, and borrowed clients), kept so the per-state total is O(1). */
+	size_t raster_bytes;
+	bool borrowed;
+	uint64_t handle;
+	uint64_t gen;
+};
+
+/* An open-addressing slot mapping a command key to its index in nodes. */
+struct rnode_slot {
+	uint64_t key;
+	size_t index;
+	bool used;
+};
+
+struct render_state {
+	struct wlr_scene_tree *tree;
+	struct rnode *nodes;
+	size_t len, cap;
+	uint64_t gen;
+	/* Command keys in draw order (popup-owners folded to the tail) from the
+	 * previous frame, to detect reordering without touching the scene when
+	 * order is unchanged. build assembles this frame's order before the fold,
+	 * kept off order so the previous final order survives the comparison. */
+	uint64_t *order;
+	size_t order_len, order_cap;
+	uint64_t *build;
+	/* key -> index into nodes, so a lookup is O(1) and the reconcile is O(N)
+	 * rather than O(N^2). Insert-only, rebuilt from nodes each pass. */
+	struct rnode_slot *map;
+	size_t map_cap;
+	/* Profiling readback: resident cairo raster bytes across all live
+	 * nodes, and buffers allocated by the current reconcile pass. */
+	size_t raster_bytes;
+	int buffers_created;
+	/* A kind-swap (rounded <-> square rect or border) destroyed and recreated
+	 * a node under an unchanged command key this pass. The recreated scene
+	 * node was appended at the top of its sibling list, so the restack must
+	 * run even though the command order is byte-identical. */
+	bool node_recreated;
+	/* The output's scale, driving device-pixel raster sizing. 1.0 is the
+	 * identity: every device_len below reduces to the logical length, so a
+	 * non-HiDPI output rasters exactly as before. */
+	float scale;
+	struct render_state *next;
+};
+
+/* Every live render_state, so a corner tile's input callback can find the node
+ * that owns it.
+ *
+ * The obvious back-pointer, wlr_scene_node.data on the tile, is not ours to
+ * use: input.c reads that field off a hit leaf buffer as a drawable_t and
+ * dereferences ->owner_type with no type tag (input.c:1734), and off parent
+ * trees as a drawin_t or a client (input.c:1759). Anything the renderer stored
+ * there would be read as one of those the moment the render tree sits in a
+ * walked layer. One entry per output's chrome, so the walk is a handful of
+ * pointers, and the callback already scans nodes linearly. */
+static struct render_state *render_states;
+
+struct render_state *render_create(struct wlr_scene_tree *parent) {
+	struct render_state *rs = calloc(1, sizeof(*rs));
+	rs->tree = wlr_scene_tree_create(parent);
+	rs->scale = 1.0f;
+	rs->next = render_states;
+	render_states = rs;
+	return rs;
+}
+
+void render_set_enabled(struct render_state *rs, bool on) {
+	wlr_scene_node_set_enabled(&rs->tree->node, on);
+}
+
+void render_set_position(struct render_state *rs, int x, int y) {
+	/* wlr_scene_node_set_position no-ops on identical coordinates. */
+	wlr_scene_node_set_position(&rs->tree->node, x, y);
+}
+
+void render_set_scale(struct render_state *rs, float scale) {
+	rs->scale = scale > 0.0f ? scale : 1.0f;
+}
+
+/* Device pixels spanned by a logical span [origin, origin+len) at scale: the
+ * difference of rounded device edges. This is wlr_scene's own scale_length
+ * (types/scene/wlr_scene.c), and matching it verbatim is what makes a raster
+ * sample 1:1 (no upscale blur) and two tiles sharing a logical edge land on the
+ * same device pixel (no seam). origin is the node's output-local logical position
+ * ((int)box coordinate); wlroots derives the same offset. At scale 1 this is len. */
+static int device_len(int origin, int len, float scale) {
+	return (int)(round((double)(origin + len) * scale) -
+		round((double)origin * scale));
+}
+
+/* Corner radii in device pixels: a rounded corner drawn into a device-sized
+ * buffer must scale its arc, or it shrinks (in logical terms) as scale grows. */
+static Clay_CornerRadius scale_corner_radius(Clay_CornerRadius r, float scale) {
+	return (Clay_CornerRadius){ r.topLeft * scale, r.topRight * scale,
+		r.bottomLeft * scale, r.bottomRight * scale };
+}
+
+static size_t rmap_hash(uint64_t key) {
+	key ^= key >> 33;
+	key *= 0xff51afd7ed558ccdULL;
+	key ^= key >> 33;
+	key *= 0xc4ceb9fe1a85ec53ULL;
+	key ^= key >> 33;
+	return (size_t)key;
+}
+
+/* Rebuild the key->index map from the current nodes, sized to keep the load
+ * factor under one half so probe chains stay short. Called at the start of a
+ * pass, and again after the sweep since swap-removal scrambles the indices. */
+static void rmap_rebuild(struct render_state *rs) {
+	size_t need = 16;
+	while (need < rs->len * 2) {
+		need *= 2;
+	}
+	if (rs->map_cap < need) {
+		free(rs->map);
+		rs->map = malloc(need * sizeof(*rs->map));
+		rs->map_cap = need;
+	}
+	memset(rs->map, 0, rs->map_cap * sizeof(*rs->map));
+	size_t mask = rs->map_cap - 1;
+	for (size_t i = 0; i < rs->len; i++) {
+		size_t s = rmap_hash(rs->nodes[i].key) & mask;
+		while (rs->map[s].used) {
+			s = (s + 1) & mask;
+		}
+		rs->map[s].key = rs->nodes[i].key;
+		rs->map[s].index = i;
+		rs->map[s].used = true;
+	}
+}
+
+/* Index of key in nodes, or SIZE_MAX. */
+static size_t rmap_get(struct render_state *rs, uint64_t key) {
+	if (rs->map_cap == 0) {
+		return SIZE_MAX;
+	}
+	size_t mask = rs->map_cap - 1;
+	size_t s = rmap_hash(key) & mask;
+	while (rs->map[s].used) {
+		if (rs->map[s].key == key) {
+			return rs->map[s].index;
+		}
+		s = (s + 1) & mask;
+	}
+	return SIZE_MAX;
+}
+
+static struct rnode *rnode_add(struct render_state *rs, uint64_t key) {
+	p_grow(&rs->nodes, rs->len + 1, &rs->cap);
+	struct rnode *n = &rs->nodes[rs->len++];
+	memset(n, 0, sizeof(*n));
+	n->key = key;
+	return n;
+}
+
+/* The two-behavior sweep: nodes the renderer created are destroyed;
+ * borrowed client trees are handed back through release, which reparents
+ * and disables them (or no-ops if the client is already gone). The stored
+ * pointer of a borrowed node is never dereferenced here. */
+static void rnode_remove(struct render_state *rs, struct rnode *n,
+		const struct render_client_hooks *hooks) {
+	free(n->text);
+	rs->raster_bytes -= n->raster_bytes;
+	if (n->borrowed) {
+		hooks->release(hooks->data, n->handle, rs);
+	} else {
+		wlr_scene_node_destroy(n->node);
+	}
+	*n = rs->nodes[--rs->len];
+}
+
+static float clay_srgb(float channel) {
+	return channel / 255.0f;
+}
+
+static void clay_color_to_float(Clay_Color c, float out[4]) {
+	/* wlr_scene_rect wants premultiplied alpha. */
+	float a = clay_srgb(c.a);
+	out[0] = clay_srgb(c.r) * a;
+	out[1] = clay_srgb(c.g) * a;
+	out[2] = clay_srgb(c.b) * a;
+	out[3] = a;
+}
+
+static bool box_pos_equal(Clay_BoundingBox a, Clay_BoundingBox b) {
+	return (int)a.x == (int)b.x && (int)a.y == (int)b.y;
+}
+
+static bool box_size_equal(Clay_BoundingBox a, Clay_BoundingBox b) {
+	return (int)a.width == (int)b.width && (int)a.height == (int)b.height;
+}
+
+/* The visible rectangle of a inside b. A degenerate (zero-area) result means a
+ * lies entirely outside the clip; callers realize that as a disabled node or a
+ * zero-size rect. */
+static Clay_BoundingBox box_intersect(Clay_BoundingBox a, Clay_BoundingBox b) {
+	float x0 = a.x > b.x ? a.x : b.x;
+	float y0 = a.y > b.y ? a.y : b.y;
+	float ax1 = a.x + a.width, ay1 = a.y + a.height;
+	float bx1 = b.x + b.width, by1 = b.y + b.height;
+	float x1 = ax1 < bx1 ? ax1 : bx1;
+	float y1 = ay1 < by1 ? ay1 : by1;
+	Clay_BoundingBox r = { x0, y0, x1 > x0 ? x1 - x0 : 0.0f, y1 > y0 ? y1 - y0 : 0.0f };
+	return r;
+}
+
+static bool box_empty(Clay_BoundingBox b) {
+	return (int)b.width <= 0 || (int)b.height <= 0;
+}
+
+/* The clip scope stored for an unclipped or clip-exempt node: so large it
+ * never bounds anything, matching the SCISSOR unclipped-axis representation. */
+static Clay_BoundingBox box_inf(void) {
+	Clay_BoundingBox b = { -CLIP_INF, -CLIP_INF, 2.0f * CLIP_INF, 2.0f * CLIP_INF };
+	return b;
+}
+
+#ifdef SOMEWM_RENDER_VERIFY
+/* inner lies within outer, with a half-pixel tolerance for float noise. */
+static bool box_contains(Clay_BoundingBox outer, Clay_BoundingBox inner) {
+	const float eps = 0.5f;
+	return inner.x >= outer.x - eps && inner.y >= outer.y - eps &&
+		inner.x + inner.width <= outer.x + outer.width + eps &&
+		inner.y + inner.height <= outer.y + outer.height + eps;
+}
+#endif
+
+/* --- shared raster helpers ---
+ *
+ * rounded_rect_path and buffer_apply_clip serve every rastered leaf (rounded
+ * rectangle, text, image): wlr_scene draws only square fills, so rounded or
+ * measured content becomes a cairo buffer that is cropped to its clip. */
+
+static bool corner_radius_zero(Clay_CornerRadius r) {
+	return r.topLeft == 0 && r.topRight == 0 &&
+		r.bottomLeft == 0 && r.bottomRight == 0;
+}
+
+static void rounded_rect_path(cairo_t *cr, double x, double y, double w,
+		double h, Clay_CornerRadius r) {
+	/* Clamp each radius to half the smaller side so opposite corners cannot
+	 * cross into a self-intersecting path. An explicit origin lets a caller add
+	 * a second, inset path (the border ring) without CTM games. */
+	double m = (w < h ? w : h) / 2.0;
+	double tl = r.topLeft > m ? m : r.topLeft;
+	double tr = r.topRight > m ? m : r.topRight;
+	double br = r.bottomRight > m ? m : r.bottomRight;
+	double bl = r.bottomLeft > m ? m : r.bottomLeft;
+	double deg = 3.14159265358979323846 / 180.0;
+	cairo_new_sub_path(cr);
+	cairo_arc(cr, x + w - tr, y + tr, tr, -90.0 * deg, 0.0);
+	cairo_arc(cr, x + w - br, y + h - br, br, 0.0, 90.0 * deg);
+	cairo_arc(cr, x + bl, y + h - bl, bl, 90.0 * deg, 180.0 * deg);
+	cairo_arc(cr, x + tl, y + tl, tl, 180.0 * deg, 270.0 * deg);
+	cairo_close_path(cr);
+}
+
+/* Is (px,py) inside the rounded rect [x,y,w,h] with corner radii r? The same
+ * shape rounded_rect_path fills, expressed as a point predicate: inside the
+ * plain rect, and inside the arc wherever a corner's radius square applies.
+ * Radii are clamped to half the smaller side, matching the path. Used by the
+ * geometric border hit test (below), never a pixel read. */
+static bool point_in_rounded_rect(double px, double py, double x, double y,
+		double w, double h, Clay_CornerRadius r) {
+	if (px < x || py < y || px >= x + w || py >= y + h) {
+		return false;
+	}
+	double m = (w < h ? w : h) / 2.0;
+	double tl = r.topLeft > m ? m : r.topLeft;
+	double tr = r.topRight > m ? m : r.topRight;
+	double br = r.bottomRight > m ? m : r.bottomRight;
+	double bl = r.bottomLeft > m ? m : r.bottomLeft;
+	double dx, dy;
+	if (px < x + tl && py < y + tl) {                  /* top-left corner */
+		dx = px - (x + tl); dy = py - (y + tl);
+		return dx * dx + dy * dy <= tl * tl;
+	}
+	if (px >= x + w - tr && py < y + tr) {             /* top-right corner */
+		dx = px - (x + w - tr); dy = py - (y + tr);
+		return dx * dx + dy * dy <= tr * tr;
+	}
+	if (px >= x + w - br && py >= y + h - br) {         /* bottom-right corner */
+		dx = px - (x + w - br); dy = py - (y + h - br);
+		return dx * dx + dy * dy <= br * br;
+	}
+	if (px < x + bl && py >= y + h - bl) {              /* bottom-left corner */
+		dx = px - (x + bl); dy = py - (y + h - bl);
+		return dx * dx + dy * dy <= bl * bl;
+	}
+	return true;                                       /* the straight interior */
+}
+
+/* Crop a buffer leaf to its realized clip box. The buffer always holds the full
+ * solved box, so a SCISSOR clip is a source-box crop, never a re-raster; a NULL
+ * source with 0,0 dest restores the natural extent when the clip no longer
+ * bites. */
+static void buffer_apply_clip(struct wlr_scene_buffer *sb,
+		Clay_RenderCommand *cmd, Clay_BoundingBox rbox, float scale) {
+	Clay_BoundingBox box = cmd->boundingBox;
+	/* dst_size is the node's LOGICAL footprint, and it is always set: the buffer
+	 * holds device pixels, so a 0,0 (natural-size) dest would make wlroots read
+	 * those device pixels as logical and draw the node scale-times oversize. */
+	bool clipped = !box_pos_equal(rbox, box) || !box_size_equal(rbox, box);
+	if (clipped) {
+		/* The visible sub-rect in the device pixels of the full-box buffer.
+		 * Every coordinate here is derived exactly as the buffer's own size
+		 * was: from the TRUNCATED logical origin, through device_len. The
+		 * buffer's pixel 0 is device round((int)box.x * scale), so taking the
+		 * crop origin from the unrounded box.x shifts every clipped raster by
+		 * a pixel whenever the solved origin has a fractional part. At scale 1
+		 * this is the plain logical crop. */
+		int ox = (int)box.x, oy = (int)box.y;
+		int rx = (int)rbox.x, ry = (int)rbox.y;
+		int rw = (int)rbox.width, rh = (int)rbox.height;
+		struct wlr_fbox src = {
+			device_len(ox, rx - ox, scale),
+			device_len(oy, ry - oy, scale),
+			device_len(rx, rw, scale),
+			device_len(ry, rh, scale) };
+		/* Truncation is not monotonic across the two boxes, so a clip flush
+		 * against the box edge can land a device pixel past the buffer; keep
+		 * the crop inside it rather than sampling off the end. */
+		double bw = device_len(ox, (int)box.width, scale);
+		double bh = device_len(oy, (int)box.height, scale);
+		src.x = fmin(src.x, bw - 1);
+		src.y = fmin(src.y, bh - 1);
+		src.width = fmax(1.0, fmin(src.width, bw - src.x));
+		src.height = fmax(1.0, fmin(src.height, bh - src.y));
+		wlr_scene_buffer_set_source_box(sb, &src);
+		wlr_scene_buffer_set_dest_size(sb, rw, rh);
+	} else {
+		wlr_scene_buffer_set_source_box(sb, NULL);
+		wlr_scene_buffer_set_dest_size(sb, (int)box.width, (int)box.height);
+	}
+}
+
+static size_t cairo_buffer_bytes(struct cairo_buffer *cb) {
+	return (size_t)cairo_image_surface_get_stride(cb->surface) *
+		(size_t)cairo_image_surface_get_height(cb->surface);
+}
+
+/* Apply the clip to a raster leaf and report whether that alone was a mutation.
+ * A re-raster already counted itself and reapplies the crop because setting a
+ * fresh buffer resets it; an empty realized box leaves the buffer alone, since
+ * the reconcile pass disables the node instead (a 0,0 dest would mean natural
+ * size, not zero). Shared by the rounded rect, text and image leaves so the
+ * three cannot drift apart. */
+static int rnode_apply_clip(struct rnode *n, struct wlr_scene_buffer *sb,
+		Clay_RenderCommand *cmd, Clay_BoundingBox rbox, float scale,
+		bool raster_changed) {
+	bool clip_changed = !box_pos_equal(n->rbox, rbox) ||
+		!box_size_equal(n->rbox, rbox);
+	if ((raster_changed || clip_changed) && !box_empty(rbox)) {
+		buffer_apply_clip(sb, cmd, rbox, scale);
+		return clip_changed && !raster_changed ? 1 : 0;
+	}
+	return 0;
+}
+
+/* Swap a raster leaf's buffer, keeping the per-state byte account current:
+ * every cairo raster resident in the scene is counted at its swap, so the
+ * profiling log reports raster bytes without walking the scene. */
+static void rnode_set_raster(struct render_state *rs, struct rnode *n,
+		struct wlr_scene_buffer *sb, struct cairo_buffer *cb) {
+	size_t bytes = 0;
+	if (cb != NULL) {
+		bytes = cairo_buffer_bytes(cb);
+		rs->buffers_created++;
+	}
+	rs->raster_bytes = rs->raster_bytes - n->raster_bytes + bytes;
+	n->raster_bytes = bytes;
+	wlr_scene_buffer_set_buffer(sb, cb != NULL ? &cb->base : NULL);
+	if (cb != NULL) {
+		wlr_buffer_drop(&cb->base);
+	}
+}
+
+/* --- rectangles ---
+ *
+ * A square rectangle is a cheap wlr_scene_rect. A rounded rectangle has no
+ * scene primitive, so it is cairo-rastered into a buffer and cropped to its
+ * clip like text and images. The node kind follows the corner radius, so a
+ * radius toggling across frames swaps the kind (handled in the dispatcher). */
+
+static struct cairo_buffer *rasterize_rounded_rect(Clay_RenderCommand *cmd,
+		float scale) {
+	Clay_RectangleRenderData *rd = &cmd->renderData.rectangle;
+	int w = device_len((int)cmd->boundingBox.x, (int)cmd->boundingBox.width, scale);
+	int h = device_len((int)cmd->boundingBox.y, (int)cmd->boundingBox.height, scale);
+	if (w < 1 || h < 1) {
+		return NULL;
+	}
+	/* Device pixels: the path fills the whole buffer (no transparent seam edge)
+	 * and the radius scales, so the corner is a true arc at the output density. */
+	struct cairo_buffer *cb = cairo_buffer_create(w, h);
+	if (cb == NULL) {
+		return NULL;
+	}
+	cairo_t *cr = cairo_create(cb->surface);
+	rounded_rect_path(cr, 0, 0, w, h, scale_corner_radius(rd->cornerRadius, scale));
+	/* Straight alpha as in rasterize_text; cairo premultiplies into ARGB32. */
+	cairo_set_source_rgba(cr,
+		clay_srgb(rd->backgroundColor.r), clay_srgb(rd->backgroundColor.g),
+		clay_srgb(rd->backgroundColor.b), clay_srgb(rd->backgroundColor.a));
+	cairo_fill(cr);
+	cairo_destroy(cr);
+	cairo_surface_flush(cb->surface);
+	return cb;
+}
+
+static int reconcile_square_rect(struct render_state *rs, struct rnode *n,
+		Clay_RenderCommand *cmd, Clay_BoundingBox rbox) {
+	Clay_RectangleRenderData *rd = &cmd->renderData.rectangle;
+	float color[4];
+	clay_color_to_float(rd->backgroundColor, color);
+	int muts = 0;
+
+	/* A solid rect crops to its clip by shrinking; the color is uniform, so
+	 * the visible region is exactly the intersection box. */
+	if (n->node == NULL) {
+		struct wlr_scene_rect *rect = wlr_scene_rect_create(rs->tree,
+			(int)rbox.width, (int)rbox.height, color);
+		n->node = &rect->node;
+		/* A radius toggle can create this rect mid-frame, when the common
+		 * placement pass no longer sees the node as new; place it now. */
+		wlr_scene_node_set_position(n->node, (int)rbox.x, (int)rbox.y);
+		return 1;
+	}
+
+	struct wlr_scene_rect *rect = wlr_scene_rect_from_node(n->node);
+	if (!box_size_equal(n->rbox, rbox)) {
+		wlr_scene_rect_set_size(rect, (int)rbox.width, (int)rbox.height);
+		muts++;
+	}
+	if (memcmp(&n->data.rectangle.backgroundColor, &rd->backgroundColor,
+			sizeof(rd->backgroundColor)) != 0) {
+		wlr_scene_rect_set_color(rect, color);
+		muts++;
+	}
+	return muts;
+}
+
+static int reconcile_rounded_rect(struct render_state *rs, struct rnode *n,
+		Clay_RenderCommand *cmd, Clay_BoundingBox rbox) {
+	Clay_RectangleRenderData *rd = &cmd->renderData.rectangle;
+	int muts = 0;
+
+	bool is_new = n->node == NULL;
+	if (is_new) {
+		struct wlr_scene_buffer *sb = wlr_scene_buffer_create(rs->tree, NULL);
+		n->node = &sb->node;
+		/* As with reconcile_square_rect, a radius toggle creates this
+		 * mid-frame, past the common placement pass. */
+		wlr_scene_node_set_position(n->node, (int)rbox.x, (int)rbox.y);
+	}
+	struct wlr_scene_buffer *sb = wlr_scene_buffer_from_node(n->node);
+
+	/* The whole Clay_RectangleRenderData (color and radius) plus the scale is the
+	 * raster key; re-raster on first sight, a solved-size change, or a rescale. */
+	bool raster_changed = is_new ||
+		!box_size_equal(n->box, cmd->boundingBox) ||
+		n->raster_scale != rs->scale ||
+		memcmp(&n->data.rectangle, rd, sizeof(*rd)) != 0;
+	if (raster_changed) {
+		rnode_set_raster(rs, n, sb, rasterize_rounded_rect(cmd, rs->scale));
+		n->raster_scale = rs->scale;
+		muts++;
+	}
+
+	muts += rnode_apply_clip(n, sb, cmd, rbox, rs->scale, raster_changed);
+	return muts;
+}
+
+/* A rect's node kind depends on its corner radius, so a radius toggling between
+ * zero and nonzero swaps the kind: destroy the old node and let the chosen path
+ * recreate it. */
+static int reconcile_rectangle(struct render_state *rs, struct rnode *n,
+		Clay_RenderCommand *cmd, Clay_BoundingBox rbox) {
+	bool rounded = !corner_radius_zero(cmd->renderData.rectangle.cornerRadius);
+	if (n->node != NULL) {
+		enum wlr_scene_node_type want = rounded ?
+			WLR_SCENE_NODE_BUFFER : WLR_SCENE_NODE_RECT;
+		if (n->node->type != want) {
+			wlr_scene_node_destroy(n->node);
+			n->node = NULL;
+			rs->raster_bytes -= n->raster_bytes;
+			n->raster_bytes = 0;
+			rs->node_recreated = true;
+		}
+	}
+	return rounded ? reconcile_rounded_rect(rs, n, cmd, rbox)
+		: reconcile_square_rect(rs, n, cmd, rbox);
+}
+
+/* --- borders: four straight edge rects, plus corner arc tiles when rounded ---
+ *
+ * One path serves square and rounded borders. The four edges are scene
+ * rects inset from the box corners by the corner radius; each rounded corner is
+ * a small cairo tile (radius-sized) drawing just its arc of the ring. A square
+ * border (radius 0) insets by nothing and shows no tiles, degenerating exactly
+ * to the old four-rect border. So the full-box ring buffer is gone: a border now
+ * costs four rects plus up to four tiles the size of the radius, not a buffer the
+ * size of the client. The tree sits at the solved box origin; borders are not
+ * clip targets (the reconcile loop leaves rbox = box), so each edge is clipped
+ * in absolute space and mapped back, a corner disabled when fully clipped. */
+
+/* The square each rounded corner occupies in the ring, indexed TL, TR, BL, BR,
+ * and 0 for a square corner.
+ *
+ * It must cover the arc (ceil of the radius) AND the full thickness of both
+ * edges meeting there, because the two straight edges are inset by exactly this
+ * and nothing else draws what neither covers. Sizing the tile to the radius
+ * alone, and insetting the edges by the radius on one axis and the border width
+ * on the other, leaves the band between the two undrawn at every corner where
+ * 0 < radius < width: for a 100x100 border of width 5 and radius 3, nothing at
+ * all draws x in [0,3), y in [3,5). A square corner needs no tile, and gets no
+ * inset here: its horizontal edge runs the full width and its vertical edge
+ * starts below, which is the plain four-rect border. */
+static void border_corner_extents(Clay_RenderCommand *cmd, int ext[4]) {
+	Clay_BorderWidth bw = cmd->renderData.border.width;
+	Clay_CornerRadius cr = cmd->renderData.border.cornerRadius;
+	int r[4] = { (int)ceilf(cr.topLeft), (int)ceilf(cr.topRight),
+		(int)ceilf(cr.bottomLeft), (int)ceilf(cr.bottomRight) };
+	/* The two edges meeting at each corner. */
+	int adj[4][2] = { { bw.top, bw.left }, { bw.top, bw.right },
+		{ bw.bottom, bw.left }, { bw.bottom, bw.right } };
+	for (int c = 0; c < 4; c++) {
+		int e = r[c];
+		if (e < 1) {
+			ext[c] = 0;
+			continue;
+		}
+		if (adj[c][0] > e) e = adj[c][0];
+		if (adj[c][1] > e) e = adj[c][1];
+		ext[c] = e;
+	}
+}
+
+/* The four straight edges, inset from each corner by that corner's extent, so
+ * edges and corner tiles partition the ring with no gap and no double-draw (a
+ * translucent border color makes an overlap as visible as a hole). A square
+ * corner has no tile, so only its vertical edge is inset, by the horizontal
+ * edge's width. */
+static void border_edge_boxes(Clay_RenderCommand *cmd, const int ext[4],
+		const Clay_BoundingBox *clip, int boxes[4][4]) {
+	int w = (int)cmd->boundingBox.width;
+	int h = (int)cmd->boundingBox.height;
+	Clay_BorderWidth bw = cmd->renderData.border.width;
+	int vtl = ext[0] > 0 ? ext[0] : bw.top;
+	int vtr = ext[1] > 0 ? ext[1] : bw.top;
+	int vbl = ext[2] > 0 ? ext[2] : bw.bottom;
+	int vbr = ext[3] > 0 ? ext[3] : bw.bottom;
+	/* top, right, bottom, left: {x, y, width, height}. */
+	int sides[4][4] = {
+		{ ext[0], 0, w - ext[0] - ext[1], bw.top },
+		{ w - bw.right, vtr, bw.right, h - vtr - vbr },
+		{ ext[2], h - bw.bottom, w - ext[2] - ext[3], bw.bottom },
+		{ 0, vtl, bw.left, h - vtl - vbl },
+	};
+	/* Clay can solve an element smaller than its borders/radii; never negative. */
+	for (int i = 0; i < 4; i++) {
+		if (sides[i][2] < 0) sides[i][2] = 0;
+		if (sides[i][3] < 0) sides[i][3] = 0;
+	}
+	if (clip != NULL) {
+		int ox = (int)cmd->boundingBox.x, oy = (int)cmd->boundingBox.y;
+		for (int i = 0; i < 4; i++) {
+			Clay_BoundingBox abs = { (float)(ox + sides[i][0]),
+				(float)(oy + sides[i][1]),
+				(float)sides[i][2], (float)sides[i][3] };
+			Clay_BoundingBox c = box_intersect(abs, *clip);
+			sides[i][0] = (int)c.x - ox;
+			sides[i][1] = (int)c.y - oy;
+			sides[i][2] = (int)c.width;
+			sides[i][3] = (int)c.height;
+		}
+	}
+	memcpy(boxes, sides, sizeof(sides));
+}
+
+/* The ring's inner hole radii: each corner radius shrunk by the thicker of the
+ * two edges meeting there. The hit test and the raster must agree on this to
+ * the pixel, or a click lands somewhere the drawn ring does not cover. */
+static Clay_CornerRadius inset_corner_radius(Clay_CornerRadius r,
+		Clay_BorderWidth bw) {
+	return (Clay_CornerRadius){
+		fmax(0.0f, r.topLeft - fmaxf(bw.top, bw.left)),
+		fmax(0.0f, r.topRight - fmaxf(bw.top, bw.right)),
+		fmax(0.0f, r.bottomLeft - fmaxf(bw.bottom, bw.left)),
+		fmax(0.0f, r.bottomRight - fmaxf(bw.bottom, bw.right)),
+	};
+}
+
+/* A rounded corner tile overlays a small square of the client body (the arc's
+ * interior is transparent), so a click there must fall through to the surface as
+ * the old full-box buffer did, or the tile shadows that corner and diverges from
+ * Clay, which ranks the surface topmost. The test is GEOMETRIC, not a pixel
+ * read: the ring is inside the outer rounded rect and outside the inner inset
+ * one, the shape the tiles fill. It runs in logical space (device scale never
+ * reaches the hit path). Only corner tiles carry it; the straight edges are
+ * opaque rects that never overlap the body. The retained node behind a tile is
+ * found by scanning the live render_states for the one holding it in
+ * border_corners, since the tile carries no back-pointer. */
+static bool border_point_accepts_input(struct wlr_scene_buffer *sb,
+		double *sx, double *sy) {
+	struct rnode *n = NULL;
+	for (struct render_state *rs = render_states;
+			rs != NULL && n == NULL; rs = rs->next) {
+		for (size_t i = 0; i < rs->len && n == NULL; i++) {
+			for (int c = 0; c < 4; c++) {
+				if (rs->nodes[i].border_corners[c] == sb) {
+					n = &rs->nodes[i];
+					break;
+				}
+			}
+		}
+	}
+	if (n == NULL) {
+		return false;
+	}
+	/* The tile sits at its corner offset within the border tree, and the tree is
+	 * at the box origin, so the tile's node position IS its box-relative origin;
+	 * add the local point to reach the box-relative coords the ring is defined in. */
+	double bx = sb->node.x + *sx;
+	double by = sb->node.y + *sy;
+	Clay_BorderRenderData *bd = &n->data.border;
+	double w = n->box.width, h = n->box.height;
+	if (!point_in_rounded_rect(bx, by, 0, 0, w, h, bd->cornerRadius)) {
+		return false;
+	}
+	Clay_BorderWidth bw = bd->width;
+	double iw = w - bw.left - bw.right, ih = h - bw.top - bw.bottom;
+	if (iw <= 0 || ih <= 0) {
+		return true;   /* borders meet or overlap: the whole box is ring. */
+	}
+	/* The inner hole; a point inside it falls through. */
+	Clay_CornerRadius ir = inset_corner_radius(bd->cornerRadius, bw);
+	return !point_in_rounded_rect(bx, by, bw.left, bw.top, iw, ih, ir);
+}
+
+/* One corner of the ring, into a small device buffer (radius-sized). The full
+ * ring path is drawn translated so this corner lands at the tile origin; the
+ * tile only rasterizes its own arc. corner: 0=TL, 1=TR, 2=BL, 3=BR. NULL for a
+ * square (radius 0) corner, where the straight edges meet with nothing to draw. */
+static struct cairo_buffer *rasterize_border_corner(Clay_RenderCommand *cmd,
+		const int ext[4], float scale, int corner) {
+	Clay_BorderRenderData *bd = &cmd->renderData.border;
+	Clay_CornerRadius cc = bd->cornerRadius;
+	int r = ext[corner];
+	int tile = device_len(0, r, scale);
+	if (r < 1 || tile < 1) {
+		return NULL;
+	}
+	int w = device_len((int)cmd->boundingBox.x, (int)cmd->boundingBox.width, scale);
+	int h = device_len((int)cmd->boundingBox.y, (int)cmd->boundingBox.height, scale);
+	if (w < 1 || h < 1) {
+		return NULL;
+	}
+	struct cairo_buffer *cb = cairo_buffer_create(tile, tile);
+	if (cb == NULL) {
+		return NULL;
+	}
+	cairo_t *cr = cairo_create(cb->surface);
+	/* Land this corner of the ring at the tile origin (right/bottom corners are
+	 * pulled back by the full box minus the tile). */
+	double tx = (corner == 1 || corner == 3) ? (double)(w - tile) : 0.0;
+	double ty = (corner == 2 || corner == 3) ? (double)(h - tile) : 0.0;
+	cairo_translate(cr, -tx, -ty);
+	Clay_BorderWidth bw = bd->width;
+	double sl = bw.left * scale, sr = bw.right * scale;
+	double st = bw.top * scale, sb = bw.bottom * scale;
+	cairo_set_fill_rule(cr, CAIRO_FILL_RULE_EVEN_ODD);
+	rounded_rect_path(cr, 0, 0, w, h, scale_corner_radius(cc, scale));
+	double iw = (double)w - sl - sr, ih = (double)h - st - sb;
+	if (iw > 0 && ih > 0) {
+		Clay_CornerRadius ir = inset_corner_radius(cc, bw);
+		rounded_rect_path(cr, sl, st, iw, ih, scale_corner_radius(ir, scale));
+	}
+	/* Straight alpha as in rasterize_text; cairo premultiplies into ARGB32. */
+	cairo_set_source_rgba(cr, clay_srgb(bd->color.r), clay_srgb(bd->color.g),
+		clay_srgb(bd->color.b), clay_srgb(bd->color.a));
+	cairo_fill(cr);
+	cairo_destroy(cr);
+	cairo_surface_flush(cb->surface);
+	return cb;
+}
+
+/* A border, square or rounded, is a tree of four edge rects plus up to four
+ * corner arc tiles. Edges carry box moves, resizes, and clip; corner tiles carry
+ * the arc, re-rastered whenever the border data, scale, or box size changes
+ * (the ring path clamps radii against the box, so the arc must always be
+ * derived from the same box the edges were inset by). */
+static int reconcile_border(struct render_state *rs, struct rnode *n,
+		Clay_RenderCommand *cmd, Clay_BoundingBox rbox,
+		const Clay_BoundingBox *clip) {
+	(void)rbox;   /* borders are not clip targets, so rbox == box. */
+	Clay_BorderRenderData *bd = &cmd->renderData.border;
+	float color[4];
+	clay_color_to_float(bd->color, color);
+	int ext[4];
+	border_corner_extents(cmd, ext);
+	int edges[4][4];
+	border_edge_boxes(cmd, ext, clip, edges);
+	int w = (int)cmd->boundingBox.width, h = (int)cmd->boundingBox.height;
+	/* Box-relative corner origins (TL, TR, BL, BR). */
+	int cpos[4][2] = { { 0, 0 }, { w - ext[1], 0 },
+		{ 0, h - ext[2] }, { w - ext[3], h - ext[3] } };
+	int muts = 0;
+
+	bool is_new = n->node == NULL;
+	if (is_new) {
+		struct wlr_scene_tree *tree = wlr_scene_tree_create(rs->tree);
+		n->node = &tree->node;
+		wlr_scene_node_set_position(n->node,
+			(int)cmd->boundingBox.x, (int)cmd->boundingBox.y);
+		for (int i = 0; i < 4; i++) {
+			n->border_sides[i] = wlr_scene_rect_create(tree,
+				edges[i][2], edges[i][3], color);
+			wlr_scene_node_set_position(&n->border_sides[i]->node,
+				edges[i][0], edges[i][1]);
+		}
+		for (int c = 0; c < 4; c++) {
+			struct wlr_scene_buffer *sb = wlr_scene_buffer_create(tree, NULL);
+			sb->point_accepts_input = border_point_accepts_input;
+			n->border_corners[c] = sb;
+		}
+	}
+
+	/* Corner arcs: keyed on border data, scale, AND box size. The ring path
+	 * clamps radii against the solved box, so a tile rastered against a small
+	 * or degenerate box goes stale when the box grows. */
+	bool corner_changed = is_new ||
+		!box_size_equal(n->box, cmd->boundingBox) ||
+		n->raster_scale != rs->scale ||
+		memcmp(&n->data.border, bd, sizeof(*bd)) != 0;
+	if (corner_changed) {
+		size_t bytes = 0;
+		for (int c = 0; c < 4; c++) {
+			struct cairo_buffer *cb =
+				rasterize_border_corner(cmd, ext, rs->scale, c);
+			wlr_scene_buffer_set_buffer(n->border_corners[c],
+				cb != NULL ? &cb->base : NULL);
+			n->border_tile[c] = cb != NULL;
+			if (cb != NULL) {
+				bytes += cairo_buffer_bytes(cb);
+				rs->buffers_created++;
+				wlr_buffer_drop(&cb->base);
+			}
+		}
+		rs->raster_bytes = rs->raster_bytes - n->raster_bytes + bytes;
+		n->raster_bytes = bytes;
+		n->raster_scale = rs->scale;
+		muts++;
+	}
+
+	/* Edges: diff realized boxes (box move, resize, width, clip) and recolor. */
+	bool color_changed = !is_new && memcmp(&n->data.border.color, &bd->color,
+		sizeof(bd->color)) != 0;
+	for (int i = 0; i < 4; i++) {
+		/* The rect itself is the record of its last realized box, so there is
+		 * no shadow copy to keep in step with what was written. */
+		struct wlr_scene_rect *side = n->border_sides[i];
+		if (side->node.x != edges[i][0] || side->node.y != edges[i][1] ||
+				side->width != edges[i][2] || side->height != edges[i][3]) {
+			wlr_scene_rect_set_size(side, edges[i][2], edges[i][3]);
+			wlr_scene_node_set_position(&side->node, edges[i][0], edges[i][1]);
+			muts++;
+		}
+		if (color_changed) {
+			wlr_scene_rect_set_color(side, color);
+			muts++;
+		}
+	}
+
+	/* Corner tiles: place at the box-relative corner, size to the logical corner
+	 * extent (the buffer is device-sized), and show only where an extent and its
+	 * raster exist and the corner is not fully clipped out. */
+	for (int c = 0; c < 4; c++) {
+		struct wlr_scene_buffer *sb = n->border_corners[c];
+		bool show = ext[c] >= 1 && n->border_tile[c];
+		if (show && clip != NULL) {
+			Clay_BoundingBox cb = { cmd->boundingBox.x + cpos[c][0],
+				cmd->boundingBox.y + cpos[c][1],
+				(float)ext[c], (float)ext[c] };
+			show = !box_empty(box_intersect(cb, *clip));
+		}
+		if (show) {
+			wlr_scene_node_set_position(&sb->node, cpos[c][0], cpos[c][1]);
+			wlr_scene_buffer_set_dest_size(sb, ext[c], ext[c]);
+		}
+		if (sb->node.enabled != show) {
+			wlr_scene_node_set_enabled(&sb->node, show);
+			if (!is_new) {
+				muts++;
+			}
+		}
+	}
+	return muts;
+}
+
+/* --- text --- */
+
+/* The device-pixel bound a truncated run is truncated to, or 0 for an untouched
+ * run.
+ *
+ * A text command's own box is the width of its glyphs, so it is never the space
+ * the run had to fit into and there is nothing on the declaration side to read.
+ * The clip its parent declared is the only bound that exists, and rbox is that
+ * clip already intersected with the run.
+ *
+ * Measured from the run's left edge to the clip's right edge rather than as
+ * rbox.width, because a clip that cuts the left as well leaves rbox narrower
+ * than the span the glyphs are laid out across, and truncating at that narrower
+ * number would cut text that is on screen. */
+static int text_ellipsis_width(Clay_RenderCommand *cmd, Clay_BoundingBox rbox,
+		float scale) {
+	if (((uintptr_t)cmd->userData & RENDER_TEXT_ELLIPSIZE) == 0) {
+		return 0;
+	}
+	double avail = (rbox.x + rbox.width) - cmd->boundingBox.x;
+	if (avail >= cmd->boundingBox.width || avail <= 0) {
+		return 0;
+	}
+	return device_len((int)cmd->boundingBox.x, (int)avail, scale);
+}
+
+static struct cairo_buffer *rasterize_text(Clay_RenderCommand *cmd, float scale,
+		int max_width) {
+	Clay_TextRenderData *td = &cmd->renderData.text;
+	int width = device_len((int)cmd->boundingBox.x, (int)cmd->boundingBox.width, scale);
+	int height = device_len((int)cmd->boundingBox.y, (int)cmd->boundingBox.height, scale);
+	if (width < 1 || height < 1) {
+		return NULL;
+	}
+
+	struct cairo_buffer *cb = cairo_buffer_create(width, height);
+	if (cb == NULL) {
+		return NULL;
+	}
+	cairo_t *cr = cairo_create(cb->surface);
+	/* Cairo takes straight alpha here, so no premultiply. */
+	cairo_set_source_rgba(cr,
+		clay_srgb(td->textColor.r), clay_srgb(td->textColor.g),
+		clay_srgb(td->textColor.b), clay_srgb(td->textColor.a));
+
+	/* Draw the glyphs at device font size into the device-sized buffer, the same
+	 * size render_measure_text measured at, so the run occupies exactly the logical
+	 * box Clay solved (scaled). Crisp on a fractional output, no CTM scaling. */
+	PangoLayout *layout = pango_cairo_create_layout(cr);
+	render_set_text(layout, td->stringContents.chars,
+		td->stringContents.length, td->fontId, td->fontSize, scale, max_width);
+	pango_cairo_show_layout(cr, layout);
+
+	g_object_unref(layout);
+	cairo_destroy(cr);
+	cairo_surface_flush(cb->surface);
+	return cb;
+}
+
+static bool text_data_equal(Clay_TextRenderData *a, Clay_TextRenderData *b) {
+	return memcmp(&a->textColor, &b->textColor, sizeof(a->textColor)) == 0 &&
+		a->fontId == b->fontId && a->fontSize == b->fontSize &&
+		a->letterSpacing == b->letterSpacing && a->lineHeight == b->lineHeight;
+}
+
+static int reconcile_text(struct render_state *rs, struct rnode *n,
+		Clay_RenderCommand *cmd, Clay_BoundingBox rbox) {
+	Clay_TextRenderData *td = &cmd->renderData.text;
+	int muts = 0;
+
+	/* Length first, and the compare only for a non-empty run: an empty one
+	 * leaves n->text NULL, and memcmp(NULL, ..., 0) is undefined even though it
+	 * reads nothing (UBSan flags it). */
+	bool content_changed = n->text_len != td->stringContents.length ||
+		(td->stringContents.length > 0 &&
+			memcmp(n->text, td->stringContents.chars,
+				td->stringContents.length) != 0);
+
+	bool is_new = n->node == NULL;
+	if (is_new) {
+		struct wlr_scene_buffer *sb = wlr_scene_buffer_create(rs->tree, NULL);
+		n->node = &sb->node;
+		content_changed = true;
+	}
+
+	/* The buffer is always rasterized at the full solved box; clipping is a
+	 * crop of that buffer, never a re-raster. Re-raster on content, solved
+	 * size, or style change.
+	 *
+	 * A truncated run is the one thing here that a crop cannot express, so its
+	 * bound joins the raster keys. Without it, narrowing a clip over a run whose
+	 * own box never moved would keep the buffer truncated at the old width and
+	 * crop the mark itself in half. */
+	int ell = text_ellipsis_width(cmd, rbox, rs->scale);
+	bool raster_changed = content_changed ||
+		!box_size_equal(n->box, cmd->boundingBox) ||
+		n->raster_scale != rs->scale ||
+		n->text_ellipsis != ell ||
+		!text_data_equal(&n->data.text, td);
+	struct wlr_scene_buffer *sb = wlr_scene_buffer_from_node(n->node);
+	if (raster_changed) {
+		rnode_set_raster(rs, n, sb, rasterize_text(cmd, rs->scale, ell));
+		n->raster_scale = rs->scale;
+		n->text_ellipsis = ell;
+		muts++;
+	}
+
+	muts += rnode_apply_clip(n, sb, cmd, rbox, rs->scale, raster_changed);
+
+	if (content_changed) {
+		free(n->text);
+		n->text = malloc(td->stringContents.length);
+		memcpy(n->text, td->stringContents.chars, td->stringContents.length);
+		n->text_len = td->stringContents.length;
+	}
+	return muts;
+}
+
+/* --- images ---
+ *
+ * The decode cache (ui.c) holds one native cairo surface per path. The image
+ * rasters per node into a box-sized buffer: cairo scales the native into the
+ * solved box and rounds the corners if asked. This mirrors reconcile_text
+ * (raster on change, then crop to the clip), so an image clips inside a scroll
+ * container for free.
+ *
+ * The colour an image command carries is a STENCIL here: the ink replaces the
+ * decoded pixels and only their alpha survives. Clay carries the colour and
+ * leaves the interpretation to the renderer, so this is a choice, and the
+ * reason for it is that the case worth having is inking a glyph whose own
+ * colour is arbitrary. Scaling each channel by the ink instead would preserve
+ * the file's shading but could only ever darken, which cannot ink a dark glyph
+ * at all. A zero-alpha ink never arrives: the solver stores no colour for it. */
+
+static struct cairo_buffer *rasterize_image(Clay_RenderCommand *cmd,
+		struct image_entry *entry, float scale) {
+	int w = device_len((int)cmd->boundingBox.x, (int)cmd->boundingBox.width, scale);
+	int h = device_len((int)cmd->boundingBox.y, (int)cmd->boundingBox.height, scale);
+	if (w < 1 || h < 1 || entry->width < 1 || entry->height < 1) {
+		return NULL;
+	}
+	struct cairo_buffer *cb = cairo_buffer_create(w, h);
+	if (cb == NULL) {
+		return NULL;
+	}
+	cairo_t *cr = cairo_create(cb->surface);
+
+	/* w and h are already device pixels, so scaling the native surface to fill
+	 * them (below) also carries the output scale: the image is sampled once, at
+	 * device density. The corner radii scale to match. */
+	Clay_CornerRadius radius = scale_corner_radius(
+		cmd->renderData.image.cornerRadius, scale);
+	if (!corner_radius_zero(radius)) {
+		rounded_rect_path(cr, 0, 0, w, h, radius);
+		cairo_clip(cr);
+	}
+	cairo_scale(cr, (double)w / entry->width, (double)h / entry->height);
+	Clay_Color ink = cmd->renderData.image.backgroundColor;
+	if (ink.a > 0) {
+		cairo_set_source_rgba(cr, clay_srgb(ink.r), clay_srgb(ink.g),
+			clay_srgb(ink.b), clay_srgb(ink.a));
+		cairo_mask_surface(cr, entry->native, 0, 0);
+	} else {
+		cairo_set_source_surface(cr, entry->native, 0, 0);
+		cairo_paint(cr);
+	}
+
+	cairo_destroy(cr);
+	cairo_surface_flush(cb->surface);
+	return cb;
+}
+
+static bool image_data_equal(Clay_ImageRenderData *a, Clay_ImageRenderData *b) {
+	return a->imageData == b->imageData &&
+		memcmp(&a->backgroundColor, &b->backgroundColor,
+			sizeof(a->backgroundColor)) == 0 &&
+		memcmp(&a->cornerRadius, &b->cornerRadius,
+			sizeof(a->cornerRadius)) == 0;
+}
+
+static int reconcile_image(struct render_state *rs, struct rnode *n,
+		Clay_RenderCommand *cmd, Clay_BoundingBox rbox) {
+	struct image_entry *entry =
+		(struct image_entry *)cmd->renderData.image.imageData;
+	int muts = 0;
+
+	bool is_new = n->node == NULL;
+	if (is_new) {
+		struct wlr_scene_buffer *sb = wlr_scene_buffer_create(rs->tree, NULL);
+		n->node = &sb->node;
+	}
+	struct wlr_scene_buffer *sb = wlr_scene_buffer_from_node(n->node);
+
+	/* A missing, failed, or not-yet-decoded entry shows nothing. */
+	bool usable = entry != NULL && !entry->failed && entry->native != NULL;
+	bool raster_changed = is_new ||
+		!box_size_equal(n->box, cmd->boundingBox) ||
+		n->raster_scale != rs->scale ||
+		!image_data_equal(&n->data.image, &cmd->renderData.image) ||
+		(usable && entry->gen != n->img_gen);
+
+	if (raster_changed) {
+		rnode_set_raster(rs, n, sb,
+			usable ? rasterize_image(cmd, entry, rs->scale) : NULL);
+		n->img_gen = usable ? entry->gen : 0;
+		n->raster_scale = rs->scale;
+		muts++;
+	}
+
+	/* Crop to the clip, exactly as reconcile_text does (buffer is ceil(box)
+	 * sized, so the source box is in box pixels). */
+	muts += rnode_apply_clip(n, sb, cmd, rbox, rs->scale, raster_changed);
+	return muts;
+}
+
+/* --- client surfaces, borrowed through the hooks ---
+ *
+ * A scene tree has one parent, so a client can be borrowed by exactly one
+ * output at a time. When a client migrates between outputs both may briefly
+ * hold a retained record for it: the new output steals the tree by
+ * reparenting, and the old output's next sweep would then reparent it home
+ * and disable it, blanking a node the new owner shows. Ownership settles
+ * that race: borrow records the reparenting render_state as owner, and a
+ * release from any other render_state is a no-op. A single client is never
+ * declared on two outputs in the same frame (a client belongs to one tag,
+ * one screen), so simultaneous double-display cannot arise through policy;
+ * if it ever did, the tree==scene verifier would abort on the position
+ * mismatch, loudly. */
+
+static int reconcile_surface(struct render_state *rs, struct rnode *n,
+		Clay_RenderCommand *cmd, const struct render_client_hooks *hooks) {
+	uint64_t handle = (uint64_t)(uintptr_t)cmd->renderData.custom.customData;
+	struct wlr_scene_tree *tree = hooks->resolve(hooks->data, handle);
+	n->borrowed = true;
+	n->handle = handle;
+
+	if (tree == NULL) {
+		/* The client died between the declare and this reconcile. Drop
+		 * any stored pointer without touching it; the sweep or the next
+		 * declare pass forgets the id. */
+		n->node = NULL;
+		return 0;
+	}
+
+	int muts = 0;
+	if (n->node == NULL) {
+		wlr_scene_node_reparent(&tree->node, rs->tree);
+		wlr_scene_node_set_enabled(&tree->node, true);
+		n->node = &tree->node;
+		hooks->borrow(hooks->data, handle, rs);
+		muts++;
+	} else if (n->node != &tree->node) {
+		/* One handle, one scene tree, for the toplevel's whole life. */
+		wlr_log(WLR_ERROR, "surface node for handle %" PRIu64
+			" changed identity", handle);
+		abort();
+	}
+
+	if (!box_size_equal(n->box, cmd->boundingBox)) {
+		hooks->configure(hooks->data, handle,
+			(int)cmd->boundingBox.width, (int)cmd->boundingBox.height);
+		muts++;
+	}
+	return muts;
+}
+
+/* --- tree==scene: every solved box must match the scene, every frame --- */
+
+#ifdef SOMEWM_RENDER_VERIFY
+
+static void verify_node(struct rnode *n) {
+	if (n->node == NULL) {
+		return;
+	}
+	/* A leaf clipped to nothing is legitimately disabled; that is the only
+	 * case where a declared node may be off. */
+	if (box_empty(n->rbox)) {
+		if (n->node->enabled) {
+			wlr_log(WLR_ERROR, "tree==scene: key %" PRIx64
+				" clipped empty but still enabled", n->key);
+			abort();
+		}
+		return;
+	}
+	if (!n->node->enabled) {
+		wlr_log(WLR_ERROR, "tree==scene: node for key %" PRIx64
+			" is disabled while declared", n->key);
+		abort();
+	}
+	/* Check 2 of the agreement invariant: no node draws outside its innermost
+	 * active scissor box. rbox is the box already intersected with that scope,
+	 * so this fires only if a future path realized a node past its clip. */
+	if (!box_contains(n->clip, n->rbox)) {
+		wlr_log(WLR_ERROR, "tree==scene: key %" PRIx64
+			" realized box %d,%d %dx%d escapes clip scope %d,%d %dx%d",
+			n->key, (int)n->rbox.x, (int)n->rbox.y,
+			(int)n->rbox.width, (int)n->rbox.height,
+			(int)n->clip.x, (int)n->clip.y,
+			(int)n->clip.width, (int)n->clip.height);
+		abort();
+	}
+	if (n->node->x != (int)n->rbox.x || n->node->y != (int)n->rbox.y) {
+		wlr_log(WLR_ERROR, "tree==scene: key %" PRIx64
+			" at %d,%d but realized box says %d,%d",
+			n->key, n->node->x, n->node->y,
+			(int)n->rbox.x, (int)n->rbox.y);
+		abort();
+	}
+	if (n->node->type == WLR_SCENE_NODE_RECT) {
+		struct wlr_scene_rect *rect = wlr_scene_rect_from_node(n->node);
+		if (rect->width != (int)n->rbox.width ||
+				rect->height != (int)n->rbox.height) {
+			wlr_log(WLR_ERROR, "tree==scene: rect %" PRIx64
+				" is %dx%d but realized box says %dx%d",
+				n->key, rect->width, rect->height,
+				(int)n->rbox.width, (int)n->rbox.height);
+			abort();
+		}
+	}
+}
+
+#endif /* SOMEWM_RENDER_VERIFY */
+
+/* Does the command key name a borrowed client that currently presents a live
+ * xdg-popup? Only a CUSTOM (place-leaf) command can, so the cheap type check
+ * skips the map lookup and the hook for every draw-leaf. Used to fold such
+ * clients to the top of the order so their popups are not occluded. */
+static bool rnode_owns_popup(struct render_state *rs, uint64_t key,
+		const struct render_client_hooks *hooks) {
+	if ((uint32_t)(key >> 32) != CLAY_RENDER_COMMAND_TYPE_CUSTOM) {
+		return false;
+	}
+	size_t idx = rmap_get(rs, key);
+	return idx != SIZE_MAX && rs->nodes[idx].borrowed &&
+		hooks->has_popup(hooks->data, rs->nodes[idx].handle);
+}
+
+#ifdef SOMEWM_RENDER_VERIFY
+
+/* Check 1 of the agreement invariant: scene sibling order equals command
+ * order. The restack raises each command's node to the top in order, so a
+ * forward walk of the children list (bottom to top) must visit exactly the
+ * nodes rs->order names, in the same sequence, skipping commands that realized
+ * no node (SCISSOR markers, dead surfaces). A dropped raise reorders a sibling
+ * and aborts here. Runs after the restack, when the map is valid. */
+static void verify_order(struct render_state *rs) {
+	struct wlr_scene_node *child;
+	size_t oi = 0;
+	wl_list_for_each(child, &rs->tree->children, link) {
+		struct wlr_scene_node *expect = NULL;
+		while (oi < rs->order_len) {
+			size_t idx = rmap_get(rs, rs->order[oi]);
+			oi++;
+			if (idx != SIZE_MAX && rs->nodes[idx].node != NULL) {
+				expect = rs->nodes[idx].node;
+				break;
+			}
+		}
+		if (child != expect) {
+			wlr_log(WLR_ERROR, "tree==scene: sibling order diverges from "
+				"command order");
+			abort();
+		}
+	}
+	/* Every command left over must be nodeless; one with a node means the
+	 * scene is missing a child the command declared. */
+	while (oi < rs->order_len) {
+		size_t idx = rmap_get(rs, rs->order[oi]);
+		oi++;
+		if (idx != SIZE_MAX && rs->nodes[idx].node != NULL) {
+			wlr_log(WLR_ERROR, "tree==scene: command %" PRIx64
+				" has no scene child", rs->order[oi - 1]);
+			abort();
+		}
+	}
+}
+
+#endif /* SOMEWM_RENDER_VERIFY */
+
+/* --- the scene-node-to-Clay-id backmap --- */
+
+uint32_t render_hit_id(struct render_state *rs, struct wlr_scene_node *node) {
+	if (node == NULL) {
+		return 0;
+	}
+	for (size_t i = 0; i < rs->len; i++) {
+		struct rnode *n = &rs->nodes[i];
+		if (n->node == NULL) {
+			continue;
+		}
+		/* The hit node is the retained node itself (rect, buffer) or a
+		 * descendant of it (a square border's side rect under its tree). */
+		for (struct wlr_scene_node *c = node; c != NULL;
+				c = c->parent != NULL ? &c->parent->node : NULL) {
+			if (c == n->node) {
+				/* RECTANGLE, IMAGE, and CUSTOM commands carry the element id
+				 * directly (comparable to Clay_GetPointerOverIds). TEXT and
+				 * BORDER commands carry a Clay-derived per-line / per-side
+				 * hash, not the element id, so they are not comparable; report
+				 * 0 for them (the structural checks cover their order and
+				 * clipping). */
+				uint32_t type = (uint32_t)(n->key >> 32);
+				if (type == CLAY_RENDER_COMMAND_TYPE_TEXT ||
+						type == CLAY_RENDER_COMMAND_TYPE_BORDER) {
+					return 0;
+				}
+				return (uint32_t)(n->key & 0xFFFFFFFF);
+			}
+			if (c == &rs->tree->node) {
+				break;
+			}
+		}
+	}
+	return 0;
+}
+
+/* --- the reconcile pass --- */
+
+int render_reconcile(struct render_state *rs, Clay_RenderCommandArray commands,
+		const struct render_client_hooks *hooks) {
+	rs->gen++;
+	rs->buffers_created = 0;
+	rs->node_recreated = false;
+	int muts = 0;
+
+	/* Map reflects the pre-pass nodes; new nodes appended below get unique
+	 * keys and are never looked up again this pass, so it stays valid. */
+	rmap_rebuild(rs);
+	size_t pre_len = rs->len;
+
+	/* One capacity for both, so p_realloc rather than p_grow: the second
+	 * p_grow would see the capacity the first already raised. */
+	if ((size_t)commands.length > rs->order_cap) {
+		rs->order_cap = commands.length;
+		p_realloc(&rs->order, rs->order_cap);
+		p_realloc(&rs->build, rs->order_cap);
+	}
+
+	/* The active SCISSOR clip scopes, innermost last, rebuilt as the walk
+	 * crosses START/END. wlr_scene has no subtree clip, so each drawn node is
+	 * clipped on its own against the top of this stack. Depth is bounded by
+	 * tree nesting; the cap is a backstop, not a real limit. */
+	Clay_BoundingBox clip_stack[CLIP_STACK_MAX];
+	int clip_depth = 0;
+
+	for (int32_t i = 0; i < commands.length; i++) {
+		Clay_RenderCommand *cmd = Clay_RenderCommandArray_Get(&commands, i);
+		uint64_t key = (uint64_t)cmd->commandType << 32 | cmd->id;
+		rs->build[i] = key;
+
+		size_t idx = rmap_get(rs, key);
+		struct rnode *n = idx == SIZE_MAX ? NULL : &rs->nodes[idx];
+		if (n == NULL) {
+			n = rnode_add(rs, key);
+		}
+		bool is_new = n->node == NULL;
+		n->gen = rs->gen;
+
+		/* The clip that applies to this command reflects every START/END
+		 * already crossed; this command's own START (below) affects only its
+		 * children. Place-leaves are exempt (client popups overhang),
+		 * so a CUSTOM subtree is never clipped. */
+		const Clay_BoundingBox *clip_top = clip_depth > 0 ?
+			&clip_stack[(clip_depth < CLIP_STACK_MAX ? clip_depth : CLIP_STACK_MAX) - 1]
+			: NULL;
+		/* A border (square or rounded) keeps its per-side clip against clip_top,
+		 * so it stays unclippable and its tree sits at the unclipped origin: the
+		 * edges clip in absolute space and each corner tile disables when fully
+		 * clipped. Only the rastered leaves crop via rbox. */
+		bool clippable = cmd->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE ||
+			cmd->commandType == CLAY_RENDER_COMMAND_TYPE_TEXT ||
+			cmd->commandType == CLAY_RENDER_COMMAND_TYPE_IMAGE;
+		Clay_BoundingBox rbox = (clip_top != NULL && clippable) ?
+			box_intersect(cmd->boundingBox, *clip_top) : cmd->boundingBox;
+
+		switch (cmd->commandType) {
+		case CLAY_RENDER_COMMAND_TYPE_RECTANGLE:
+			muts += reconcile_rectangle(rs, n, cmd, rbox);
+			break;
+		case CLAY_RENDER_COMMAND_TYPE_BORDER:
+			muts += reconcile_border(rs, n, cmd, rbox, clip_top);
+			break;
+		case CLAY_RENDER_COMMAND_TYPE_TEXT:
+			muts += reconcile_text(rs, n, cmd, rbox);
+			break;
+		case CLAY_RENDER_COMMAND_TYPE_IMAGE:
+			muts += reconcile_image(rs, n, cmd, rbox);
+			break;
+		case CLAY_RENDER_COMMAND_TYPE_CUSTOM:
+			muts += reconcile_surface(rs, n, cmd, hooks);
+			break;
+		case CLAY_RENDER_COMMAND_TYPE_SCISSOR_START: {
+			/* The clip rect is the command's own box; the two bools name which
+			 * axes clip, so an unclipped axis is left unbounded. Nested scopes
+			 * compose by intersecting with the enclosing clip.
+			 *
+			 * Naming NEITHER axis means both, not none. Clay emits this command
+			 * from two places: a clip element, which fills in its own config's
+			 * two bools, and a FLOATING element whose clipTo names an ancestor
+			 * clip, which fills in nothing at all and hands over that ancestor's
+			 * box. Reading that second one
+			 * as "no axis clips" is a scene-vs-Clay divergence by construction:
+			 * Clay's own hit test clips such a root to that box on BOTH axes,
+			 * so the scene would draw content Clay says is not there, which is
+			 * exactly what the agreement invariant aborts on (the debug panel's
+			 * element list is such a float, and its rows once drew over the
+			 * pane below it). Scissoring the box unconditionally is the only
+			 * reading that matches the solver. */
+			Clay_BoundingBox clip = cmd->boundingBox;
+			bool both = !cmd->renderData.clip.horizontal &&
+				!cmd->renderData.clip.vertical;
+			if (!cmd->renderData.clip.horizontal && !both) {
+				clip.x = -CLIP_INF;
+				clip.width = 2.0f * CLIP_INF;
+			}
+			if (!cmd->renderData.clip.vertical && !both) {
+				clip.y = -CLIP_INF;
+				clip.height = 2.0f * CLIP_INF;
+			}
+			if (clip_top != NULL) {
+				clip = box_intersect(*clip_top, clip);
+			}
+			if (clip_depth < CLIP_STACK_MAX) {
+				clip_stack[clip_depth] = clip;
+			}
+			clip_depth++;
+			break;
+		}
+		case CLAY_RENDER_COMMAND_TYPE_SCISSOR_END:
+			if (clip_depth > 0) {
+				clip_depth--;
+			} else {
+				wlr_log(WLR_ERROR, "unbalanced SCISSOR_END");
+			}
+			break;
+		default:
+			/* Every Clay command type is handled above; a new one is a bug. */
+			wlr_log(WLR_ERROR, "unhandled render command type %d",
+				cmd->commandType);
+			abort();
+		}
+
+		/* Position and visibility are common to every realized node. Placement
+		 * of a new node is part of its creation mutation, not a second one. A
+		 * NULL node is a SCISSOR marker or a surface whose client died
+		 * mid-frame; skip it. Position uses the realized box, so a node clipped
+		 * on its left or top edge sits at the clip boundary. */
+		if (n->node != NULL) {
+			if (is_new || !box_pos_equal(n->rbox, rbox)) {
+				wlr_scene_node_set_position(n->node, (int)rbox.x, (int)rbox.y);
+				if (!is_new) {
+					muts++;
+				}
+				/* A borrowed client tree that was placed or moved invalidates
+				 * any geometry the owner keyed to its scene position:
+				 * xdg-popups unconstrained against the pre-move box, and X11
+				 * root coordinates. Fires on first placement too, because the
+				 * borrow's configure above ran before this position existed.
+				 * Fire after set_position so the owner reads the new coords.
+				 * C to C, no reconcile reentry. */
+				if (n->borrowed && hooks->reposition != NULL) {
+					hooks->reposition(hooks->data, n->handle);
+				}
+			}
+			bool want_enabled = !box_empty(rbox);
+			if (n->node->enabled != want_enabled) {
+				wlr_scene_node_set_enabled(n->node, want_enabled);
+				if (!is_new) {
+					muts++;
+				}
+			}
+		}
+
+		n->box = cmd->boundingBox;
+		n->rbox = rbox;
+		/* The scope rbox was realized against, mirroring the rbox computation
+		 * above: the active clip for a clippable node, else unbounded. */
+		n->clip = (clip_top != NULL && clippable) ? *clip_top : box_inf();
+		n->data = cmd->renderData;
+	}
+	size_t build_len = commands.length;
+	if (clip_depth != 0) {
+		wlr_log(WLR_ERROR, "unbalanced SCISSOR scopes: depth %d at frame end",
+			clip_depth);
+	}
+
+	/* Sweep ids that vanished this frame. */
+	bool swept = false;
+	for (size_t i = 0; i < rs->len; ) {
+		if (rs->nodes[i].gen != rs->gen) {
+			rnode_remove(rs, &rs->nodes[i], hooks);
+			swept = true;
+			muts++;
+		} else {
+			i++;
+		}
+	}
+
+	/* The sweep's swap-removal scrambles indices, and nodes appended during the
+	 * declare loop were never inserted; either way the fold and the restack read
+	 * the map by key, so it has to be rebuilt. A frame that added and removed
+	 * nothing did neither, which is the frame worth keeping free of per-node
+	 * work. */
+	if (swept || rs->len != pre_len) {
+		rmap_rebuild(rs);
+	}
+
+	/* Fold popup-owner clients to the tail (the top): a borrowed client showing
+	 * a live xdg-popup is raised above its sibling clients so the popup, which
+	 * may overhang into a neighbor tile, is not occluded. Stable partition, so
+	 * a steadily-open popup yields the identical order every frame. The
+	 * reconciler stays the single stacking authority, so verify_order (check 1)
+	 * holds against this same order. */
+	if (hooks->has_popup != NULL) {
+		size_t no = 0;
+		for (size_t i = 0; i < build_len; i++) {
+			if (rnode_owns_popup(rs, rs->build[i], hooks)) {
+				no++;
+			}
+		}
+		if (no > 0) {
+			uint64_t *owners = malloc(no * sizeof(*owners));
+			size_t oi = 0, w = 0;
+			for (size_t i = 0; i < build_len; i++) {
+				if (rnode_owns_popup(rs, rs->build[i], hooks)) {
+					owners[oi++] = rs->build[i];
+				} else {
+					rs->build[w++] = rs->build[i];
+				}
+			}
+			for (size_t j = 0; j < no; j++) {
+				rs->build[w++] = owners[j];
+			}
+			free(owners);
+		}
+	}
+
+	/* order_changed against the previous frame's FINAL (folded) order, so an
+	 * identical frame, popup open or not, still restacks nothing. A kind-swap
+	 * recreation forces it regardless: the fresh scene node sits at the top
+	 * of the sibling list while its command key is unchanged. */
+	bool order_changed = build_len != rs->order_len || rs->node_recreated;
+	for (size_t i = 0; !order_changed && i < build_len; i++) {
+		if (rs->build[i] != rs->order[i]) {
+			order_changed = true;
+		}
+	}
+	memcpy(rs->order, rs->build, build_len * sizeof(*rs->order));
+	rs->order_len = build_len;
+
+	/* Commands are sorted by z (popup-owners folded on top); restack only when
+	 * the order changed. */
+	if (order_changed) {
+		for (size_t i = 0; i < rs->order_len; i++) {
+			size_t idx = rmap_get(rs, rs->order[i]);
+			assert(idx != SIZE_MAX);
+			struct rnode *n = &rs->nodes[idx];
+			if (n->node != NULL) {
+				wlr_scene_node_raise_to_top(n->node);
+				muts++;
+			}
+		}
+	}
+
+#ifdef SOMEWM_RENDER_VERIFY
+	for (size_t i = 0; i < rs->len; i++) {
+		verify_node(&rs->nodes[i]);
+	}
+	verify_order(rs);
+#endif
+
+	return muts;
+}
+
+void render_destroy(struct render_state *rs,
+		const struct render_client_hooks *hooks) {
+	/* Borrowed trees must leave before the render tree is destroyed, or
+	 * the clients' scene nodes would be destroyed with it. */
+	for (size_t i = 0; i < rs->len; i++) {
+		if (rs->nodes[i].borrowed) {
+			hooks->release(hooks->data, rs->nodes[i].handle, rs);
+		}
+		free(rs->nodes[i].text);
+	}
+	wlr_scene_node_destroy(&rs->tree->node);
+	for (struct render_state **p = &render_states; *p != NULL; p = &(*p)->next) {
+		if (*p == rs) {
+			*p = rs->next;
+			break;
+		}
+	}
+	free(rs->nodes);
+	free(rs->order);
+	free(rs->build);
+	free(rs->map);
+	free(rs);
+}
+
+size_t render_node_count(struct render_state *rs) {
+	return rs->len;
+}
+
+size_t render_raster_bytes(struct render_state *rs) {
+	return rs->raster_bytes;
+}
+
+int render_buffers_created(struct render_state *rs) {
+	return rs->buffers_created;
+}

--- a/render.h
+++ b/render.h
@@ -1,0 +1,98 @@
+#ifndef SOMEWM_RENDER_H
+#define SOMEWM_RENDER_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "clay.h"
+
+struct wlr_scene_tree;
+struct wlr_scene_node;
+
+struct render_state;
+
+/* How the renderer reaches client surfaces. resolve returns the client's
+ * scene tree for a handle, or NULL if the client is gone (then the
+ * renderer must not touch any stored pointer). configure asks the client
+ * to match its solved box. borrow records the render_state that reparented
+ * the tree as its current owner. release returns a borrowed tree to its
+ * home parent, disabled, but only if the caller is still the owner: after a
+ * client migrates to another output, the old output's sweep must not
+ * disable a node the new owner is showing. The owner token is an opaque
+ * render_state pointer. reposition notes that a borrowed tree moved this
+ * frame (its solved position changed), so the owner can re-derive anything
+ * keyed to the tree's scene position, namely xdg-popup unconstrain and X11
+ * root coordinates. C to C, never Lua; optional (a NULL reposition is not
+ * called).
+ *
+ * The renderer holds no client knowledge. Nothing implements these hooks yet:
+ * somewm's mapping (handle = the client, resolve returns c->scene) arrives with
+ * the declare pass in stage 4. */
+struct render_client_hooks {
+	struct wlr_scene_tree *(*resolve)(void *data, uint64_t handle);
+	void (*configure)(void *data, uint64_t handle, int width, int height);
+	void (*borrow)(void *data, uint64_t handle, void *owner);
+	void (*release)(void *data, uint64_t handle, void *owner);
+	void (*reposition)(void *data, uint64_t handle);
+	/* True while the client presents a live xdg-popup: the reconciler folds it
+	 * to the top of the draw order so the popup, which may overhang into a
+	 * neighbor tile, is not occluded by that sibling. C to C, never Lua;
+	 * optional (a NULL has_popup means no client is ever folded up). */
+	bool (*has_popup)(void *data, uint64_t handle);
+	void *data;
+};
+
+struct render_state *render_create(struct wlr_scene_tree *parent);
+
+/* Show or hide everything this render_state drew, without dropping the retained
+ * nodes, so a band that is raised again does not first flash its last frame. */
+void render_set_enabled(struct render_state *rs, bool on);
+void render_destroy(struct render_state *rs,
+	const struct render_client_hooks *hooks);
+
+/* Reconcile a solved command array into the scene. Returns the number of
+ * scene mutations performed (0 for an identical frame). Afterwards, in builds
+ * compiled with SOMEWM_RENDER_VERIFY, the tree==scene verifier compares every
+ * command box against the scene and aborts on divergence. */
+int render_reconcile(struct render_state *rs, Clay_RenderCommandArray commands,
+	const struct render_client_hooks *hooks);
+
+/* Move the per-output UI tree to the output's position in the layout. */
+void render_set_position(struct render_state *rs, int x, int y);
+
+/* The output's scale, applied to every raster from the next reconcile on: buffers
+ * are sized in device pixels (edges rounded in device space, so shared tile edges
+ * cannot seam) and content is drawn at device density, so a fractional output is
+ * sharp. Clay still solves in logical px (wlr_output_effective_resolution divides
+ * by scale), so this touches only the raster, never the layout. A change re-rasters
+ * this output's nodes (scale joins the raster cache key). */
+void render_set_scale(struct render_state *rs, float scale);
+
+/* The scene-node-to-Clay-id backmap: given a scene node the scene hit test
+ * returned, find the retained chrome node that drew it (the node itself, or an
+ * ancestor for a square border's side rects) and return that command's Clay
+ * element id. Only RECTANGLE, IMAGE, and CUSTOM commands carry the element id
+ * directly; TEXT and BORDER commands carry a Clay-derived per-line / per-side
+ * hash that is not the element id, so those report 0 (not comparable to
+ * Clay_GetPointerOverIds). Also 0 for a node this render_state did not draw (a
+ * client surface, another output's chrome). Chrome is small and hit events are
+ * rare, so a linear scan is fine.
+ *
+ * One RECTANGLE is not an element: for a border with betweenChildren > 0 Clay
+ * emits a divider rectangle per gap carrying Clay__HashNumber(parentId, n)
+ * (clay.h:3002, 3017). That id is well-formed but names no element, and the
+ * command array carries no flag telling it apart from a real one, so a caller
+ * must treat an id that resolves to nothing as no match rather than as an
+ * unknown widget. */
+uint32_t render_hit_id(struct render_state *rs, struct wlr_scene_node *node);
+
+/* Profiling readback, logged on every solve so a long-running session can
+ * assert growth stays proportional to on-screen content: live retained nodes,
+ * resident cairo raster bytes across them, and buffers allocated by the last
+ * reconcile pass. */
+size_t render_node_count(struct render_state *rs);
+size_t render_raster_bytes(struct render_state *rs);
+int render_buffers_created(struct render_state *rs);
+
+#endif

--- a/render_image.c
+++ b/render_image.c
@@ -1,0 +1,260 @@
+/* The image cache: decode once per key, hand the renderer a stable entry, and
+ * keep resident pixels under a byte budget. Ported from kiln (ui.c). */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <wlr/util/log.h>
+
+#include "common/util.h"
+#include "render_image.h"
+
+/* Default image decode budget, MB. Two panel-sized wallpapers plus icon change;
+ * a working set larger than the budget stays correct but re-decodes per frame.
+ * SOMEWM_IMAGE_BUDGET_MB overrides. */
+#define IMAGE_BUDGET_MB 64
+
+struct image_cache {
+	/* Entries are heap-stable for the process (Clay carries their addresses as
+	 * imageData), so this holds pointers. */
+	struct image_entry **images;
+	size_t images_len, images_cap;
+	size_t bytes, budget;
+	uint64_t clock;
+};
+
+/* gdk-pixbuf gives non-premultiplied R,G,B[,A] bytes; cairo ARGB32 wants a
+ * native-endian uint32 with premultiplied alpha (little-endian here, so the
+ * bytes land B,G,R,A). Written from the gdk-pixbuf/cairo contracts, not lifted. */
+static cairo_surface_t *pixbuf_to_cairo(GdkPixbuf *pb) {
+	int w = gdk_pixbuf_get_width(pb);
+	int h = gdk_pixbuf_get_height(pb);
+	int channels = gdk_pixbuf_get_n_channels(pb);
+	int pb_stride = gdk_pixbuf_get_rowstride(pb);
+	bool has_alpha = gdk_pixbuf_get_has_alpha(pb);
+	const guchar *pixels = gdk_pixbuf_get_pixels(pb);
+
+	cairo_surface_t *surface = cairo_image_surface_create(
+		CAIRO_FORMAT_ARGB32, w, h);
+	if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) {
+		cairo_surface_destroy(surface);
+		return NULL;
+	}
+	int c_stride = cairo_image_surface_get_stride(surface);
+	unsigned char *dst = cairo_image_surface_get_data(surface);
+	for (int y = 0; y < h; y++) {
+		const guchar *s = pixels + (size_t)y * pb_stride;
+		uint32_t *d = (uint32_t *)(dst + (size_t)y * c_stride);
+		for (int x = 0; x < w; x++) {
+			uint8_t r = s[0], g = s[1], b = s[2];
+			uint8_t a = has_alpha ? s[3] : 0xff;
+			r = (uint8_t)((uint32_t)r * a / 255);
+			g = (uint8_t)((uint32_t)g * a / 255);
+			b = (uint8_t)((uint32_t)b * a / 255);
+			d[x] = ((uint32_t)a << 24) | ((uint32_t)r << 16) |
+				((uint32_t)g << 8) | (uint32_t)b;
+			s += channels;
+		}
+	}
+	cairo_surface_mark_dirty(surface);
+	return surface;
+}
+
+static struct image_entry *image_find(struct image_cache *ic, const char *path) {
+	for (size_t i = 0; i < ic->images_len; i++) {
+		if (strcmp(ic->images[i]->path, path) == 0) {
+			return ic->images[i];
+		}
+	}
+	return NULL;
+}
+
+static void image_decode(struct image_entry *e) {
+	e->decoded = true;
+	GError *err = NULL;
+	GdkPixbuf *pb = gdk_pixbuf_new_from_file(e->path, &err);
+	if (pb == NULL) {
+		e->failed = true;
+		wlr_log(WLR_ERROR, "image decode failed for %s: %s", e->path,
+			err != NULL ? err->message : "unknown");
+		if (err != NULL) {
+			g_error_free(err);
+		}
+		return;
+	}
+	e->native = pixbuf_to_cairo(pb);
+	g_object_unref(pb);
+	if (e->native == NULL) {
+		e->failed = true;
+		return;
+	}
+	e->width = cairo_image_surface_get_width(e->native);
+	e->height = cairo_image_surface_get_height(e->native);
+	e->failed = false;
+	e->gen++;
+}
+
+/* Drop least-recently-declared decoded pixels until the budget holds. Entries
+ * touched by the in-progress solve are exempt: their native pointer may be read
+ * by this solve's reconcile. If everything resident is exempt, the budget yields
+ * to the live set. Pixels only; the entry struct and its imageData pointer are
+ * stable for the process. */
+static void image_evict(struct image_cache *ic) {
+	while (ic->bytes > ic->budget) {
+		struct image_entry *lru = NULL;
+		for (size_t i = 0; i < ic->images_len; i++) {
+			struct image_entry *e = ic->images[i];
+			if (e->native == NULL || e->touch >= ic->clock) {
+				continue;
+			}
+			if (lru == NULL || e->touch < lru->touch) {
+				lru = e;
+			}
+		}
+		if (lru == NULL) {
+			return;
+		}
+		cairo_surface_destroy(lru->native);
+		lru->native = NULL;
+		lru->decoded = false;
+		ic->bytes -= lru->bytes;
+		lru->bytes = 0;
+	}
+}
+
+/* Find or create the entry for a key, without deciding anything about pixels.
+ * The key is only a path when something means to decode a file from it. */
+static struct image_entry *image_intern(struct image_cache *ic, const char *key) {
+	struct image_entry *e = image_find(ic, key);
+	if (e != NULL) {
+		return e;
+	}
+	e = calloc(1, sizeof(*e));
+	e->path = strdup(key);
+	p_grow(&ic->images, ic->images_len + 1, &ic->images_cap);
+	ic->images[ic->images_len++] = e;
+	return e;
+}
+
+struct image_entry *image_cache_get(struct image_cache *ic, const char *path) {
+	struct image_entry *e = image_intern(ic, path);
+	e->touch = ic->clock;
+	if (!e->decoded) {
+		image_decode(e);
+		if (e->native != NULL) {
+			e->bytes = (size_t)cairo_image_surface_get_stride(e->native) *
+				e->height;
+			ic->bytes += e->bytes;
+			image_evict(ic);
+		}
+	}
+	return e;
+}
+
+bool image_cache_put(struct image_cache *ic, const char *key, int width,
+		int height, int rowstride, bool has_alpha, int bits_per_sample,
+		int channels, const uint8_t *pixels, size_t pixels_len) {
+	int want_channels = has_alpha ? 4 : 3;
+	/* The row span is compared in 64 bits: these numbers come straight off the
+	 * D-Bus image-data hint, and width * channels overflows int to a negative
+	 * (so passes this check) from width 2^29 up with four channels. The length
+	 * check below still catches such a message on a 64-bit size_t, so this is
+	 * the guard holding on its own rather than a reachable overread. */
+	if (width <= 0 || height <= 0 || rowstride <= 0 || bits_per_sample != 8 ||
+			channels != want_channels ||
+			(int64_t)rowstride < (int64_t)width * channels) {
+		return false;
+	}
+	/* The sender's own numbers say how much it should have sent. A message that
+	 * disagrees with itself is a short buffer we would read off the end of. */
+	size_t need = (size_t)rowstride * (size_t)(height - 1) +
+		(size_t)width * (size_t)channels;
+	if (pixels_len < need) {
+		return false;
+	}
+
+	/* Borrowed, not owned: the pixbuf is a view over the caller's bytes for the
+	 * length of the conversion, which copies into the cairo surface. */
+	GdkPixbuf *pb = gdk_pixbuf_new_from_data(pixels, GDK_COLORSPACE_RGB,
+		has_alpha, bits_per_sample, width, height, rowstride, NULL, NULL);
+	if (pb == NULL) {
+		return false;
+	}
+	cairo_surface_t *native = pixbuf_to_cairo(pb);
+	g_object_unref(pb);
+	if (native == NULL) {
+		return false;
+	}
+
+	struct image_entry *e = image_intern(ic, key);
+	if (e->native != NULL) {
+		cairo_surface_destroy(e->native);
+		ic->bytes -= e->bytes;
+	}
+	e->native = native;
+	e->width = cairo_image_surface_get_width(native);
+	e->height = cairo_image_surface_get_height(native);
+	e->decoded = true;
+	e->failed = false;
+	/* gen is what tells the renderer to re-raster an entry whose pointer never
+	 * changes, so a replacing image (a progress icon, a tray item swapping its
+	 * icon) redraws instead of showing the old pixels. */
+	e->gen++;
+	e->bytes = (size_t)cairo_image_surface_get_stride(native) * e->height;
+	e->touch = ic->clock;
+	ic->bytes += e->bytes;
+	image_evict(ic);
+	return true;
+}
+
+void image_cache_reload(struct image_cache *ic, const char *path) {
+	struct image_entry *e = image_find(ic, path);
+	if (e == NULL) {
+		return;
+	}
+	if (e->native != NULL) {
+		cairo_surface_destroy(e->native);
+		e->native = NULL;
+		ic->bytes -= e->bytes;
+		e->bytes = 0;
+	}
+	/* decoded=false forces the next declare's image_cache_get to re-decode and
+	 * bump gen; the entry pointer (live imageData) is untouched. */
+	e->decoded = false;
+	e->failed = false;
+}
+
+void image_cache_begin_declare(struct image_cache *ic) {
+	ic->clock++;
+}
+
+void image_cache_sweep(struct image_cache *ic) {
+	image_evict(ic);
+}
+
+size_t image_cache_bytes(struct image_cache *ic) {
+	return ic->bytes;
+}
+
+struct image_cache *image_cache_create(void) {
+	struct image_cache *ic = calloc(1, sizeof(*ic));
+	ic->budget = (size_t)IMAGE_BUDGET_MB << 20;
+	const char *budget_mb = getenv("SOMEWM_IMAGE_BUDGET_MB");
+	if (budget_mb != NULL && atoi(budget_mb) > 0) {
+		ic->budget = (size_t)atoi(budget_mb) << 20;
+	}
+	return ic;
+}
+
+void image_cache_destroy(struct image_cache *ic) {
+	for (size_t i = 0; i < ic->images_len; i++) {
+		if (ic->images[i]->native != NULL) {
+			cairo_surface_destroy(ic->images[i]->native);
+		}
+		free(ic->images[i]->path);
+		free(ic->images[i]);
+	}
+	free(ic->images);
+	free(ic);
+}

--- a/render_image.h
+++ b/render_image.h
@@ -1,0 +1,81 @@
+#ifndef SOMEWM_RENDER_IMAGE_H
+#define SOMEWM_RENDER_IMAGE_H
+
+#include <cairo.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* The image cache, ported from kiln (ui.h:165-205, ui.c). One entry per key,
+ * decoded once (gdk-pixbuf) to a cairo surface the renderer scales and rounds
+ * into the solved box. The entry pointer is stable for the process (it is what
+ * Clay carries as imageData across the solve); only its contents change on
+ * reload. gen bumps on every successful (re)decode so the renderer knows to
+ * re-raster.
+ *
+ * Decoded pixels live under a byte budget, enforced after every decode and
+ * again at the end of every solve: least-recently-declared surfaces are dropped
+ * (pixels only; the entry struct stays, preserving pointer stability) and
+ * re-decode on their next declare. Entries declared by the in-progress solve are
+ * never dropped, so a live command's native pointer stays valid through its
+ * reconcile. bytes is the decoded surface size; touch is the solve clock of the
+ * last declare that asked for the entry.
+ *
+ * The cache is an explicit object rather than a field of an owner, because the
+ * owner it hung off in kiln has no counterpart here yet; the declare pass takes
+ * one in stage 4. */
+struct image_entry {
+	char *path;
+	cairo_surface_t *native;
+	int width, height;
+	uint64_t gen;
+	size_t bytes;
+	uint64_t touch;
+	bool decoded, failed;
+};
+
+struct image_cache;
+
+/* SOMEWM_IMAGE_BUDGET_MB overrides the default decode budget. */
+struct image_cache *image_cache_create(void);
+void image_cache_destroy(struct image_cache *ic);
+
+/* Advance the eviction clock, once per solve before the declare pass: entries
+ * this solve declares are stamped with the new value and exempt from eviction
+ * until it passes. */
+void image_cache_begin_declare(struct image_cache *ic);
+
+/* Enforce the budget, once per solve after the reconcile. Not only at decode
+ * time: a declare that stopped mentioning images must release their pixels, or
+ * the cache is monotonic until the next unrelated decode. This solve's entries
+ * are exempt by their touch stamp, and the reconcile is done, so nothing still
+ * reads an older entry's surface. */
+void image_cache_sweep(struct image_cache *ic);
+
+/* Resolves path to its stable cache entry, decoding on first sight. Never stats
+ * an already-cached path (the declare pass stays I/O free). */
+struct image_entry *image_cache_get(struct image_cache *ic, const char *path);
+
+/* Puts already-decoded pixels in the cache under a key, for images that arrive
+ * in a message rather than on disk: the notification image-data hint, and tray
+ * icons. The pixel layout is the hint's own (iiibiiay: width, height, rowstride,
+ * has_alpha, bits_per_sample, channels, data), which is gdk-pixbuf's layout, so
+ * the caller forwards it verbatim and owns nothing afterwards. false if the
+ * message's own numbers do not describe the buffer it sent.
+ *
+ * The key is not a path and never resolves to one, which makes the entry
+ * unre-decodable: an eviction is permanent and the leaf renders blank. That is
+ * the existing failed-entry path, and it is not reachable for a displayed image,
+ * since eviction claims the least-recently-DECLARED pixels. */
+bool image_cache_put(struct image_cache *ic, const char *key, int width,
+	int height, int rowstride, bool has_alpha, int bits_per_sample,
+	int channels, const uint8_t *pixels, size_t pixels_len);
+
+/* Drops the decoded surface so the next image_cache_get re-decodes and bumps
+ * gen. The only invalidation there is; nothing implicit. */
+void image_cache_reload(struct image_cache *ic, const char *path);
+
+/* Profiling readback: resident decoded bytes. */
+size_t image_cache_bytes(struct image_cache *ic);
+
+#endif

--- a/render_text.c
+++ b/render_text.c
@@ -1,0 +1,133 @@
+/* The font table and the shared Pango setup both the measure callback and the
+ * raster path go through, ported from kiln (ui.c). */
+
+#include <string.h>
+#include <pango/pangocairo.h>
+
+#include "render_text.h"
+
+/* Entry 0 of the font table, and the face a declaration naming none gets.
+ * Clay passes fontId 0 for its debug view's own text (clay.h:380-381), so entry
+ * 0 has to name a face that exists whatever a config does with the rest of the
+ * table. */
+#define RENDER_FONT_FAMILY "Sans"
+
+/* The font table's cap. An interned face is never evicted and its id never
+ * reused, so this is what bounds a config building description strings in a
+ * loop instead of naming a fixed set: past it interning refuses. */
+#define RENDER_MAX_FONTS 64
+
+/* Ids are write-once: an entry is appended, never rewritten, so a live
+ * declaration's id keeps meaning the face it was interned for. Rewriting one
+ * would leave Clay's measure cache answering with the old face's widths for
+ * good, because that cache keys on the id (clay.h:1508-1531). */
+static struct {
+	const char *name;
+	PangoFontDescription *desc;
+} render_fonts[RENDER_MAX_FONTS];
+static int render_fonts_len;
+
+/* The layout every measurement is taken on, and the scale it is taken at. */
+static PangoContext *render_pango;
+static PangoLayout *render_measure_layout;
+static float render_measure_scale = 1.0f;
+
+static void render_fonts_init(void) {
+	if (render_fonts_len > 0) {
+		return;
+	}
+	render_fonts[0].name = RENDER_FONT_FAMILY;
+	render_fonts[0].desc = pango_font_description_from_string(RENDER_FONT_FAMILY);
+	render_fonts_len = 1;
+}
+
+int32_t render_font_intern(const char *name) {
+	render_fonts_init();
+	for (int i = 0; i < render_fonts_len; i++) {
+		if (strcmp(render_fonts[i].name, name) == 0) {
+			return i;
+		}
+	}
+
+	/* Pango's own parser is the only thing that knows what a description means,
+	 * so a carried size is its set-fields mask rather than a scan for a trailing
+	 * number: a family whose name ends in a digit is not a size. Refused before
+	 * the cap is consulted, so a bad description names its real problem even
+	 * with the table full. */
+	PangoFontDescription *desc = pango_font_description_from_string(name);
+	if (pango_font_description_get_set_fields(desc) & PANGO_FONT_MASK_SIZE) {
+		pango_font_description_free(desc);
+		return RENDER_FONT_ERR_SIZE;
+	}
+	if (render_fonts_len == RENDER_MAX_FONTS) {
+		pango_font_description_free(desc);
+		return RENDER_FONT_ERR_FULL;
+	}
+
+	render_fonts[render_fonts_len].name = strdup(name);
+	render_fonts[render_fonts_len].desc = desc;
+	return render_fonts_len++;
+}
+
+void render_set_text(PangoLayout *layout, const char *text, int len,
+		uint16_t font_id, uint16_t font_size, float scale, int max_width) {
+	render_fonts_init();
+	/* An id past the table resolves to entry 0 rather than aborting: the id is
+	 * whatever a declaration put in the field, and Clay's debug view writes 0
+	 * into it without interning anything. */
+	PangoFontDescription *desc = font_id < render_fonts_len
+		? render_fonts[font_id].desc : render_fonts[0].desc;
+	pango_font_description_set_absolute_size(desc,
+		(double)font_size * scale * PANGO_SCALE);
+	pango_layout_set_font_description(layout, desc);
+
+	/* Both set unconditionally, because the measure layout is reused across
+	 * every leaf on the output: a bound left behind by the previous call would
+	 * truncate the next run. Unbounded is Pango's -1 rather than 0, which is a
+	 * layout zero pixels wide. Where the cut lands is Pango's to choose, since
+	 * only it knows where a cluster ends. */
+	pango_layout_set_width(layout,
+		max_width > 0 ? max_width * PANGO_SCALE : -1);
+	pango_layout_set_ellipsize(layout,
+		max_width > 0 ? PANGO_ELLIPSIZE_END : PANGO_ELLIPSIZE_NONE);
+	pango_layout_set_text(layout, text, len);
+}
+
+void render_text_set_measure_scale(float scale) {
+	render_measure_scale = scale > 0.0f ? scale : 1.0f;
+}
+
+Clay_Dimensions render_measure_text(Clay_StringSlice text,
+		Clay_TextElementConfig *config, void *user_data) {
+	(void)user_data;
+	if (render_measure_layout == NULL) {
+		render_pango = pango_font_map_create_context(
+			pango_cairo_font_map_get_default());
+		render_measure_layout = pango_layout_new(render_pango);
+	}
+	float scale = render_measure_scale;
+
+	/* Measure at device size, report logical: Pango rounds glyph advances to
+	 * whole DEVICE pixels, so dividing the device extent by scale hands Clay the
+	 * exact logical size the raster will reproduce (the raster path uses the same
+	 * device font size). Wrap and box sizing then match the raster to the pixel.
+	 *
+	 * Never bounded, whatever the declaration asked for: what a truncated run is
+	 * bounded BY is derived from the box this measurement produces, so bounding
+	 * the measurement too would feed that derivation its own output. */
+	render_set_text(render_measure_layout, text.chars, text.length,
+		config->fontId, config->fontSize, scale, 0);
+	int width, height;
+	pango_layout_get_pixel_size(render_measure_layout, &width, &height);
+
+	return (Clay_Dimensions) { .width = width / scale, .height = height / scale };
+}
+
+void render_text_finish(void) {
+	if (render_measure_layout != NULL) {
+		g_object_unref(render_measure_layout);
+		g_object_unref(render_pango);
+		render_measure_layout = NULL;
+		render_pango = NULL;
+	}
+}

--- a/render_text.h
+++ b/render_text.h
@@ -1,0 +1,80 @@
+#ifndef SOMEWM_RENDER_TEXT_H
+#define SOMEWM_RENDER_TEXT_H
+
+#include <pango/pango.h>
+#include <stdint.h>
+
+#include "clay.h"
+
+/* The font table and the shared text setup, ported from kiln (ui.h:115-163,
+ * ui.c). The table is file-static in render_text.c rather than a field of an
+ * owner object because the raster path is handed a render command and a scale
+ * and has no owner to reach, and the measure and the raster have to resolve an
+ * id the same way or text wraps where it does not draw. */
+
+/* Intern a Pango font description into the font table, returning the id a text
+ * declaration carries as fontId, so a config names a face in the string form
+ * Pango parses and never handles the integer Clay actually carries. Ids are
+ * write-once, so one stays safe to hold for as long as the process lives.
+ *
+ * No length argument, because Pango wants the NUL a Lua string already carries,
+ * not a count.
+ *
+ * Negative is a refusal:
+ *
+ *   RENDER_FONT_ERR_SIZE  the description carries a size, which would be
+ *                         silently overridden because size is its own channel,
+ *                         set at the output's device scale per call.
+ *   RENDER_FONT_ERR_FULL  the table is at its cap.
+ *
+ * A family no font on the system provides is not a refusal; Pango substitutes,
+ * which keeps a typo a visual bug instead of a dead session. */
+#define RENDER_FONT_ERR_SIZE (-1)
+#define RENDER_FONT_ERR_FULL (-2)
+int32_t render_font_intern(const char *name);
+
+/* Flags a text declaration carries through Clay's per-element userData, which is
+ * documented as passed through untouched to the render command (clay.h:375-376,
+ * 688-689) and is not part of the measure cache key (clay.h:1508-1531, which
+ * hashes only the text, fontId, fontSize and letterSpacing). A flag word in a
+ * pointer slot because that slot is the only channel from a text declaration
+ * to the renderer that Clay leaves to its host: everything else on a text
+ * config has a meaning Clay assigns. */
+#define RENDER_TEXT_ELLIPSIZE 1u
+
+/* Shared font and text setup so measurement and rasterization agree, on every
+ * axis that decides a glyph run's extent. font_id resolves through the font
+ * table above, and is in this signature rather than read from somewhere both
+ * callers reach so that a face reaching one path and not the other is a compile
+ * error: it would otherwise show up as text wrapping where it does not draw.
+ * scale is the output's scale, and the font is set at device size (font_size *
+ * scale) so measurement and the raster both work in device pixels, which is
+ * what keeps a fractional output's text sharp and its wrap decisions matching
+ * the raster.
+ *
+ * max_width is a device-pixel bound past which the run is truncated with an
+ * ellipsis, or 0 for none. It is in this signature for the same reason font_id
+ * is, and the measure path is the caller that must always pass 0: a measure
+ * bounded by the same number the bound is derived FROM would shrink the box, and
+ * a smaller box means a tighter bound, which is a run that truncates itself away
+ * over a few frames. */
+void render_set_text(PangoLayout *layout, const char *text, int len,
+	uint16_t font_id, uint16_t font_size, float scale, int max_width);
+
+/* The scale of the output currently solving, published before each Clay pass so
+ * the measure callback below measures text at that output's device size. Its own
+ * channel rather than the callback's userData because there is no per-output
+ * object on this side of the port yet; the declare pass sets it in stage 4. */
+void render_text_set_measure_scale(float scale);
+
+/* Clay's measure callback, handed to Clay_SetMeasureTextFunction once per
+ * context. Pure and callable at any point in a solve, because Clay caches
+ * measured words across frames and only calls in on a miss. */
+Clay_Dimensions render_measure_text(Clay_StringSlice text,
+	Clay_TextElementConfig *config, void *user_data);
+
+/* Drop the shared measure layout. The font table is process-lifetime by design
+ * (ids are write-once), so it is not touched. */
+void render_text_finish(void);
+
+#endif

--- a/tests/lsan-suppressions.txt
+++ b/tests/lsan-suppressions.txt
@@ -1,0 +1,9 @@
+# Fontconfig builds a process-wide font cache on first use and never frees it,
+# and pango's font maps hang off it. Nothing in the renderer owns those
+# allocations.
+#
+# Deliberately only fontconfig. LeakSanitizer suppresses a leak when ANY frame
+# in its allocation stack matches, so a broader entry (libcairo, libglib,
+# libgobject) would also hide a cairo surface or a PangoLayout the renderer
+# itself leaked, which is exactly what this test exists to catch.
+leak:libfontconfig.so

--- a/tests/test-render.c
+++ b/tests/test-render.c
@@ -1,0 +1,956 @@
+/* Unit tests for the Clay reconciler: hand-built command arrays in, wlr_scene
+ * out. No compositor and no output; wlr_scene is a plain data structure until
+ * something drives an output from it, so the whole reconcile path runs in
+ * process. Nothing in the compositor calls the renderer yet, so this is the
+ * only thing exercising it. */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <wlr/types/wlr_scene.h>
+
+#include "clay.h"
+#include "render.h"
+#include "render_image.h"
+#include "render_text.h"
+
+static int failures;
+static const char *current_test;
+
+#define CHECK(cond) do { \
+	if (!(cond)) { \
+		fprintf(stderr, "%s:%d: %s: FAIL %s\n", __FILE__, __LINE__, \
+			current_test, #cond); \
+		failures++; \
+	} \
+} while (0)
+
+#define CHECK_EQ(got, want) do { \
+	long long g_ = (long long)(got), w_ = (long long)(want); \
+	if (g_ != w_) { \
+		fprintf(stderr, "%s:%d: %s: FAIL %s: got %lld, want %lld\n", \
+			__FILE__, __LINE__, current_test, #got, g_, w_); \
+		failures++; \
+	} \
+} while (0)
+
+/* --- command builders --- */
+
+static Clay_RenderCommand cmd_rect(uint32_t id, float x, float y, float w,
+		float h, float radius) {
+	Clay_RenderCommand c = { 0 };
+	c.commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+	c.id = id;
+	c.boundingBox = (Clay_BoundingBox) { x, y, w, h };
+	c.renderData.rectangle.backgroundColor = (Clay_Color) { 255, 0, 0, 255 };
+	c.renderData.rectangle.cornerRadius =
+		(Clay_CornerRadius) { radius, radius, radius, radius };
+	return c;
+}
+
+static Clay_RenderCommand cmd_border(uint32_t id, float x, float y, float w,
+		float h, int width, float radius) {
+	Clay_RenderCommand c = { 0 };
+	c.commandType = CLAY_RENDER_COMMAND_TYPE_BORDER;
+	c.id = id;
+	c.boundingBox = (Clay_BoundingBox) { x, y, w, h };
+	c.renderData.border.color = (Clay_Color) { 0, 255, 0, 255 };
+	c.renderData.border.width =
+		(Clay_BorderWidth) { width, width, width, width, 0 };
+	c.renderData.border.cornerRadius =
+		(Clay_CornerRadius) { radius, radius, radius, radius };
+	return c;
+}
+
+static Clay_RenderCommand cmd_text(uint32_t id, float x, float y, float w,
+		float h, const char *text, bool ellipsize) {
+	Clay_RenderCommand c = { 0 };
+	c.commandType = CLAY_RENDER_COMMAND_TYPE_TEXT;
+	c.id = id;
+	c.boundingBox = (Clay_BoundingBox) { x, y, w, h };
+	c.renderData.text.stringContents = (Clay_StringSlice) {
+		.length = (int32_t)strlen(text), .chars = text, .baseChars = text };
+	c.renderData.text.textColor = (Clay_Color) { 255, 255, 255, 255 };
+	c.renderData.text.fontSize = 12;
+	c.userData = ellipsize ? (void *)(uintptr_t)RENDER_TEXT_ELLIPSIZE : NULL;
+	return c;
+}
+
+static Clay_RenderCommand cmd_image(uint32_t id, float x, float y, float w,
+		float h, struct image_entry *entry) {
+	Clay_RenderCommand c = { 0 };
+	c.commandType = CLAY_RENDER_COMMAND_TYPE_IMAGE;
+	c.id = id;
+	c.boundingBox = (Clay_BoundingBox) { x, y, w, h };
+	c.renderData.image.imageData = entry;
+	return c;
+}
+
+static Clay_RenderCommand cmd_custom(uint32_t id, uint64_t handle, float x,
+		float y, float w, float h) {
+	Clay_RenderCommand c = { 0 };
+	c.commandType = CLAY_RENDER_COMMAND_TYPE_CUSTOM;
+	c.id = id;
+	c.boundingBox = (Clay_BoundingBox) { x, y, w, h };
+	c.renderData.custom.customData = (void *)(uintptr_t)handle;
+	return c;
+}
+
+static Clay_RenderCommand cmd_clip(uint32_t id, float x, float y, float w,
+		float h, bool horizontal, bool vertical) {
+	Clay_RenderCommand c = { 0 };
+	c.commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+	c.id = id;
+	c.boundingBox = (Clay_BoundingBox) { x, y, w, h };
+	c.renderData.clip.horizontal = horizontal;
+	c.renderData.clip.vertical = vertical;
+	return c;
+}
+
+static Clay_RenderCommand cmd_clip_end(uint32_t id) {
+	Clay_RenderCommand c = { 0 };
+	c.commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
+	c.id = id;
+	return c;
+}
+
+static Clay_RenderCommandArray commands_of(Clay_RenderCommand *cmds, int32_t n) {
+	return (Clay_RenderCommandArray) {
+		.capacity = n, .length = n, .internalArray = cmds };
+}
+
+/* --- scene inspection ---
+ *
+ * render_create puts its retained nodes in a tree of its own under the parent
+ * it was handed, so the parent's only child is that tree and its children are
+ * the retained nodes, bottom to top. */
+
+static struct wlr_scene_tree *render_tree(struct wlr_scene_tree *parent) {
+	struct wlr_scene_node *node =
+		wl_container_of(parent->children.next, node, link);
+	return wlr_scene_tree_from_node(node);
+}
+
+static int child_count(struct wlr_scene_tree *tree) {
+	return wl_list_length(&tree->children);
+}
+
+/* The nth child from the bottom of the draw order, or NULL. */
+static struct wlr_scene_node *child_at(struct wlr_scene_tree *tree, int n) {
+	struct wlr_scene_node *child;
+	int i = 0;
+	wl_list_for_each(child, &tree->children, link) {
+		if (i++ == n) {
+			return child;
+		}
+	}
+	return NULL;
+}
+
+/* --- the client hooks fake ---
+ *
+ * One scene tree per handle, parented to a home tree the way a real client's
+ * tree hangs off its layer, so release has somewhere to hand it back to. */
+
+#define FAKE_CLIENTS 4
+
+struct fake_clients {
+	struct wlr_scene_tree *home;
+	struct wlr_scene_tree *trees[FAKE_CLIENTS];
+	bool gone[FAKE_CLIENTS];
+	bool popup[FAKE_CLIENTS];
+	void *owner[FAKE_CLIENTS];
+	int borrows, releases, repositions;
+	int configured_w, configured_h, configures;
+};
+
+static struct wlr_scene_tree *fake_resolve(void *data, uint64_t handle) {
+	struct fake_clients *fc = data;
+	return fc->gone[handle] ? NULL : fc->trees[handle];
+}
+
+static void fake_configure(void *data, uint64_t handle, int width, int height) {
+	struct fake_clients *fc = data;
+	(void)handle;
+	fc->configured_w = width;
+	fc->configured_h = height;
+	fc->configures++;
+}
+
+static void fake_borrow(void *data, uint64_t handle, void *owner) {
+	struct fake_clients *fc = data;
+	fc->owner[handle] = owner;
+	fc->borrows++;
+}
+
+static void fake_release(void *data, uint64_t handle, void *owner) {
+	struct fake_clients *fc = data;
+	if (fc->owner[handle] != owner) {
+		return;   /* not the owner: the migration race, a no-op by contract */
+	}
+	fc->owner[handle] = NULL;
+	fc->releases++;
+	if (!fc->gone[handle]) {
+		wlr_scene_node_reparent(&fc->trees[handle]->node, fc->home);
+		wlr_scene_node_set_enabled(&fc->trees[handle]->node, false);
+	}
+}
+
+static void fake_reposition(void *data, uint64_t handle) {
+	struct fake_clients *fc = data;
+	(void)handle;
+	fc->repositions++;
+}
+
+static bool fake_has_popup(void *data, uint64_t handle) {
+	struct fake_clients *fc = data;
+	return fc->popup[handle];
+}
+
+static void fake_clients_init(struct fake_clients *fc,
+		struct wlr_scene_tree *root, struct render_client_hooks *hooks) {
+	memset(fc, 0, sizeof(*fc));
+	fc->home = wlr_scene_tree_create(root);
+	for (int i = 0; i < FAKE_CLIENTS; i++) {
+		fc->trees[i] = wlr_scene_tree_create(fc->home);
+		wlr_scene_node_set_enabled(&fc->trees[i]->node, false);
+	}
+	*hooks = (struct render_client_hooks) {
+		.resolve = fake_resolve,
+		.configure = fake_configure,
+		.borrow = fake_borrow,
+		.release = fake_release,
+		.reposition = fake_reposition,
+		.has_popup = fake_has_popup,
+		.data = fc,
+	};
+}
+
+/* For the cases that declare no CUSTOM command. Not a zeroed table: the
+ * reconciler calls resolve for every CUSTOM command before anything is
+ * borrowed, and marks the node borrowed either way, so the sweep calls release
+ * too. Answering NULL degrades a stray CUSTOM command to "client is gone"
+ * instead of a NULL call. */
+static struct wlr_scene_tree *no_resolve(void *data, uint64_t handle) {
+	(void)data; (void)handle;
+	return NULL;
+}
+static void no_release(void *data, uint64_t handle, void *owner) {
+	(void)data; (void)handle; (void)owner;
+}
+static const struct render_client_hooks no_hooks = {
+	.resolve = no_resolve,
+	.release = no_release,
+};
+
+/* --- fixture --- */
+
+struct fixture {
+	struct wlr_scene *scene;
+	struct wlr_scene_tree *parent;
+	struct render_state *rs;
+};
+
+static void fixture_init(struct fixture *f) {
+	f->scene = wlr_scene_create();
+	f->parent = wlr_scene_tree_create(&f->scene->tree);
+	f->rs = render_create(f->parent);
+}
+
+static void fixture_finish(struct fixture *f,
+		const struct render_client_hooks *hooks) {
+	render_destroy(f->rs, hooks);
+	wlr_scene_node_destroy(&f->scene->tree.node);
+}
+
+/* A fixture with clients behind it, for the CUSTOM cases. */
+static void fixture_init_clients(struct fixture *f, struct fake_clients *fc,
+		struct render_client_hooks *hooks) {
+	fixture_init(f);
+	fake_clients_init(fc, &f->scene->tree, hooks);
+}
+
+/* --- tests --- */
+
+static void test_identical_frame_reconciles_to_zero(void) {
+	struct fixture f;
+	fixture_init(&f);
+	Clay_RenderCommand cmds[] = {
+		cmd_rect(1, 0, 0, 100, 20, 0),
+		cmd_rect(2, 10, 30, 40, 40, 8),
+		cmd_border(3, 0, 0, 100, 100, 2, 0),
+	};
+	Clay_RenderCommandArray arr = commands_of(cmds, 3);
+
+	CHECK(render_reconcile(f.rs, arr, &no_hooks) > 0);
+	CHECK_EQ(render_node_count(f.rs), 3);
+	CHECK_EQ(render_reconcile(f.rs, arr, &no_hooks), 0);
+	CHECK_EQ(render_reconcile(f.rs, arr, &no_hooks), 0);
+	/* Nothing re-rastered on the identical frames. */
+	CHECK_EQ(render_buffers_created(f.rs), 0);
+
+	fixture_finish(&f, &no_hooks);
+}
+
+static void test_add_remove_move(void) {
+	struct fixture f;
+	fixture_init(&f);
+	Clay_RenderCommand cmds[] = {
+		cmd_rect(1, 0, 0, 100, 20, 0),
+		cmd_rect(2, 0, 30, 100, 20, 0),
+		cmd_rect(3, 0, 60, 100, 20, 0),
+	};
+	struct wlr_scene_tree *rt;
+
+	render_reconcile(f.rs, commands_of(cmds, 2), &no_hooks);
+	rt = render_tree(f.parent);
+	CHECK_EQ(child_count(rt), 2);
+	CHECK_EQ(render_node_count(f.rs), 2);
+
+	/* Add: the third command creates a node. */
+	render_reconcile(f.rs, commands_of(cmds, 3), &no_hooks);
+	CHECK_EQ(child_count(rt), 3);
+	CHECK_EQ(render_node_count(f.rs), 3);
+
+	/* Move: one position change, one mutation, no restack. */
+	cmds[1].boundingBox.y = 35;
+	CHECK_EQ(render_reconcile(f.rs, commands_of(cmds, 3), &no_hooks), 1);
+	CHECK_EQ(child_at(rt, 1)->y, 35);
+
+	/* Remove: the vanished id is swept. */
+	CHECK(render_reconcile(f.rs, commands_of(cmds, 2), &no_hooks) > 0);
+	CHECK_EQ(child_count(rt), 2);
+	CHECK_EQ(render_node_count(f.rs), 2);
+
+	fixture_finish(&f, &no_hooks);
+}
+
+static void test_kind_swap_destroys_and_restacks(void) {
+	struct fixture f;
+	fixture_init(&f);
+	/* The swapping command is FIRST, so a recreated node appended at the top
+	 * of the sibling list is in the wrong place unless the swap forces a
+	 * restack. With the verifier compiled in, a missed restack aborts here. */
+	Clay_RenderCommand cmds[] = {
+		cmd_rect(1, 0, 0, 50, 50, 0),
+		cmd_rect(2, 100, 0, 50, 50, 0),
+	};
+	struct wlr_scene_tree *rt;
+
+	render_reconcile(f.rs, commands_of(cmds, 2), &no_hooks);
+	rt = render_tree(f.parent);
+	CHECK_EQ(child_at(rt, 0)->type, WLR_SCENE_NODE_RECT);
+	CHECK_EQ(child_at(rt, 0)->x, 0);
+
+	/* Square to rounded: a scene rect cannot draw an arc, so the node kind
+	 * changes and the old node is destroyed. */
+	cmds[0] = cmd_rect(1, 0, 0, 50, 50, 8);
+	CHECK(render_reconcile(f.rs, commands_of(cmds, 2), &no_hooks) > 0);
+	CHECK_EQ(child_count(rt), 2);
+	CHECK_EQ(child_at(rt, 0)->type, WLR_SCENE_NODE_BUFFER);
+	CHECK_EQ(child_at(rt, 0)->x, 0);
+	CHECK_EQ(child_at(rt, 1)->x, 100);
+
+	/* And back, with the frame after each swap settling to zero. */
+	CHECK_EQ(render_reconcile(f.rs, commands_of(cmds, 2), &no_hooks), 0);
+	cmds[0] = cmd_rect(1, 0, 0, 50, 50, 0);
+	CHECK(render_reconcile(f.rs, commands_of(cmds, 2), &no_hooks) > 0);
+	CHECK_EQ(child_at(rt, 0)->type, WLR_SCENE_NODE_RECT);
+	CHECK_EQ(child_at(rt, 0)->x, 0);
+	CHECK_EQ(render_reconcile(f.rs, commands_of(cmds, 2), &no_hooks), 0);
+
+	fixture_finish(&f, &no_hooks);
+}
+
+static void test_restack_only_when_order_changed(void) {
+	struct fixture f;
+	fixture_init(&f);
+	Clay_RenderCommand cmds[] = {
+		cmd_rect(1, 0, 0, 10, 10, 0),
+		cmd_rect(2, 20, 0, 10, 10, 0),
+		cmd_rect(3, 40, 0, 10, 10, 0),
+	};
+	struct wlr_scene_tree *rt;
+
+	render_reconcile(f.rs, commands_of(cmds, 3), &no_hooks);
+	rt = render_tree(f.parent);
+	CHECK_EQ(child_at(rt, 0)->x, 0);
+	CHECK_EQ(child_at(rt, 2)->x, 40);
+	CHECK_EQ(render_reconcile(f.rs, commands_of(cmds, 3), &no_hooks), 0);
+
+	/* Same commands, new draw order: the scene follows, and the restack is
+	 * the only mutation (one raise per node). */
+	Clay_RenderCommand swapped[] = { cmds[2], cmds[0], cmds[1] };
+	CHECK_EQ(render_reconcile(f.rs, commands_of(swapped, 3), &no_hooks), 3);
+	CHECK_EQ(child_at(rt, 0)->x, 40);
+	CHECK_EQ(child_at(rt, 1)->x, 0);
+	CHECK_EQ(child_at(rt, 2)->x, 20);
+
+	/* Settled again in the new order. */
+	CHECK_EQ(render_reconcile(f.rs, commands_of(swapped, 3), &no_hooks), 0);
+
+	fixture_finish(&f, &no_hooks);
+}
+
+static void test_clip_stack(void) {
+	struct fixture f;
+	fixture_init(&f);
+	/* A clip scope, a leaf straddling it, a leaf entirely outside it, a
+	 * nested scope, and a leaf after the scope closes. */
+	Clay_RenderCommand cmds[] = {
+		cmd_clip(10, 0, 0, 50, 50, true, true),
+		cmd_rect(1, 25, 25, 50, 50, 0),          /* clipped to 25x25 */
+		cmd_rect(2, 100, 100, 10, 10, 0),        /* fully outside */
+		cmd_clip(11, 0, 0, 30, 100, true, true), /* nested: intersects to 30x50 */
+		cmd_rect(3, 20, 20, 40, 40, 0),          /* clipped to 10x30 */
+		cmd_clip_end(11),
+		cmd_clip_end(10),
+		cmd_rect(4, 200, 0, 10, 10, 0),          /* unclipped */
+	};
+	struct wlr_scene_tree *rt;
+
+	render_reconcile(f.rs, commands_of(cmds, 8), &no_hooks);
+	rt = render_tree(f.parent);
+	/* SCISSOR commands realize no node. */
+	CHECK_EQ(child_count(rt), 4);
+
+	struct wlr_scene_rect *r = wlr_scene_rect_from_node(child_at(rt, 0));
+	CHECK_EQ(child_at(rt, 0)->x, 25);
+	CHECK_EQ(r->width, 25);
+	CHECK_EQ(r->height, 25);
+
+	/* Clipped to nothing: disabled, not drawn at a degenerate size. */
+	CHECK(!child_at(rt, 1)->enabled);
+
+	r = wlr_scene_rect_from_node(child_at(rt, 2));
+	CHECK_EQ(child_at(rt, 2)->x, 20);
+	CHECK_EQ(r->width, 10);
+	CHECK_EQ(r->height, 30);
+
+	r = wlr_scene_rect_from_node(child_at(rt, 3));
+	CHECK_EQ(child_at(rt, 3)->x, 200);
+	CHECK_EQ(r->width, 10);
+
+	CHECK_EQ(render_reconcile(f.rs, commands_of(cmds, 8), &no_hooks), 0);
+
+	fixture_finish(&f, &no_hooks);
+}
+
+static void test_clip_axes(void) {
+	/* Naming neither axis means both, not none: Clay emits an unfilled clip
+	 * config for a floating element whose clipTo names an ancestor, and its own
+	 * hit test clips such a root on both axes. A single named axis leaves the
+	 * other one unbounded. */
+	static const struct {
+		bool horizontal, vertical;
+		int want_w, want_h;
+	} cases[] = {
+		{ false, false, 25, 25 },
+		{ true,  false, 25, 50 },
+		{ false, true,  50, 25 },
+		{ true,  true,  25, 25 },
+	};
+
+	for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+		struct fixture f;
+		fixture_init(&f);
+		Clay_RenderCommand cmds[] = {
+			cmd_clip(10, 0, 0, 50, 50, cases[i].horizontal, cases[i].vertical),
+			cmd_rect(1, 25, 25, 50, 50, 0),
+			cmd_clip_end(10),
+		};
+		render_reconcile(f.rs, commands_of(cmds, 3), &no_hooks);
+		struct wlr_scene_rect *r =
+			wlr_scene_rect_from_node(child_at(render_tree(f.parent), 0));
+		CHECK_EQ(r->width, cases[i].want_w);
+		CHECK_EQ(r->height, cases[i].want_h);
+		fixture_finish(&f, &no_hooks);
+	}
+}
+
+static void test_client_surface_hooks(void) {
+	struct fixture f;
+	struct fake_clients fc;
+	struct render_client_hooks hooks;
+	fixture_init_clients(&f, &fc, &hooks);
+
+	Clay_RenderCommand cmds[] = {
+		cmd_custom(1, 0, 0, 0, 400, 300),
+		cmd_custom(2, 1, 400, 0, 400, 300),
+	};
+
+	render_reconcile(f.rs, commands_of(cmds, 2), &hooks);
+	struct wlr_scene_tree *rt = render_tree(f.parent);
+	/* Borrowed, not owned: the client's own tree is reparented in. */
+	CHECK_EQ(child_count(rt), 2);
+	CHECK_EQ(child_at(rt, 0), &fc.trees[0]->node);
+	CHECK_EQ(child_at(rt, 1), &fc.trees[1]->node);
+	CHECK(child_at(rt, 0)->enabled);
+	CHECK_EQ(fc.borrows, 2);
+	CHECK_EQ(fc.configures, 2);
+	CHECK_EQ(fc.configured_w, 400);
+	CHECK_EQ(fc.configured_h, 300);
+	/* Both placements fire reposition; the borrow's configure ran before the
+	 * position existed. */
+	CHECK_EQ(fc.repositions, 2);
+
+	CHECK_EQ(render_reconcile(f.rs, commands_of(cmds, 2), &hooks), 0);
+	CHECK_EQ(fc.repositions, 2);
+
+	/* A move re-derives anything keyed to the tree's scene position. */
+	cmds[1].boundingBox.x = 500;
+	render_reconcile(f.rs, commands_of(cmds, 2), &hooks);
+	CHECK_EQ(fc.repositions, 3);
+	CHECK_EQ(fc.trees[1]->node.x, 500);
+
+	/* A resize configures, without a reposition. */
+	cmds[1].boundingBox.width = 300;
+	render_reconcile(f.rs, commands_of(cmds, 2), &hooks);
+	CHECK_EQ(fc.configures, 3);
+	CHECK_EQ(fc.configured_w, 300);
+	CHECK_EQ(fc.repositions, 3);
+
+	/* Undeclared: the sweep hands the tree back, disabled, at home. */
+	render_reconcile(f.rs, commands_of(cmds, 1), &hooks);
+	CHECK_EQ(fc.releases, 1);
+	CHECK_EQ(child_count(rt), 1);
+	CHECK(!fc.trees[1]->node.enabled);
+	CHECK_EQ(fc.trees[1]->node.parent, fc.home);
+
+	/* A client that died between declare and reconcile realizes no node. */
+	fc.gone[1] = true;
+	render_reconcile(f.rs, commands_of(cmds, 2), &hooks);
+	CHECK_EQ(child_count(rt), 1);
+
+	fixture_finish(&f, &hooks);
+}
+
+static void test_popup_owner_folds_to_top(void) {
+	struct fixture f;
+	struct fake_clients fc;
+	struct render_client_hooks hooks;
+	fixture_init_clients(&f, &fc, &hooks);
+
+	Clay_RenderCommand cmds[] = {
+		cmd_custom(1, 0, 0, 0, 400, 300),
+		cmd_custom(2, 1, 400, 0, 400, 300),
+	};
+	render_reconcile(f.rs, commands_of(cmds, 2), &hooks);
+	struct wlr_scene_tree *rt = render_tree(f.parent);
+	CHECK_EQ(child_at(rt, 0), &fc.trees[0]->node);
+
+	/* The lower client opens a popup that may overhang its neighbor, so it is
+	 * folded to the top of the draw order. */
+	fc.popup[0] = true;
+	CHECK(render_reconcile(f.rs, commands_of(cmds, 2), &hooks) > 0);
+	CHECK_EQ(child_at(rt, 0), &fc.trees[1]->node);
+	CHECK_EQ(child_at(rt, 1), &fc.trees[0]->node);
+
+	/* A steadily-open popup yields the identical order every frame. */
+	CHECK_EQ(render_reconcile(f.rs, commands_of(cmds, 2), &hooks), 0);
+
+	fc.popup[0] = false;
+	CHECK(render_reconcile(f.rs, commands_of(cmds, 2), &hooks) > 0);
+	CHECK_EQ(child_at(rt, 0), &fc.trees[0]->node);
+
+	fixture_finish(&f, &hooks);
+}
+
+static void test_custom_is_never_clipped(void) {
+	struct fixture f;
+	struct fake_clients fc;
+	struct render_client_hooks hooks;
+	fixture_init_clients(&f, &fc, &hooks);
+
+	/* A client subtree is exempt from the clip stack, so a popup that overhangs
+	 * its tile is not cropped. */
+	Clay_RenderCommand cmds[] = {
+		cmd_clip(10, 0, 0, 50, 50, true, true),
+		cmd_custom(1, 0, 25, 25, 400, 300),
+		cmd_clip_end(10),
+	};
+	render_reconcile(f.rs, commands_of(cmds, 3), &hooks);
+	CHECK_EQ(fc.trees[0]->node.x, 25);
+	CHECK(fc.trees[0]->node.enabled);
+	CHECK_EQ(fc.configured_w, 400);
+	CHECK_EQ(fc.configured_h, 300);
+
+	fixture_finish(&f, &hooks);
+}
+
+static void test_float_boxes_truncate(void) {
+	struct fixture f;
+	fixture_init(&f);
+	/* Clay solves in float32, and the reconciler truncates at the scene
+	 * boundary. Anything that wants pixel parity with somewm's integer
+	 * geometry has to round before it declares, not after. */
+	Clay_RenderCommand cmds[] = { cmd_rect(1, 10.6f, 20.4f, 30.7f, 40.2f, 0) };
+	render_reconcile(f.rs, commands_of(cmds, 1), &no_hooks);
+	struct wlr_scene_tree *rt = render_tree(f.parent);
+	struct wlr_scene_rect *r = wlr_scene_rect_from_node(child_at(rt, 0));
+	CHECK_EQ(child_at(rt, 0)->x, 10);
+	CHECK_EQ(child_at(rt, 0)->y, 20);
+	CHECK_EQ(r->width, 30);
+	CHECK_EQ(r->height, 40);
+
+	/* A sub-pixel drift that truncates to the same integers is not a change. */
+	cmds[0].boundingBox.x = 10.9f;
+	CHECK_EQ(render_reconcile(f.rs, commands_of(cmds, 1), &no_hooks), 0);
+
+	fixture_finish(&f, &no_hooks);
+}
+
+static void test_text_rasters_once_per_change(void) {
+	struct fixture f;
+	fixture_init(&f);
+	Clay_RenderCommand cmds[] = { cmd_text(1, 0, 0, 80, 16, "hello", false) };
+
+	CHECK(render_reconcile(f.rs, commands_of(cmds, 1), &no_hooks) > 0);
+	struct wlr_scene_tree *rt = render_tree(f.parent);
+	CHECK_EQ(child_count(rt), 1);
+	CHECK_EQ(child_at(rt, 0)->type, WLR_SCENE_NODE_BUFFER);
+	CHECK_EQ(render_reconcile(f.rs, commands_of(cmds, 1), &no_hooks), 0);
+
+	/* New content re-rasters, and nothing else moves. */
+	cmds[0] = cmd_text(1, 0, 0, 80, 16, "goodbye", false);
+	CHECK_EQ(render_reconcile(f.rs, commands_of(cmds, 1), &no_hooks), 1);
+	CHECK_EQ(render_reconcile(f.rs, commands_of(cmds, 1), &no_hooks), 0);
+
+	/* A style change with the same string re-rasters too. */
+	cmds[0].renderData.text.textColor = (Clay_Color) { 0, 0, 0, 255 };
+	CHECK_EQ(render_reconcile(f.rs, commands_of(cmds, 1), &no_hooks), 1);
+
+	/* An empty run: a real case (a label with nothing in it), and the one that
+	 * puts NULL through the content compare, which UBSan rejects. */
+	cmds[0] = cmd_text(2, 0, 0, 80, 16, "", false);
+	render_reconcile(f.rs, commands_of(cmds, 1), &no_hooks);
+	CHECK_EQ(render_reconcile(f.rs, commands_of(cmds, 1), &no_hooks), 0);
+
+	fixture_finish(&f, &no_hooks);
+}
+
+static void test_text_crops_to_its_clip(void) {
+	struct fixture f;
+	fixture_init(&f);
+	/* The run is wider than the clip, so it crops. Its own box never moves, so
+	 * only the clip can tell the raster where to truncate. */
+	Clay_RenderCommand cmds[] = {
+		cmd_clip(10, 0, 0, 40, 16, true, true),
+		cmd_text(1, 0, 0, 80, 16, "a long enough run", true),
+		cmd_clip_end(10),
+	};
+	render_reconcile(f.rs, commands_of(cmds, 3), &no_hooks);
+	struct wlr_scene_tree *rt = render_tree(f.parent);
+	struct wlr_scene_buffer *sb = wlr_scene_buffer_from_node(child_at(rt, 0));
+	CHECK_EQ(child_at(rt, 0)->x, 0);
+	CHECK_EQ(sb->dst_width, 40);
+	CHECK_EQ(render_reconcile(f.rs, commands_of(cmds, 3), &no_hooks), 0);
+
+	/* Narrowing the clip re-rasters at the tighter bound. */
+	cmds[0].boundingBox.width = 20;
+	CHECK(render_reconcile(f.rs, commands_of(cmds, 3), &no_hooks) > 0);
+	CHECK_EQ(sb->dst_width, 20);
+
+	fixture_finish(&f, &no_hooks);
+}
+
+/* A decoded entry built by hand, so the image path is testable without going
+ * through a file. The cache produces exactly this shape. */
+static void fake_image_entry(struct image_entry *e, int w, int h) {
+	memset(e, 0, sizeof(*e));
+	e->path = NULL;
+	e->native = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, w, h);
+	e->width = w;
+	e->height = h;
+	e->decoded = true;
+	e->gen = 1;
+}
+
+static void test_image_rerasters_on_generation_bump(void) {
+	struct fixture f;
+	fixture_init(&f);
+	struct image_entry entry;
+	fake_image_entry(&entry, 4, 4);
+	Clay_RenderCommand cmds[] = { cmd_image(1, 0, 0, 32, 32, &entry) };
+
+	render_reconcile(f.rs, commands_of(cmds, 1), &no_hooks);
+	CHECK_EQ(render_buffers_created(f.rs), 1);
+	CHECK(render_raster_bytes(f.rs) > 0);
+	CHECK_EQ(render_reconcile(f.rs, commands_of(cmds, 1), &no_hooks), 0);
+	CHECK_EQ(render_buffers_created(f.rs), 0);
+
+	/* The entry pointer never changes across a reload, so gen is what tells the
+	 * renderer the pixels are new. */
+	entry.gen++;
+	CHECK_EQ(render_reconcile(f.rs, commands_of(cmds, 1), &no_hooks), 1);
+	CHECK_EQ(render_buffers_created(f.rs), 1);
+
+	fixture_finish(&f, &no_hooks);
+	cairo_surface_destroy(entry.native);
+
+	/* An entry that never decoded draws nothing at all. */
+	struct image_entry failed = { .decoded = true, .failed = true };
+	Clay_RenderCommand miss[] = { cmd_image(2, 0, 0, 32, 32, &failed) };
+	struct fixture g;
+	fixture_init(&g);
+	render_reconcile(g.rs, commands_of(miss, 1), &no_hooks);
+	CHECK_EQ(child_count(render_tree(g.parent)), 1);
+	CHECK_EQ(render_buffers_created(g.rs), 0);
+	CHECK_EQ(render_raster_bytes(g.rs), 0);
+	fixture_finish(&g, &no_hooks);
+}
+
+static void test_image_cache_rejects_bad_messages(void) {
+	struct image_cache *ic = image_cache_create();
+	uint8_t pixels[4 * 4 * 4] = { 0 };
+
+	/* A message whose own numbers do not describe the buffer it sent. */
+	CHECK(!image_cache_put(ic, "k", 4, 4, 16, true, 8, 4, pixels, 16));
+	CHECK(!image_cache_put(ic, "k", 4, 4, 16, true, 8, 3, pixels, sizeof(pixels)));
+	CHECK(!image_cache_put(ic, "k", 4, 4, 4, true, 8, 4, pixels, sizeof(pixels)));
+	CHECK(!image_cache_put(ic, "k", 0, 4, 16, true, 8, 4, pixels, sizeof(pixels)));
+	CHECK(!image_cache_put(ic, "k", 4, 4, 16, true, 16, 4, pixels, sizeof(pixels)));
+	/* width * channels overflows int to a negative here, so a rowstride far too
+	 * short for the claimed row passes a 32-bit comparison. */
+	CHECK(!image_cache_put(ic, "k", 1 << 29, 4, 16, true, 8, 4, pixels,
+		sizeof(pixels)));
+	CHECK(!image_cache_put(ic, "k", 4, 4, -1, true, 8, 4, pixels, sizeof(pixels)));
+	CHECK_EQ(image_cache_bytes(ic), 0);
+
+	CHECK(image_cache_put(ic, "k", 4, 4, 16, true, 8, 4, pixels, sizeof(pixels)));
+	CHECK(image_cache_bytes(ic) > 0);
+
+	image_cache_destroy(ic);
+}
+
+static void test_image_cache_evicts_least_recently_declared(void) {
+	setenv("SOMEWM_IMAGE_BUDGET_MB", "1", 1);
+	struct image_cache *ic = image_cache_create();
+	unsetenv("SOMEWM_IMAGE_BUDGET_MB");
+
+	/* Over a megabyte each, so two of them do not fit the budget. */
+	const int side = 600;
+	uint8_t *pixels = calloc((size_t)side * side, 4);
+
+	image_cache_begin_declare(ic);
+	CHECK(image_cache_put(ic, "a", side, side, side * 4, true, 8, 4,
+		pixels, (size_t)side * side * 4));
+	size_t one = image_cache_bytes(ic);
+	CHECK(one > (size_t)1 << 20);
+
+	/* The budget yields to the live set: everything resident was declared by
+	 * this solve, so there is nothing evictable. */
+	image_cache_sweep(ic);
+	CHECK_EQ(image_cache_bytes(ic), one);
+
+	/* Next solve: "a" was not declared again, so it is the one that goes. */
+	image_cache_begin_declare(ic);
+	CHECK(image_cache_put(ic, "b", side, side, side * 4, true, 8, 4,
+		pixels, (size_t)side * side * 4));
+	CHECK_EQ(image_cache_bytes(ic), one);
+
+	free(pixels);
+	image_cache_destroy(ic);
+}
+
+static void test_font_interning(void) {
+	/* Entry 0 is the fallback face, and Clay's debug view writes fontId 0
+	 * without interning anything. */
+	CHECK_EQ(render_font_intern("Sans"), 0);
+	int32_t mono = render_font_intern("Monospace");
+	CHECK(mono > 0);
+	/* Write-once: the same description resolves to the same id. */
+	CHECK_EQ(render_font_intern("Monospace"), mono);
+
+	/* A description carrying a size is refused, because size is its own
+	 * channel and would be silently overridden. */
+	CHECK_EQ(render_font_intern("Monospace 12"), RENDER_FONT_ERR_SIZE);
+	/* Pango's parser is what decides: it reads a trailing number as a size, and
+	 * a family whose name ends in a digit with no space before it as a family. */
+	CHECK(render_font_intern("M+ 1c") > 0);
+}
+
+static void test_measure_is_monotonic(void) {
+	/* Font availability is the system's, so the only claims here are the ones
+	 * that hold with any face, including none at all. */
+	render_text_set_measure_scale(1.0f);
+	Clay_TextElementConfig config = { .fontId = 0, .fontSize = 12 };
+	Clay_StringSlice empty = { .length = 0, .chars = "", .baseChars = "" };
+	Clay_StringSlice run = { .length = 5, .chars = "hello", .baseChars = "hello" };
+
+	Clay_Dimensions d_empty = render_measure_text(empty, &config, NULL);
+	Clay_Dimensions d_run = render_measure_text(run, &config, NULL);
+	CHECK_EQ(d_empty.width, 0);
+	CHECK(d_run.width >= d_empty.width);
+	/* Same input, same answer: the measure callback is pure. */
+	CHECK_EQ(render_measure_text(run, &config, NULL).width, d_run.width);
+}
+
+/* The verifier aborts the process, so the divergence runs in a child. */
+/* Every box a border draws, whether it is an edge rect or a corner tile. */
+static int ring_cover(struct wlr_scene_tree *bt, int px, int py) {
+	int n = 0;
+	struct wlr_scene_node *child;
+	wl_list_for_each(child, &bt->children, link) {
+		if (!child->enabled) {
+			continue;
+		}
+		int w, h;
+		if (child->type == WLR_SCENE_NODE_RECT) {
+			struct wlr_scene_rect *r = wlr_scene_rect_from_node(child);
+			w = r->width;
+			h = r->height;
+		} else {
+			struct wlr_scene_buffer *b = wlr_scene_buffer_from_node(child);
+			w = b->dst_width;
+			h = b->dst_height;
+		}
+		if (px >= child->x && px < child->x + w &&
+				py >= child->y && py < child->y + h) {
+			n++;
+		}
+	}
+	return n;
+}
+
+/* The four edges and the corner tiles must partition the border frame: every
+ * pixel of it drawn, and no pixel drawn twice (the border color can be
+ * translucent, so a double-draw shows as plainly as a hole). The case that
+ * fails when the edges are inset by the radius on one axis and the border width
+ * on the other is 0 < radius < width: nothing then draws the band between them
+ * at any corner. */
+static void test_border_ring_has_no_gap_or_overlap(void) {
+	static const struct { int width, radius; } cases[] = {
+		{ 5, 0 }, { 5, 3 }, { 5, 5 }, { 5, 10 }, { 2, 8 }, { 8, 1 },
+	};
+	const int size = 100;
+	for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+		struct fixture f;
+		fixture_init(&f);
+		int bw = cases[i].width;
+		Clay_RenderCommand c = cmd_border(1, 0, 0, (float)size, (float)size,
+			bw, (float)cases[i].radius);
+		render_reconcile(f.rs, commands_of(&c, 1), &no_hooks);
+		struct wlr_scene_tree *bt =
+			wlr_scene_tree_from_node(child_at(render_tree(f.parent), 0));
+
+		int gaps = 0, overlaps = 0;
+		for (int y = 0; y < size; y++) {
+			for (int x = 0; x < size; x++) {
+				bool frame = x < bw || y < bw ||
+					x >= size - bw || y >= size - bw;
+				int n = ring_cover(bt, x, y);
+				if (frame && n == 0) {
+					gaps++;
+				}
+				if (n > 1) {
+					overlaps++;
+				}
+			}
+		}
+		if (gaps != 0 || overlaps != 0) {
+			fprintf(stderr, "  width %d radius %d: %d gap px, %d overlap px\n",
+				bw, cases[i].radius, gaps, overlaps);
+		}
+		CHECK_EQ(gaps, 0);
+		CHECK_EQ(overlaps, 0);
+		fixture_finish(&f, &no_hooks);
+	}
+}
+
+/* A clipped raster is a crop of the full-box buffer, so the crop has to be
+ * expressed on the grid that buffer was sized on: device_len from the truncated
+ * logical origin. Reading the crop origin off the unrounded box.x instead moves
+ * the whole raster by a pixel whenever the solved origin is fractional. */
+static void test_clip_source_matches_the_buffer_grid(void) {
+	struct fixture f;
+	fixture_init(&f);
+	/* The buffer spans logical [10, 50); the clip starts at 15, its 5th column.
+	 * Rounding 10.6 to 11 instead would call it the 4th. */
+	Clay_RenderCommand cmds[] = {
+		cmd_clip(10, 15, 0, 100, 20, true, true),
+		cmd_rect(1, 10.6f, 0, 40, 20, 4),
+		cmd_clip_end(10),
+	};
+	render_reconcile(f.rs, commands_of(cmds, 3), &no_hooks);
+	struct wlr_scene_node *node = child_at(render_tree(f.parent), 0);
+	struct wlr_scene_buffer *sb = wlr_scene_buffer_from_node(node);
+	CHECK_EQ(node->x, 15);
+	CHECK_EQ((int)sb->src_box.x, 5);
+	CHECK_EQ((int)sb->src_box.width, 35);
+	CHECK_EQ(sb->dst_width, 35);
+	fixture_finish(&f, &no_hooks);
+}
+
+static void test_verifier_catches_divergence(void) {
+#ifndef SOMEWM_RENDER_VERIFY
+	fprintf(stderr, "skipped: built without SOMEWM_RENDER_VERIFY\n");
+	return;
+#else
+	pid_t pid = fork();
+	CHECK(pid >= 0);
+	if (pid == 0) {
+		/* The abort's own diagnostic is the expected output here, not a
+		 * failure to report. */
+		freopen("/dev/null", "w", stderr);
+		struct fixture f;
+		fixture_init(&f);
+		Clay_RenderCommand cmds[] = { cmd_rect(1, 0, 0, 10, 10, 0) };
+		render_reconcile(f.rs, commands_of(cmds, 1), &no_hooks);
+		/* Move the node behind the reconciler's back. The next pass sees an
+		 * unchanged command, so nothing repositions it and the scene no longer
+		 * agrees with the tree. */
+		wlr_scene_node_set_position(child_at(render_tree(f.parent), 0), 999, 999);
+		render_reconcile(f.rs, commands_of(cmds, 1), &no_hooks);
+		_exit(0);   /* reached only if the verifier let the divergence stand */
+	}
+	int status = 0;
+	CHECK(waitpid(pid, &status, 0) == pid);
+	CHECK(WIFSIGNALED(status));
+	CHECK_EQ(WTERMSIG(status), SIGABRT);
+#endif
+}
+
+int main(void) {
+	static const struct {
+		const char *name;
+		void (*fn)(void);
+	} tests[] = {
+		{ "identical frame reconciles to zero", test_identical_frame_reconciles_to_zero },
+		{ "add, remove and move", test_add_remove_move },
+		{ "kind swap destroys and restacks", test_kind_swap_destroys_and_restacks },
+		{ "restack only when order changed", test_restack_only_when_order_changed },
+		{ "clip stack", test_clip_stack },
+		{ "clip axes", test_clip_axes },
+		{ "client surface hooks", test_client_surface_hooks },
+		{ "popup owner folds to top", test_popup_owner_folds_to_top },
+		{ "custom is never clipped", test_custom_is_never_clipped },
+		{ "float boxes truncate", test_float_boxes_truncate },
+		{ "text rasters once per change", test_text_rasters_once_per_change },
+		{ "text crops to its clip", test_text_crops_to_its_clip },
+		{ "image rerasters on generation bump", test_image_rerasters_on_generation_bump },
+		{ "image cache rejects bad messages", test_image_cache_rejects_bad_messages },
+		{ "image cache evicts least recently declared", test_image_cache_evicts_least_recently_declared },
+		{ "font interning", test_font_interning },
+		{ "measure is monotonic", test_measure_is_monotonic },
+		{ "border ring has no gap or overlap", test_border_ring_has_no_gap_or_overlap },
+		{ "clip source matches the buffer grid", test_clip_source_matches_the_buffer_grid },
+		{ "verifier catches divergence", test_verifier_catches_divergence },
+	};
+
+	for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {
+		current_test = tests[i].name;
+		int before = failures;
+		tests[i].fn();
+		printf("%s %s\n", failures == before ? "ok  " : "FAIL", tests[i].name);
+	}
+	render_text_finish();
+	if (failures > 0) {
+		fprintf(stderr, "%d check(s) failed\n", failures);
+	}
+	return failures > 0 ? 1 : 0;
+}

--- a/third_party/clay.h
+++ b/third_party/clay.h
@@ -1,0 +1,4393 @@
+// VERSION: 0.14
+
+/*
+    NOTE: In order to use this library you must define
+    the following macro in exactly one file, _before_ including clay.h:
+
+    #define CLAY_IMPLEMENTATION
+    #include "clay.h"
+
+    See the examples folder for details.
+*/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+// SIMD includes on supported platforms
+#if !defined(CLAY_DISABLE_SIMD) && (defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64))
+#include <emmintrin.h>
+#elif !defined(CLAY_DISABLE_SIMD) && defined(__aarch64__)
+#include <arm_neon.h>
+#endif
+
+// -----------------------------------------
+// HEADER DECLARATIONS ---------------------
+// -----------------------------------------
+
+#ifndef CLAY_HEADER
+#define CLAY_HEADER
+
+#if !( \
+    (defined(__cplusplus) && __cplusplus >= 202002L) || \
+    (defined(__STDC__) && __STDC__ == 1 && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || \
+    defined(_MSC_VER) \
+)
+#error "Clay requires C99, C++20, or MSVC"
+#endif
+
+#ifdef CLAY_WASM
+#define CLAY_WASM_EXPORT(name) __attribute__((export_name(name)))
+#else
+#define CLAY_WASM_EXPORT(null)
+#endif
+
+#ifdef CLAY_DLL
+#define CLAY_DLL_EXPORT __declspec(dllexport) __stdcall
+#else
+#define CLAY_DLL_EXPORT
+#endif
+
+// Public Macro API ------------------------
+
+#define CLAY__MAX(x, y) (((x) > (y)) ? (x) : (y))
+#define CLAY__MIN(x, y) (((x) < (y)) ? (x) : (y))
+
+#define CLAY_TEXT_CONFIG(...) Clay__StoreTextElementConfig(CLAY__CONFIG_WRAPPER(Clay_TextElementConfig, __VA_ARGS__))
+
+#define CLAY_BORDER_OUTSIDE(widthValue) {widthValue, widthValue, widthValue, widthValue, 0}
+
+#define CLAY_BORDER_ALL(widthValue) {widthValue, widthValue, widthValue, widthValue, widthValue}
+
+#define CLAY_CORNER_RADIUS(radius) (CLAY__INIT(Clay_CornerRadius) { radius, radius, radius, radius })
+
+#define CLAY_PADDING_ALL(padding) CLAY__CONFIG_WRAPPER(Clay_Padding, { padding, padding, padding, padding })
+
+#define CLAY_SIZING_FIT(...) (CLAY__INIT(Clay_SizingAxis) { .size = { .minMax = { __VA_ARGS__ } }, .type = CLAY__SIZING_TYPE_FIT })
+
+#define CLAY_SIZING_GROW(...) (CLAY__INIT(Clay_SizingAxis) { .size = { .minMax = { __VA_ARGS__ } }, .type = CLAY__SIZING_TYPE_GROW })
+
+#define CLAY_SIZING_FIXED(fixedSize) (CLAY__INIT(Clay_SizingAxis) { .size = { .minMax = { fixedSize, fixedSize } }, .type = CLAY__SIZING_TYPE_FIXED })
+
+#define CLAY_SIZING_PERCENT(percentOfParent) (CLAY__INIT(Clay_SizingAxis) { .size = { .percent = (percentOfParent) }, .type = CLAY__SIZING_TYPE_PERCENT })
+
+// Note: If a compile error led you here, you might be trying to use CLAY_ID with something other than a string literal. To construct an ID with a dynamic string, use CLAY_SID instead.
+#define CLAY_ID(label) CLAY_IDI(label, 0)
+
+#define CLAY_SID(label) CLAY_SIDI(label, 0)
+
+// Note: If a compile error led you here, you might be trying to use CLAY_IDI with something other than a string literal. To construct an ID with a dynamic string, use CLAY_SIDI instead.
+#define CLAY_IDI(label, index) CLAY_SIDI(CLAY_STRING(label), index)
+
+#define CLAY_SIDI(label, index) Clay__HashString(label, index, 0)
+
+// Note: If a compile error led you here, you might be trying to use CLAY_ID_LOCAL with something other than a string literal. To construct an ID with a dynamic string, use CLAY_SID_LOCAL instead.
+#define CLAY_ID_LOCAL(label) CLAY_IDI_LOCAL(label, 0)
+
+#define CLAY_SID_LOCAL(label) CLAY_SIDI_LOCAL(label, 0)
+
+// Note: If a compile error led you here, you might be trying to use CLAY_IDI_LOCAL with something other than a string literal. To construct an ID with a dynamic string, use CLAY_SIDI_LOCAL instead.
+#define CLAY_IDI_LOCAL(label, index) CLAY_SIDI_LOCAL(CLAY_STRING(label), index)
+
+#define CLAY_SIDI_LOCAL(label, index) Clay__HashString(label, index, Clay__GetParentElementId())
+
+#define CLAY__STRING_LENGTH(s) ((sizeof(s) / sizeof((s)[0])) - sizeof((s)[0]))
+
+#define CLAY__ENSURE_STRING_LITERAL(x) ("" x "")
+
+// Note: If an error led you here, it's because CLAY_STRING can only be used with string literals, i.e. CLAY_STRING("SomeString") and not CLAY_STRING(yourString)
+#define CLAY_STRING(string) (CLAY__INIT(Clay_String) { .isStaticallyAllocated = true, .length = CLAY__STRING_LENGTH(CLAY__ENSURE_STRING_LITERAL(string)), .chars = (string) })
+
+#define CLAY_STRING_CONST(string) { .isStaticallyAllocated = true, .length = CLAY__STRING_LENGTH(CLAY__ENSURE_STRING_LITERAL(string)), .chars = (string) }
+
+static uint8_t CLAY__ELEMENT_DEFINITION_LATCH;
+
+// GCC marks the above CLAY__ELEMENT_DEFINITION_LATCH as an unused variable for files that include clay.h but don't declare any layout
+// This is to suppress that warning
+static inline void Clay__SuppressUnusedLatchDefinitionVariableWarning(void) { (void) CLAY__ELEMENT_DEFINITION_LATCH; }
+
+// Publicly visible layout element macros -----------------------------------------------------
+
+/* This macro looks scary on the surface, but is actually quite simple.
+  It turns a macro call like this:
+
+  CLAY({
+    .id = CLAY_ID("Container"),
+    .backgroundColor = { 255, 200, 200, 255 }
+  }) {
+      ...children declared here
+  }
+
+  Into calls like this:
+
+  Clay_OpenElement();
+  Clay_ConfigureOpenElement((Clay_ElementDeclaration) {
+    .id = CLAY_ID("Container"),
+    .backgroundColor = { 255, 200, 200, 255 }
+  });
+  ...children declared here
+  Clay_CloseElement();
+
+  The for loop will only ever run a single iteration, putting Clay__CloseElement() in the increment of the loop
+  means that it will run after the body - where the children are declared. It just exists to make sure you don't forget
+  to call Clay_CloseElement().
+*/
+#define CLAY(...)                                                                                                                                           \
+    for (                                                                                                                                                   \
+        CLAY__ELEMENT_DEFINITION_LATCH = (Clay__OpenElement(), Clay__ConfigureOpenElement(CLAY__CONFIG_WRAPPER(Clay_ElementDeclaration, __VA_ARGS__)), 0);  \
+        CLAY__ELEMENT_DEFINITION_LATCH < 1;                                                                                                                 \
+        CLAY__ELEMENT_DEFINITION_LATCH=1, Clay__CloseElement()                                                                                              \
+    )
+
+// These macros exist to allow the CLAY() macro to be called both with an inline struct definition, such as
+// CLAY({ .id = something... });
+// As well as by passing a predefined declaration struct
+// Clay_ElementDeclaration declarationStruct = ...
+// CLAY(declarationStruct);
+#define CLAY__WRAPPER_TYPE(type) Clay__##type##Wrapper
+#define CLAY__WRAPPER_STRUCT(type) typedef struct { type wrapped; } CLAY__WRAPPER_TYPE(type)
+#define CLAY__CONFIG_WRAPPER(type, ...) (CLAY__INIT(CLAY__WRAPPER_TYPE(type)) { __VA_ARGS__ }).wrapped
+
+#define CLAY_TEXT(text, textConfig) Clay__OpenTextElement(text, textConfig)
+
+#ifdef __cplusplus
+
+#define CLAY__INIT(type) type
+
+#define CLAY_PACKED_ENUM enum : uint8_t
+
+#define CLAY__DEFAULT_STRUCT {}
+
+#else
+
+#define CLAY__INIT(type) (type)
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#define CLAY_PACKED_ENUM __pragma(pack(push, 1)) enum __pragma(pack(pop))
+#else
+#define CLAY_PACKED_ENUM enum __attribute__((__packed__))
+#endif
+
+#if __STDC_VERSION__ >= 202311L
+#define CLAY__DEFAULT_STRUCT {}
+#else
+#define CLAY__DEFAULT_STRUCT {0}
+#endif
+
+#endif // __cplusplus
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Utility Structs -------------------------
+
+// Note: Clay_String is not guaranteed to be null terminated. It may be if created from a literal C string,
+// but it is also used to represent slices.
+typedef struct Clay_String {
+    // Set this boolean to true if the char* data underlying this string will live for the entire lifetime of the program.
+    // This will automatically be set for strings created with CLAY_STRING, as the macro requires a string literal.
+    bool isStaticallyAllocated;
+    int32_t length;
+    // The underlying character memory. Note: this will not be copied and will not extend the lifetime of the underlying memory.
+    const char *chars;
+} Clay_String;
+
+// Clay_StringSlice is used to represent non owning string slices, and includes
+// a baseChars field which points to the string this slice is derived from.
+typedef struct Clay_StringSlice {
+    int32_t length;
+    const char *chars;
+    const char *baseChars; // The source string / char* that this slice was derived from
+} Clay_StringSlice;
+
+typedef struct Clay_Context Clay_Context;
+
+// Clay_Arena is a memory arena structure that is used by clay to manage its internal allocations.
+// Rather than creating it by hand, it's easier to use Clay_CreateArenaWithCapacityAndMemory()
+typedef struct Clay_Arena {
+    uintptr_t nextAllocation;
+    size_t capacity;
+    char *memory;
+} Clay_Arena;
+
+typedef struct Clay_Dimensions {
+    float width, height;
+} Clay_Dimensions;
+
+typedef struct Clay_Vector2 {
+    float x, y;
+} Clay_Vector2;
+
+// Internally clay conventionally represents colors as 0-255, but interpretation is up to the renderer.
+typedef struct Clay_Color {
+    float r, g, b, a;
+} Clay_Color;
+
+typedef struct Clay_BoundingBox {
+    float x, y, width, height;
+} Clay_BoundingBox;
+
+// Primarily created via the CLAY_ID(), CLAY_IDI(), CLAY_ID_LOCAL() and CLAY_IDI_LOCAL() macros.
+// Represents a hashed string ID used for identifying and finding specific clay UI elements, required
+// by functions such as Clay_PointerOver() and Clay_GetElementData().
+typedef struct Clay_ElementId {
+    uint32_t id; // The resulting hash generated from the other fields.
+    uint32_t offset; // A numerical offset applied after computing the hash from stringId.
+    uint32_t baseId; // A base hash value to start from, for example the parent element ID is used when calculating CLAY_ID_LOCAL().
+    Clay_String stringId; // The string id to hash.
+} Clay_ElementId;
+
+// A sized array of Clay_ElementId.
+typedef struct
+{
+    int32_t capacity;
+    int32_t length;
+    Clay_ElementId *internalArray;
+} Clay_ElementIdArray;
+
+// Controls the "radius", or corner rounding of elements, including rectangles, borders and images.
+// The rounding is determined by drawing a circle inset into the element corner by (radius, radius) pixels.
+typedef struct Clay_CornerRadius {
+    float topLeft;
+    float topRight;
+    float bottomLeft;
+    float bottomRight;
+} Clay_CornerRadius;
+
+// Element Configs ---------------------------
+
+// Controls the direction in which child elements will be automatically laid out.
+typedef CLAY_PACKED_ENUM {
+    // (Default) Lays out child elements from left to right with increasing x.
+    CLAY_LEFT_TO_RIGHT,
+    // Lays out child elements from top to bottom with increasing y.
+    CLAY_TOP_TO_BOTTOM,
+} Clay_LayoutDirection;
+
+// Controls the alignment along the x axis (horizontal) of child elements.
+typedef CLAY_PACKED_ENUM {
+    // (Default) Aligns child elements to the left hand side of this element, offset by padding.width.left
+    CLAY_ALIGN_X_LEFT,
+    // Aligns child elements to the right hand side of this element, offset by padding.width.right
+    CLAY_ALIGN_X_RIGHT,
+    // Aligns child elements horizontally to the center of this element
+    CLAY_ALIGN_X_CENTER,
+} Clay_LayoutAlignmentX;
+
+// Controls the alignment along the y axis (vertical) of child elements.
+typedef CLAY_PACKED_ENUM {
+    // (Default) Aligns child elements to the top of this element, offset by padding.width.top
+    CLAY_ALIGN_Y_TOP,
+    // Aligns child elements to the bottom of this element, offset by padding.width.bottom
+    CLAY_ALIGN_Y_BOTTOM,
+    // Aligns child elements vertically to the center of this element
+    CLAY_ALIGN_Y_CENTER,
+} Clay_LayoutAlignmentY;
+
+// Controls how the element takes up space inside its parent container.
+typedef CLAY_PACKED_ENUM {
+    // (default) Wraps tightly to the size of the element's contents.
+    CLAY__SIZING_TYPE_FIT,
+    // Expands along this axis to fill available space in the parent element, sharing it with other GROW elements.
+    CLAY__SIZING_TYPE_GROW,
+    // Expects 0-1 range. Clamps the axis size to a percent of the parent container's axis size minus padding and child gaps.
+    CLAY__SIZING_TYPE_PERCENT,
+    // Clamps the axis size to an exact size in pixels.
+    CLAY__SIZING_TYPE_FIXED,
+} Clay__SizingType;
+
+// Controls how child elements are aligned on each axis.
+typedef struct Clay_ChildAlignment {
+    Clay_LayoutAlignmentX x; // Controls alignment of children along the x axis.
+    Clay_LayoutAlignmentY y; // Controls alignment of children along the y axis.
+} Clay_ChildAlignment;
+
+// Controls the minimum and maximum size in pixels that this element is allowed to grow or shrink to,
+// overriding sizing types such as FIT or GROW.
+typedef struct Clay_SizingMinMax {
+    float min; // The smallest final size of the element on this axis will be this value in pixels.
+    float max; // The largest final size of the element on this axis will be this value in pixels.
+} Clay_SizingMinMax;
+
+// Controls the sizing of this element along one axis inside its parent container.
+typedef struct Clay_SizingAxis {
+    union {
+        Clay_SizingMinMax minMax; // Controls the minimum and maximum size in pixels that this element is allowed to grow or shrink to, overriding sizing types such as FIT or GROW.
+        float percent; // Expects 0-1 range. Clamps the axis size to a percent of the parent container's axis size minus padding and child gaps.
+    } size;
+    Clay__SizingType type; // Controls how the element takes up space inside its parent container.
+} Clay_SizingAxis;
+
+// Controls the sizing of this element along one axis inside its parent container.
+typedef struct Clay_Sizing {
+    Clay_SizingAxis width; // Controls the width sizing of the element, along the x axis.
+    Clay_SizingAxis height;  // Controls the height sizing of the element, along the y axis.
+} Clay_Sizing;
+
+// Controls "padding" in pixels, which is a gap between the bounding box of this element and where its children
+// will be placed.
+typedef struct Clay_Padding {
+    uint16_t left;
+    uint16_t right;
+    uint16_t top;
+    uint16_t bottom;
+} Clay_Padding;
+
+CLAY__WRAPPER_STRUCT(Clay_Padding);
+
+// Controls various settings that affect the size and position of an element, as well as the sizes and positions
+// of any child elements.
+typedef struct Clay_LayoutConfig {
+    Clay_Sizing sizing; // Controls the sizing of this element inside it's parent container, including FIT, GROW, PERCENT and FIXED sizing.
+    Clay_Padding padding; // Controls "padding" in pixels, which is a gap between the bounding box of this element and where its children will be placed.
+    uint16_t childGap; // Controls the gap in pixels between child elements along the layout axis (horizontal gap for LEFT_TO_RIGHT, vertical gap for TOP_TO_BOTTOM).
+    Clay_ChildAlignment childAlignment; // Controls how child elements are aligned on each axis.
+    Clay_LayoutDirection layoutDirection; // Controls the direction in which child elements will be automatically laid out.
+} Clay_LayoutConfig;
+
+CLAY__WRAPPER_STRUCT(Clay_LayoutConfig);
+
+extern Clay_LayoutConfig CLAY_LAYOUT_DEFAULT;
+
+// Controls how text "wraps", that is how it is broken into multiple lines when there is insufficient horizontal space.
+typedef CLAY_PACKED_ENUM {
+    // (default) breaks on whitespace characters.
+    CLAY_TEXT_WRAP_WORDS,
+    // Don't break on space characters, only on newlines.
+    CLAY_TEXT_WRAP_NEWLINES,
+    // Disable text wrapping entirely.
+    CLAY_TEXT_WRAP_NONE,
+} Clay_TextElementConfigWrapMode;
+
+// Controls how wrapped lines of text are horizontally aligned within the outer text bounding box.
+typedef CLAY_PACKED_ENUM {
+    // (default) Horizontally aligns wrapped lines of text to the left hand side of their bounding box.
+    CLAY_TEXT_ALIGN_LEFT,
+    // Horizontally aligns wrapped lines of text to the center of their bounding box.
+    CLAY_TEXT_ALIGN_CENTER,
+    // Horizontally aligns wrapped lines of text to the right hand side of their bounding box.
+    CLAY_TEXT_ALIGN_RIGHT,
+} Clay_TextAlignment;
+
+// Controls various functionality related to text elements.
+typedef struct Clay_TextElementConfig {
+    // A pointer that will be transparently passed through to the resulting render command.
+    void *userData;
+    // The RGBA color of the font to render, conventionally specified as 0-255.
+    Clay_Color textColor;
+    // An integer transparently passed to Clay_MeasureText to identify the font to use.
+    // The debug view will pass fontId = 0 for its internal text.
+    uint16_t fontId;
+    // Controls the size of the font. Handled by the function provided to Clay_MeasureText.
+    uint16_t fontSize;
+    // Controls extra horizontal spacing between characters. Handled by the function provided to Clay_MeasureText.
+    uint16_t letterSpacing;
+    // Controls additional vertical space between wrapped lines of text.
+    uint16_t lineHeight;
+    // Controls how text "wraps", that is how it is broken into multiple lines when there is insufficient horizontal space.
+    // CLAY_TEXT_WRAP_WORDS (default) breaks on whitespace characters.
+    // CLAY_TEXT_WRAP_NEWLINES doesn't break on space characters, only on newlines.
+    // CLAY_TEXT_WRAP_NONE disables wrapping entirely.
+    Clay_TextElementConfigWrapMode wrapMode;
+    // Controls how wrapped lines of text are horizontally aligned within the outer text bounding box.
+    // CLAY_TEXT_ALIGN_LEFT (default) - Horizontally aligns wrapped lines of text to the left hand side of their bounding box.
+    // CLAY_TEXT_ALIGN_CENTER - Horizontally aligns wrapped lines of text to the center of their bounding box.
+    // CLAY_TEXT_ALIGN_RIGHT - Horizontally aligns wrapped lines of text to the right hand side of their bounding box.
+    Clay_TextAlignment textAlignment;
+} Clay_TextElementConfig;
+
+CLAY__WRAPPER_STRUCT(Clay_TextElementConfig);
+
+// Aspect Ratio --------------------------------
+
+// Controls various settings related to aspect ratio scaling element.
+typedef struct Clay_AspectRatioElementConfig {
+    float aspectRatio; // A float representing the target "Aspect ratio" for an element, which is its final width divided by its final height.
+} Clay_AspectRatioElementConfig;
+
+CLAY__WRAPPER_STRUCT(Clay_AspectRatioElementConfig);
+
+// Image --------------------------------
+
+// Controls various settings related to image elements.
+typedef struct Clay_ImageElementConfig {
+    void* imageData; // A transparent pointer used to pass image data through to the renderer.
+} Clay_ImageElementConfig;
+
+CLAY__WRAPPER_STRUCT(Clay_ImageElementConfig);
+
+// Floating -----------------------------
+
+// Controls where a floating element is offset relative to its parent element.
+// Note: see https://github.com/user-attachments/assets/b8c6dfaa-c1b1-41a4-be55-013473e4a6ce for a visual explanation.
+typedef CLAY_PACKED_ENUM {
+    CLAY_ATTACH_POINT_LEFT_TOP,
+    CLAY_ATTACH_POINT_LEFT_CENTER,
+    CLAY_ATTACH_POINT_LEFT_BOTTOM,
+    CLAY_ATTACH_POINT_CENTER_TOP,
+    CLAY_ATTACH_POINT_CENTER_CENTER,
+    CLAY_ATTACH_POINT_CENTER_BOTTOM,
+    CLAY_ATTACH_POINT_RIGHT_TOP,
+    CLAY_ATTACH_POINT_RIGHT_CENTER,
+    CLAY_ATTACH_POINT_RIGHT_BOTTOM,
+} Clay_FloatingAttachPointType;
+
+// Controls where a floating element is offset relative to its parent element.
+typedef struct Clay_FloatingAttachPoints {
+    Clay_FloatingAttachPointType element; // Controls the origin point on a floating element that attaches to its parent.
+    Clay_FloatingAttachPointType parent; // Controls the origin point on the parent element that the floating element attaches to.
+} Clay_FloatingAttachPoints;
+
+// Controls how mouse pointer events like hover and click are captured or passed through to elements underneath a floating element.
+typedef CLAY_PACKED_ENUM {
+    // (default) "Capture" the pointer event and don't allow events like hover and click to pass through to elements underneath.
+    CLAY_POINTER_CAPTURE_MODE_CAPTURE,
+    //    CLAY_POINTER_CAPTURE_MODE_PARENT, TODO pass pointer through to attached parent
+
+    // Transparently pass through pointer events like hover and click to elements underneath the floating element.
+    CLAY_POINTER_CAPTURE_MODE_PASSTHROUGH,
+} Clay_PointerCaptureMode;
+
+// Controls which element a floating element is "attached" to (i.e. relative offset from).
+typedef CLAY_PACKED_ENUM {
+    // (default) Disables floating for this element.
+    CLAY_ATTACH_TO_NONE,
+    // Attaches this floating element to its parent, positioned based on the .attachPoints and .offset fields.
+    CLAY_ATTACH_TO_PARENT,
+    // Attaches this floating element to an element with a specific ID, specified with the .parentId field. positioned based on the .attachPoints and .offset fields.
+    CLAY_ATTACH_TO_ELEMENT_WITH_ID,
+    // Attaches this floating element to the root of the layout, which combined with the .offset field provides functionality similar to "absolute positioning".
+    CLAY_ATTACH_TO_ROOT,
+} Clay_FloatingAttachToElement;
+
+// Controls whether or not a floating element is clipped to the same clipping rectangle as the element it's attached to.
+typedef CLAY_PACKED_ENUM {
+    // (default) - The floating element does not inherit clipping.
+    CLAY_CLIP_TO_NONE,
+    // The floating element is clipped to the same clipping rectangle as the element it's attached to.
+    CLAY_CLIP_TO_ATTACHED_PARENT
+} Clay_FloatingClipToElement;
+
+// Controls various settings related to "floating" elements, which are elements that "float" above other elements, potentially overlapping their boundaries,
+// and not affecting the layout of sibling or parent elements.
+typedef struct Clay_FloatingElementConfig {
+    // Offsets this floating element by the provided x,y coordinates from its attachPoints.
+    Clay_Vector2 offset;
+    // Expands the boundaries of the outer floating element without affecting its children.
+    Clay_Dimensions expand;
+    // When used in conjunction with .attachTo = CLAY_ATTACH_TO_ELEMENT_WITH_ID, attaches this floating element to the element in the hierarchy with the provided ID.
+    // Hint: attach the ID to the other element with .id = CLAY_ID("yourId"), and specify the id the same way, with .parentId = CLAY_ID("yourId").id
+    uint32_t parentId;
+    // Controls the z index of this floating element and all its children. Floating elements are sorted in ascending z order before output.
+    // zIndex is also passed to the renderer for all elements contained within this floating element.
+    int16_t zIndex;
+    // Controls how mouse pointer events like hover and click are captured or passed through to elements underneath / behind a floating element.
+    // Enum is of the form CLAY_ATTACH_POINT_foo_bar. See Clay_FloatingAttachPoints for more details.
+    // Note: see <img src="https://github.com/user-attachments/assets/b8c6dfaa-c1b1-41a4-be55-013473e4a6ce />
+    // and <img src="https://github.com/user-attachments/assets/ebe75e0d-1904-46b0-982d-418f929d1516 /> for a visual explanation.
+    Clay_FloatingAttachPoints attachPoints;
+    // Controls how mouse pointer events like hover and click are captured or passed through to elements underneath a floating element.
+    // CLAY_POINTER_CAPTURE_MODE_CAPTURE (default) - "Capture" the pointer event and don't allow events like hover and click to pass through to elements underneath.
+    // CLAY_POINTER_CAPTURE_MODE_PASSTHROUGH - Transparently pass through pointer events like hover and click to elements underneath the floating element.
+    Clay_PointerCaptureMode pointerCaptureMode;
+    // Controls which element a floating element is "attached" to (i.e. relative offset from).
+    // CLAY_ATTACH_TO_NONE (default) - Disables floating for this element.
+    // CLAY_ATTACH_TO_PARENT - Attaches this floating element to its parent, positioned based on the .attachPoints and .offset fields.
+    // CLAY_ATTACH_TO_ELEMENT_WITH_ID - Attaches this floating element to an element with a specific ID, specified with the .parentId field. positioned based on the .attachPoints and .offset fields.
+    // CLAY_ATTACH_TO_ROOT - Attaches this floating element to the root of the layout, which combined with the .offset field provides functionality similar to "absolute positioning".
+    Clay_FloatingAttachToElement attachTo;
+    // Controls whether or not a floating element is clipped to the same clipping rectangle as the element it's attached to.
+    // CLAY_CLIP_TO_NONE (default) - The floating element does not inherit clipping.
+    // CLAY_CLIP_TO_ATTACHED_PARENT - The floating element is clipped to the same clipping rectangle as the element it's attached to.
+    Clay_FloatingClipToElement clipTo;
+} Clay_FloatingElementConfig;
+
+CLAY__WRAPPER_STRUCT(Clay_FloatingElementConfig);
+
+// Custom -----------------------------
+
+// Controls various settings related to custom elements.
+typedef struct Clay_CustomElementConfig {
+    // A transparent pointer through which you can pass custom data to the renderer.
+    // Generates CUSTOM render commands.
+    void* customData;
+} Clay_CustomElementConfig;
+
+CLAY__WRAPPER_STRUCT(Clay_CustomElementConfig);
+
+// Scroll -----------------------------
+
+// Controls the axis on which an element switches to "scrolling", which clips the contents and allows scrolling in that direction.
+typedef struct Clay_ClipElementConfig {
+    bool horizontal; // Clip overflowing elements on the X axis.
+    bool vertical; // Clip overflowing elements on the Y axis.
+    Clay_Vector2 childOffset; // Offsets the x,y positions of all child elements. Used primarily for scrolling containers.
+} Clay_ClipElementConfig;
+
+CLAY__WRAPPER_STRUCT(Clay_ClipElementConfig);
+
+// Border -----------------------------
+
+// Controls the widths of individual element borders.
+typedef struct Clay_BorderWidth {
+    uint16_t left;
+    uint16_t right;
+    uint16_t top;
+    uint16_t bottom;
+    // Creates borders between each child element, depending on the .layoutDirection.
+    // e.g. for LEFT_TO_RIGHT, borders will be vertical lines, and for TOP_TO_BOTTOM borders will be horizontal lines.
+    // .betweenChildren borders will result in individual RECTANGLE render commands being generated.
+    uint16_t betweenChildren;
+} Clay_BorderWidth;
+
+// Controls settings related to element borders.
+typedef struct Clay_BorderElementConfig {
+    Clay_Color color; // Controls the color of all borders with width > 0. Conventionally represented as 0-255, but interpretation is up to the renderer.
+    Clay_BorderWidth width; // Controls the widths of individual borders. At least one of these should be > 0 for a BORDER render command to be generated.
+} Clay_BorderElementConfig;
+
+CLAY__WRAPPER_STRUCT(Clay_BorderElementConfig);
+
+// Render Command Data -----------------------------
+
+// Render command data when commandType == CLAY_RENDER_COMMAND_TYPE_TEXT
+typedef struct Clay_TextRenderData {
+    // A string slice containing the text to be rendered.
+    // Note: this is not guaranteed to be null terminated.
+    Clay_StringSlice stringContents;
+    // Conventionally represented as 0-255 for each channel, but interpretation is up to the renderer.
+    Clay_Color textColor;
+    // An integer representing the font to use to render this text, transparently passed through from the text declaration.
+    uint16_t fontId;
+    uint16_t fontSize;
+    // Specifies the extra whitespace gap in pixels between each character.
+    uint16_t letterSpacing;
+    // The height of the bounding box for this line of text.
+    uint16_t lineHeight;
+} Clay_TextRenderData;
+
+// Render command data when commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE
+typedef struct Clay_RectangleRenderData {
+    // The solid background color to fill this rectangle with. Conventionally represented as 0-255 for each channel, but interpretation is up to the renderer.
+    Clay_Color backgroundColor;
+    // Controls the "radius", or corner rounding of elements, including rectangles, borders and images.
+    // The rounding is determined by drawing a circle inset into the element corner by (radius, radius) pixels.
+    Clay_CornerRadius cornerRadius;
+} Clay_RectangleRenderData;
+
+// Render command data when commandType == CLAY_RENDER_COMMAND_TYPE_IMAGE
+typedef struct Clay_ImageRenderData {
+    // The tint color for this image. Note that the default value is 0,0,0,0 and should likely be interpreted
+    // as "untinted".
+    // Conventionally represented as 0-255 for each channel, but interpretation is up to the renderer.
+    Clay_Color backgroundColor;
+    // Controls the "radius", or corner rounding of this image.
+    // The rounding is determined by drawing a circle inset into the element corner by (radius, radius) pixels.
+    Clay_CornerRadius cornerRadius;
+    // A pointer transparently passed through from the original element definition, typically used to represent image data.
+    void* imageData;
+} Clay_ImageRenderData;
+
+// Render command data when commandType == CLAY_RENDER_COMMAND_TYPE_CUSTOM
+typedef struct Clay_CustomRenderData {
+    // Passed through from .backgroundColor in the original element declaration.
+    // Conventionally represented as 0-255 for each channel, but interpretation is up to the renderer.
+    Clay_Color backgroundColor;
+    // Controls the "radius", or corner rounding of this custom element.
+    // The rounding is determined by drawing a circle inset into the element corner by (radius, radius) pixels.
+    Clay_CornerRadius cornerRadius;
+    // A pointer transparently passed through from the original element definition.
+    void* customData;
+} Clay_CustomRenderData;
+
+// Render command data when commandType == CLAY_RENDER_COMMAND_TYPE_SCISSOR_START || commandType == CLAY_RENDER_COMMAND_TYPE_SCISSOR_END
+typedef struct Clay_ScrollRenderData {
+    bool horizontal;
+    bool vertical;
+} Clay_ClipRenderData;
+
+// Render command data when commandType == CLAY_RENDER_COMMAND_TYPE_BORDER
+typedef struct Clay_BorderRenderData {
+    // Controls a shared color for all this element's borders.
+    // Conventionally represented as 0-255 for each channel, but interpretation is up to the renderer.
+    Clay_Color color;
+    // Specifies the "radius", or corner rounding of this border element.
+    // The rounding is determined by drawing a circle inset into the element corner by (radius, radius) pixels.
+    Clay_CornerRadius cornerRadius;
+    // Controls individual border side widths.
+    Clay_BorderWidth width;
+} Clay_BorderRenderData;
+
+// A struct union containing data specific to this command's .commandType
+typedef union Clay_RenderData {
+    // Render command data when commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE
+    Clay_RectangleRenderData rectangle;
+    // Render command data when commandType == CLAY_RENDER_COMMAND_TYPE_TEXT
+    Clay_TextRenderData text;
+    // Render command data when commandType == CLAY_RENDER_COMMAND_TYPE_IMAGE
+    Clay_ImageRenderData image;
+    // Render command data when commandType == CLAY_RENDER_COMMAND_TYPE_CUSTOM
+    Clay_CustomRenderData custom;
+    // Render command data when commandType == CLAY_RENDER_COMMAND_TYPE_BORDER
+    Clay_BorderRenderData border;
+    // Render command data when commandType == CLAY_RENDER_COMMAND_TYPE_SCISSOR_START|END
+    Clay_ClipRenderData clip;
+} Clay_RenderData;
+
+// Miscellaneous Structs & Enums ---------------------------------
+
+// Data representing the current internal state of a scrolling element.
+typedef struct Clay_ScrollContainerData {
+    // Note: This is a pointer to the real internal scroll position, mutating it may cause a change in final layout.
+    // Intended for use with external functionality that modifies scroll position, such as scroll bars or auto scrolling.
+    Clay_Vector2 *scrollPosition;
+    // The bounding box of the scroll element.
+    Clay_Dimensions scrollContainerDimensions;
+    // The outer dimensions of the inner scroll container content, including the padding of the parent scroll container.
+    Clay_Dimensions contentDimensions;
+    // The config that was originally passed to the clip element.
+    Clay_ClipElementConfig config;
+    // Indicates whether an actual scroll container matched the provided ID or if the default struct was returned.
+    bool found;
+} Clay_ScrollContainerData;
+
+// Bounding box and other data for a specific UI element.
+typedef struct Clay_ElementData {
+    // The rectangle that encloses this UI element, with the position relative to the root of the layout.
+    Clay_BoundingBox boundingBox;
+    // Indicates whether an actual Element matched the provided ID or if the default struct was returned.
+    bool found;
+} Clay_ElementData;
+
+// Used by renderers to determine specific handling for each render command.
+typedef CLAY_PACKED_ENUM {
+    // This command type should be skipped.
+    CLAY_RENDER_COMMAND_TYPE_NONE,
+    // The renderer should draw a solid color rectangle.
+    CLAY_RENDER_COMMAND_TYPE_RECTANGLE,
+    // The renderer should draw a colored border inset into the bounding box.
+    CLAY_RENDER_COMMAND_TYPE_BORDER,
+    // The renderer should draw text.
+    CLAY_RENDER_COMMAND_TYPE_TEXT,
+    // The renderer should draw an image.
+    CLAY_RENDER_COMMAND_TYPE_IMAGE,
+    // The renderer should begin clipping all future draw commands, only rendering content that falls within the provided boundingBox.
+    CLAY_RENDER_COMMAND_TYPE_SCISSOR_START,
+    // The renderer should finish any previously active clipping, and begin rendering elements in full again.
+    CLAY_RENDER_COMMAND_TYPE_SCISSOR_END,
+    // The renderer should provide a custom implementation for handling this render command based on its .customData
+    CLAY_RENDER_COMMAND_TYPE_CUSTOM,
+} Clay_RenderCommandType;
+
+typedef struct Clay_RenderCommand {
+    // A rectangular box that fully encloses this UI element, with the position relative to the root of the layout.
+    Clay_BoundingBox boundingBox;
+    // A struct union containing data specific to this command's commandType.
+    Clay_RenderData renderData;
+    // A pointer transparently passed through from the original element declaration.
+    void *userData;
+    // The id of this element, transparently passed through from the original element declaration.
+    uint32_t id;
+    // The z order required for drawing this command correctly.
+    // Note: the render command array is already sorted in ascending order, and will produce correct results if drawn in naive order.
+    // This field is intended for use in batching renderers for improved performance.
+    int16_t zIndex;
+    // Specifies how to handle rendering of this command.
+    // CLAY_RENDER_COMMAND_TYPE_RECTANGLE - The renderer should draw a solid color rectangle.
+    // CLAY_RENDER_COMMAND_TYPE_BORDER - The renderer should draw a colored border inset into the bounding box.
+    // CLAY_RENDER_COMMAND_TYPE_TEXT - The renderer should draw text.
+    // CLAY_RENDER_COMMAND_TYPE_IMAGE - The renderer should draw an image.
+    // CLAY_RENDER_COMMAND_TYPE_SCISSOR_START - The renderer should begin clipping all future draw commands, only rendering content that falls within the provided boundingBox.
+    // CLAY_RENDER_COMMAND_TYPE_SCISSOR_END - The renderer should finish any previously active clipping, and begin rendering elements in full again.
+    // CLAY_RENDER_COMMAND_TYPE_CUSTOM - The renderer should provide a custom implementation for handling this render command based on its .customData
+    Clay_RenderCommandType commandType;
+} Clay_RenderCommand;
+
+// A sized array of render commands.
+typedef struct Clay_RenderCommandArray {
+    // The underlying max capacity of the array, not necessarily all initialized.
+    int32_t capacity;
+    // The number of initialized elements in this array. Used for loops and iteration.
+    int32_t length;
+    // A pointer to the first element in the internal array.
+    Clay_RenderCommand* internalArray;
+} Clay_RenderCommandArray;
+
+// Represents the current state of interaction with clay this frame.
+typedef CLAY_PACKED_ENUM {
+    // A left mouse click, or touch occurred this frame.
+    CLAY_POINTER_DATA_PRESSED_THIS_FRAME,
+    // The left mouse button click or touch happened at some point in the past, and is still currently held down this frame.
+    CLAY_POINTER_DATA_PRESSED,
+    // The left mouse button click or touch was released this frame.
+    CLAY_POINTER_DATA_RELEASED_THIS_FRAME,
+    // The left mouse button click or touch is not currently down / was released at some point in the past.
+    CLAY_POINTER_DATA_RELEASED,
+} Clay_PointerDataInteractionState;
+
+// Information on the current state of pointer interactions this frame.
+typedef struct Clay_PointerData {
+    // The position of the mouse / touch / pointer relative to the root of the layout.
+    Clay_Vector2 position;
+    // Represents the current state of interaction with clay this frame.
+    // CLAY_POINTER_DATA_PRESSED_THIS_FRAME - A left mouse click, or touch occurred this frame.
+    // CLAY_POINTER_DATA_PRESSED - The left mouse button click or touch happened at some point in the past, and is still currently held down this frame.
+    // CLAY_POINTER_DATA_RELEASED_THIS_FRAME - The left mouse button click or touch was released this frame.
+    // CLAY_POINTER_DATA_RELEASED - The left mouse button click or touch is not currently down / was released at some point in the past.
+    Clay_PointerDataInteractionState state;
+} Clay_PointerData;
+
+typedef struct Clay_ElementDeclaration {
+    // Primarily created via the CLAY_ID(), CLAY_IDI(), CLAY_ID_LOCAL() and CLAY_IDI_LOCAL() macros.
+    // Represents a hashed string ID used for identifying and finding specific clay UI elements, required by functions such as Clay_PointerOver() and Clay_GetElementData().
+    Clay_ElementId id;
+    // Controls various settings that affect the size and position of an element, as well as the sizes and positions of any child elements.
+    Clay_LayoutConfig layout;
+    // Controls the background color of the resulting element.
+    // By convention specified as 0-255, but interpretation is up to the renderer.
+    // If no other config is specified, .backgroundColor will generate a RECTANGLE render command, otherwise it will be passed as a property to IMAGE or CUSTOM render commands.
+    Clay_Color backgroundColor;
+    // Controls the "radius", or corner rounding of elements, including rectangles, borders and images.
+    Clay_CornerRadius cornerRadius;
+    // Controls settings related to aspect ratio scaling.
+    Clay_AspectRatioElementConfig aspectRatio;
+    // Controls settings related to image elements.
+    Clay_ImageElementConfig image;
+    // Controls whether and how an element "floats", which means it layers over the top of other elements in z order, and doesn't affect the position and size of siblings or parent elements.
+    // Note: in order to activate floating, .floating.attachTo must be set to something other than the default value.
+    Clay_FloatingElementConfig floating;
+    // Used to create CUSTOM render commands, usually to render element types not supported by Clay.
+    Clay_CustomElementConfig custom;
+    // Controls whether an element should clip its contents, as well as providing child x,y offset configuration for scrolling.
+    Clay_ClipElementConfig clip;
+    // Controls settings related to element borders, and will generate BORDER render commands.
+    Clay_BorderElementConfig border;
+    // A pointer that will be transparently passed through to resulting render commands.
+    void *userData;
+} Clay_ElementDeclaration;
+
+CLAY__WRAPPER_STRUCT(Clay_ElementDeclaration);
+
+// Represents the type of error clay encountered while computing layout.
+typedef CLAY_PACKED_ENUM {
+    // A text measurement function wasn't provided using Clay_SetMeasureTextFunction(), or the provided function was null.
+    CLAY_ERROR_TYPE_TEXT_MEASUREMENT_FUNCTION_NOT_PROVIDED,
+    // Clay attempted to allocate its internal data structures but ran out of space.
+    // The arena passed to Clay_Initialize was created with a capacity smaller than that required by Clay_MinMemorySize().
+    CLAY_ERROR_TYPE_ARENA_CAPACITY_EXCEEDED,
+    // Clay ran out of capacity in its internal array for storing elements. This limit can be increased with Clay_SetMaxElementCount().
+    CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED,
+    // Clay ran out of capacity in its internal array for storing elements. This limit can be increased with Clay_SetMaxMeasureTextCacheWordCount().
+    CLAY_ERROR_TYPE_TEXT_MEASUREMENT_CAPACITY_EXCEEDED,
+    // Two elements were declared with exactly the same ID within one layout.
+    CLAY_ERROR_TYPE_DUPLICATE_ID,
+    // A floating element was declared using CLAY_ATTACH_TO_ELEMENT_ID and either an invalid .parentId was provided or no element with the provided .parentId was found.
+    CLAY_ERROR_TYPE_FLOATING_CONTAINER_PARENT_NOT_FOUND,
+    // An element was declared that using CLAY_SIZING_PERCENT but the percentage value was over 1. Percentage values are expected to be in the 0-1 range.
+    CLAY_ERROR_TYPE_PERCENTAGE_OVER_1,
+    // Clay encountered an internal error. It would be wonderful if you could report this so we can fix it!
+    CLAY_ERROR_TYPE_INTERNAL_ERROR,
+} Clay_ErrorType;
+
+// Data to identify the error that clay has encountered.
+typedef struct Clay_ErrorData {
+    // Represents the type of error clay encountered while computing layout.
+    // CLAY_ERROR_TYPE_TEXT_MEASUREMENT_FUNCTION_NOT_PROVIDED - A text measurement function wasn't provided using Clay_SetMeasureTextFunction(), or the provided function was null.
+    // CLAY_ERROR_TYPE_ARENA_CAPACITY_EXCEEDED - Clay attempted to allocate its internal data structures but ran out of space. The arena passed to Clay_Initialize was created with a capacity smaller than that required by Clay_MinMemorySize().
+    // CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED - Clay ran out of capacity in its internal array for storing elements. This limit can be increased with Clay_SetMaxElementCount().
+    // CLAY_ERROR_TYPE_TEXT_MEASUREMENT_CAPACITY_EXCEEDED - Clay ran out of capacity in its internal array for storing elements. This limit can be increased with Clay_SetMaxMeasureTextCacheWordCount().
+    // CLAY_ERROR_TYPE_DUPLICATE_ID - Two elements were declared with exactly the same ID within one layout.
+    // CLAY_ERROR_TYPE_FLOATING_CONTAINER_PARENT_NOT_FOUND - A floating element was declared using CLAY_ATTACH_TO_ELEMENT_ID and either an invalid .parentId was provided or no element with the provided .parentId was found.
+    // CLAY_ERROR_TYPE_PERCENTAGE_OVER_1 - An element was declared that using CLAY_SIZING_PERCENT but the percentage value was over 1. Percentage values are expected to be in the 0-1 range.
+    // CLAY_ERROR_TYPE_INTERNAL_ERROR - Clay encountered an internal error. It would be wonderful if you could report this so we can fix it!
+    Clay_ErrorType errorType;
+    // A string containing human-readable error text that explains the error in more detail.
+    Clay_String errorText;
+    // A transparent pointer passed through from when the error handler was first provided.
+    void *userData;
+} Clay_ErrorData;
+
+// A wrapper struct around Clay's error handler function.
+typedef struct {
+    // A user provided function to call when Clay encounters an error during layout.
+    void (*errorHandlerFunction)(Clay_ErrorData errorText);
+    // A pointer that will be transparently passed through to the error handler when it is called.
+    void *userData;
+} Clay_ErrorHandler;
+
+// Function Forward Declarations ---------------------------------
+
+// Public API functions ------------------------------------------
+
+// Returns the size, in bytes, of the minimum amount of memory Clay requires to operate at its current settings.
+CLAY_DLL_EXPORT uint32_t Clay_MinMemorySize(void);
+// Creates an arena for clay to use for its internal allocations, given a certain capacity in bytes and a pointer to an allocation of at least that size.
+// Intended to be used with Clay_MinMemorySize in the following way:
+// uint32_t minMemoryRequired = Clay_MinMemorySize();
+// Clay_Arena clayMemory = Clay_CreateArenaWithCapacityAndMemory(minMemoryRequired, malloc(minMemoryRequired));
+CLAY_DLL_EXPORT Clay_Arena Clay_CreateArenaWithCapacityAndMemory(size_t capacity, void *memory);
+// Sets the state of the "pointer" (i.e. the mouse or touch) in Clay's internal data. Used for detecting and responding to mouse events in the debug view,
+// as well as for Clay_Hovered() and scroll element handling.
+CLAY_DLL_EXPORT void Clay_SetPointerState(Clay_Vector2 position, bool pointerDown);
+// Initialize Clay's internal arena and setup required data before layout can begin. Only needs to be called once.
+// - arena can be created using Clay_CreateArenaWithCapacityAndMemory()
+// - layoutDimensions are the initial bounding dimensions of the layout (i.e. the screen width and height for a full screen layout)
+// - errorHandler is used by Clay to inform you if something has gone wrong in configuration or layout.
+CLAY_DLL_EXPORT Clay_Context* Clay_Initialize(Clay_Arena arena, Clay_Dimensions layoutDimensions, Clay_ErrorHandler errorHandler);
+// Returns the Context that clay is currently using. Used when using multiple instances of clay simultaneously.
+CLAY_DLL_EXPORT Clay_Context* Clay_GetCurrentContext(void);
+// Sets the context that clay will use to compute the layout.
+// Used to restore a context saved from Clay_GetCurrentContext when using multiple instances of clay simultaneously.
+CLAY_DLL_EXPORT void Clay_SetCurrentContext(Clay_Context* context);
+// Updates the state of Clay's internal scroll data, updating scroll content positions if scrollDelta is non zero, and progressing momentum scrolling.
+// - enableDragScrolling when set to true will enable mobile device like "touch drag" scroll of scroll containers, including momentum scrolling after the touch has ended.
+// - scrollDelta is the amount to scroll this frame on each axis in pixels.
+// - deltaTime is the time in seconds since the last "frame" (scroll update)
+CLAY_DLL_EXPORT void Clay_UpdateScrollContainers(bool enableDragScrolling, Clay_Vector2 scrollDelta, float deltaTime);
+// Returns the internally stored scroll offset for the currently open element.
+// Generally intended for use with clip elements to create scrolling containers.
+CLAY_DLL_EXPORT Clay_Vector2 Clay_GetScrollOffset(void);
+// Updates the layout dimensions in response to the window or outer container being resized.
+CLAY_DLL_EXPORT void Clay_SetLayoutDimensions(Clay_Dimensions dimensions);
+// Called before starting any layout declarations.
+CLAY_DLL_EXPORT void Clay_BeginLayout(void);
+// Called when all layout declarations are finished.
+// Computes the layout and generates and returns the array of render commands to draw.
+CLAY_DLL_EXPORT Clay_RenderCommandArray Clay_EndLayout(void);
+// Calculates a hash ID from the given idString.
+// Generally only used for dynamic strings when CLAY_ID("stringLiteral") can't be used.
+CLAY_DLL_EXPORT Clay_ElementId Clay_GetElementId(Clay_String idString);
+// Calculates a hash ID from the given idString and index.
+// - index is used to avoid constructing dynamic ID strings in loops.
+// Generally only used for dynamic strings when CLAY_IDI("stringLiteral", index) can't be used.
+CLAY_DLL_EXPORT Clay_ElementId Clay_GetElementIdWithIndex(Clay_String idString, uint32_t index);
+// Returns layout data such as the final calculated bounding box for an element with a given ID.
+// The returned Clay_ElementData contains a `found` bool that will be true if an element with the provided ID was found.
+// This ID can be calculated either with CLAY_ID() for string literal IDs, or Clay_GetElementId for dynamic strings.
+CLAY_DLL_EXPORT Clay_ElementData Clay_GetElementData(Clay_ElementId id);
+// Returns true if the pointer position provided by Clay_SetPointerState is within the current element's bounding box.
+// Works during element declaration, e.g. CLAY({ .backgroundColor = Clay_Hovered() ? BLUE : RED });
+CLAY_DLL_EXPORT bool Clay_Hovered(void);
+// Bind a callback that will be called when the pointer position provided by Clay_SetPointerState is within the current element's bounding box.
+// - onHoverFunction is a function pointer to a user defined function.
+// - userData is a pointer that will be transparently passed through when the onHoverFunction is called.
+CLAY_DLL_EXPORT void Clay_OnHover(void (*onHoverFunction)(Clay_ElementId elementId, Clay_PointerData pointerData, intptr_t userData), intptr_t userData);
+// An imperative function that returns true if the pointer position provided by Clay_SetPointerState is within the element with the provided ID's bounding box.
+// This ID can be calculated either with CLAY_ID() for string literal IDs, or Clay_GetElementId for dynamic strings.
+CLAY_DLL_EXPORT bool Clay_PointerOver(Clay_ElementId elementId);
+// Returns the array of element IDs that the pointer is currently over.
+CLAY_DLL_EXPORT Clay_ElementIdArray Clay_GetPointerOverIds(void);
+// Returns data representing the state of the scrolling element with the provided ID.
+// The returned Clay_ScrollContainerData contains a `found` bool that will be true if a scroll element was found with the provided ID.
+// An imperative function that returns true if the pointer position provided by Clay_SetPointerState is within the element with the provided ID's bounding box.
+// This ID can be calculated either with CLAY_ID() for string literal IDs, or Clay_GetElementId for dynamic strings.
+CLAY_DLL_EXPORT Clay_ScrollContainerData Clay_GetScrollContainerData(Clay_ElementId id);
+// Binds a callback function that Clay will call to determine the dimensions of a given string slice.
+// - measureTextFunction is a user provided function that adheres to the interface Clay_Dimensions (Clay_StringSlice text, Clay_TextElementConfig *config, void *userData);
+// - userData is a pointer that will be transparently passed through when the measureTextFunction is called.
+CLAY_DLL_EXPORT void Clay_SetMeasureTextFunction(Clay_Dimensions (*measureTextFunction)(Clay_StringSlice text, Clay_TextElementConfig *config, void *userData), void *userData);
+// Experimental - Used in cases where Clay needs to integrate with a system that manages its own scrolling containers externally.
+// Please reach out if you plan to use this function, as it may be subject to change.
+CLAY_DLL_EXPORT void Clay_SetQueryScrollOffsetFunction(Clay_Vector2 (*queryScrollOffsetFunction)(uint32_t elementId, void *userData), void *userData);
+// A bounds-checked "get" function for the Clay_RenderCommandArray returned from Clay_EndLayout().
+CLAY_DLL_EXPORT Clay_RenderCommand * Clay_RenderCommandArray_Get(Clay_RenderCommandArray* array, int32_t index);
+// Enables and disables Clay's internal debug tools.
+// This state is retained and does not need to be set each frame.
+CLAY_DLL_EXPORT void Clay_SetDebugModeEnabled(bool enabled);
+// Returns true if Clay's internal debug tools are currently enabled.
+CLAY_DLL_EXPORT bool Clay_IsDebugModeEnabled(void);
+// Enables and disables visibility culling. By default, Clay will not generate render commands for elements whose bounding box is entirely outside the screen.
+CLAY_DLL_EXPORT void Clay_SetCullingEnabled(bool enabled);
+// Returns the maximum number of UI elements supported by Clay's current configuration.
+CLAY_DLL_EXPORT int32_t Clay_GetMaxElementCount(void);
+// Modifies the maximum number of UI elements supported by Clay's current configuration.
+// This may require reallocating additional memory, and re-calling Clay_Initialize();
+CLAY_DLL_EXPORT void Clay_SetMaxElementCount(int32_t maxElementCount);
+// Returns the maximum number of measured "words" (whitespace seperated runs of characters) that Clay can store in its internal text measurement cache.
+CLAY_DLL_EXPORT int32_t Clay_GetMaxMeasureTextCacheWordCount(void);
+// Modifies the maximum number of measured "words" (whitespace seperated runs of characters) that Clay can store in its internal text measurement cache.
+// This may require reallocating additional memory, and re-calling Clay_Initialize();
+CLAY_DLL_EXPORT void Clay_SetMaxMeasureTextCacheWordCount(int32_t maxMeasureTextCacheWordCount);
+// Resets Clay's internal text measurement cache. Useful if font mappings have changed or fonts have been reloaded.
+CLAY_DLL_EXPORT void Clay_ResetMeasureTextCache(void);
+
+// Internal API functions required by macros ----------------------
+
+CLAY_DLL_EXPORT void Clay__OpenElement(void);
+CLAY_DLL_EXPORT void Clay__ConfigureOpenElement(const Clay_ElementDeclaration config);
+CLAY_DLL_EXPORT void Clay__ConfigureOpenElementPtr(const Clay_ElementDeclaration *config);
+CLAY_DLL_EXPORT void Clay__CloseElement(void);
+CLAY_DLL_EXPORT Clay_ElementId Clay__HashString(Clay_String key, uint32_t offset, uint32_t seed);
+CLAY_DLL_EXPORT void Clay__OpenTextElement(Clay_String text, Clay_TextElementConfig *textConfig);
+CLAY_DLL_EXPORT Clay_TextElementConfig *Clay__StoreTextElementConfig(Clay_TextElementConfig config);
+CLAY_DLL_EXPORT uint32_t Clay__GetParentElementId(void);
+
+extern Clay_Color Clay__debugViewHighlightColor;
+extern uint32_t Clay__debugViewWidth;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CLAY_HEADER
+
+// -----------------------------------------
+// IMPLEMENTATION --------------------------
+// -----------------------------------------
+#ifdef CLAY_IMPLEMENTATION
+#undef CLAY_IMPLEMENTATION
+
+#ifndef CLAY__NULL
+#define CLAY__NULL 0
+#endif
+
+#ifndef CLAY__MAXFLOAT
+#define CLAY__MAXFLOAT 3.40282346638528859812e+38F
+#endif
+
+Clay_LayoutConfig CLAY_LAYOUT_DEFAULT = CLAY__DEFAULT_STRUCT;
+
+Clay_Color Clay__Color_DEFAULT = CLAY__DEFAULT_STRUCT;
+Clay_CornerRadius Clay__CornerRadius_DEFAULT = CLAY__DEFAULT_STRUCT;
+Clay_BorderWidth Clay__BorderWidth_DEFAULT = CLAY__DEFAULT_STRUCT;
+
+// The below functions define array bounds checking and convenience functions for a provided type.
+#define CLAY__ARRAY_DEFINE_FUNCTIONS(typeName, arrayName)                                                       \
+                                                                                                                \
+typedef struct                                                                                                  \
+{                                                                                                               \
+    int32_t length;                                                                                             \
+    typeName *internalArray;                                                                                    \
+} arrayName##Slice;                                                                                             \
+                                                                                                                \
+typeName typeName##_DEFAULT = CLAY__DEFAULT_STRUCT;                                                             \
+                                                                                                                \
+arrayName arrayName##_Allocate_Arena(int32_t capacity, Clay_Arena *arena) {                                     \
+    return CLAY__INIT(arrayName){.capacity = capacity, .length = 0,                                             \
+        .internalArray = (typeName *)Clay__Array_Allocate_Arena(capacity, sizeof(typeName), arena)};            \
+}                                                                                                               \
+                                                                                                                \
+typeName *arrayName##_Get(arrayName *array, int32_t index) {                                                    \
+    return Clay__Array_RangeCheck(index, array->length) ? &array->internalArray[index] : &typeName##_DEFAULT;   \
+}                                                                                                               \
+                                                                                                                \
+typeName arrayName##_GetValue(arrayName *array, int32_t index) {                                                \
+    return Clay__Array_RangeCheck(index, array->length) ? array->internalArray[index] : typeName##_DEFAULT;     \
+}                                                                                                               \
+                                                                                                                \
+typeName *arrayName##_Add(arrayName *array, typeName item) {                                                    \
+    if (Clay__Array_AddCapacityCheck(array->length, array->capacity)) {                                         \
+        array->internalArray[array->length++] = item;                                                           \
+        return &array->internalArray[array->length - 1];                                                        \
+    }                                                                                                           \
+    return &typeName##_DEFAULT;                                                                                 \
+}                                                                                                               \
+                                                                                                                \
+typeName *arrayName##Slice_Get(arrayName##Slice *slice, int32_t index) {                                        \
+    return Clay__Array_RangeCheck(index, slice->length) ? &slice->internalArray[index] : &typeName##_DEFAULT;   \
+}                                                                                                               \
+                                                                                                                \
+typeName arrayName##_RemoveSwapback(arrayName *array, int32_t index) {                                          \
+	if (Clay__Array_RangeCheck(index, array->length)) {                                                         \
+		array->length--;                                                                                        \
+		typeName removed = array->internalArray[index];                                                         \
+		array->internalArray[index] = array->internalArray[array->length];                                      \
+		return removed;                                                                                         \
+	}                                                                                                           \
+	return typeName##_DEFAULT;                                                                                  \
+}                                                                                                               \
+                                                                                                                \
+void arrayName##_Set(arrayName *array, int32_t index, typeName value) {                                         \
+	if (Clay__Array_RangeCheck(index, array->capacity)) {                                                       \
+		array->internalArray[index] = value;                                                                    \
+		array->length = index < array->length ? array->length : index + 1;                                      \
+	}                                                                                                           \
+}                                                                                                               \
+
+#define CLAY__ARRAY_DEFINE(typeName, arrayName)     \
+typedef struct                                      \
+{                                                   \
+    int32_t capacity;                               \
+    int32_t length;                                 \
+    typeName *internalArray;                        \
+} arrayName;                                        \
+                                                    \
+CLAY__ARRAY_DEFINE_FUNCTIONS(typeName, arrayName)   \
+
+Clay_Context *Clay__currentContext;
+int32_t Clay__defaultMaxElementCount = 8192;
+int32_t Clay__defaultMaxMeasureTextWordCacheCount = 16384;
+
+void Clay__ErrorHandlerFunctionDefault(Clay_ErrorData errorText) {
+    (void) errorText;
+}
+
+Clay_String CLAY__SPACECHAR = { .length = 1, .chars = " " };
+Clay_String CLAY__STRING_DEFAULT = { .length = 0, .chars = NULL };
+
+typedef struct {
+    bool maxElementsExceeded;
+    bool maxRenderCommandsExceeded;
+    bool maxTextMeasureCacheExceeded;
+    bool textMeasurementFunctionNotSet;
+} Clay_BooleanWarnings;
+
+typedef struct {
+    Clay_String baseMessage;
+    Clay_String dynamicMessage;
+} Clay__Warning;
+
+Clay__Warning CLAY__WARNING_DEFAULT = CLAY__DEFAULT_STRUCT;
+
+typedef struct {
+    int32_t capacity;
+    int32_t length;
+    Clay__Warning *internalArray;
+} Clay__WarningArray;
+
+typedef struct {
+    Clay_Color backgroundColor;
+    Clay_CornerRadius cornerRadius;
+    void* userData;
+} Clay_SharedElementConfig;
+
+CLAY__WRAPPER_STRUCT(Clay_SharedElementConfig);
+
+Clay__WarningArray Clay__WarningArray_Allocate_Arena(int32_t capacity, Clay_Arena *arena);
+Clay__Warning *Clay__WarningArray_Add(Clay__WarningArray *array, Clay__Warning item);
+void* Clay__Array_Allocate_Arena(int32_t capacity, uint32_t itemSize, Clay_Arena *arena);
+bool Clay__Array_RangeCheck(int32_t index, int32_t length);
+bool Clay__Array_AddCapacityCheck(int32_t length, int32_t capacity);
+
+CLAY__ARRAY_DEFINE(bool, Clay__boolArray)
+CLAY__ARRAY_DEFINE(int32_t, Clay__int32_tArray)
+CLAY__ARRAY_DEFINE(char, Clay__charArray)
+CLAY__ARRAY_DEFINE_FUNCTIONS(Clay_ElementId, Clay_ElementIdArray)
+CLAY__ARRAY_DEFINE(Clay_LayoutConfig, Clay__LayoutConfigArray)
+CLAY__ARRAY_DEFINE(Clay_TextElementConfig, Clay__TextElementConfigArray)
+CLAY__ARRAY_DEFINE(Clay_AspectRatioElementConfig, Clay__AspectRatioElementConfigArray)
+CLAY__ARRAY_DEFINE(Clay_ImageElementConfig, Clay__ImageElementConfigArray)
+CLAY__ARRAY_DEFINE(Clay_FloatingElementConfig, Clay__FloatingElementConfigArray)
+CLAY__ARRAY_DEFINE(Clay_CustomElementConfig, Clay__CustomElementConfigArray)
+CLAY__ARRAY_DEFINE(Clay_ClipElementConfig, Clay__ClipElementConfigArray)
+CLAY__ARRAY_DEFINE(Clay_BorderElementConfig, Clay__BorderElementConfigArray)
+CLAY__ARRAY_DEFINE(Clay_String, Clay__StringArray)
+CLAY__ARRAY_DEFINE(Clay_SharedElementConfig, Clay__SharedElementConfigArray)
+CLAY__ARRAY_DEFINE_FUNCTIONS(Clay_RenderCommand, Clay_RenderCommandArray)
+
+typedef CLAY_PACKED_ENUM {
+    CLAY__ELEMENT_CONFIG_TYPE_NONE,
+    CLAY__ELEMENT_CONFIG_TYPE_BORDER,
+    CLAY__ELEMENT_CONFIG_TYPE_FLOATING,
+    CLAY__ELEMENT_CONFIG_TYPE_CLIP,
+    CLAY__ELEMENT_CONFIG_TYPE_ASPECT,
+    CLAY__ELEMENT_CONFIG_TYPE_IMAGE,
+    CLAY__ELEMENT_CONFIG_TYPE_TEXT,
+    CLAY__ELEMENT_CONFIG_TYPE_CUSTOM,
+    CLAY__ELEMENT_CONFIG_TYPE_SHARED,
+} Clay__ElementConfigType;
+
+typedef union {
+    Clay_TextElementConfig *textElementConfig;
+    Clay_AspectRatioElementConfig *aspectRatioElementConfig;
+    Clay_ImageElementConfig *imageElementConfig;
+    Clay_FloatingElementConfig *floatingElementConfig;
+    Clay_CustomElementConfig *customElementConfig;
+    Clay_ClipElementConfig *clipElementConfig;
+    Clay_BorderElementConfig *borderElementConfig;
+    Clay_SharedElementConfig *sharedElementConfig;
+} Clay_ElementConfigUnion;
+
+typedef struct {
+    Clay__ElementConfigType type;
+    Clay_ElementConfigUnion config;
+} Clay_ElementConfig;
+
+CLAY__ARRAY_DEFINE(Clay_ElementConfig, Clay__ElementConfigArray)
+
+typedef struct {
+    Clay_Dimensions dimensions;
+    Clay_String line;
+} Clay__WrappedTextLine;
+
+CLAY__ARRAY_DEFINE(Clay__WrappedTextLine, Clay__WrappedTextLineArray)
+
+typedef struct {
+    Clay_String text;
+    Clay_Dimensions preferredDimensions;
+    int32_t elementIndex;
+    Clay__WrappedTextLineArraySlice wrappedLines;
+} Clay__TextElementData;
+
+CLAY__ARRAY_DEFINE(Clay__TextElementData, Clay__TextElementDataArray)
+
+typedef struct {
+    int32_t *elements;
+    uint16_t length;
+} Clay__LayoutElementChildren;
+
+typedef struct {
+    union {
+        Clay__LayoutElementChildren children;
+        Clay__TextElementData *textElementData;
+    } childrenOrTextContent;
+    Clay_Dimensions dimensions;
+    Clay_Dimensions minDimensions;
+    Clay_LayoutConfig *layoutConfig;
+    Clay__ElementConfigArraySlice elementConfigs;
+    uint32_t id;
+} Clay_LayoutElement;
+
+CLAY__ARRAY_DEFINE(Clay_LayoutElement, Clay_LayoutElementArray)
+
+typedef struct {
+    Clay_LayoutElement *layoutElement;
+    Clay_BoundingBox boundingBox;
+    Clay_Dimensions contentSize;
+    Clay_Vector2 scrollOrigin;
+    Clay_Vector2 pointerOrigin;
+    Clay_Vector2 scrollMomentum;
+    Clay_Vector2 scrollPosition;
+    Clay_Vector2 previousDelta;
+    float momentumTime;
+    uint32_t elementId;
+    bool openThisFrame;
+    bool pointerScrollActive;
+} Clay__ScrollContainerDataInternal;
+
+CLAY__ARRAY_DEFINE(Clay__ScrollContainerDataInternal, Clay__ScrollContainerDataInternalArray)
+
+typedef struct {
+    bool collision;
+    bool collapsed;
+} Clay__DebugElementData;
+
+CLAY__ARRAY_DEFINE(Clay__DebugElementData, Clay__DebugElementDataArray)
+
+typedef struct { // todo get this struct into a single cache line
+    Clay_BoundingBox boundingBox;
+    Clay_ElementId elementId;
+    Clay_LayoutElement* layoutElement;
+    void (*onHoverFunction)(Clay_ElementId elementId, Clay_PointerData pointerInfo, intptr_t userData);
+    intptr_t hoverFunctionUserData;
+    int32_t nextIndex;
+    uint32_t generation;
+    uint32_t idAlias;
+    Clay__DebugElementData *debugData;
+} Clay_LayoutElementHashMapItem;
+
+CLAY__ARRAY_DEFINE(Clay_LayoutElementHashMapItem, Clay__LayoutElementHashMapItemArray)
+
+typedef struct {
+    int32_t startOffset;
+    int32_t length;
+    float width;
+    int32_t next;
+} Clay__MeasuredWord;
+
+CLAY__ARRAY_DEFINE(Clay__MeasuredWord, Clay__MeasuredWordArray)
+
+typedef struct {
+    Clay_Dimensions unwrappedDimensions;
+    int32_t measuredWordsStartIndex;
+    float minWidth;
+    bool containsNewlines;
+    // Hash map data
+    uint32_t id;
+    int32_t nextIndex;
+    uint32_t generation;
+} Clay__MeasureTextCacheItem;
+
+CLAY__ARRAY_DEFINE(Clay__MeasureTextCacheItem, Clay__MeasureTextCacheItemArray)
+
+typedef struct {
+    Clay_LayoutElement *layoutElement;
+    Clay_Vector2 position;
+    Clay_Vector2 nextChildOffset;
+} Clay__LayoutElementTreeNode;
+
+CLAY__ARRAY_DEFINE(Clay__LayoutElementTreeNode, Clay__LayoutElementTreeNodeArray)
+
+typedef struct {
+    int32_t layoutElementIndex;
+    uint32_t parentId; // This can be zero in the case of the root layout tree
+    uint32_t clipElementId; // This can be zero if there is no clip element
+    int16_t zIndex;
+    Clay_Vector2 pointerOffset; // Only used when scroll containers are managed externally
+} Clay__LayoutElementTreeRoot;
+
+CLAY__ARRAY_DEFINE(Clay__LayoutElementTreeRoot, Clay__LayoutElementTreeRootArray)
+
+struct Clay_Context {
+    int32_t maxElementCount;
+    int32_t maxMeasureTextCacheWordCount;
+    bool warningsEnabled;
+    Clay_ErrorHandler errorHandler;
+    Clay_BooleanWarnings booleanWarnings;
+    Clay__WarningArray warnings;
+
+    Clay_PointerData pointerInfo;
+    Clay_Dimensions layoutDimensions;
+    Clay_ElementId dynamicElementIndexBaseHash;
+    uint32_t dynamicElementIndex;
+    bool debugModeEnabled;
+    bool disableCulling;
+    bool externalScrollHandlingEnabled;
+    uint32_t debugSelectedElementId;
+    uint32_t generation;
+    uintptr_t arenaResetOffset;
+    void *measureTextUserData;
+    void *queryScrollOffsetUserData;
+    Clay_Arena internalArena;
+    // Layout Elements / Render Commands
+    Clay_LayoutElementArray layoutElements;
+    Clay_RenderCommandArray renderCommands;
+    Clay__int32_tArray openLayoutElementStack;
+    Clay__int32_tArray layoutElementChildren;
+    Clay__int32_tArray layoutElementChildrenBuffer;
+    Clay__TextElementDataArray textElementData;
+    Clay__int32_tArray aspectRatioElementIndexes;
+    Clay__int32_tArray reusableElementIndexBuffer;
+    Clay__int32_tArray layoutElementClipElementIds;
+    // Configs
+    Clay__LayoutConfigArray layoutConfigs;
+    Clay__ElementConfigArray elementConfigs;
+    Clay__TextElementConfigArray textElementConfigs;
+    Clay__AspectRatioElementConfigArray aspectRatioElementConfigs;
+    Clay__ImageElementConfigArray imageElementConfigs;
+    Clay__FloatingElementConfigArray floatingElementConfigs;
+    Clay__ClipElementConfigArray clipElementConfigs;
+    Clay__CustomElementConfigArray customElementConfigs;
+    Clay__BorderElementConfigArray borderElementConfigs;
+    Clay__SharedElementConfigArray sharedElementConfigs;
+    // Misc Data Structures
+    Clay__StringArray layoutElementIdStrings;
+    Clay__WrappedTextLineArray wrappedTextLines;
+    Clay__LayoutElementTreeNodeArray layoutElementTreeNodeArray1;
+    Clay__LayoutElementTreeRootArray layoutElementTreeRoots;
+    Clay__LayoutElementHashMapItemArray layoutElementsHashMapInternal;
+    Clay__int32_tArray layoutElementsHashMap;
+    Clay__MeasureTextCacheItemArray measureTextHashMapInternal;
+    Clay__int32_tArray measureTextHashMapInternalFreeList;
+    Clay__int32_tArray measureTextHashMap;
+    Clay__MeasuredWordArray measuredWords;
+    Clay__int32_tArray measuredWordsFreeList;
+    Clay__int32_tArray openClipElementStack;
+    Clay_ElementIdArray pointerOverIds;
+    Clay__ScrollContainerDataInternalArray scrollContainerDatas;
+    Clay__boolArray treeNodeVisited;
+    Clay__charArray dynamicStringData;
+    Clay__DebugElementDataArray debugElementData;
+};
+
+Clay_Context* Clay__Context_Allocate_Arena(Clay_Arena *arena) {
+    size_t totalSizeBytes = sizeof(Clay_Context);
+    uintptr_t memoryAddress = (uintptr_t)arena->memory;
+    // Make sure the memory address passed in for clay to use is cache line aligned
+    uintptr_t nextAllocOffset = (memoryAddress % 64);
+    if (nextAllocOffset + totalSizeBytes > arena->capacity)
+    {
+        return NULL;
+    }
+    arena->nextAllocation = nextAllocOffset + totalSizeBytes;
+    return (Clay_Context*)(memoryAddress + nextAllocOffset);
+}
+
+Clay_String Clay__WriteStringToCharBuffer(Clay__charArray *buffer, Clay_String string) {
+    for (int32_t i = 0; i < string.length; i++) {
+        buffer->internalArray[buffer->length + i] = string.chars[i];
+    }
+    buffer->length += string.length;
+    return CLAY__INIT(Clay_String) { .length = string.length, .chars = (const char *)(buffer->internalArray + buffer->length - string.length) };
+}
+
+#ifdef CLAY_WASM
+    __attribute__((import_module("clay"), import_name("measureTextFunction"))) Clay_Dimensions Clay__MeasureText(Clay_StringSlice text, Clay_TextElementConfig *config, void *userData);
+    __attribute__((import_module("clay"), import_name("queryScrollOffsetFunction"))) Clay_Vector2 Clay__QueryScrollOffset(uint32_t elementId, void *userData);
+#else
+    Clay_Dimensions (*Clay__MeasureText)(Clay_StringSlice text, Clay_TextElementConfig *config, void *userData);
+    Clay_Vector2 (*Clay__QueryScrollOffset)(uint32_t elementId, void *userData);
+#endif
+
+Clay_LayoutElement* Clay__GetOpenLayoutElement(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    return Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_GetValue(&context->openLayoutElementStack, context->openLayoutElementStack.length - 1));
+}
+
+uint32_t Clay__GetParentElementId(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    return Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_GetValue(&context->openLayoutElementStack, context->openLayoutElementStack.length - 2))->id;
+}
+
+Clay_LayoutConfig * Clay__StoreLayoutConfig(Clay_LayoutConfig config) {  return Clay_GetCurrentContext()->booleanWarnings.maxElementsExceeded ? &CLAY_LAYOUT_DEFAULT : Clay__LayoutConfigArray_Add(&Clay_GetCurrentContext()->layoutConfigs, config); }
+Clay_TextElementConfig * Clay__StoreTextElementConfig(Clay_TextElementConfig config) {  return Clay_GetCurrentContext()->booleanWarnings.maxElementsExceeded ? &Clay_TextElementConfig_DEFAULT : Clay__TextElementConfigArray_Add(&Clay_GetCurrentContext()->textElementConfigs, config); }
+Clay_AspectRatioElementConfig * Clay__StoreAspectRatioElementConfig(Clay_AspectRatioElementConfig config) {  return Clay_GetCurrentContext()->booleanWarnings.maxElementsExceeded ? &Clay_AspectRatioElementConfig_DEFAULT : Clay__AspectRatioElementConfigArray_Add(&Clay_GetCurrentContext()->aspectRatioElementConfigs, config); }
+Clay_ImageElementConfig * Clay__StoreImageElementConfig(Clay_ImageElementConfig config) {  return Clay_GetCurrentContext()->booleanWarnings.maxElementsExceeded ? &Clay_ImageElementConfig_DEFAULT : Clay__ImageElementConfigArray_Add(&Clay_GetCurrentContext()->imageElementConfigs, config); }
+Clay_FloatingElementConfig * Clay__StoreFloatingElementConfig(Clay_FloatingElementConfig config) {  return Clay_GetCurrentContext()->booleanWarnings.maxElementsExceeded ? &Clay_FloatingElementConfig_DEFAULT : Clay__FloatingElementConfigArray_Add(&Clay_GetCurrentContext()->floatingElementConfigs, config); }
+Clay_CustomElementConfig * Clay__StoreCustomElementConfig(Clay_CustomElementConfig config) {  return Clay_GetCurrentContext()->booleanWarnings.maxElementsExceeded ? &Clay_CustomElementConfig_DEFAULT : Clay__CustomElementConfigArray_Add(&Clay_GetCurrentContext()->customElementConfigs, config); }
+Clay_ClipElementConfig * Clay__StoreClipElementConfig(Clay_ClipElementConfig config) {  return Clay_GetCurrentContext()->booleanWarnings.maxElementsExceeded ? &Clay_ClipElementConfig_DEFAULT : Clay__ClipElementConfigArray_Add(&Clay_GetCurrentContext()->clipElementConfigs, config); }
+Clay_BorderElementConfig * Clay__StoreBorderElementConfig(Clay_BorderElementConfig config) {  return Clay_GetCurrentContext()->booleanWarnings.maxElementsExceeded ? &Clay_BorderElementConfig_DEFAULT : Clay__BorderElementConfigArray_Add(&Clay_GetCurrentContext()->borderElementConfigs, config); }
+Clay_SharedElementConfig * Clay__StoreSharedElementConfig(Clay_SharedElementConfig config) {  return Clay_GetCurrentContext()->booleanWarnings.maxElementsExceeded ? &Clay_SharedElementConfig_DEFAULT : Clay__SharedElementConfigArray_Add(&Clay_GetCurrentContext()->sharedElementConfigs, config); }
+
+Clay_ElementConfig Clay__AttachElementConfig(Clay_ElementConfigUnion config, Clay__ElementConfigType type) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context->booleanWarnings.maxElementsExceeded) {
+        return CLAY__INIT(Clay_ElementConfig) CLAY__DEFAULT_STRUCT;
+    }
+    Clay_LayoutElement *openLayoutElement = Clay__GetOpenLayoutElement();
+    openLayoutElement->elementConfigs.length++;
+    return *Clay__ElementConfigArray_Add(&context->elementConfigs, CLAY__INIT(Clay_ElementConfig) { .type = type, .config = config });
+}
+
+Clay_ElementConfigUnion Clay__FindElementConfigWithType(Clay_LayoutElement *element, Clay__ElementConfigType type) {
+    for (int32_t i = 0; i < element->elementConfigs.length; i++) {
+        Clay_ElementConfig *config = Clay__ElementConfigArraySlice_Get(&element->elementConfigs, i);
+        if (config->type == type) {
+            return config->config;
+        }
+    }
+    return CLAY__INIT(Clay_ElementConfigUnion) { NULL };
+}
+
+Clay_ElementId Clay__HashNumber(const uint32_t offset, const uint32_t seed) {
+    uint32_t hash = seed;
+    hash += (offset + 48);
+    hash += (hash << 10);
+    hash ^= (hash >> 6);
+
+    hash += (hash << 3);
+    hash ^= (hash >> 11);
+    hash += (hash << 15);
+    return CLAY__INIT(Clay_ElementId) { .id = hash + 1, .offset = offset, .baseId = seed, .stringId = CLAY__STRING_DEFAULT }; // Reserve the hash result of zero as "null id"
+}
+
+Clay_ElementId Clay__HashString(Clay_String key, const uint32_t offset, const uint32_t seed) {
+    uint32_t hash = 0;
+    uint32_t base = seed;
+
+    for (int32_t i = 0; i < key.length; i++) {
+        base += key.chars[i];
+        base += (base << 10);
+        base ^= (base >> 6);
+    }
+    hash = base;
+    hash += offset;
+    hash += (hash << 10);
+    hash ^= (hash >> 6);
+
+    hash += (hash << 3);
+    base += (base << 3);
+    hash ^= (hash >> 11);
+    base ^= (base >> 11);
+    hash += (hash << 15);
+    base += (base << 15);
+    return CLAY__INIT(Clay_ElementId) { .id = hash + 1, .offset = offset, .baseId = base + 1, .stringId = key }; // Reserve the hash result of zero as "null id"
+}
+
+#if !defined(CLAY_DISABLE_SIMD) && (defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64))
+static inline __m128i Clay__SIMDRotateLeft(__m128i x, int r) {
+    return _mm_or_si128(_mm_slli_epi64(x, r), _mm_srli_epi64(x, 64 - r));
+}
+
+static inline void Clay__SIMDARXMix(__m128i* a, __m128i* b) {
+    *a = _mm_add_epi64(*a, *b);
+    *b = _mm_xor_si128(Clay__SIMDRotateLeft(*b, 17), *a);
+}
+
+uint64_t Clay__HashData(const uint8_t* data, size_t length) {
+    // Pinched these constants from the BLAKE implementation
+    __m128i v0 = _mm_set1_epi64x(0x6a09e667f3bcc908ULL);
+    __m128i v1 = _mm_set1_epi64x(0xbb67ae8584caa73bULL);
+    __m128i v2 = _mm_set1_epi64x(0x3c6ef372fe94f82bULL);
+    __m128i v3 = _mm_set1_epi64x(0xa54ff53a5f1d36f1ULL);
+
+    uint8_t overflowBuffer[16] = { 0 };  // Temporary buffer for small inputs
+
+    while (length > 0) {
+        __m128i msg;
+        if (length >= 16) {
+            msg = _mm_loadu_si128((const __m128i*)data);
+            data += 16;
+            length -= 16;
+        }
+        else {
+            for (size_t i = 0; i < length; i++) {
+                overflowBuffer[i] = data[i];
+            }
+            msg = _mm_loadu_si128((const __m128i*)overflowBuffer);
+            length = 0;
+        }
+
+        v0 = _mm_xor_si128(v0, msg);
+        Clay__SIMDARXMix(&v0, &v1);
+        Clay__SIMDARXMix(&v2, &v3);
+
+        v0 = _mm_add_epi64(v0, v2);
+        v1 = _mm_add_epi64(v1, v3);
+    }
+
+    Clay__SIMDARXMix(&v0, &v1);
+    Clay__SIMDARXMix(&v2, &v3);
+    v0 = _mm_add_epi64(v0, v2);
+    v1 = _mm_add_epi64(v1, v3);
+    v0 = _mm_add_epi64(v0, v1);
+
+    uint64_t result[2];
+    _mm_storeu_si128((__m128i*)result, v0);
+
+    return result[0] ^ result[1];
+}
+#elif !defined(CLAY_DISABLE_SIMD) && defined(__aarch64__)
+static inline void Clay__SIMDARXMix(uint64x2_t* a, uint64x2_t* b) {
+    *a = vaddq_u64(*a, *b);
+    *b = veorq_u64(vorrq_u64(vshlq_n_u64(*b, 17), vshrq_n_u64(*b, 64 - 17)), *a);
+}
+
+uint64_t Clay__HashData(const uint8_t* data, size_t length) {
+    // Pinched these constants from the BLAKE implementation
+    uint64x2_t v0 = vdupq_n_u64(0x6a09e667f3bcc908ULL);
+    uint64x2_t v1 = vdupq_n_u64(0xbb67ae8584caa73bULL);
+    uint64x2_t v2 = vdupq_n_u64(0x3c6ef372fe94f82bULL);
+    uint64x2_t v3 = vdupq_n_u64(0xa54ff53a5f1d36f1ULL);
+
+    uint8_t overflowBuffer[8] = { 0 };
+
+    while (length > 0) {
+        uint64x2_t msg;
+        if (length > 16) {
+            msg = vld1q_u64((const uint64_t*)data);
+            data += 16;
+            length -= 16;
+        }
+        else if (length > 8) {
+            msg = vcombine_u64(vld1_u64((const uint64_t*)data), vdup_n_u64(0));
+            data += 8;
+            length -= 8;
+        }
+        else {
+            for (size_t i = 0; i < length; i++) {
+                overflowBuffer[i] = data[i];
+            }
+            uint8x8_t lower = vld1_u8(overflowBuffer);
+            msg = vreinterpretq_u64_u8(vcombine_u8(lower, vdup_n_u8(0)));
+            length = 0;
+        }
+        v0 = veorq_u64(v0, msg);
+        Clay__SIMDARXMix(&v0, &v1);
+        Clay__SIMDARXMix(&v2, &v3);
+
+        v0 = vaddq_u64(v0, v2);
+        v1 = vaddq_u64(v1, v3);
+    }
+
+    Clay__SIMDARXMix(&v0, &v1);
+    Clay__SIMDARXMix(&v2, &v3);
+    v0 = vaddq_u64(v0, v2);
+    v1 = vaddq_u64(v1, v3);
+    v0 = vaddq_u64(v0, v1);
+
+    uint64_t result[2];
+    vst1q_u64(result, v0);
+
+    return result[0] ^ result[1];
+}
+#else
+uint64_t Clay__HashData(const uint8_t* data, size_t length) {
+    uint64_t hash = 0;
+
+    for (size_t i = 0; i < length; i++) {
+        hash += data[i];
+        hash += (hash << 10);
+        hash ^= (hash >> 6);
+    }
+    return hash;
+}
+#endif
+
+uint32_t Clay__HashStringContentsWithConfig(Clay_String *text, Clay_TextElementConfig *config) {
+    uint32_t hash = 0;
+    if (text->isStaticallyAllocated) {
+        hash += (uintptr_t)text->chars;
+        hash += (hash << 10);
+        hash ^= (hash >> 6);
+        hash += text->length;
+        hash += (hash << 10);
+        hash ^= (hash >> 6);
+    } else {
+        hash = Clay__HashData((const uint8_t *)text->chars, text->length) % UINT32_MAX;
+    }
+
+    hash += config->fontId;
+    hash += (hash << 10);
+    hash ^= (hash >> 6);
+
+    hash += config->fontSize;
+    hash += (hash << 10);
+    hash ^= (hash >> 6);
+
+    hash += config->letterSpacing;
+    hash += (hash << 10);
+    hash ^= (hash >> 6);
+
+    hash += (hash << 3);
+    hash ^= (hash >> 11);
+    hash += (hash << 15);
+    return hash + 1; // Reserve the hash result of zero as "null id"
+}
+
+Clay__MeasuredWord *Clay__AddMeasuredWord(Clay__MeasuredWord word, Clay__MeasuredWord *previousWord) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context->measuredWordsFreeList.length > 0) {
+        uint32_t newItemIndex = Clay__int32_tArray_GetValue(&context->measuredWordsFreeList, (int)context->measuredWordsFreeList.length - 1);
+        context->measuredWordsFreeList.length--;
+        Clay__MeasuredWordArray_Set(&context->measuredWords, (int)newItemIndex, word);
+        previousWord->next = (int32_t)newItemIndex;
+        return Clay__MeasuredWordArray_Get(&context->measuredWords, (int)newItemIndex);
+    } else {
+        previousWord->next = (int32_t)context->measuredWords.length;
+        return Clay__MeasuredWordArray_Add(&context->measuredWords, word);
+    }
+}
+
+Clay__MeasureTextCacheItem *Clay__MeasureTextCached(Clay_String *text, Clay_TextElementConfig *config) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    #ifndef CLAY_WASM
+    if (!Clay__MeasureText) {
+        if (!context->booleanWarnings.textMeasurementFunctionNotSet) {
+            context->booleanWarnings.textMeasurementFunctionNotSet = true;
+            context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
+                    .errorType = CLAY_ERROR_TYPE_TEXT_MEASUREMENT_FUNCTION_NOT_PROVIDED,
+                    .errorText = CLAY_STRING("Clay's internal MeasureText function is null. You may have forgotten to call Clay_SetMeasureTextFunction(), or passed a NULL function pointer by mistake."),
+                    .userData = context->errorHandler.userData });
+        }
+        return &Clay__MeasureTextCacheItem_DEFAULT;
+    }
+    #endif
+    uint32_t id = Clay__HashStringContentsWithConfig(text, config);
+    uint32_t hashBucket = id % (context->maxMeasureTextCacheWordCount / 32);
+    int32_t elementIndexPrevious = 0;
+    int32_t elementIndex = context->measureTextHashMap.internalArray[hashBucket];
+    while (elementIndex != 0) {
+        Clay__MeasureTextCacheItem *hashEntry = Clay__MeasureTextCacheItemArray_Get(&context->measureTextHashMapInternal, elementIndex);
+        if (hashEntry->id == id) {
+            hashEntry->generation = context->generation;
+            return hashEntry;
+        }
+        // This element hasn't been seen in a few frames, delete the hash map item
+        if (context->generation - hashEntry->generation > 2) {
+            // Add all the measured words that were included in this measurement to the freelist
+            int32_t nextWordIndex = hashEntry->measuredWordsStartIndex;
+            while (nextWordIndex != -1) {
+                Clay__MeasuredWord *measuredWord = Clay__MeasuredWordArray_Get(&context->measuredWords, nextWordIndex);
+                Clay__int32_tArray_Add(&context->measuredWordsFreeList, nextWordIndex);
+                nextWordIndex = measuredWord->next;
+            }
+
+            int32_t nextIndex = hashEntry->nextIndex;
+            Clay__MeasureTextCacheItemArray_Set(&context->measureTextHashMapInternal, elementIndex, CLAY__INIT(Clay__MeasureTextCacheItem) { .measuredWordsStartIndex = -1 });
+            Clay__int32_tArray_Add(&context->measureTextHashMapInternalFreeList, elementIndex);
+            if (elementIndexPrevious == 0) {
+                context->measureTextHashMap.internalArray[hashBucket] = nextIndex;
+            } else {
+                Clay__MeasureTextCacheItem *previousHashEntry = Clay__MeasureTextCacheItemArray_Get(&context->measureTextHashMapInternal, elementIndexPrevious);
+                previousHashEntry->nextIndex = nextIndex;
+            }
+            elementIndex = nextIndex;
+        } else {
+            elementIndexPrevious = elementIndex;
+            elementIndex = hashEntry->nextIndex;
+        }
+    }
+
+    int32_t newItemIndex = 0;
+    Clay__MeasureTextCacheItem newCacheItem = { .measuredWordsStartIndex = -1, .id = id, .generation = context->generation };
+    Clay__MeasureTextCacheItem *measured = NULL;
+    if (context->measureTextHashMapInternalFreeList.length > 0) {
+        newItemIndex = Clay__int32_tArray_GetValue(&context->measureTextHashMapInternalFreeList, context->measureTextHashMapInternalFreeList.length - 1);
+        context->measureTextHashMapInternalFreeList.length--;
+        Clay__MeasureTextCacheItemArray_Set(&context->measureTextHashMapInternal, newItemIndex, newCacheItem);
+        measured = Clay__MeasureTextCacheItemArray_Get(&context->measureTextHashMapInternal, newItemIndex);
+    } else {
+        if (context->measureTextHashMapInternal.length == context->measureTextHashMapInternal.capacity - 1) {
+            if (!context->booleanWarnings.maxTextMeasureCacheExceeded) {
+                context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
+                        .errorType = CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED,
+                        .errorText = CLAY_STRING("Clay ran out of capacity while attempting to measure text elements. Try using Clay_SetMaxElementCount() with a higher value."),
+                        .userData = context->errorHandler.userData });
+                context->booleanWarnings.maxTextMeasureCacheExceeded = true;
+            }
+            return &Clay__MeasureTextCacheItem_DEFAULT;
+        }
+        measured = Clay__MeasureTextCacheItemArray_Add(&context->measureTextHashMapInternal, newCacheItem);
+        newItemIndex = context->measureTextHashMapInternal.length - 1;
+    }
+
+    int32_t start = 0;
+    int32_t end = 0;
+    float lineWidth = 0;
+    float measuredWidth = 0;
+    float measuredHeight = 0;
+    float spaceWidth = Clay__MeasureText(CLAY__INIT(Clay_StringSlice) { .length = 1, .chars = CLAY__SPACECHAR.chars, .baseChars = CLAY__SPACECHAR.chars }, config, context->measureTextUserData).width;
+    Clay__MeasuredWord tempWord = { .next = -1 };
+    Clay__MeasuredWord *previousWord = &tempWord;
+    while (end < text->length) {
+        if (context->measuredWords.length == context->measuredWords.capacity - 1) {
+            if (!context->booleanWarnings.maxTextMeasureCacheExceeded) {
+                context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
+                    .errorType = CLAY_ERROR_TYPE_TEXT_MEASUREMENT_CAPACITY_EXCEEDED,
+                    .errorText = CLAY_STRING("Clay has run out of space in it's internal text measurement cache. Try using Clay_SetMaxMeasureTextCacheWordCount() (default 16384, with 1 unit storing 1 measured word)."),
+                    .userData = context->errorHandler.userData });
+                context->booleanWarnings.maxTextMeasureCacheExceeded = true;
+            }
+            return &Clay__MeasureTextCacheItem_DEFAULT;
+        }
+        char current = text->chars[end];
+        if (current == ' ' || current == '\n') {
+            int32_t length = end - start;
+            Clay_Dimensions dimensions = Clay__MeasureText(CLAY__INIT(Clay_StringSlice) { .length = length, .chars = &text->chars[start], .baseChars = text->chars }, config, context->measureTextUserData);
+            measured->minWidth = CLAY__MAX(dimensions.width, measured->minWidth);
+            measuredHeight = CLAY__MAX(measuredHeight, dimensions.height);
+            if (current == ' ') {
+                dimensions.width += spaceWidth;
+                previousWord = Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .startOffset = start, .length = length + 1, .width = dimensions.width, .next = -1 }, previousWord);
+                lineWidth += dimensions.width;
+            }
+            if (current == '\n') {
+                if (length > 0) {
+                    previousWord = Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .startOffset = start, .length = length, .width = dimensions.width, .next = -1 }, previousWord);
+                }
+                previousWord = Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .startOffset = end + 1, .length = 0, .width = 0, .next = -1 }, previousWord);
+                lineWidth += dimensions.width;
+                measuredWidth = CLAY__MAX(lineWidth, measuredWidth);
+                measured->containsNewlines = true;
+                lineWidth = 0;
+            }
+            start = end + 1;
+        }
+        end++;
+    }
+    if (end - start > 0) {
+        Clay_Dimensions dimensions = Clay__MeasureText(CLAY__INIT(Clay_StringSlice) { .length = end - start, .chars = &text->chars[start], .baseChars = text->chars }, config, context->measureTextUserData);
+        Clay__AddMeasuredWord(CLAY__INIT(Clay__MeasuredWord) { .startOffset = start, .length = end - start, .width = dimensions.width, .next = -1 }, previousWord);
+        lineWidth += dimensions.width;
+        measuredHeight = CLAY__MAX(measuredHeight, dimensions.height);
+        measured->minWidth = CLAY__MAX(dimensions.width, measured->minWidth);
+    }
+    measuredWidth = CLAY__MAX(lineWidth, measuredWidth) - config->letterSpacing;
+
+    measured->measuredWordsStartIndex = tempWord.next;
+    measured->unwrappedDimensions.width = measuredWidth;
+    measured->unwrappedDimensions.height = measuredHeight;
+
+    if (elementIndexPrevious != 0) {
+        Clay__MeasureTextCacheItemArray_Get(&context->measureTextHashMapInternal, elementIndexPrevious)->nextIndex = newItemIndex;
+    } else {
+        context->measureTextHashMap.internalArray[hashBucket] = newItemIndex;
+    }
+    return measured;
+}
+
+bool Clay__PointIsInsideRect(Clay_Vector2 point, Clay_BoundingBox rect) {
+    return point.x >= rect.x && point.x <= rect.x + rect.width && point.y >= rect.y && point.y <= rect.y + rect.height;
+}
+
+Clay_LayoutElementHashMapItem* Clay__AddHashMapItem(Clay_ElementId elementId, Clay_LayoutElement* layoutElement, uint32_t idAlias) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context->layoutElementsHashMapInternal.length == context->layoutElementsHashMapInternal.capacity - 1) {
+        return NULL;
+    }
+    Clay_LayoutElementHashMapItem item = { .elementId = elementId, .layoutElement = layoutElement, .nextIndex = -1, .generation = context->generation + 1, .idAlias = idAlias };
+    uint32_t hashBucket = elementId.id % context->layoutElementsHashMap.capacity;
+    int32_t hashItemPrevious = -1;
+    int32_t hashItemIndex = context->layoutElementsHashMap.internalArray[hashBucket];
+    while (hashItemIndex != -1) { // Just replace collision, not a big deal - leave it up to the end user
+        Clay_LayoutElementHashMapItem *hashItem = Clay__LayoutElementHashMapItemArray_Get(&context->layoutElementsHashMapInternal, hashItemIndex);
+        if (hashItem->elementId.id == elementId.id) { // Collision - resolve based on generation
+            item.nextIndex = hashItem->nextIndex;
+            if (hashItem->generation <= context->generation) { // First collision - assume this is the "same" element
+                hashItem->elementId = elementId; // Make sure to copy this across. If the stringId reference has changed, we should update the hash item to use the new one.
+                hashItem->idAlias = idAlias;
+                hashItem->generation = context->generation + 1;
+                hashItem->layoutElement = layoutElement;
+                hashItem->debugData->collision = false;
+                hashItem->onHoverFunction = NULL;
+                hashItem->hoverFunctionUserData = 0;
+            } else { // Multiple collisions this frame - two elements have the same ID
+                context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
+                    .errorType = CLAY_ERROR_TYPE_DUPLICATE_ID,
+                    .errorText = CLAY_STRING("An element with this ID was already previously declared during this layout."),
+                    .userData = context->errorHandler.userData });
+                if (context->debugModeEnabled) {
+                    hashItem->debugData->collision = true;
+                }
+            }
+            return hashItem;
+        }
+        hashItemPrevious = hashItemIndex;
+        hashItemIndex = hashItem->nextIndex;
+    }
+    Clay_LayoutElementHashMapItem *hashItem = Clay__LayoutElementHashMapItemArray_Add(&context->layoutElementsHashMapInternal, item);
+    hashItem->debugData = Clay__DebugElementDataArray_Add(&context->debugElementData, CLAY__INIT(Clay__DebugElementData) CLAY__DEFAULT_STRUCT);
+    if (hashItemPrevious != -1) {
+        Clay__LayoutElementHashMapItemArray_Get(&context->layoutElementsHashMapInternal, hashItemPrevious)->nextIndex = (int32_t)context->layoutElementsHashMapInternal.length - 1;
+    } else {
+        context->layoutElementsHashMap.internalArray[hashBucket] = (int32_t)context->layoutElementsHashMapInternal.length - 1;
+    }
+    return hashItem;
+}
+
+Clay_LayoutElementHashMapItem *Clay__GetHashMapItem(uint32_t id) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    uint32_t hashBucket = id % context->layoutElementsHashMap.capacity;
+    int32_t elementIndex = context->layoutElementsHashMap.internalArray[hashBucket];
+    while (elementIndex != -1) {
+        Clay_LayoutElementHashMapItem *hashEntry = Clay__LayoutElementHashMapItemArray_Get(&context->layoutElementsHashMapInternal, elementIndex);
+        if (hashEntry->elementId.id == id) {
+            return hashEntry;
+        }
+        elementIndex = hashEntry->nextIndex;
+    }
+    return &Clay_LayoutElementHashMapItem_DEFAULT;
+}
+
+Clay_ElementId Clay__GenerateIdForAnonymousElement(Clay_LayoutElement *openLayoutElement) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    Clay_LayoutElement *parentElement = Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_GetValue(&context->openLayoutElementStack, context->openLayoutElementStack.length - 2));
+    Clay_ElementId elementId = Clay__HashNumber(parentElement->childrenOrTextContent.children.length, parentElement->id);
+    openLayoutElement->id = elementId.id;
+    Clay__AddHashMapItem(elementId, openLayoutElement, 0);
+    Clay__StringArray_Add(&context->layoutElementIdStrings, elementId.stringId);
+    return elementId;
+}
+
+bool Clay__ElementHasConfig(Clay_LayoutElement *layoutElement, Clay__ElementConfigType type) {
+    for (int32_t i = 0; i < layoutElement->elementConfigs.length; i++) {
+        if (Clay__ElementConfigArraySlice_Get(&layoutElement->elementConfigs, i)->type == type) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void Clay__UpdateAspectRatioBox(Clay_LayoutElement *layoutElement) {
+    for (int32_t j = 0; j < layoutElement->elementConfigs.length; j++) {
+        Clay_ElementConfig *config = Clay__ElementConfigArraySlice_Get(&layoutElement->elementConfigs, j);
+        if (config->type == CLAY__ELEMENT_CONFIG_TYPE_ASPECT) {
+            Clay_AspectRatioElementConfig *aspectConfig = config->config.aspectRatioElementConfig;
+            if (aspectConfig->aspectRatio == 0) {
+                break;
+            }
+            if (layoutElement->dimensions.width == 0 && layoutElement->dimensions.height != 0) {
+                layoutElement->dimensions.width = layoutElement->dimensions.height * aspectConfig->aspectRatio;
+            } else if (layoutElement->dimensions.width != 0 && layoutElement->dimensions.height == 0) {
+                layoutElement->dimensions.height = layoutElement->dimensions.width * (1 / aspectConfig->aspectRatio);
+            }
+            break;
+        }
+    }
+}
+
+void Clay__CloseElement(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context->booleanWarnings.maxElementsExceeded) {
+        return;
+    }
+    Clay_LayoutElement *openLayoutElement = Clay__GetOpenLayoutElement();
+    Clay_LayoutConfig *layoutConfig = openLayoutElement->layoutConfig;
+    bool elementHasScrollHorizontal = false;
+    bool elementHasScrollVertical = false;
+    for (int32_t i = 0; i < openLayoutElement->elementConfigs.length; i++) {
+        Clay_ElementConfig *config = Clay__ElementConfigArraySlice_Get(&openLayoutElement->elementConfigs, i);
+        if (config->type == CLAY__ELEMENT_CONFIG_TYPE_CLIP) {
+            elementHasScrollHorizontal = config->config.clipElementConfig->horizontal;
+            elementHasScrollVertical = config->config.clipElementConfig->vertical;
+            context->openClipElementStack.length--;
+            break;
+        } else if (config->type == CLAY__ELEMENT_CONFIG_TYPE_FLOATING) {
+            context->openClipElementStack.length--;
+        }
+    }
+
+    float leftRightPadding = (float)(layoutConfig->padding.left + layoutConfig->padding.right);
+    float topBottomPadding = (float)(layoutConfig->padding.top + layoutConfig->padding.bottom);
+
+    // Attach children to the current open element
+    openLayoutElement->childrenOrTextContent.children.elements = &context->layoutElementChildren.internalArray[context->layoutElementChildren.length];
+    if (layoutConfig->layoutDirection == CLAY_LEFT_TO_RIGHT) {
+        openLayoutElement->dimensions.width = leftRightPadding;
+        openLayoutElement->minDimensions.width = leftRightPadding;
+        for (int32_t i = 0; i < openLayoutElement->childrenOrTextContent.children.length; i++) {
+            int32_t childIndex = Clay__int32_tArray_GetValue(&context->layoutElementChildrenBuffer, (int)context->layoutElementChildrenBuffer.length - openLayoutElement->childrenOrTextContent.children.length + i);
+            Clay_LayoutElement *child = Clay_LayoutElementArray_Get(&context->layoutElements, childIndex);
+            openLayoutElement->dimensions.width += child->dimensions.width;
+            openLayoutElement->dimensions.height = CLAY__MAX(openLayoutElement->dimensions.height, child->dimensions.height + topBottomPadding);
+            // Minimum size of child elements doesn't matter to scroll containers as they can shrink and hide their contents
+            if (!elementHasScrollHorizontal) {
+                openLayoutElement->minDimensions.width += child->minDimensions.width;
+            }
+            if (!elementHasScrollVertical) {
+                openLayoutElement->minDimensions.height = CLAY__MAX(openLayoutElement->minDimensions.height, child->minDimensions.height + topBottomPadding);
+            }
+            Clay__int32_tArray_Add(&context->layoutElementChildren, childIndex);
+        }
+        float childGap = (float)(CLAY__MAX(openLayoutElement->childrenOrTextContent.children.length - 1, 0) * layoutConfig->childGap);
+        openLayoutElement->dimensions.width += childGap; // TODO this is technically a bug with childgap and scroll containers
+        openLayoutElement->minDimensions.width += childGap;
+    }
+    else if (layoutConfig->layoutDirection == CLAY_TOP_TO_BOTTOM) {
+        openLayoutElement->dimensions.height = topBottomPadding;
+        openLayoutElement->minDimensions.height = topBottomPadding;
+        for (int32_t i = 0; i < openLayoutElement->childrenOrTextContent.children.length; i++) {
+            int32_t childIndex = Clay__int32_tArray_GetValue(&context->layoutElementChildrenBuffer, (int)context->layoutElementChildrenBuffer.length - openLayoutElement->childrenOrTextContent.children.length + i);
+            Clay_LayoutElement *child = Clay_LayoutElementArray_Get(&context->layoutElements, childIndex);
+            openLayoutElement->dimensions.height += child->dimensions.height;
+            openLayoutElement->dimensions.width = CLAY__MAX(openLayoutElement->dimensions.width, child->dimensions.width + leftRightPadding);
+            // Minimum size of child elements doesn't matter to scroll containers as they can shrink and hide their contents
+            if (!elementHasScrollVertical) {
+                openLayoutElement->minDimensions.height += child->minDimensions.height;
+            }
+            if (!elementHasScrollHorizontal) {
+                openLayoutElement->minDimensions.width = CLAY__MAX(openLayoutElement->minDimensions.width, child->minDimensions.width + leftRightPadding);
+            }
+            Clay__int32_tArray_Add(&context->layoutElementChildren, childIndex);
+        }
+        float childGap = (float)(CLAY__MAX(openLayoutElement->childrenOrTextContent.children.length - 1, 0) * layoutConfig->childGap);
+        openLayoutElement->dimensions.height += childGap; // TODO this is technically a bug with childgap and scroll containers
+        openLayoutElement->minDimensions.height += childGap;
+    }
+
+    context->layoutElementChildrenBuffer.length -= openLayoutElement->childrenOrTextContent.children.length;
+
+    // Clamp element min and max width to the values configured in the layout
+    if (layoutConfig->sizing.width.type != CLAY__SIZING_TYPE_PERCENT) {
+        if (layoutConfig->sizing.width.size.minMax.max <= 0) { // Set the max size if the user didn't specify, makes calculations easier
+            layoutConfig->sizing.width.size.minMax.max = CLAY__MAXFLOAT;
+        }
+        openLayoutElement->dimensions.width = CLAY__MIN(CLAY__MAX(openLayoutElement->dimensions.width, layoutConfig->sizing.width.size.minMax.min), layoutConfig->sizing.width.size.minMax.max);
+        openLayoutElement->minDimensions.width = CLAY__MIN(CLAY__MAX(openLayoutElement->minDimensions.width, layoutConfig->sizing.width.size.minMax.min), layoutConfig->sizing.width.size.minMax.max);
+    } else {
+        openLayoutElement->dimensions.width = 0;
+    }
+
+    // Clamp element min and max height to the values configured in the layout
+    if (layoutConfig->sizing.height.type != CLAY__SIZING_TYPE_PERCENT) {
+        if (layoutConfig->sizing.height.size.minMax.max <= 0) { // Set the max size if the user didn't specify, makes calculations easier
+            layoutConfig->sizing.height.size.minMax.max = CLAY__MAXFLOAT;
+        }
+        openLayoutElement->dimensions.height = CLAY__MIN(CLAY__MAX(openLayoutElement->dimensions.height, layoutConfig->sizing.height.size.minMax.min), layoutConfig->sizing.height.size.minMax.max);
+        openLayoutElement->minDimensions.height = CLAY__MIN(CLAY__MAX(openLayoutElement->minDimensions.height, layoutConfig->sizing.height.size.minMax.min), layoutConfig->sizing.height.size.minMax.max);
+    } else {
+        openLayoutElement->dimensions.height = 0;
+    }
+
+    Clay__UpdateAspectRatioBox(openLayoutElement);
+
+    bool elementIsFloating = Clay__ElementHasConfig(openLayoutElement, CLAY__ELEMENT_CONFIG_TYPE_FLOATING);
+
+    // Close the currently open element
+    int32_t closingElementIndex = Clay__int32_tArray_RemoveSwapback(&context->openLayoutElementStack, (int)context->openLayoutElementStack.length - 1);
+    openLayoutElement = Clay__GetOpenLayoutElement();
+
+    if (!elementIsFloating && context->openLayoutElementStack.length > 1) {
+        openLayoutElement->childrenOrTextContent.children.length++;
+        Clay__int32_tArray_Add(&context->layoutElementChildrenBuffer, closingElementIndex);
+    }
+}
+
+bool Clay__MemCmp(const char *s1, const char *s2, int32_t length);
+#if !defined(CLAY_DISABLE_SIMD) && (defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64))
+    bool Clay__MemCmp(const char *s1, const char *s2, int32_t length) {
+        while (length >= 16) {
+            __m128i v1 = _mm_loadu_si128((const __m128i *)s1);
+            __m128i v2 = _mm_loadu_si128((const __m128i *)s2);
+
+            if (_mm_movemask_epi8(_mm_cmpeq_epi8(v1, v2)) != 0xFFFF) { // If any byte differs
+                return false;
+            }
+
+            s1 += 16;
+            s2 += 16;
+            length -= 16;
+        }
+
+        // Handle remaining bytes
+        while (length--) {
+            if (*s1 != *s2) {
+                return false;
+            }
+            s1++;
+            s2++;
+        }
+
+        return true;
+    }
+#elif !defined(CLAY_DISABLE_SIMD) && defined(__aarch64__)
+    bool Clay__MemCmp(const char *s1, const char *s2, int32_t length) {
+        while (length >= 16) {
+            uint8x16_t v1 = vld1q_u8((const uint8_t *)s1);
+            uint8x16_t v2 = vld1q_u8((const uint8_t *)s2);
+
+            // Compare vectors
+            if (vminvq_u32(vreinterpretq_u32_u8(vceqq_u8(v1, v2))) != 0xFFFFFFFF) { // If there's a difference
+                return false;
+            }
+
+            s1 += 16;
+            s2 += 16;
+            length -= 16;
+        }
+
+        // Handle remaining bytes
+        while (length--) {
+            if (*s1 != *s2) {
+                return false;
+            }
+            s1++;
+            s2++;
+        }
+
+        return true;
+    }
+#else
+    bool Clay__MemCmp(const char *s1, const char *s2, int32_t length) {
+        for (int32_t i = 0; i < length; i++) {
+            if (s1[i] != s2[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+#endif
+
+void Clay__OpenElement(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context->layoutElements.length == context->layoutElements.capacity - 1 || context->booleanWarnings.maxElementsExceeded) {
+        context->booleanWarnings.maxElementsExceeded = true;
+        return;
+    }
+    Clay_LayoutElement layoutElement = CLAY__DEFAULT_STRUCT;
+    Clay_LayoutElementArray_Add(&context->layoutElements, layoutElement);
+    Clay__int32_tArray_Add(&context->openLayoutElementStack, context->layoutElements.length - 1);
+    if (context->openClipElementStack.length > 0) {
+        Clay__int32_tArray_Set(&context->layoutElementClipElementIds, context->layoutElements.length - 1, Clay__int32_tArray_GetValue(&context->openClipElementStack, (int)context->openClipElementStack.length - 1));
+    } else {
+        Clay__int32_tArray_Set(&context->layoutElementClipElementIds, context->layoutElements.length - 1, 0);
+    }
+}
+
+void Clay__OpenTextElement(Clay_String text, Clay_TextElementConfig *textConfig) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context->layoutElements.length == context->layoutElements.capacity - 1 || context->booleanWarnings.maxElementsExceeded) {
+        context->booleanWarnings.maxElementsExceeded = true;
+        return;
+    }
+    Clay_LayoutElement *parentElement = Clay__GetOpenLayoutElement();
+
+    Clay_LayoutElement layoutElement = CLAY__DEFAULT_STRUCT;
+    Clay_LayoutElement *textElement = Clay_LayoutElementArray_Add(&context->layoutElements, layoutElement);
+    if (context->openClipElementStack.length > 0) {
+        Clay__int32_tArray_Set(&context->layoutElementClipElementIds, context->layoutElements.length - 1, Clay__int32_tArray_GetValue(&context->openClipElementStack, (int)context->openClipElementStack.length - 1));
+    } else {
+        Clay__int32_tArray_Set(&context->layoutElementClipElementIds, context->layoutElements.length - 1, 0);
+    }
+
+    Clay__int32_tArray_Add(&context->layoutElementChildrenBuffer, context->layoutElements.length - 1);
+    Clay__MeasureTextCacheItem *textMeasured = Clay__MeasureTextCached(&text, textConfig);
+    Clay_ElementId elementId = Clay__HashNumber(parentElement->childrenOrTextContent.children.length, parentElement->id);
+    textElement->id = elementId.id;
+    Clay__AddHashMapItem(elementId, textElement, 0);
+    Clay__StringArray_Add(&context->layoutElementIdStrings, elementId.stringId);
+    Clay_Dimensions textDimensions = { .width = textMeasured->unwrappedDimensions.width, .height = textConfig->lineHeight > 0 ? (float)textConfig->lineHeight : textMeasured->unwrappedDimensions.height };
+    textElement->dimensions = textDimensions;
+    textElement->minDimensions = CLAY__INIT(Clay_Dimensions) { .width = textMeasured->minWidth, .height = textDimensions.height };
+    textElement->childrenOrTextContent.textElementData = Clay__TextElementDataArray_Add(&context->textElementData, CLAY__INIT(Clay__TextElementData) { .text = text, .preferredDimensions = textMeasured->unwrappedDimensions, .elementIndex = context->layoutElements.length - 1 });
+    textElement->elementConfigs = CLAY__INIT(Clay__ElementConfigArraySlice) {
+            .length = 1,
+            .internalArray = Clay__ElementConfigArray_Add(&context->elementConfigs, CLAY__INIT(Clay_ElementConfig) { .type = CLAY__ELEMENT_CONFIG_TYPE_TEXT, .config = { .textElementConfig = textConfig }})
+    };
+    textElement->layoutConfig = &CLAY_LAYOUT_DEFAULT;
+    parentElement->childrenOrTextContent.children.length++;
+}
+
+Clay_ElementId Clay__AttachId(Clay_ElementId elementId) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context->booleanWarnings.maxElementsExceeded) {
+        return Clay_ElementId_DEFAULT;
+    }
+    Clay_LayoutElement *openLayoutElement = Clay__GetOpenLayoutElement();
+    uint32_t idAlias = openLayoutElement->id;
+    openLayoutElement->id = elementId.id;
+    Clay__AddHashMapItem(elementId, openLayoutElement, idAlias);
+    Clay__StringArray_Set(&context->layoutElementIdStrings, context->layoutElements.length - 1, elementId.stringId);
+    return elementId;
+}
+
+void Clay__ConfigureOpenElementPtr(const Clay_ElementDeclaration *declaration) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    Clay_LayoutElement *openLayoutElement = Clay__GetOpenLayoutElement();
+    openLayoutElement->layoutConfig = Clay__StoreLayoutConfig(declaration->layout);
+    if ((declaration->layout.sizing.width.type == CLAY__SIZING_TYPE_PERCENT && declaration->layout.sizing.width.size.percent > 1) || (declaration->layout.sizing.height.type == CLAY__SIZING_TYPE_PERCENT && declaration->layout.sizing.height.size.percent > 1)) {
+        context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
+                .errorType = CLAY_ERROR_TYPE_PERCENTAGE_OVER_1,
+                .errorText = CLAY_STRING("An element was configured with CLAY_SIZING_PERCENT, but the provided percentage value was over 1.0. Clay expects a value between 0 and 1, i.e. 20% is 0.2."),
+                .userData = context->errorHandler.userData });
+    }
+
+    Clay_ElementId openLayoutElementId = declaration->id;
+
+    openLayoutElement->elementConfigs.internalArray = &context->elementConfigs.internalArray[context->elementConfigs.length];
+    Clay_SharedElementConfig *sharedConfig = NULL;
+    if (declaration->backgroundColor.a > 0) {
+        sharedConfig = Clay__StoreSharedElementConfig(CLAY__INIT(Clay_SharedElementConfig) { .backgroundColor = declaration->backgroundColor });
+        Clay__AttachElementConfig(CLAY__INIT(Clay_ElementConfigUnion) { .sharedElementConfig = sharedConfig }, CLAY__ELEMENT_CONFIG_TYPE_SHARED);
+    }
+    if (!Clay__MemCmp((char *)(&declaration->cornerRadius), (char *)(&Clay__CornerRadius_DEFAULT), sizeof(Clay_CornerRadius))) {
+        if (sharedConfig) {
+            sharedConfig->cornerRadius = declaration->cornerRadius;
+        } else {
+            sharedConfig = Clay__StoreSharedElementConfig(CLAY__INIT(Clay_SharedElementConfig) { .cornerRadius = declaration->cornerRadius });
+            Clay__AttachElementConfig(CLAY__INIT(Clay_ElementConfigUnion) { .sharedElementConfig = sharedConfig }, CLAY__ELEMENT_CONFIG_TYPE_SHARED);
+        }
+    }
+    if (declaration->userData != 0) {
+        if (sharedConfig) {
+            sharedConfig->userData = declaration->userData;
+        } else {
+            sharedConfig = Clay__StoreSharedElementConfig(CLAY__INIT(Clay_SharedElementConfig) { .userData = declaration->userData });
+            Clay__AttachElementConfig(CLAY__INIT(Clay_ElementConfigUnion) { .sharedElementConfig = sharedConfig }, CLAY__ELEMENT_CONFIG_TYPE_SHARED);
+        }
+    }
+    if (declaration->image.imageData) {
+        Clay__AttachElementConfig(CLAY__INIT(Clay_ElementConfigUnion) { .imageElementConfig = Clay__StoreImageElementConfig(declaration->image) }, CLAY__ELEMENT_CONFIG_TYPE_IMAGE);
+    }
+    if (declaration->aspectRatio.aspectRatio > 0) {
+        Clay__AttachElementConfig(CLAY__INIT(Clay_ElementConfigUnion) { .aspectRatioElementConfig = Clay__StoreAspectRatioElementConfig(declaration->aspectRatio) }, CLAY__ELEMENT_CONFIG_TYPE_ASPECT);
+        Clay__int32_tArray_Add(&context->aspectRatioElementIndexes, context->layoutElements.length - 1);
+    }
+    if (declaration->floating.attachTo != CLAY_ATTACH_TO_NONE) {
+        Clay_FloatingElementConfig floatingConfig = declaration->floating;
+        // This looks dodgy but because of the auto generated root element the depth of the tree will always be at least 2 here
+        Clay_LayoutElement *hierarchicalParent = Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_GetValue(&context->openLayoutElementStack, context->openLayoutElementStack.length - 2));
+        if (hierarchicalParent) {
+            uint32_t clipElementId = 0;
+            if (declaration->floating.attachTo == CLAY_ATTACH_TO_PARENT) {
+                // Attach to the element's direct hierarchical parent
+                floatingConfig.parentId = hierarchicalParent->id;
+                if (context->openClipElementStack.length > 0) {
+                    clipElementId = Clay__int32_tArray_GetValue(&context->openClipElementStack, (int)context->openClipElementStack.length - 1);
+                }
+            } else if (declaration->floating.attachTo == CLAY_ATTACH_TO_ELEMENT_WITH_ID) {
+                Clay_LayoutElementHashMapItem *parentItem = Clay__GetHashMapItem(floatingConfig.parentId);
+                if (parentItem == &Clay_LayoutElementHashMapItem_DEFAULT) {
+                    context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
+                            .errorType = CLAY_ERROR_TYPE_FLOATING_CONTAINER_PARENT_NOT_FOUND,
+                            .errorText = CLAY_STRING("A floating element was declared with a parentId, but no element with that ID was found."),
+                            .userData = context->errorHandler.userData });
+                } else {
+                    clipElementId = Clay__int32_tArray_GetValue(&context->layoutElementClipElementIds, (int32_t)(parentItem->layoutElement - context->layoutElements.internalArray));
+                }
+            } else if (declaration->floating.attachTo == CLAY_ATTACH_TO_ROOT) {
+                floatingConfig.parentId = Clay__HashString(CLAY_STRING("Clay__RootContainer"), 0, 0).id;
+            }
+            if (!openLayoutElementId.id) {
+                openLayoutElementId = Clay__HashString(CLAY_STRING("Clay__FloatingContainer"), context->layoutElementTreeRoots.length, 0);
+            }
+            if (declaration->floating.clipTo == CLAY_CLIP_TO_NONE) {
+                clipElementId = 0;
+            }
+            int32_t currentElementIndex = Clay__int32_tArray_GetValue(&context->openLayoutElementStack, context->openLayoutElementStack.length - 1);
+            Clay__int32_tArray_Set(&context->layoutElementClipElementIds, currentElementIndex, clipElementId);
+            Clay__int32_tArray_Add(&context->openClipElementStack, clipElementId);
+            Clay__LayoutElementTreeRootArray_Add(&context->layoutElementTreeRoots, CLAY__INIT(Clay__LayoutElementTreeRoot) {
+                    .layoutElementIndex = Clay__int32_tArray_GetValue(&context->openLayoutElementStack, context->openLayoutElementStack.length - 1),
+                    .parentId = floatingConfig.parentId,
+                    .clipElementId = clipElementId,
+                    .zIndex = floatingConfig.zIndex,
+            });
+            Clay__AttachElementConfig(CLAY__INIT(Clay_ElementConfigUnion) { .floatingElementConfig = Clay__StoreFloatingElementConfig(floatingConfig) }, CLAY__ELEMENT_CONFIG_TYPE_FLOATING);
+        }
+    }
+    if (declaration->custom.customData) {
+        Clay__AttachElementConfig(CLAY__INIT(Clay_ElementConfigUnion) { .customElementConfig = Clay__StoreCustomElementConfig(declaration->custom) }, CLAY__ELEMENT_CONFIG_TYPE_CUSTOM);
+    }
+
+    if (openLayoutElementId.id != 0) {
+        Clay__AttachId(openLayoutElementId);
+    } else if (openLayoutElement->id == 0) {
+        openLayoutElementId = Clay__GenerateIdForAnonymousElement(openLayoutElement);
+    }
+
+    if (declaration->clip.horizontal | declaration->clip.vertical) {
+        Clay__AttachElementConfig(CLAY__INIT(Clay_ElementConfigUnion) { .clipElementConfig = Clay__StoreClipElementConfig(declaration->clip) }, CLAY__ELEMENT_CONFIG_TYPE_CLIP);
+        Clay__int32_tArray_Add(&context->openClipElementStack, (int)openLayoutElement->id);
+        // Retrieve or create cached data to track scroll position across frames
+        Clay__ScrollContainerDataInternal *scrollOffset = CLAY__NULL;
+        for (int32_t i = 0; i < context->scrollContainerDatas.length; i++) {
+            Clay__ScrollContainerDataInternal *mapping = Clay__ScrollContainerDataInternalArray_Get(&context->scrollContainerDatas, i);
+            if (openLayoutElement->id == mapping->elementId) {
+                scrollOffset = mapping;
+                scrollOffset->layoutElement = openLayoutElement;
+                scrollOffset->openThisFrame = true;
+            }
+        }
+        if (!scrollOffset) {
+            scrollOffset = Clay__ScrollContainerDataInternalArray_Add(&context->scrollContainerDatas, CLAY__INIT(Clay__ScrollContainerDataInternal){.layoutElement = openLayoutElement, .scrollOrigin = {-1,-1}, .elementId = openLayoutElement->id, .openThisFrame = true});
+        }
+        if (context->externalScrollHandlingEnabled) {
+            scrollOffset->scrollPosition = Clay__QueryScrollOffset(scrollOffset->elementId, context->queryScrollOffsetUserData);
+        }
+    }
+    if (!Clay__MemCmp((char *)(&declaration->border.width), (char *)(&Clay__BorderWidth_DEFAULT), sizeof(Clay_BorderWidth))) {
+        Clay__AttachElementConfig(CLAY__INIT(Clay_ElementConfigUnion) { .borderElementConfig = Clay__StoreBorderElementConfig(declaration->border) }, CLAY__ELEMENT_CONFIG_TYPE_BORDER);
+    }
+}
+
+void Clay__ConfigureOpenElement(const Clay_ElementDeclaration declaration) {
+    Clay__ConfigureOpenElementPtr(&declaration);
+}
+
+void Clay__InitializeEphemeralMemory(Clay_Context* context) {
+    int32_t maxElementCount = context->maxElementCount;
+    // Ephemeral Memory - reset every frame
+    Clay_Arena *arena = &context->internalArena;
+    arena->nextAllocation = context->arenaResetOffset;
+
+    context->layoutElementChildrenBuffer = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena);
+    context->layoutElements = Clay_LayoutElementArray_Allocate_Arena(maxElementCount, arena);
+    context->warnings = Clay__WarningArray_Allocate_Arena(100, arena);
+
+    context->layoutConfigs = Clay__LayoutConfigArray_Allocate_Arena(maxElementCount, arena);
+    context->elementConfigs = Clay__ElementConfigArray_Allocate_Arena(maxElementCount, arena);
+    context->textElementConfigs = Clay__TextElementConfigArray_Allocate_Arena(maxElementCount, arena);
+    context->aspectRatioElementConfigs = Clay__AspectRatioElementConfigArray_Allocate_Arena(maxElementCount, arena);
+    context->imageElementConfigs = Clay__ImageElementConfigArray_Allocate_Arena(maxElementCount, arena);
+    context->floatingElementConfigs = Clay__FloatingElementConfigArray_Allocate_Arena(maxElementCount, arena);
+    context->clipElementConfigs = Clay__ClipElementConfigArray_Allocate_Arena(maxElementCount, arena);
+    context->customElementConfigs = Clay__CustomElementConfigArray_Allocate_Arena(maxElementCount, arena);
+    context->borderElementConfigs = Clay__BorderElementConfigArray_Allocate_Arena(maxElementCount, arena);
+    context->sharedElementConfigs = Clay__SharedElementConfigArray_Allocate_Arena(maxElementCount, arena);
+
+    context->layoutElementIdStrings = Clay__StringArray_Allocate_Arena(maxElementCount, arena);
+    context->wrappedTextLines = Clay__WrappedTextLineArray_Allocate_Arena(maxElementCount, arena);
+    context->layoutElementTreeNodeArray1 = Clay__LayoutElementTreeNodeArray_Allocate_Arena(maxElementCount, arena);
+    context->layoutElementTreeRoots = Clay__LayoutElementTreeRootArray_Allocate_Arena(maxElementCount, arena);
+    context->layoutElementChildren = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena);
+    context->openLayoutElementStack = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena);
+    context->textElementData = Clay__TextElementDataArray_Allocate_Arena(maxElementCount, arena);
+    context->aspectRatioElementIndexes = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena);
+    context->renderCommands = Clay_RenderCommandArray_Allocate_Arena(maxElementCount, arena);
+    context->treeNodeVisited = Clay__boolArray_Allocate_Arena(maxElementCount, arena);
+    context->treeNodeVisited.length = context->treeNodeVisited.capacity; // This array is accessed directly rather than behaving as a list
+    context->openClipElementStack = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena);
+    context->reusableElementIndexBuffer = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena);
+    context->layoutElementClipElementIds = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena);
+    context->dynamicStringData = Clay__charArray_Allocate_Arena(maxElementCount, arena);
+}
+
+void Clay__InitializePersistentMemory(Clay_Context* context) {
+    // Persistent memory - initialized once and not reset
+    int32_t maxElementCount = context->maxElementCount;
+    int32_t maxMeasureTextCacheWordCount = context->maxMeasureTextCacheWordCount;
+    Clay_Arena *arena = &context->internalArena;
+
+    context->scrollContainerDatas = Clay__ScrollContainerDataInternalArray_Allocate_Arena(10, arena);
+    context->layoutElementsHashMapInternal = Clay__LayoutElementHashMapItemArray_Allocate_Arena(maxElementCount, arena);
+    context->layoutElementsHashMap = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena);
+    context->measureTextHashMapInternal = Clay__MeasureTextCacheItemArray_Allocate_Arena(maxElementCount, arena);
+    context->measureTextHashMapInternalFreeList = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena);
+    context->measuredWordsFreeList = Clay__int32_tArray_Allocate_Arena(maxMeasureTextCacheWordCount, arena);
+    context->measureTextHashMap = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena);
+    context->measuredWords = Clay__MeasuredWordArray_Allocate_Arena(maxMeasureTextCacheWordCount, arena);
+    context->pointerOverIds = Clay_ElementIdArray_Allocate_Arena(maxElementCount, arena);
+    context->debugElementData = Clay__DebugElementDataArray_Allocate_Arena(maxElementCount, arena);
+    context->arenaResetOffset = arena->nextAllocation;
+}
+
+const float CLAY__EPSILON = 0.01;
+
+bool Clay__FloatEqual(float left, float right) {
+    float subtracted = left - right;
+    return subtracted < CLAY__EPSILON && subtracted > -CLAY__EPSILON;
+}
+
+void Clay__SizeContainersAlongAxis(bool xAxis) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    Clay__int32_tArray bfsBuffer = context->layoutElementChildrenBuffer;
+    Clay__int32_tArray resizableContainerBuffer = context->openLayoutElementStack;
+    for (int32_t rootIndex = 0; rootIndex < context->layoutElementTreeRoots.length; ++rootIndex) {
+        bfsBuffer.length = 0;
+        Clay__LayoutElementTreeRoot *root = Clay__LayoutElementTreeRootArray_Get(&context->layoutElementTreeRoots, rootIndex);
+        Clay_LayoutElement *rootElement = Clay_LayoutElementArray_Get(&context->layoutElements, (int)root->layoutElementIndex);
+        Clay__int32_tArray_Add(&bfsBuffer, (int32_t)root->layoutElementIndex);
+
+        // Size floating containers to their parents
+        if (Clay__ElementHasConfig(rootElement, CLAY__ELEMENT_CONFIG_TYPE_FLOATING)) {
+            Clay_FloatingElementConfig *floatingElementConfig = Clay__FindElementConfigWithType(rootElement, CLAY__ELEMENT_CONFIG_TYPE_FLOATING).floatingElementConfig;
+            Clay_LayoutElementHashMapItem *parentItem = Clay__GetHashMapItem(floatingElementConfig->parentId);
+            if (parentItem && parentItem != &Clay_LayoutElementHashMapItem_DEFAULT) {
+                Clay_LayoutElement *parentLayoutElement = parentItem->layoutElement;
+                if (rootElement->layoutConfig->sizing.width.type == CLAY__SIZING_TYPE_GROW) {
+                    rootElement->dimensions.width = parentLayoutElement->dimensions.width;
+                }
+                if (rootElement->layoutConfig->sizing.height.type == CLAY__SIZING_TYPE_GROW) {
+                    rootElement->dimensions.height = parentLayoutElement->dimensions.height;
+                }
+            }
+        }
+
+        rootElement->dimensions.width = CLAY__MIN(CLAY__MAX(rootElement->dimensions.width, rootElement->layoutConfig->sizing.width.size.minMax.min), rootElement->layoutConfig->sizing.width.size.minMax.max);
+        rootElement->dimensions.height = CLAY__MIN(CLAY__MAX(rootElement->dimensions.height, rootElement->layoutConfig->sizing.height.size.minMax.min), rootElement->layoutConfig->sizing.height.size.minMax.max);
+
+        for (int32_t i = 0; i < bfsBuffer.length; ++i) {
+            int32_t parentIndex = Clay__int32_tArray_GetValue(&bfsBuffer, i);
+            Clay_LayoutElement *parent = Clay_LayoutElementArray_Get(&context->layoutElements, parentIndex);
+            Clay_LayoutConfig *parentStyleConfig = parent->layoutConfig;
+            int32_t growContainerCount = 0;
+            float parentSize = xAxis ? parent->dimensions.width : parent->dimensions.height;
+            float parentPadding = (float)(xAxis ? (parent->layoutConfig->padding.left + parent->layoutConfig->padding.right) : (parent->layoutConfig->padding.top + parent->layoutConfig->padding.bottom));
+            float innerContentSize = 0, totalPaddingAndChildGaps = parentPadding;
+            bool sizingAlongAxis = (xAxis && parentStyleConfig->layoutDirection == CLAY_LEFT_TO_RIGHT) || (!xAxis && parentStyleConfig->layoutDirection == CLAY_TOP_TO_BOTTOM);
+            resizableContainerBuffer.length = 0;
+            float parentChildGap = parentStyleConfig->childGap;
+
+            for (int32_t childOffset = 0; childOffset < parent->childrenOrTextContent.children.length; childOffset++) {
+                int32_t childElementIndex = parent->childrenOrTextContent.children.elements[childOffset];
+                Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, childElementIndex);
+                Clay_SizingAxis childSizing = xAxis ? childElement->layoutConfig->sizing.width : childElement->layoutConfig->sizing.height;
+                float childSize = xAxis ? childElement->dimensions.width : childElement->dimensions.height;
+
+                if (!Clay__ElementHasConfig(childElement, CLAY__ELEMENT_CONFIG_TYPE_TEXT) && childElement->childrenOrTextContent.children.length > 0) {
+                    Clay__int32_tArray_Add(&bfsBuffer, childElementIndex);
+                }
+
+                if (childSizing.type != CLAY__SIZING_TYPE_PERCENT
+                    && childSizing.type != CLAY__SIZING_TYPE_FIXED
+                    && (!Clay__ElementHasConfig(childElement, CLAY__ELEMENT_CONFIG_TYPE_TEXT) || (Clay__FindElementConfigWithType(childElement, CLAY__ELEMENT_CONFIG_TYPE_TEXT).textElementConfig->wrapMode == CLAY_TEXT_WRAP_WORDS)) // todo too many loops
+//                    && (xAxis || !Clay__ElementHasConfig(childElement, CLAY__ELEMENT_CONFIG_TYPE_ASPECT))
+                ) {
+                    Clay__int32_tArray_Add(&resizableContainerBuffer, childElementIndex);
+                }
+
+                if (sizingAlongAxis) {
+                    innerContentSize += (childSizing.type == CLAY__SIZING_TYPE_PERCENT ? 0 : childSize);
+                    if (childSizing.type == CLAY__SIZING_TYPE_GROW) {
+                        growContainerCount++;
+                    }
+                    if (childOffset > 0) {
+                        innerContentSize += parentChildGap; // For children after index 0, the childAxisOffset is the gap from the previous child
+                        totalPaddingAndChildGaps += parentChildGap;
+                    }
+                } else {
+                    innerContentSize = CLAY__MAX(childSize, innerContentSize);
+                }
+            }
+
+            // Expand percentage containers to size
+            for (int32_t childOffset = 0; childOffset < parent->childrenOrTextContent.children.length; childOffset++) {
+                int32_t childElementIndex = parent->childrenOrTextContent.children.elements[childOffset];
+                Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, childElementIndex);
+                Clay_SizingAxis childSizing = xAxis ? childElement->layoutConfig->sizing.width : childElement->layoutConfig->sizing.height;
+                float *childSize = xAxis ? &childElement->dimensions.width : &childElement->dimensions.height;
+                if (childSizing.type == CLAY__SIZING_TYPE_PERCENT) {
+                    *childSize = (parentSize - totalPaddingAndChildGaps) * childSizing.size.percent;
+                    if (sizingAlongAxis) {
+                        innerContentSize += *childSize;
+                    }
+                    Clay__UpdateAspectRatioBox(childElement);
+                }
+            }
+
+            if (sizingAlongAxis) {
+                float sizeToDistribute = parentSize - parentPadding - innerContentSize;
+                // The content is too large, compress the children as much as possible
+                if (sizeToDistribute < 0) {
+                    // If the parent clips content in this axis direction, don't compress children, just leave them alone
+                    Clay_ClipElementConfig *clipElementConfig = Clay__FindElementConfigWithType(parent, CLAY__ELEMENT_CONFIG_TYPE_CLIP).clipElementConfig;
+                    if (clipElementConfig) {
+                        if (((xAxis && clipElementConfig->horizontal) || (!xAxis && clipElementConfig->vertical))) {
+                            continue;
+                        }
+                    }
+                    // Scrolling containers preferentially compress before others
+                    while (sizeToDistribute < -CLAY__EPSILON && resizableContainerBuffer.length > 0) {
+                        float largest = 0;
+                        float secondLargest = 0;
+                        float widthToAdd = sizeToDistribute;
+                        for (int childIndex = 0; childIndex < resizableContainerBuffer.length; childIndex++) {
+                            Clay_LayoutElement *child = Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_GetValue(&resizableContainerBuffer, childIndex));
+                            float childSize = xAxis ? child->dimensions.width : child->dimensions.height;
+                            if (Clay__FloatEqual(childSize, largest)) { continue; }
+                            if (childSize > largest) {
+                                secondLargest = largest;
+                                largest = childSize;
+                            }
+                            if (childSize < largest) {
+                                secondLargest = CLAY__MAX(secondLargest, childSize);
+                                widthToAdd = secondLargest - largest;
+                            }
+                        }
+
+                        widthToAdd = CLAY__MAX(widthToAdd, sizeToDistribute / resizableContainerBuffer.length);
+
+                        for (int childIndex = 0; childIndex < resizableContainerBuffer.length; childIndex++) {
+                            Clay_LayoutElement *child = Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_GetValue(&resizableContainerBuffer, childIndex));
+                            float *childSize = xAxis ? &child->dimensions.width : &child->dimensions.height;
+                            float minSize = xAxis ? child->minDimensions.width : child->minDimensions.height;
+                            float previousWidth = *childSize;
+                            if (Clay__FloatEqual(*childSize, largest)) {
+                                *childSize += widthToAdd;
+                                if (*childSize <= minSize) {
+                                    *childSize = minSize;
+                                    Clay__int32_tArray_RemoveSwapback(&resizableContainerBuffer, childIndex--);
+                                }
+                                sizeToDistribute -= (*childSize - previousWidth);
+                            }
+                        }
+                    }
+                // The content is too small, allow SIZING_GROW containers to expand
+                } else if (sizeToDistribute > 0 && growContainerCount > 0) {
+                    for (int childIndex = 0; childIndex < resizableContainerBuffer.length; childIndex++) {
+                        Clay_LayoutElement *child = Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_GetValue(&resizableContainerBuffer, childIndex));
+                        Clay__SizingType childSizing = xAxis ? child->layoutConfig->sizing.width.type : child->layoutConfig->sizing.height.type;
+                        if (childSizing != CLAY__SIZING_TYPE_GROW) {
+                            Clay__int32_tArray_RemoveSwapback(&resizableContainerBuffer, childIndex--);
+                        }
+                    }
+                    while (sizeToDistribute > CLAY__EPSILON && resizableContainerBuffer.length > 0) {
+                        float smallest = CLAY__MAXFLOAT;
+                        float secondSmallest = CLAY__MAXFLOAT;
+                        float widthToAdd = sizeToDistribute;
+                        for (int childIndex = 0; childIndex < resizableContainerBuffer.length; childIndex++) {
+                            Clay_LayoutElement *child = Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_GetValue(&resizableContainerBuffer, childIndex));
+                            float childSize = xAxis ? child->dimensions.width : child->dimensions.height;
+                            if (Clay__FloatEqual(childSize, smallest)) { continue; }
+                            if (childSize < smallest) {
+                                secondSmallest = smallest;
+                                smallest = childSize;
+                            }
+                            if (childSize > smallest) {
+                                secondSmallest = CLAY__MIN(secondSmallest, childSize);
+                                widthToAdd = secondSmallest - smallest;
+                            }
+                        }
+
+                        widthToAdd = CLAY__MIN(widthToAdd, sizeToDistribute / resizableContainerBuffer.length);
+
+                        for (int childIndex = 0; childIndex < resizableContainerBuffer.length; childIndex++) {
+                            Clay_LayoutElement *child = Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_GetValue(&resizableContainerBuffer, childIndex));
+                            float *childSize = xAxis ? &child->dimensions.width : &child->dimensions.height;
+                            float maxSize = xAxis ? child->layoutConfig->sizing.width.size.minMax.max : child->layoutConfig->sizing.height.size.minMax.max;
+                            float previousWidth = *childSize;
+                            if (Clay__FloatEqual(*childSize, smallest)) {
+                                *childSize += widthToAdd;
+                                if (*childSize >= maxSize) {
+                                    *childSize = maxSize;
+                                    Clay__int32_tArray_RemoveSwapback(&resizableContainerBuffer, childIndex--);
+                                }
+                                sizeToDistribute -= (*childSize - previousWidth);
+                            }
+                        }
+                    }
+                }
+            // Sizing along the non layout axis ("off axis")
+            } else {
+                for (int32_t childOffset = 0; childOffset < resizableContainerBuffer.length; childOffset++) {
+                    Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_GetValue(&resizableContainerBuffer, childOffset));
+                    Clay_SizingAxis childSizing = xAxis ? childElement->layoutConfig->sizing.width : childElement->layoutConfig->sizing.height;
+                    float minSize = xAxis ? childElement->minDimensions.width : childElement->minDimensions.height;
+                    float *childSize = xAxis ? &childElement->dimensions.width : &childElement->dimensions.height;
+
+                    float maxSize = parentSize - parentPadding;
+                    // If we're laying out the children of a scroll panel, grow containers expand to the size of the inner content, not the outer container
+                    if (Clay__ElementHasConfig(parent, CLAY__ELEMENT_CONFIG_TYPE_CLIP)) {
+                        Clay_ClipElementConfig *clipElementConfig = Clay__FindElementConfigWithType(parent, CLAY__ELEMENT_CONFIG_TYPE_CLIP).clipElementConfig;
+                        if (((xAxis && clipElementConfig->horizontal) || (!xAxis && clipElementConfig->vertical))) {
+                            maxSize = CLAY__MAX(maxSize, innerContentSize);
+                        }
+                    }
+                    if (childSizing.type == CLAY__SIZING_TYPE_GROW) {
+                        *childSize = CLAY__MIN(maxSize, childSizing.size.minMax.max);
+                    }
+                    *childSize = CLAY__MAX(minSize, CLAY__MIN(*childSize, maxSize));
+                }
+            }
+        }
+    }
+}
+
+Clay_String Clay__IntToString(int32_t integer) {
+    if (integer == 0) {
+        return CLAY__INIT(Clay_String) { .length = 1, .chars = "0" };
+    }
+    Clay_Context* context = Clay_GetCurrentContext();
+    char *chars = (char *)(context->dynamicStringData.internalArray + context->dynamicStringData.length);
+    int32_t length = 0;
+    int32_t sign = integer;
+
+    if (integer < 0) {
+        integer = -integer;
+    }
+    while (integer > 0) {
+        chars[length++] = (char)(integer % 10 + '0');
+        integer /= 10;
+    }
+
+    if (sign < 0) {
+        chars[length++] = '-';
+    }
+
+    // Reverse the string to get the correct order
+    for (int32_t j = 0, k = length - 1; j < k; j++, k--) {
+        char temp = chars[j];
+        chars[j] = chars[k];
+        chars[k] = temp;
+    }
+    context->dynamicStringData.length += length;
+    return CLAY__INIT(Clay_String) { .length = length, .chars = chars };
+}
+
+void Clay__AddRenderCommand(Clay_RenderCommand renderCommand) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context->renderCommands.length < context->renderCommands.capacity - 1) {
+        Clay_RenderCommandArray_Add(&context->renderCommands, renderCommand);
+    } else {
+        if (!context->booleanWarnings.maxRenderCommandsExceeded) {
+            context->booleanWarnings.maxRenderCommandsExceeded = true;
+            context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
+                .errorType = CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED,
+                .errorText = CLAY_STRING("Clay ran out of capacity while attempting to create render commands. This is usually caused by a large amount of wrapping text elements while close to the max element capacity. Try using Clay_SetMaxElementCount() with a higher value."),
+                .userData = context->errorHandler.userData });
+        }
+    }
+}
+
+bool Clay__ElementIsOffscreen(Clay_BoundingBox *boundingBox) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context->disableCulling) {
+        return false;
+    }
+
+    return (boundingBox->x > (float)context->layoutDimensions.width) ||
+           (boundingBox->y > (float)context->layoutDimensions.height) ||
+           (boundingBox->x + boundingBox->width < 0) ||
+           (boundingBox->y + boundingBox->height < 0);
+}
+
+void Clay__CalculateFinalLayout(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    // Calculate sizing along the X axis
+    Clay__SizeContainersAlongAxis(true);
+
+    // Wrap text
+    for (int32_t textElementIndex = 0; textElementIndex < context->textElementData.length; ++textElementIndex) {
+        Clay__TextElementData *textElementData = Clay__TextElementDataArray_Get(&context->textElementData, textElementIndex);
+        textElementData->wrappedLines = CLAY__INIT(Clay__WrappedTextLineArraySlice) { .length = 0, .internalArray = &context->wrappedTextLines.internalArray[context->wrappedTextLines.length] };
+        Clay_LayoutElement *containerElement = Clay_LayoutElementArray_Get(&context->layoutElements, (int)textElementData->elementIndex);
+        Clay_TextElementConfig *textConfig = Clay__FindElementConfigWithType(containerElement, CLAY__ELEMENT_CONFIG_TYPE_TEXT).textElementConfig;
+        Clay__MeasureTextCacheItem *measureTextCacheItem = Clay__MeasureTextCached(&textElementData->text, textConfig);
+        float lineWidth = 0;
+        float lineHeight = textConfig->lineHeight > 0 ? (float)textConfig->lineHeight : textElementData->preferredDimensions.height;
+        int32_t lineLengthChars = 0;
+        int32_t lineStartOffset = 0;
+        if (!measureTextCacheItem->containsNewlines && textElementData->preferredDimensions.width <= containerElement->dimensions.width) {
+            Clay__WrappedTextLineArray_Add(&context->wrappedTextLines, CLAY__INIT(Clay__WrappedTextLine) { containerElement->dimensions,  textElementData->text });
+            textElementData->wrappedLines.length++;
+            continue;
+        }
+        float spaceWidth = Clay__MeasureText(CLAY__INIT(Clay_StringSlice) { .length = 1, .chars = CLAY__SPACECHAR.chars, .baseChars = CLAY__SPACECHAR.chars }, textConfig, context->measureTextUserData).width;
+        int32_t wordIndex = measureTextCacheItem->measuredWordsStartIndex;
+        while (wordIndex != -1) {
+            if (context->wrappedTextLines.length > context->wrappedTextLines.capacity - 1) {
+                break;
+            }
+            Clay__MeasuredWord *measuredWord = Clay__MeasuredWordArray_Get(&context->measuredWords, wordIndex);
+            // Only word on the line is too large, just render it anyway
+            if (lineLengthChars == 0 && lineWidth + measuredWord->width > containerElement->dimensions.width) {
+                Clay__WrappedTextLineArray_Add(&context->wrappedTextLines, CLAY__INIT(Clay__WrappedTextLine) { { measuredWord->width, lineHeight }, { .length = measuredWord->length, .chars = &textElementData->text.chars[measuredWord->startOffset] } });
+                textElementData->wrappedLines.length++;
+                wordIndex = measuredWord->next;
+                lineStartOffset = measuredWord->startOffset + measuredWord->length;
+            }
+            // measuredWord->length == 0 means a newline character
+            else if (measuredWord->length == 0 || lineWidth + measuredWord->width > containerElement->dimensions.width) {
+                // Wrapped text lines list has overflowed, just render out the line
+                bool finalCharIsSpace = textElementData->text.chars[lineStartOffset + lineLengthChars - 1] == ' ';
+                Clay__WrappedTextLineArray_Add(&context->wrappedTextLines, CLAY__INIT(Clay__WrappedTextLine) { { lineWidth + (finalCharIsSpace ? -spaceWidth : 0), lineHeight }, { .length = lineLengthChars + (finalCharIsSpace ? -1 : 0), .chars = &textElementData->text.chars[lineStartOffset] } });
+                textElementData->wrappedLines.length++;
+                if (lineLengthChars == 0 || measuredWord->length == 0) {
+                    wordIndex = measuredWord->next;
+                }
+                lineWidth = 0;
+                lineLengthChars = 0;
+                lineStartOffset = measuredWord->startOffset;
+            } else {
+                lineWidth += measuredWord->width + textConfig->letterSpacing;
+                lineLengthChars += measuredWord->length;
+                wordIndex = measuredWord->next;
+            }
+        }
+        if (lineLengthChars > 0) {
+            Clay__WrappedTextLineArray_Add(&context->wrappedTextLines, CLAY__INIT(Clay__WrappedTextLine) { { lineWidth - textConfig->letterSpacing, lineHeight }, {.length = lineLengthChars, .chars = &textElementData->text.chars[lineStartOffset] } });
+            textElementData->wrappedLines.length++;
+        }
+        containerElement->dimensions.height = lineHeight * (float)textElementData->wrappedLines.length;
+    }
+
+    // Scale vertical heights according to aspect ratio
+    for (int32_t i = 0; i < context->aspectRatioElementIndexes.length; ++i) {
+        Clay_LayoutElement* aspectElement = Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_GetValue(&context->aspectRatioElementIndexes, i));
+        Clay_AspectRatioElementConfig *config = Clay__FindElementConfigWithType(aspectElement, CLAY__ELEMENT_CONFIG_TYPE_ASPECT).aspectRatioElementConfig;
+        aspectElement->dimensions.height = (1 / config->aspectRatio) * aspectElement->dimensions.width;
+        aspectElement->layoutConfig->sizing.height.size.minMax.max = aspectElement->dimensions.height;
+    }
+
+    // Propagate effect of text wrapping, aspect scaling etc. on height of parents
+    Clay__LayoutElementTreeNodeArray dfsBuffer = context->layoutElementTreeNodeArray1;
+    dfsBuffer.length = 0;
+    for (int32_t i = 0; i < context->layoutElementTreeRoots.length; ++i) {
+        Clay__LayoutElementTreeRoot *root = Clay__LayoutElementTreeRootArray_Get(&context->layoutElementTreeRoots, i);
+        context->treeNodeVisited.internalArray[dfsBuffer.length] = false;
+        Clay__LayoutElementTreeNodeArray_Add(&dfsBuffer, CLAY__INIT(Clay__LayoutElementTreeNode) { .layoutElement = Clay_LayoutElementArray_Get(&context->layoutElements, (int)root->layoutElementIndex) });
+    }
+    while (dfsBuffer.length > 0) {
+        Clay__LayoutElementTreeNode *currentElementTreeNode = Clay__LayoutElementTreeNodeArray_Get(&dfsBuffer, (int)dfsBuffer.length - 1);
+        Clay_LayoutElement *currentElement = currentElementTreeNode->layoutElement;
+        if (!context->treeNodeVisited.internalArray[dfsBuffer.length - 1]) {
+            context->treeNodeVisited.internalArray[dfsBuffer.length - 1] = true;
+            // If the element has no children or is the container for a text element, don't bother inspecting it
+            if (Clay__ElementHasConfig(currentElement, CLAY__ELEMENT_CONFIG_TYPE_TEXT) || currentElement->childrenOrTextContent.children.length == 0) {
+                dfsBuffer.length--;
+                continue;
+            }
+            // Add the children to the DFS buffer (needs to be pushed in reverse so that stack traversal is in correct layout order)
+            for (int32_t i = 0; i < currentElement->childrenOrTextContent.children.length; i++) {
+                context->treeNodeVisited.internalArray[dfsBuffer.length] = false;
+                Clay__LayoutElementTreeNodeArray_Add(&dfsBuffer, CLAY__INIT(Clay__LayoutElementTreeNode) { .layoutElement = Clay_LayoutElementArray_Get(&context->layoutElements, currentElement->childrenOrTextContent.children.elements[i]) });
+            }
+            continue;
+        }
+        dfsBuffer.length--;
+
+        // DFS node has been visited, this is on the way back up to the root
+        Clay_LayoutConfig *layoutConfig = currentElement->layoutConfig;
+        if (layoutConfig->layoutDirection == CLAY_LEFT_TO_RIGHT) {
+            // Resize any parent containers that have grown in height along their non layout axis
+            for (int32_t j = 0; j < currentElement->childrenOrTextContent.children.length; ++j) {
+                Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, currentElement->childrenOrTextContent.children.elements[j]);
+                float childHeightWithPadding = CLAY__MAX(childElement->dimensions.height + layoutConfig->padding.top + layoutConfig->padding.bottom, currentElement->dimensions.height);
+                currentElement->dimensions.height = CLAY__MIN(CLAY__MAX(childHeightWithPadding, layoutConfig->sizing.height.size.minMax.min), layoutConfig->sizing.height.size.minMax.max);
+            }
+        } else if (layoutConfig->layoutDirection == CLAY_TOP_TO_BOTTOM) {
+            // Resizing along the layout axis
+            float contentHeight = (float)(layoutConfig->padding.top + layoutConfig->padding.bottom);
+            for (int32_t j = 0; j < currentElement->childrenOrTextContent.children.length; ++j) {
+                Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, currentElement->childrenOrTextContent.children.elements[j]);
+                contentHeight += childElement->dimensions.height;
+            }
+            contentHeight += (float)(CLAY__MAX(currentElement->childrenOrTextContent.children.length - 1, 0) * layoutConfig->childGap);
+            currentElement->dimensions.height = CLAY__MIN(CLAY__MAX(contentHeight, layoutConfig->sizing.height.size.minMax.min), layoutConfig->sizing.height.size.minMax.max);
+        }
+    }
+
+    // Calculate sizing along the Y axis
+    Clay__SizeContainersAlongAxis(false);
+
+    // Scale horizontal widths according to aspect ratio
+    for (int32_t i = 0; i < context->aspectRatioElementIndexes.length; ++i) {
+        Clay_LayoutElement* aspectElement = Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_GetValue(&context->aspectRatioElementIndexes, i));
+        Clay_AspectRatioElementConfig *config = Clay__FindElementConfigWithType(aspectElement, CLAY__ELEMENT_CONFIG_TYPE_ASPECT).aspectRatioElementConfig;
+        aspectElement->dimensions.width = config->aspectRatio * aspectElement->dimensions.height;
+    }
+
+    // Sort tree roots by z-index
+    int32_t sortMax = context->layoutElementTreeRoots.length - 1;
+    while (sortMax > 0) { // todo dumb bubble sort
+        for (int32_t i = 0; i < sortMax; ++i) {
+            Clay__LayoutElementTreeRoot current = *Clay__LayoutElementTreeRootArray_Get(&context->layoutElementTreeRoots, i);
+            Clay__LayoutElementTreeRoot next = *Clay__LayoutElementTreeRootArray_Get(&context->layoutElementTreeRoots, i + 1);
+            if (next.zIndex < current.zIndex) {
+                Clay__LayoutElementTreeRootArray_Set(&context->layoutElementTreeRoots, i, next);
+                Clay__LayoutElementTreeRootArray_Set(&context->layoutElementTreeRoots, i + 1, current);
+            }
+        }
+        sortMax--;
+    }
+
+    // Calculate final positions and generate render commands
+    context->renderCommands.length = 0;
+    dfsBuffer.length = 0;
+    for (int32_t rootIndex = 0; rootIndex < context->layoutElementTreeRoots.length; ++rootIndex) {
+        dfsBuffer.length = 0;
+        Clay__LayoutElementTreeRoot *root = Clay__LayoutElementTreeRootArray_Get(&context->layoutElementTreeRoots, rootIndex);
+        Clay_LayoutElement *rootElement = Clay_LayoutElementArray_Get(&context->layoutElements, (int)root->layoutElementIndex);
+        Clay_Vector2 rootPosition = CLAY__DEFAULT_STRUCT;
+        Clay_LayoutElementHashMapItem *parentHashMapItem = Clay__GetHashMapItem(root->parentId);
+        // Position root floating containers
+        if (Clay__ElementHasConfig(rootElement, CLAY__ELEMENT_CONFIG_TYPE_FLOATING) && parentHashMapItem) {
+            Clay_FloatingElementConfig *config = Clay__FindElementConfigWithType(rootElement, CLAY__ELEMENT_CONFIG_TYPE_FLOATING).floatingElementConfig;
+            Clay_Dimensions rootDimensions = rootElement->dimensions;
+            Clay_BoundingBox parentBoundingBox = parentHashMapItem->boundingBox;
+            // Set X position
+            Clay_Vector2 targetAttachPosition = CLAY__DEFAULT_STRUCT;
+            switch (config->attachPoints.parent) {
+                case CLAY_ATTACH_POINT_LEFT_TOP:
+                case CLAY_ATTACH_POINT_LEFT_CENTER:
+                case CLAY_ATTACH_POINT_LEFT_BOTTOM: targetAttachPosition.x = parentBoundingBox.x; break;
+                case CLAY_ATTACH_POINT_CENTER_TOP:
+                case CLAY_ATTACH_POINT_CENTER_CENTER:
+                case CLAY_ATTACH_POINT_CENTER_BOTTOM: targetAttachPosition.x = parentBoundingBox.x + (parentBoundingBox.width / 2); break;
+                case CLAY_ATTACH_POINT_RIGHT_TOP:
+                case CLAY_ATTACH_POINT_RIGHT_CENTER:
+                case CLAY_ATTACH_POINT_RIGHT_BOTTOM: targetAttachPosition.x = parentBoundingBox.x + parentBoundingBox.width; break;
+            }
+            switch (config->attachPoints.element) {
+                case CLAY_ATTACH_POINT_LEFT_TOP:
+                case CLAY_ATTACH_POINT_LEFT_CENTER:
+                case CLAY_ATTACH_POINT_LEFT_BOTTOM: break;
+                case CLAY_ATTACH_POINT_CENTER_TOP:
+                case CLAY_ATTACH_POINT_CENTER_CENTER:
+                case CLAY_ATTACH_POINT_CENTER_BOTTOM: targetAttachPosition.x -= (rootDimensions.width / 2); break;
+                case CLAY_ATTACH_POINT_RIGHT_TOP:
+                case CLAY_ATTACH_POINT_RIGHT_CENTER:
+                case CLAY_ATTACH_POINT_RIGHT_BOTTOM: targetAttachPosition.x -= rootDimensions.width; break;
+            }
+            switch (config->attachPoints.parent) { // I know I could merge the x and y switch statements, but this is easier to read
+                case CLAY_ATTACH_POINT_LEFT_TOP:
+                case CLAY_ATTACH_POINT_RIGHT_TOP:
+                case CLAY_ATTACH_POINT_CENTER_TOP: targetAttachPosition.y = parentBoundingBox.y; break;
+                case CLAY_ATTACH_POINT_LEFT_CENTER:
+                case CLAY_ATTACH_POINT_CENTER_CENTER:
+                case CLAY_ATTACH_POINT_RIGHT_CENTER: targetAttachPosition.y = parentBoundingBox.y + (parentBoundingBox.height / 2); break;
+                case CLAY_ATTACH_POINT_LEFT_BOTTOM:
+                case CLAY_ATTACH_POINT_CENTER_BOTTOM:
+                case CLAY_ATTACH_POINT_RIGHT_BOTTOM: targetAttachPosition.y = parentBoundingBox.y + parentBoundingBox.height; break;
+            }
+            switch (config->attachPoints.element) {
+                case CLAY_ATTACH_POINT_LEFT_TOP:
+                case CLAY_ATTACH_POINT_RIGHT_TOP:
+                case CLAY_ATTACH_POINT_CENTER_TOP: break;
+                case CLAY_ATTACH_POINT_LEFT_CENTER:
+                case CLAY_ATTACH_POINT_CENTER_CENTER:
+                case CLAY_ATTACH_POINT_RIGHT_CENTER: targetAttachPosition.y -= (rootDimensions.height / 2); break;
+                case CLAY_ATTACH_POINT_LEFT_BOTTOM:
+                case CLAY_ATTACH_POINT_CENTER_BOTTOM:
+                case CLAY_ATTACH_POINT_RIGHT_BOTTOM: targetAttachPosition.y -= rootDimensions.height; break;
+            }
+            targetAttachPosition.x += config->offset.x;
+            targetAttachPosition.y += config->offset.y;
+            rootPosition = targetAttachPosition;
+        }
+        if (root->clipElementId) {
+            Clay_LayoutElementHashMapItem *clipHashMapItem = Clay__GetHashMapItem(root->clipElementId);
+            if (clipHashMapItem) {
+                // Floating elements that are attached to scrolling contents won't be correctly positioned if external scroll handling is enabled, fix here
+                if (context->externalScrollHandlingEnabled) {
+                    Clay_ClipElementConfig *clipConfig = Clay__FindElementConfigWithType(clipHashMapItem->layoutElement, CLAY__ELEMENT_CONFIG_TYPE_CLIP).clipElementConfig;
+                    if (clipConfig->horizontal) {
+                        rootPosition.x += clipConfig->childOffset.x;
+                    }
+                    if (clipConfig->vertical) {
+                        rootPosition.y += clipConfig->childOffset.y;
+                    }
+                    break;
+                }
+                Clay__AddRenderCommand(CLAY__INIT(Clay_RenderCommand) {
+                    .boundingBox = clipHashMapItem->boundingBox,
+                    .userData = 0,
+                    .id = Clay__HashNumber(rootElement->id, rootElement->childrenOrTextContent.children.length + 10).id, // TODO need a better strategy for managing derived ids
+                    .zIndex = root->zIndex,
+                    .commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START,
+                });
+            }
+        }
+        Clay__LayoutElementTreeNodeArray_Add(&dfsBuffer, CLAY__INIT(Clay__LayoutElementTreeNode) { .layoutElement = rootElement, .position = rootPosition, .nextChildOffset = { .x = (float)rootElement->layoutConfig->padding.left, .y = (float)rootElement->layoutConfig->padding.top } });
+
+        context->treeNodeVisited.internalArray[0] = false;
+        while (dfsBuffer.length > 0) {
+            Clay__LayoutElementTreeNode *currentElementTreeNode = Clay__LayoutElementTreeNodeArray_Get(&dfsBuffer, (int)dfsBuffer.length - 1);
+            Clay_LayoutElement *currentElement = currentElementTreeNode->layoutElement;
+            Clay_LayoutConfig *layoutConfig = currentElement->layoutConfig;
+            Clay_Vector2 scrollOffset = CLAY__DEFAULT_STRUCT;
+
+            // This will only be run a single time for each element in downwards DFS order
+            if (!context->treeNodeVisited.internalArray[dfsBuffer.length - 1]) {
+                context->treeNodeVisited.internalArray[dfsBuffer.length - 1] = true;
+
+                Clay_BoundingBox currentElementBoundingBox = { currentElementTreeNode->position.x, currentElementTreeNode->position.y, currentElement->dimensions.width, currentElement->dimensions.height };
+                if (Clay__ElementHasConfig(currentElement, CLAY__ELEMENT_CONFIG_TYPE_FLOATING)) {
+                    Clay_FloatingElementConfig *floatingElementConfig = Clay__FindElementConfigWithType(currentElement, CLAY__ELEMENT_CONFIG_TYPE_FLOATING).floatingElementConfig;
+                    Clay_Dimensions expand = floatingElementConfig->expand;
+                    currentElementBoundingBox.x -= expand.width;
+                    currentElementBoundingBox.width += expand.width * 2;
+                    currentElementBoundingBox.y -= expand.height;
+                    currentElementBoundingBox.height += expand.height * 2;
+                }
+
+                Clay__ScrollContainerDataInternal *scrollContainerData = CLAY__NULL;
+                // Apply scroll offsets to container
+                if (Clay__ElementHasConfig(currentElement, CLAY__ELEMENT_CONFIG_TYPE_CLIP)) {
+                    Clay_ClipElementConfig *clipConfig = Clay__FindElementConfigWithType(currentElement, CLAY__ELEMENT_CONFIG_TYPE_CLIP).clipElementConfig;
+
+                    // This linear scan could theoretically be slow under very strange conditions, but I can't imagine a real UI with more than a few 10's of scroll containers
+                    for (int32_t i = 0; i < context->scrollContainerDatas.length; i++) {
+                        Clay__ScrollContainerDataInternal *mapping = Clay__ScrollContainerDataInternalArray_Get(&context->scrollContainerDatas, i);
+                        if (mapping->layoutElement == currentElement) {
+                            scrollContainerData = mapping;
+                            mapping->boundingBox = currentElementBoundingBox;
+                            scrollOffset = clipConfig->childOffset;
+                            if (context->externalScrollHandlingEnabled) {
+                                scrollOffset = CLAY__INIT(Clay_Vector2) CLAY__DEFAULT_STRUCT;
+                            }
+                            break;
+                        }
+                    }
+                }
+
+                Clay_LayoutElementHashMapItem *hashMapItem = Clay__GetHashMapItem(currentElement->id);
+                if (hashMapItem) {
+                    hashMapItem->boundingBox = currentElementBoundingBox;
+                    if (hashMapItem->idAlias) {
+                        Clay_LayoutElementHashMapItem *hashMapItemAlias = Clay__GetHashMapItem(hashMapItem->idAlias);
+                        if (hashMapItemAlias) {
+                            hashMapItemAlias->boundingBox = currentElementBoundingBox;
+                        }
+                    }
+                }
+
+                int32_t sortedConfigIndexes[20];
+                for (int32_t elementConfigIndex = 0; elementConfigIndex < currentElement->elementConfigs.length; ++elementConfigIndex) {
+                    sortedConfigIndexes[elementConfigIndex] = elementConfigIndex;
+                }
+                sortMax = currentElement->elementConfigs.length - 1;
+                while (sortMax > 0) { // todo dumb bubble sort
+                    for (int32_t i = 0; i < sortMax; ++i) {
+                        int32_t current = sortedConfigIndexes[i];
+                        int32_t next = sortedConfigIndexes[i + 1];
+                        Clay__ElementConfigType currentType = Clay__ElementConfigArraySlice_Get(&currentElement->elementConfigs, current)->type;
+                        Clay__ElementConfigType nextType = Clay__ElementConfigArraySlice_Get(&currentElement->elementConfigs, next)->type;
+                        if (nextType == CLAY__ELEMENT_CONFIG_TYPE_CLIP || currentType == CLAY__ELEMENT_CONFIG_TYPE_BORDER) {
+                            sortedConfigIndexes[i] = next;
+                            sortedConfigIndexes[i + 1] = current;
+                        }
+                    }
+                    sortMax--;
+                }
+
+                bool emitRectangle = false;
+                // Create the render commands for this element
+                Clay_SharedElementConfig *sharedConfig = Clay__FindElementConfigWithType(currentElement, CLAY__ELEMENT_CONFIG_TYPE_SHARED).sharedElementConfig;
+                if (sharedConfig && sharedConfig->backgroundColor.a > 0) {
+                   emitRectangle = true;
+                }
+                else if (!sharedConfig) {
+                    emitRectangle = false;
+                    sharedConfig = &Clay_SharedElementConfig_DEFAULT;
+                }
+                for (int32_t elementConfigIndex = 0; elementConfigIndex < currentElement->elementConfigs.length; ++elementConfigIndex) {
+                    Clay_ElementConfig *elementConfig = Clay__ElementConfigArraySlice_Get(&currentElement->elementConfigs, sortedConfigIndexes[elementConfigIndex]);
+                    Clay_RenderCommand renderCommand = {
+                        .boundingBox = currentElementBoundingBox,
+                        .userData = sharedConfig->userData,
+                        .id = currentElement->id,
+                    };
+
+                    bool offscreen = Clay__ElementIsOffscreen(&currentElementBoundingBox);
+                    // Culling - Don't bother to generate render commands for rectangles entirely outside the screen - this won't stop their children from being rendered if they overflow
+                    bool shouldRender = !offscreen;
+                    switch (elementConfig->type) {
+                        case CLAY__ELEMENT_CONFIG_TYPE_ASPECT:
+                        case CLAY__ELEMENT_CONFIG_TYPE_FLOATING:
+                        case CLAY__ELEMENT_CONFIG_TYPE_SHARED:
+                        case CLAY__ELEMENT_CONFIG_TYPE_BORDER: {
+                            shouldRender = false;
+                            break;
+                        }
+                        case CLAY__ELEMENT_CONFIG_TYPE_CLIP: {
+                            renderCommand.commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+                            renderCommand.renderData = CLAY__INIT(Clay_RenderData) {
+                                .clip = {
+                                    .horizontal = elementConfig->config.clipElementConfig->horizontal,
+                                    .vertical = elementConfig->config.clipElementConfig->vertical,
+                                }
+                            };
+                            break;
+                        }
+                        case CLAY__ELEMENT_CONFIG_TYPE_IMAGE: {
+                            renderCommand.commandType = CLAY_RENDER_COMMAND_TYPE_IMAGE;
+                            renderCommand.renderData = CLAY__INIT(Clay_RenderData) {
+                                .image = {
+                                    .backgroundColor = sharedConfig->backgroundColor,
+                                    .cornerRadius = sharedConfig->cornerRadius,
+                                    .imageData = elementConfig->config.imageElementConfig->imageData,
+                               }
+                            };
+                            emitRectangle = false;
+                            break;
+                        }
+                        case CLAY__ELEMENT_CONFIG_TYPE_TEXT: {
+                            if (!shouldRender) {
+                                break;
+                            }
+                            shouldRender = false;
+                            Clay_ElementConfigUnion configUnion = elementConfig->config;
+                            Clay_TextElementConfig *textElementConfig = configUnion.textElementConfig;
+                            float naturalLineHeight = currentElement->childrenOrTextContent.textElementData->preferredDimensions.height;
+                            float finalLineHeight = textElementConfig->lineHeight > 0 ? (float)textElementConfig->lineHeight : naturalLineHeight;
+                            float lineHeightOffset = (finalLineHeight - naturalLineHeight) / 2;
+                            float yPosition = lineHeightOffset;
+                            for (int32_t lineIndex = 0; lineIndex < currentElement->childrenOrTextContent.textElementData->wrappedLines.length; ++lineIndex) {
+                                Clay__WrappedTextLine *wrappedLine = Clay__WrappedTextLineArraySlice_Get(&currentElement->childrenOrTextContent.textElementData->wrappedLines, lineIndex);
+                                if (wrappedLine->line.length == 0) {
+                                    yPosition += finalLineHeight;
+                                    continue;
+                                }
+                                float offset = (currentElementBoundingBox.width - wrappedLine->dimensions.width);
+                                if (textElementConfig->textAlignment == CLAY_TEXT_ALIGN_LEFT) {
+                                    offset = 0;
+                                }
+                                if (textElementConfig->textAlignment == CLAY_TEXT_ALIGN_CENTER) {
+                                    offset /= 2;
+                                }
+                                Clay__AddRenderCommand(CLAY__INIT(Clay_RenderCommand) {
+                                    .boundingBox = { currentElementBoundingBox.x + offset, currentElementBoundingBox.y + yPosition, wrappedLine->dimensions.width, wrappedLine->dimensions.height },
+                                    .renderData = { .text = {
+                                        .stringContents = CLAY__INIT(Clay_StringSlice) { .length = wrappedLine->line.length, .chars = wrappedLine->line.chars, .baseChars = currentElement->childrenOrTextContent.textElementData->text.chars },
+                                        .textColor = textElementConfig->textColor,
+                                        .fontId = textElementConfig->fontId,
+                                        .fontSize = textElementConfig->fontSize,
+                                        .letterSpacing = textElementConfig->letterSpacing,
+                                        .lineHeight = textElementConfig->lineHeight,
+                                    }},
+                                    .userData = textElementConfig->userData,
+                                    .id = Clay__HashNumber(lineIndex, currentElement->id).id,
+                                    .zIndex = root->zIndex,
+                                    .commandType = CLAY_RENDER_COMMAND_TYPE_TEXT,
+                                });
+                                yPosition += finalLineHeight;
+
+                                if (!context->disableCulling && (currentElementBoundingBox.y + yPosition > context->layoutDimensions.height)) {
+                                    break;
+                                }
+                            }
+                            break;
+                        }
+                        case CLAY__ELEMENT_CONFIG_TYPE_CUSTOM: {
+                            renderCommand.commandType = CLAY_RENDER_COMMAND_TYPE_CUSTOM;
+                            renderCommand.renderData = CLAY__INIT(Clay_RenderData) {
+                                .custom = {
+                                    .backgroundColor = sharedConfig->backgroundColor,
+                                    .cornerRadius = sharedConfig->cornerRadius,
+                                    .customData = elementConfig->config.customElementConfig->customData,
+                                }
+                            };
+                            emitRectangle = false;
+                            break;
+                        }
+                        default: break;
+                    }
+                    if (shouldRender) {
+                        Clay__AddRenderCommand(renderCommand);
+                    }
+                    if (offscreen) {
+                        // NOTE: You may be tempted to try an early return / continue if an element is off screen. Why bother calculating layout for its children, right?
+                        // Unfortunately, a FLOATING_CONTAINER may be defined that attaches to a child or grandchild of this element, which is large enough to still
+                        // be on screen, even if this element isn't. That depends on this element and it's children being laid out correctly (even if they are entirely off screen)
+                    }
+                }
+
+                if (emitRectangle) {
+                    Clay__AddRenderCommand(CLAY__INIT(Clay_RenderCommand) {
+                        .boundingBox = currentElementBoundingBox,
+                        .renderData = { .rectangle = {
+                                .backgroundColor = sharedConfig->backgroundColor,
+                                .cornerRadius = sharedConfig->cornerRadius,
+                        }},
+                        .userData = sharedConfig->userData,
+                        .id = currentElement->id,
+                        .zIndex = root->zIndex,
+                        .commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE,
+                    });
+                }
+
+                // Setup initial on-axis alignment
+                if (!Clay__ElementHasConfig(currentElementTreeNode->layoutElement, CLAY__ELEMENT_CONFIG_TYPE_TEXT)) {
+                    Clay_Dimensions contentSize = {0,0};
+                    if (layoutConfig->layoutDirection == CLAY_LEFT_TO_RIGHT) {
+                        for (int32_t i = 0; i < currentElement->childrenOrTextContent.children.length; ++i) {
+                            Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, currentElement->childrenOrTextContent.children.elements[i]);
+                            contentSize.width += childElement->dimensions.width;
+                            contentSize.height = CLAY__MAX(contentSize.height, childElement->dimensions.height);
+                        }
+                        contentSize.width += (float)(CLAY__MAX(currentElement->childrenOrTextContent.children.length - 1, 0) * layoutConfig->childGap);
+                        float extraSpace = currentElement->dimensions.width - (float)(layoutConfig->padding.left + layoutConfig->padding.right) - contentSize.width;
+                        switch (layoutConfig->childAlignment.x) {
+                            case CLAY_ALIGN_X_LEFT: extraSpace = 0; break;
+                            case CLAY_ALIGN_X_CENTER: extraSpace /= 2; break;
+                            default: break;
+                        }
+                        currentElementTreeNode->nextChildOffset.x += extraSpace;
+                    } else {
+                        for (int32_t i = 0; i < currentElement->childrenOrTextContent.children.length; ++i) {
+                            Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, currentElement->childrenOrTextContent.children.elements[i]);
+                            contentSize.width = CLAY__MAX(contentSize.width, childElement->dimensions.width);
+                            contentSize.height += childElement->dimensions.height;
+                        }
+                        contentSize.height += (float)(CLAY__MAX(currentElement->childrenOrTextContent.children.length - 1, 0) * layoutConfig->childGap);
+                        float extraSpace = currentElement->dimensions.height - (float)(layoutConfig->padding.top + layoutConfig->padding.bottom) - contentSize.height;
+                        switch (layoutConfig->childAlignment.y) {
+                            case CLAY_ALIGN_Y_TOP: extraSpace = 0; break;
+                            case CLAY_ALIGN_Y_CENTER: extraSpace /= 2; break;
+                            default: break;
+                        }
+                        currentElementTreeNode->nextChildOffset.y += extraSpace;
+                    }
+
+                    if (scrollContainerData) {
+                        scrollContainerData->contentSize = CLAY__INIT(Clay_Dimensions) { contentSize.width + (float)(layoutConfig->padding.left + layoutConfig->padding.right), contentSize.height + (float)(layoutConfig->padding.top + layoutConfig->padding.bottom) };
+                    }
+                }
+            }
+            else {
+                // DFS is returning upwards backwards
+                bool closeClipElement = false;
+                Clay_ClipElementConfig *clipConfig = Clay__FindElementConfigWithType(currentElement, CLAY__ELEMENT_CONFIG_TYPE_CLIP).clipElementConfig;
+                if (clipConfig) {
+                    closeClipElement = true;
+                    for (int32_t i = 0; i < context->scrollContainerDatas.length; i++) {
+                        Clay__ScrollContainerDataInternal *mapping = Clay__ScrollContainerDataInternalArray_Get(&context->scrollContainerDatas, i);
+                        if (mapping->layoutElement == currentElement) {
+                            scrollOffset = clipConfig->childOffset;
+                            if (context->externalScrollHandlingEnabled) {
+                                scrollOffset = CLAY__INIT(Clay_Vector2) CLAY__DEFAULT_STRUCT;
+                            }
+                            break;
+                        }
+                    }
+                }
+
+                if (Clay__ElementHasConfig(currentElement, CLAY__ELEMENT_CONFIG_TYPE_BORDER)) {
+                    Clay_LayoutElementHashMapItem *currentElementData = Clay__GetHashMapItem(currentElement->id);
+                    Clay_BoundingBox currentElementBoundingBox = currentElementData->boundingBox;
+
+                    // Culling - Don't bother to generate render commands for rectangles entirely outside the screen - this won't stop their children from being rendered if they overflow
+                    if (!Clay__ElementIsOffscreen(&currentElementBoundingBox)) {
+                        Clay_SharedElementConfig *sharedConfig = Clay__ElementHasConfig(currentElement, CLAY__ELEMENT_CONFIG_TYPE_SHARED) ? Clay__FindElementConfigWithType(currentElement, CLAY__ELEMENT_CONFIG_TYPE_SHARED).sharedElementConfig : &Clay_SharedElementConfig_DEFAULT;
+                        Clay_BorderElementConfig *borderConfig = Clay__FindElementConfigWithType(currentElement, CLAY__ELEMENT_CONFIG_TYPE_BORDER).borderElementConfig;
+                        Clay_RenderCommand renderCommand = {
+                                .boundingBox = currentElementBoundingBox,
+                                .renderData = { .border = {
+                                    .color = borderConfig->color,
+                                    .cornerRadius = sharedConfig->cornerRadius,
+                                    .width = borderConfig->width
+                                }},
+                                .userData = sharedConfig->userData,
+                                .id = Clay__HashNumber(currentElement->id, currentElement->childrenOrTextContent.children.length).id,
+                                .commandType = CLAY_RENDER_COMMAND_TYPE_BORDER,
+                        };
+                        Clay__AddRenderCommand(renderCommand);
+                        if (borderConfig->width.betweenChildren > 0 && borderConfig->color.a > 0) {
+                            float halfGap = layoutConfig->childGap / 2;
+                            Clay_Vector2 borderOffset = { (float)layoutConfig->padding.left - halfGap, (float)layoutConfig->padding.top - halfGap };
+                            if (layoutConfig->layoutDirection == CLAY_LEFT_TO_RIGHT) {
+                                for (int32_t i = 0; i < currentElement->childrenOrTextContent.children.length; ++i) {
+                                    Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, currentElement->childrenOrTextContent.children.elements[i]);
+                                    if (i > 0) {
+                                        Clay__AddRenderCommand(CLAY__INIT(Clay_RenderCommand) {
+                                            .boundingBox = { currentElementBoundingBox.x + borderOffset.x + scrollOffset.x, currentElementBoundingBox.y + scrollOffset.y, (float)borderConfig->width.betweenChildren, currentElement->dimensions.height },
+                                            .renderData = { .rectangle = {
+                                                .backgroundColor = borderConfig->color,
+                                            } },
+                                            .userData = sharedConfig->userData,
+                                            .id = Clay__HashNumber(currentElement->id, currentElement->childrenOrTextContent.children.length + 1 + i).id,
+                                            .commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE,
+                                        });
+                                    }
+                                    borderOffset.x += (childElement->dimensions.width + (float)layoutConfig->childGap);
+                                }
+                            } else {
+                                for (int32_t i = 0; i < currentElement->childrenOrTextContent.children.length; ++i) {
+                                    Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, currentElement->childrenOrTextContent.children.elements[i]);
+                                    if (i > 0) {
+                                        Clay__AddRenderCommand(CLAY__INIT(Clay_RenderCommand) {
+                                            .boundingBox = { currentElementBoundingBox.x + scrollOffset.x, currentElementBoundingBox.y + borderOffset.y + scrollOffset.y, currentElement->dimensions.width, (float)borderConfig->width.betweenChildren },
+                                            .renderData = { .rectangle = {
+                                                    .backgroundColor = borderConfig->color,
+                                            } },
+                                            .userData = sharedConfig->userData,
+                                            .id = Clay__HashNumber(currentElement->id, currentElement->childrenOrTextContent.children.length + 1 + i).id,
+                                            .commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE,
+                                        });
+                                    }
+                                    borderOffset.y += (childElement->dimensions.height + (float)layoutConfig->childGap);
+                                }
+                            }
+                        }
+                    }
+                }
+                // This exists because the scissor needs to end _after_ borders between elements
+                if (closeClipElement) {
+                    Clay__AddRenderCommand(CLAY__INIT(Clay_RenderCommand) {
+                        .id = Clay__HashNumber(currentElement->id, rootElement->childrenOrTextContent.children.length + 11).id,
+                        .commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END,
+                    });
+                }
+
+                dfsBuffer.length--;
+                continue;
+            }
+
+            // Add children to the DFS buffer
+            if (!Clay__ElementHasConfig(currentElement, CLAY__ELEMENT_CONFIG_TYPE_TEXT)) {
+                dfsBuffer.length += currentElement->childrenOrTextContent.children.length;
+                for (int32_t i = 0; i < currentElement->childrenOrTextContent.children.length; ++i) {
+                    Clay_LayoutElement *childElement = Clay_LayoutElementArray_Get(&context->layoutElements, currentElement->childrenOrTextContent.children.elements[i]);
+                    // Alignment along non layout axis
+                    if (layoutConfig->layoutDirection == CLAY_LEFT_TO_RIGHT) {
+                        currentElementTreeNode->nextChildOffset.y = currentElement->layoutConfig->padding.top;
+                        float whiteSpaceAroundChild = currentElement->dimensions.height - (float)(layoutConfig->padding.top + layoutConfig->padding.bottom) - childElement->dimensions.height;
+                        switch (layoutConfig->childAlignment.y) {
+                            case CLAY_ALIGN_Y_TOP: break;
+                            case CLAY_ALIGN_Y_CENTER: currentElementTreeNode->nextChildOffset.y += whiteSpaceAroundChild / 2; break;
+                            case CLAY_ALIGN_Y_BOTTOM: currentElementTreeNode->nextChildOffset.y += whiteSpaceAroundChild; break;
+                        }
+                    } else {
+                        currentElementTreeNode->nextChildOffset.x = currentElement->layoutConfig->padding.left;
+                        float whiteSpaceAroundChild = currentElement->dimensions.width - (float)(layoutConfig->padding.left + layoutConfig->padding.right) - childElement->dimensions.width;
+                        switch (layoutConfig->childAlignment.x) {
+                            case CLAY_ALIGN_X_LEFT: break;
+                            case CLAY_ALIGN_X_CENTER: currentElementTreeNode->nextChildOffset.x += whiteSpaceAroundChild / 2; break;
+                            case CLAY_ALIGN_X_RIGHT: currentElementTreeNode->nextChildOffset.x += whiteSpaceAroundChild; break;
+                        }
+                    }
+
+                    Clay_Vector2 childPosition = {
+                        currentElementTreeNode->position.x + currentElementTreeNode->nextChildOffset.x + scrollOffset.x,
+                        currentElementTreeNode->position.y + currentElementTreeNode->nextChildOffset.y + scrollOffset.y,
+                    };
+
+                    // DFS buffer elements need to be added in reverse because stack traversal happens backwards
+                    uint32_t newNodeIndex = dfsBuffer.length - 1 - i;
+                    dfsBuffer.internalArray[newNodeIndex] = CLAY__INIT(Clay__LayoutElementTreeNode) {
+                        .layoutElement = childElement,
+                        .position = { childPosition.x, childPosition.y },
+                        .nextChildOffset = { .x = (float)childElement->layoutConfig->padding.left, .y = (float)childElement->layoutConfig->padding.top },
+                    };
+                    context->treeNodeVisited.internalArray[newNodeIndex] = false;
+
+                    // Update parent offsets
+                    if (layoutConfig->layoutDirection == CLAY_LEFT_TO_RIGHT) {
+                        currentElementTreeNode->nextChildOffset.x += childElement->dimensions.width + (float)layoutConfig->childGap;
+                    } else {
+                        currentElementTreeNode->nextChildOffset.y += childElement->dimensions.height + (float)layoutConfig->childGap;
+                    }
+                }
+            }
+        }
+
+        if (root->clipElementId) {
+            Clay__AddRenderCommand(CLAY__INIT(Clay_RenderCommand) { .id = Clay__HashNumber(rootElement->id, rootElement->childrenOrTextContent.children.length + 11).id, .commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END });
+        }
+    }
+}
+
+CLAY_WASM_EXPORT("Clay_GetPointerOverIds")
+CLAY_DLL_EXPORT Clay_ElementIdArray Clay_GetPointerOverIds(void) {
+    return Clay_GetCurrentContext()->pointerOverIds;
+}
+
+#pragma region DebugTools
+Clay_Color CLAY__DEBUGVIEW_COLOR_1 = {58, 56, 52, 255};
+Clay_Color CLAY__DEBUGVIEW_COLOR_2 = {62, 60, 58, 255};
+Clay_Color CLAY__DEBUGVIEW_COLOR_3 = {141, 133, 135, 255};
+Clay_Color CLAY__DEBUGVIEW_COLOR_4 = {238, 226, 231, 255};
+Clay_Color CLAY__DEBUGVIEW_COLOR_SELECTED_ROW = {102, 80, 78, 255};
+const int32_t CLAY__DEBUGVIEW_ROW_HEIGHT = 30;
+const int32_t CLAY__DEBUGVIEW_OUTER_PADDING = 10;
+const int32_t CLAY__DEBUGVIEW_INDENT_WIDTH = 16;
+Clay_TextElementConfig Clay__DebugView_TextNameConfig = {.textColor = {238, 226, 231, 255}, .fontSize = 16, .wrapMode = CLAY_TEXT_WRAP_NONE };
+Clay_LayoutConfig Clay__DebugView_ScrollViewItemLayoutConfig = CLAY__DEFAULT_STRUCT;
+
+typedef struct {
+    Clay_String label;
+    Clay_Color color;
+} Clay__DebugElementConfigTypeLabelConfig;
+
+Clay__DebugElementConfigTypeLabelConfig Clay__DebugGetElementConfigTypeLabel(Clay__ElementConfigType type) {
+    switch (type) {
+        case CLAY__ELEMENT_CONFIG_TYPE_SHARED: return CLAY__INIT(Clay__DebugElementConfigTypeLabelConfig) { CLAY_STRING("Shared"), {243,134,48,255} };
+        case CLAY__ELEMENT_CONFIG_TYPE_TEXT: return CLAY__INIT(Clay__DebugElementConfigTypeLabelConfig) { CLAY_STRING("Text"), {105,210,231,255} };
+        case CLAY__ELEMENT_CONFIG_TYPE_ASPECT: return CLAY__INIT(Clay__DebugElementConfigTypeLabelConfig) { CLAY_STRING("Aspect"), {101,149,194,255} };
+        case CLAY__ELEMENT_CONFIG_TYPE_IMAGE: return CLAY__INIT(Clay__DebugElementConfigTypeLabelConfig) { CLAY_STRING("Image"), {121,189,154,255} };
+        case CLAY__ELEMENT_CONFIG_TYPE_FLOATING: return CLAY__INIT(Clay__DebugElementConfigTypeLabelConfig) { CLAY_STRING("Floating"), {250,105,0,255} };
+        case CLAY__ELEMENT_CONFIG_TYPE_CLIP: return CLAY__INIT(Clay__DebugElementConfigTypeLabelConfig) {CLAY_STRING("Scroll"), {242, 196, 90, 255} };
+        case CLAY__ELEMENT_CONFIG_TYPE_BORDER: return CLAY__INIT(Clay__DebugElementConfigTypeLabelConfig) {CLAY_STRING("Border"), {108, 91, 123, 255} };
+        case CLAY__ELEMENT_CONFIG_TYPE_CUSTOM: return CLAY__INIT(Clay__DebugElementConfigTypeLabelConfig) { CLAY_STRING("Custom"), {11,72,107,255} };
+        default: break;
+    }
+    return CLAY__INIT(Clay__DebugElementConfigTypeLabelConfig) { CLAY_STRING("Error"), {0,0,0,255} };
+}
+
+typedef struct {
+    int32_t rowCount;
+    int32_t selectedElementRowIndex;
+} Clay__RenderDebugLayoutData;
+
+// Returns row count
+Clay__RenderDebugLayoutData Clay__RenderDebugLayoutElementsList(int32_t initialRootsLength, int32_t highlightedRowIndex) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    Clay__int32_tArray dfsBuffer = context->reusableElementIndexBuffer;
+    Clay__DebugView_ScrollViewItemLayoutConfig = CLAY__INIT(Clay_LayoutConfig) { .sizing = { .height = CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT) }, .childGap = 6, .childAlignment = { .y = CLAY_ALIGN_Y_CENTER }};
+    Clay__RenderDebugLayoutData layoutData = CLAY__DEFAULT_STRUCT;
+
+    uint32_t highlightedElementId = 0;
+
+    for (int32_t rootIndex = 0; rootIndex < initialRootsLength; ++rootIndex) {
+        dfsBuffer.length = 0;
+        Clay__LayoutElementTreeRoot *root = Clay__LayoutElementTreeRootArray_Get(&context->layoutElementTreeRoots, rootIndex);
+        Clay__int32_tArray_Add(&dfsBuffer, (int32_t)root->layoutElementIndex);
+        context->treeNodeVisited.internalArray[0] = false;
+        if (rootIndex > 0) {
+            CLAY({ .id = CLAY_IDI("Clay__DebugView_EmptyRowOuter", rootIndex), .layout = { .sizing = {.width = CLAY_SIZING_GROW(0)}, .padding = {CLAY__DEBUGVIEW_INDENT_WIDTH / 2, 0, 0, 0} } }) {
+                CLAY({ .id = CLAY_IDI("Clay__DebugView_EmptyRow", rootIndex), .layout = { .sizing = { .width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_FIXED((float)CLAY__DEBUGVIEW_ROW_HEIGHT) }}, .border = { .color = CLAY__DEBUGVIEW_COLOR_3, .width = { .top = 1 } } }) {}
+            }
+            layoutData.rowCount++;
+        }
+        while (dfsBuffer.length > 0) {
+            int32_t currentElementIndex = Clay__int32_tArray_GetValue(&dfsBuffer, (int)dfsBuffer.length - 1);
+            Clay_LayoutElement *currentElement = Clay_LayoutElementArray_Get(&context->layoutElements, (int)currentElementIndex);
+            if (context->treeNodeVisited.internalArray[dfsBuffer.length - 1]) {
+                if (!Clay__ElementHasConfig(currentElement, CLAY__ELEMENT_CONFIG_TYPE_TEXT) && currentElement->childrenOrTextContent.children.length > 0) {
+                    Clay__CloseElement();
+                    Clay__CloseElement();
+                    Clay__CloseElement();
+                }
+                dfsBuffer.length--;
+                continue;
+            }
+
+            if (highlightedRowIndex == layoutData.rowCount) {
+                if (context->pointerInfo.state == CLAY_POINTER_DATA_PRESSED_THIS_FRAME) {
+                    context->debugSelectedElementId = currentElement->id;
+                }
+                highlightedElementId = currentElement->id;
+            }
+
+            context->treeNodeVisited.internalArray[dfsBuffer.length - 1] = true;
+            Clay_LayoutElementHashMapItem *currentElementData = Clay__GetHashMapItem(currentElement->id);
+            bool offscreen = Clay__ElementIsOffscreen(&currentElementData->boundingBox);
+            if (context->debugSelectedElementId == currentElement->id) {
+                layoutData.selectedElementRowIndex = layoutData.rowCount;
+            }
+            CLAY({ .id = CLAY_IDI("Clay__DebugView_ElementOuter", currentElement->id), .layout = Clay__DebugView_ScrollViewItemLayoutConfig }) {
+                // Collapse icon / button
+                if (!(Clay__ElementHasConfig(currentElement, CLAY__ELEMENT_CONFIG_TYPE_TEXT) || currentElement->childrenOrTextContent.children.length == 0)) {
+                    CLAY({
+                        .id = CLAY_IDI("Clay__DebugView_CollapseElement", currentElement->id),
+                        .layout = { .sizing = {CLAY_SIZING_FIXED(16), CLAY_SIZING_FIXED(16)}, .childAlignment = { CLAY_ALIGN_X_CENTER, CLAY_ALIGN_Y_CENTER} },
+                        .cornerRadius = CLAY_CORNER_RADIUS(4),
+                        .border = { .color = CLAY__DEBUGVIEW_COLOR_3, .width = {1, 1, 1, 1, 0} },
+                    }) {
+                        CLAY_TEXT((currentElementData && currentElementData->debugData->collapsed) ? CLAY_STRING("+") : CLAY_STRING("-"), CLAY_TEXT_CONFIG({ .textColor = CLAY__DEBUGVIEW_COLOR_4, .fontSize = 16 }));
+                    }
+                } else { // Square dot for empty containers
+                    CLAY({ .layout = { .sizing = {CLAY_SIZING_FIXED(16), CLAY_SIZING_FIXED(16)}, .childAlignment = { CLAY_ALIGN_X_CENTER, CLAY_ALIGN_Y_CENTER } } }) {
+                        CLAY({ .layout = { .sizing = {CLAY_SIZING_FIXED(8), CLAY_SIZING_FIXED(8)} }, .backgroundColor = CLAY__DEBUGVIEW_COLOR_3, .cornerRadius = CLAY_CORNER_RADIUS(2) }) {}
+                    }
+                }
+                // Collisions and offscreen info
+                if (currentElementData) {
+                    if (currentElementData->debugData->collision) {
+                        CLAY({ .layout = { .padding = { 8, 8, 2, 2 }}, .border = { .color = {177, 147, 8, 255}, .width = {1, 1, 1, 1, 0} } }) {
+                            CLAY_TEXT(CLAY_STRING("Duplicate ID"), CLAY_TEXT_CONFIG({ .textColor = CLAY__DEBUGVIEW_COLOR_3, .fontSize = 16 }));
+                        }
+                    }
+                    if (offscreen) {
+                        CLAY({ .layout = { .padding = { 8, 8, 2, 2 } }, .border = {  .color = CLAY__DEBUGVIEW_COLOR_3, .width = { 1, 1, 1, 1, 0} } }) {
+                            CLAY_TEXT(CLAY_STRING("Offscreen"), CLAY_TEXT_CONFIG({ .textColor = CLAY__DEBUGVIEW_COLOR_3, .fontSize = 16 }));
+                        }
+                    }
+                }
+                Clay_String idString = context->layoutElementIdStrings.internalArray[currentElementIndex];
+                if (idString.length > 0) {
+                    CLAY_TEXT(idString, offscreen ? CLAY_TEXT_CONFIG({ .textColor = CLAY__DEBUGVIEW_COLOR_3, .fontSize = 16 }) : &Clay__DebugView_TextNameConfig);
+                }
+                for (int32_t elementConfigIndex = 0; elementConfigIndex < currentElement->elementConfigs.length; ++elementConfigIndex) {
+                    Clay_ElementConfig *elementConfig = Clay__ElementConfigArraySlice_Get(&currentElement->elementConfigs, elementConfigIndex);
+                    if (elementConfig->type == CLAY__ELEMENT_CONFIG_TYPE_SHARED) {
+                        Clay_Color labelColor = {243,134,48,90};
+                        labelColor.a = 90;
+                        Clay_Color backgroundColor = elementConfig->config.sharedElementConfig->backgroundColor;
+                        Clay_CornerRadius radius = elementConfig->config.sharedElementConfig->cornerRadius;
+                        if (backgroundColor.a > 0) {
+                            CLAY({ .layout = { .padding = { 8, 8, 2, 2 } }, .backgroundColor = labelColor, .cornerRadius = CLAY_CORNER_RADIUS(4), .border = { .color = labelColor, .width = { 1, 1, 1, 1, 0} } }) {
+                                CLAY_TEXT(CLAY_STRING("Color"), CLAY_TEXT_CONFIG({ .textColor = offscreen ? CLAY__DEBUGVIEW_COLOR_3 : CLAY__DEBUGVIEW_COLOR_4, .fontSize = 16 }));
+                            }
+                        }
+                        if (radius.bottomLeft > 0) {
+                            CLAY({ .layout = { .padding = { 8, 8, 2, 2 } }, .backgroundColor = labelColor, .cornerRadius = CLAY_CORNER_RADIUS(4), .border = { .color = labelColor, .width = { 1, 1, 1, 1, 0 } } }) {
+                                CLAY_TEXT(CLAY_STRING("Radius"), CLAY_TEXT_CONFIG({ .textColor = offscreen ? CLAY__DEBUGVIEW_COLOR_3 : CLAY__DEBUGVIEW_COLOR_4, .fontSize = 16 }));
+                            }
+                        }
+                        continue;
+                    }
+                    Clay__DebugElementConfigTypeLabelConfig config = Clay__DebugGetElementConfigTypeLabel(elementConfig->type);
+                    Clay_Color backgroundColor = config.color;
+                    backgroundColor.a = 90;
+                    CLAY({ .layout = { .padding = { 8, 8, 2, 2 } }, .backgroundColor = backgroundColor, .cornerRadius = CLAY_CORNER_RADIUS(4), .border = { .color = config.color, .width = { 1, 1, 1, 1, 0 } } }) {
+                        CLAY_TEXT(config.label, CLAY_TEXT_CONFIG({ .textColor = offscreen ? CLAY__DEBUGVIEW_COLOR_3 : CLAY__DEBUGVIEW_COLOR_4, .fontSize = 16 }));
+                    }
+                }
+            }
+
+            // Render the text contents below the element as a non-interactive row
+            if (Clay__ElementHasConfig(currentElement, CLAY__ELEMENT_CONFIG_TYPE_TEXT)) {
+                layoutData.rowCount++;
+                Clay__TextElementData *textElementData = currentElement->childrenOrTextContent.textElementData;
+                Clay_TextElementConfig *rawTextConfig = offscreen ? CLAY_TEXT_CONFIG({ .textColor = CLAY__DEBUGVIEW_COLOR_3, .fontSize = 16 }) : &Clay__DebugView_TextNameConfig;
+                CLAY({ .layout = { .sizing = { .height = CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT)}, .childAlignment = { .y = CLAY_ALIGN_Y_CENTER } } }) {
+                    CLAY({ .layout = { .sizing = {.width = CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_INDENT_WIDTH + 16) } } }) {}
+                    CLAY_TEXT(CLAY_STRING("\""), rawTextConfig);
+                    CLAY_TEXT(textElementData->text.length > 40 ? (CLAY__INIT(Clay_String) { .length = 40, .chars = textElementData->text.chars }) : textElementData->text, rawTextConfig);
+                    if (textElementData->text.length > 40) {
+                        CLAY_TEXT(CLAY_STRING("..."), rawTextConfig);
+                    }
+                    CLAY_TEXT(CLAY_STRING("\""), rawTextConfig);
+                }
+            } else if (currentElement->childrenOrTextContent.children.length > 0) {
+                Clay__OpenElement();
+                Clay__ConfigureOpenElement(CLAY__INIT(Clay_ElementDeclaration) { .layout = { .padding = { .left = 8 } } });
+                Clay__OpenElement();
+                Clay__ConfigureOpenElement(CLAY__INIT(Clay_ElementDeclaration) { .layout = { .padding = { .left = CLAY__DEBUGVIEW_INDENT_WIDTH }}, .border = { .color = CLAY__DEBUGVIEW_COLOR_3, .width = { .left = 1 } }});
+                Clay__OpenElement();
+                Clay__ConfigureOpenElement(CLAY__INIT(Clay_ElementDeclaration) { .layout = { .layoutDirection = CLAY_TOP_TO_BOTTOM } });
+            }
+
+            layoutData.rowCount++;
+            if (!(Clay__ElementHasConfig(currentElement, CLAY__ELEMENT_CONFIG_TYPE_TEXT) || (currentElementData && currentElementData->debugData->collapsed))) {
+                for (int32_t i = currentElement->childrenOrTextContent.children.length - 1; i >= 0; --i) {
+                    Clay__int32_tArray_Add(&dfsBuffer, currentElement->childrenOrTextContent.children.elements[i]);
+                    context->treeNodeVisited.internalArray[dfsBuffer.length - 1] = false; // TODO needs to be ranged checked
+                }
+            }
+        }
+    }
+
+    if (context->pointerInfo.state == CLAY_POINTER_DATA_PRESSED_THIS_FRAME) {
+        Clay_ElementId collapseButtonId = Clay__HashString(CLAY_STRING("Clay__DebugView_CollapseElement"), 0, 0);
+        for (int32_t i = (int)context->pointerOverIds.length - 1; i >= 0; i--) {
+            Clay_ElementId *elementId = Clay_ElementIdArray_Get(&context->pointerOverIds, i);
+            if (elementId->baseId == collapseButtonId.baseId) {
+                Clay_LayoutElementHashMapItem *highlightedItem = Clay__GetHashMapItem(elementId->offset);
+                highlightedItem->debugData->collapsed = !highlightedItem->debugData->collapsed;
+                break;
+            }
+        }
+    }
+
+    if (highlightedElementId) {
+        CLAY({ .id = CLAY_ID("Clay__DebugView_ElementHighlight"), .layout = { .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)} }, .floating = { .parentId = highlightedElementId, .zIndex = 32767, .pointerCaptureMode = CLAY_POINTER_CAPTURE_MODE_PASSTHROUGH, .attachTo = CLAY_ATTACH_TO_ELEMENT_WITH_ID } }) {
+            CLAY({ .id = CLAY_ID("Clay__DebugView_ElementHighlightRectangle"), .layout = { .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)} }, .backgroundColor = Clay__debugViewHighlightColor }) {}
+        }
+    }
+    return layoutData;
+}
+
+void Clay__RenderDebugLayoutSizing(Clay_SizingAxis sizing, Clay_TextElementConfig *infoTextConfig) {
+    Clay_String sizingLabel = CLAY_STRING("GROW");
+    if (sizing.type == CLAY__SIZING_TYPE_FIT) {
+        sizingLabel = CLAY_STRING("FIT");
+    } else if (sizing.type == CLAY__SIZING_TYPE_PERCENT) {
+        sizingLabel = CLAY_STRING("PERCENT");
+    } else if (sizing.type == CLAY__SIZING_TYPE_FIXED) {
+        sizingLabel = CLAY_STRING("FIXED");
+    }
+    CLAY_TEXT(sizingLabel, infoTextConfig);
+    if (sizing.type == CLAY__SIZING_TYPE_GROW || sizing.type == CLAY__SIZING_TYPE_FIT || sizing.type == CLAY__SIZING_TYPE_FIXED) {
+        CLAY_TEXT(CLAY_STRING("("), infoTextConfig);
+        if (sizing.size.minMax.min != 0) {
+            CLAY_TEXT(CLAY_STRING("min: "), infoTextConfig);
+            CLAY_TEXT(Clay__IntToString(sizing.size.minMax.min), infoTextConfig);
+            if (sizing.size.minMax.max != CLAY__MAXFLOAT) {
+                CLAY_TEXT(CLAY_STRING(", "), infoTextConfig);
+            }
+        }
+        if (sizing.size.minMax.max != CLAY__MAXFLOAT) {
+            CLAY_TEXT(CLAY_STRING("max: "), infoTextConfig);
+            CLAY_TEXT(Clay__IntToString(sizing.size.minMax.max), infoTextConfig);
+        }
+        CLAY_TEXT(CLAY_STRING(")"), infoTextConfig);
+    } else if (sizing.type == CLAY__SIZING_TYPE_PERCENT) {
+        CLAY_TEXT(CLAY_STRING("("), infoTextConfig);
+        CLAY_TEXT(Clay__IntToString(sizing.size.percent * 100), infoTextConfig);
+        CLAY_TEXT(CLAY_STRING("%)"), infoTextConfig);
+    }
+}
+
+void Clay__RenderDebugViewElementConfigHeader(Clay_String elementId, Clay__ElementConfigType type) {
+    Clay__DebugElementConfigTypeLabelConfig config = Clay__DebugGetElementConfigTypeLabel(type);
+    Clay_Color backgroundColor = config.color;
+    backgroundColor.a = 90;
+    CLAY({ .layout = { .sizing = { .width = CLAY_SIZING_GROW(0) }, .padding = CLAY_PADDING_ALL(CLAY__DEBUGVIEW_OUTER_PADDING), .childAlignment = { .y = CLAY_ALIGN_Y_CENTER } } }) {
+        CLAY({ .layout = { .padding = { 8, 8, 2, 2 } }, .backgroundColor = backgroundColor, .cornerRadius = CLAY_CORNER_RADIUS(4), .border = { .color = config.color, .width = { 1, 1, 1, 1, 0 } } }) {
+            CLAY_TEXT(config.label, CLAY_TEXT_CONFIG({ .textColor = CLAY__DEBUGVIEW_COLOR_4, .fontSize = 16 }));
+        }
+        CLAY({ .layout = { .sizing = { .width = CLAY_SIZING_GROW(0) } } }) {}
+        CLAY_TEXT(elementId, CLAY_TEXT_CONFIG({ .textColor = CLAY__DEBUGVIEW_COLOR_3, .fontSize = 16, .wrapMode = CLAY_TEXT_WRAP_NONE }));
+    }
+}
+
+void Clay__RenderDebugViewColor(Clay_Color color, Clay_TextElementConfig *textConfig) {
+    CLAY({ .layout = { .childAlignment = {.y = CLAY_ALIGN_Y_CENTER} } }) {
+        CLAY_TEXT(CLAY_STRING("{ r: "), textConfig);
+        CLAY_TEXT(Clay__IntToString(color.r), textConfig);
+        CLAY_TEXT(CLAY_STRING(", g: "), textConfig);
+        CLAY_TEXT(Clay__IntToString(color.g), textConfig);
+        CLAY_TEXT(CLAY_STRING(", b: "), textConfig);
+        CLAY_TEXT(Clay__IntToString(color.b), textConfig);
+        CLAY_TEXT(CLAY_STRING(", a: "), textConfig);
+        CLAY_TEXT(Clay__IntToString(color.a), textConfig);
+        CLAY_TEXT(CLAY_STRING(" }"), textConfig);
+        CLAY({ .layout = { .sizing = { .width = CLAY_SIZING_FIXED(10) } } }) {}
+        CLAY({ .layout = { .sizing = { CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT - 8), CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT - 8)} }, .backgroundColor = color, .cornerRadius = CLAY_CORNER_RADIUS(4), .border = { .color = CLAY__DEBUGVIEW_COLOR_4, .width = { 1, 1, 1, 1, 0 } } }) {}
+    }
+}
+
+void Clay__RenderDebugViewCornerRadius(Clay_CornerRadius cornerRadius, Clay_TextElementConfig *textConfig) {
+    CLAY({ .layout = { .childAlignment = {.y = CLAY_ALIGN_Y_CENTER} } }) {
+        CLAY_TEXT(CLAY_STRING("{ topLeft: "), textConfig);
+        CLAY_TEXT(Clay__IntToString(cornerRadius.topLeft), textConfig);
+        CLAY_TEXT(CLAY_STRING(", topRight: "), textConfig);
+        CLAY_TEXT(Clay__IntToString(cornerRadius.topRight), textConfig);
+        CLAY_TEXT(CLAY_STRING(", bottomLeft: "), textConfig);
+        CLAY_TEXT(Clay__IntToString(cornerRadius.bottomLeft), textConfig);
+        CLAY_TEXT(CLAY_STRING(", bottomRight: "), textConfig);
+        CLAY_TEXT(Clay__IntToString(cornerRadius.bottomRight), textConfig);
+        CLAY_TEXT(CLAY_STRING(" }"), textConfig);
+    }
+}
+
+void HandleDebugViewCloseButtonInteraction(Clay_ElementId elementId, Clay_PointerData pointerInfo, intptr_t userData) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    (void) elementId; (void) pointerInfo; (void) userData;
+    if (pointerInfo.state == CLAY_POINTER_DATA_PRESSED_THIS_FRAME) {
+        context->debugModeEnabled = false;
+    }
+}
+
+void Clay__RenderDebugView(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    Clay_ElementId closeButtonId = Clay__HashString(CLAY_STRING("Clay__DebugViewTopHeaderCloseButtonOuter"), 0, 0);
+    if (context->pointerInfo.state == CLAY_POINTER_DATA_PRESSED_THIS_FRAME) {
+        for (int32_t i = 0; i < context->pointerOverIds.length; ++i) {
+            Clay_ElementId *elementId = Clay_ElementIdArray_Get(&context->pointerOverIds, i);
+            if (elementId->id == closeButtonId.id) {
+                context->debugModeEnabled = false;
+                return;
+            }
+        }
+    }
+
+    uint32_t initialRootsLength = context->layoutElementTreeRoots.length;
+    uint32_t initialElementsLength = context->layoutElements.length;
+    Clay_TextElementConfig *infoTextConfig = CLAY_TEXT_CONFIG({ .textColor = CLAY__DEBUGVIEW_COLOR_4, .fontSize = 16, .wrapMode = CLAY_TEXT_WRAP_NONE });
+    Clay_TextElementConfig *infoTitleConfig = CLAY_TEXT_CONFIG({ .textColor = CLAY__DEBUGVIEW_COLOR_3, .fontSize = 16, .wrapMode = CLAY_TEXT_WRAP_NONE });
+    Clay_ElementId scrollId = Clay__HashString(CLAY_STRING("Clay__DebugViewOuterScrollPane"), 0, 0);
+    float scrollYOffset = 0;
+    bool pointerInDebugView = context->pointerInfo.position.y < context->layoutDimensions.height - 300;
+    for (int32_t i = 0; i < context->scrollContainerDatas.length; ++i) {
+        Clay__ScrollContainerDataInternal *scrollContainerData = Clay__ScrollContainerDataInternalArray_Get(&context->scrollContainerDatas, i);
+        if (scrollContainerData->elementId == scrollId.id) {
+            if (!context->externalScrollHandlingEnabled) {
+                scrollYOffset = scrollContainerData->scrollPosition.y;
+            } else {
+                pointerInDebugView = context->pointerInfo.position.y + scrollContainerData->scrollPosition.y < context->layoutDimensions.height - 300;
+            }
+            break;
+        }
+    }
+    int32_t highlightedRow = pointerInDebugView
+            ? (int32_t)((context->pointerInfo.position.y - scrollYOffset) / (float)CLAY__DEBUGVIEW_ROW_HEIGHT) - 1
+            : -1;
+    if (context->pointerInfo.position.x < context->layoutDimensions.width - (float)Clay__debugViewWidth) {
+        highlightedRow = -1;
+    }
+    Clay__RenderDebugLayoutData layoutData = CLAY__DEFAULT_STRUCT;
+    CLAY({ .id = CLAY_ID("Clay__DebugView"),
+         .layout = { .sizing = { CLAY_SIZING_FIXED((float)Clay__debugViewWidth) , CLAY_SIZING_FIXED(context->layoutDimensions.height) }, .layoutDirection = CLAY_TOP_TO_BOTTOM },
+        .floating = { .zIndex = 32765, .attachPoints = { .element = CLAY_ATTACH_POINT_LEFT_CENTER, .parent = CLAY_ATTACH_POINT_RIGHT_CENTER }, .attachTo = CLAY_ATTACH_TO_ROOT, .clipTo = CLAY_CLIP_TO_ATTACHED_PARENT },
+        .border = { .color = CLAY__DEBUGVIEW_COLOR_3, .width = { .bottom = 1 } }
+    }) {
+        CLAY({ .layout = { .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT)}, .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, CLAY__DEBUGVIEW_OUTER_PADDING, 0, 0 }, .childAlignment = {.y = CLAY_ALIGN_Y_CENTER} }, .backgroundColor = CLAY__DEBUGVIEW_COLOR_2 }) {
+            CLAY_TEXT(CLAY_STRING("Clay Debug Tools"), infoTextConfig);
+            CLAY({ .layout = { .sizing = { .width = CLAY_SIZING_GROW(0) } } }) {}
+            // Close button
+            CLAY({
+                .layout = { .sizing = {CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT - 10), CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT - 10)}, .childAlignment = {CLAY_ALIGN_X_CENTER, CLAY_ALIGN_Y_CENTER} },
+                .backgroundColor = {217,91,67,80},
+                .cornerRadius = CLAY_CORNER_RADIUS(4),
+                .border = { .color = { 217,91,67,255 }, .width = { 1, 1, 1, 1, 0 } },
+            }) {
+                Clay_OnHover(HandleDebugViewCloseButtonInteraction, 0);
+                CLAY_TEXT(CLAY_STRING("x"), CLAY_TEXT_CONFIG({ .textColor = CLAY__DEBUGVIEW_COLOR_4, .fontSize = 16 }));
+            }
+        }
+        CLAY({ .layout = { .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_FIXED(1)} }, .backgroundColor = CLAY__DEBUGVIEW_COLOR_3 } ) {}
+        CLAY({ .id = scrollId, .layout = { .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)} }, .clip = { .horizontal = true, .vertical = true, .childOffset = Clay_GetScrollOffset() } }) {
+            CLAY({ .layout = { .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)}, .layoutDirection = CLAY_TOP_TO_BOTTOM }, .backgroundColor = ((initialElementsLength + initialRootsLength) & 1) == 0 ? CLAY__DEBUGVIEW_COLOR_2 : CLAY__DEBUGVIEW_COLOR_1 }) {
+                Clay_ElementId panelContentsId = Clay__HashString(CLAY_STRING("Clay__DebugViewPaneOuter"), 0, 0);
+                // Element list
+                CLAY({ .id = panelContentsId, .layout = { .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)} }, .floating = { .zIndex = 32766, .pointerCaptureMode = CLAY_POINTER_CAPTURE_MODE_PASSTHROUGH, .attachTo = CLAY_ATTACH_TO_PARENT, .clipTo = CLAY_CLIP_TO_ATTACHED_PARENT } }) {
+                    CLAY({ .layout = { .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)}, .padding = { CLAY__DEBUGVIEW_OUTER_PADDING, CLAY__DEBUGVIEW_OUTER_PADDING, 0, 0 }, .layoutDirection = CLAY_TOP_TO_BOTTOM } }) {
+                        layoutData = Clay__RenderDebugLayoutElementsList((int32_t)initialRootsLength, highlightedRow);
+                    }
+                }
+                float contentWidth = Clay__GetHashMapItem(panelContentsId.id)->layoutElement->dimensions.width;
+                CLAY({ .layout = { .sizing = {.width = CLAY_SIZING_FIXED(contentWidth) }, .layoutDirection = CLAY_TOP_TO_BOTTOM } }) {}
+                for (int32_t i = 0; i < layoutData.rowCount; i++) {
+                    Clay_Color rowColor = (i & 1) == 0 ? CLAY__DEBUGVIEW_COLOR_2 : CLAY__DEBUGVIEW_COLOR_1;
+                    if (i == layoutData.selectedElementRowIndex) {
+                        rowColor = CLAY__DEBUGVIEW_COLOR_SELECTED_ROW;
+                    }
+                    if (i == highlightedRow) {
+                        rowColor.r *= 1.25f;
+                        rowColor.g *= 1.25f;
+                        rowColor.b *= 1.25f;
+                    }
+                    CLAY({ .layout = { .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT)}, .layoutDirection = CLAY_TOP_TO_BOTTOM }, .backgroundColor = rowColor } ) {}
+                }
+            }
+        }
+        CLAY({ .layout = { .sizing = {.width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_FIXED(1)} }, .backgroundColor = CLAY__DEBUGVIEW_COLOR_3 }) {}
+        if (context->debugSelectedElementId != 0) {
+            Clay_LayoutElementHashMapItem *selectedItem = Clay__GetHashMapItem(context->debugSelectedElementId);
+            CLAY({
+                .layout = { .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_FIXED(300)}, .layoutDirection = CLAY_TOP_TO_BOTTOM },
+                .backgroundColor = CLAY__DEBUGVIEW_COLOR_2 ,
+                .clip = { .vertical = true, .childOffset = Clay_GetScrollOffset() },
+                .border = { .color = CLAY__DEBUGVIEW_COLOR_3, .width = { .betweenChildren = 1 } }
+            }) {
+                CLAY({ .layout = { .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT + 8)}, .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, CLAY__DEBUGVIEW_OUTER_PADDING, 0, 0 }, .childAlignment = {.y = CLAY_ALIGN_Y_CENTER} } }) {
+                    CLAY_TEXT(CLAY_STRING("Layout Config"), infoTextConfig);
+                    CLAY({ .layout = { .sizing = { .width = CLAY_SIZING_GROW(0) } } }) {}
+                    if (selectedItem->elementId.stringId.length != 0) {
+                        CLAY_TEXT(selectedItem->elementId.stringId, infoTitleConfig);
+                        if (selectedItem->elementId.offset != 0) {
+                            CLAY_TEXT(CLAY_STRING(" ("), infoTitleConfig);
+                            CLAY_TEXT(Clay__IntToString(selectedItem->elementId.offset), infoTitleConfig);
+                            CLAY_TEXT(CLAY_STRING(")"), infoTitleConfig);
+                        }
+                    }
+                }
+                Clay_Padding attributeConfigPadding = {CLAY__DEBUGVIEW_OUTER_PADDING, CLAY__DEBUGVIEW_OUTER_PADDING, 8, 8};
+                // Clay_LayoutConfig debug info
+                CLAY({ .layout = { .padding = attributeConfigPadding, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM } }) {
+                    // .boundingBox
+                    CLAY_TEXT(CLAY_STRING("Bounding Box"), infoTitleConfig);
+                    CLAY({ .layout = { .layoutDirection = CLAY_LEFT_TO_RIGHT } }) {
+                        CLAY_TEXT(CLAY_STRING("{ x: "), infoTextConfig);
+                        CLAY_TEXT(Clay__IntToString(selectedItem->boundingBox.x), infoTextConfig);
+                        CLAY_TEXT(CLAY_STRING(", y: "), infoTextConfig);
+                        CLAY_TEXT(Clay__IntToString(selectedItem->boundingBox.y), infoTextConfig);
+                        CLAY_TEXT(CLAY_STRING(", width: "), infoTextConfig);
+                        CLAY_TEXT(Clay__IntToString(selectedItem->boundingBox.width), infoTextConfig);
+                        CLAY_TEXT(CLAY_STRING(", height: "), infoTextConfig);
+                        CLAY_TEXT(Clay__IntToString(selectedItem->boundingBox.height), infoTextConfig);
+                        CLAY_TEXT(CLAY_STRING(" }"), infoTextConfig);
+                    }
+                    // .layoutDirection
+                    CLAY_TEXT(CLAY_STRING("Layout Direction"), infoTitleConfig);
+                    Clay_LayoutConfig *layoutConfig = selectedItem->layoutElement->layoutConfig;
+                    CLAY_TEXT(layoutConfig->layoutDirection == CLAY_TOP_TO_BOTTOM ? CLAY_STRING("TOP_TO_BOTTOM") : CLAY_STRING("LEFT_TO_RIGHT"), infoTextConfig);
+                    // .sizing
+                    CLAY_TEXT(CLAY_STRING("Sizing"), infoTitleConfig);
+                    CLAY({ .layout = { .layoutDirection = CLAY_LEFT_TO_RIGHT } }) {
+                        CLAY_TEXT(CLAY_STRING("width: "), infoTextConfig);
+                        Clay__RenderDebugLayoutSizing(layoutConfig->sizing.width, infoTextConfig);
+                    }
+                    CLAY({ .layout = { .layoutDirection = CLAY_LEFT_TO_RIGHT } }) {
+                        CLAY_TEXT(CLAY_STRING("height: "), infoTextConfig);
+                        Clay__RenderDebugLayoutSizing(layoutConfig->sizing.height, infoTextConfig);
+                    }
+                    // .padding
+                    CLAY_TEXT(CLAY_STRING("Padding"), infoTitleConfig);
+                    CLAY({ .id = CLAY_ID("Clay__DebugViewElementInfoPadding") }) {
+                        CLAY_TEXT(CLAY_STRING("{ left: "), infoTextConfig);
+                        CLAY_TEXT(Clay__IntToString(layoutConfig->padding.left), infoTextConfig);
+                        CLAY_TEXT(CLAY_STRING(", right: "), infoTextConfig);
+                        CLAY_TEXT(Clay__IntToString(layoutConfig->padding.right), infoTextConfig);
+                        CLAY_TEXT(CLAY_STRING(", top: "), infoTextConfig);
+                        CLAY_TEXT(Clay__IntToString(layoutConfig->padding.top), infoTextConfig);
+                        CLAY_TEXT(CLAY_STRING(", bottom: "), infoTextConfig);
+                        CLAY_TEXT(Clay__IntToString(layoutConfig->padding.bottom), infoTextConfig);
+                        CLAY_TEXT(CLAY_STRING(" }"), infoTextConfig);
+                    }
+                    // .childGap
+                    CLAY_TEXT(CLAY_STRING("Child Gap"), infoTitleConfig);
+                    CLAY_TEXT(Clay__IntToString(layoutConfig->childGap), infoTextConfig);
+                    // .childAlignment
+                    CLAY_TEXT(CLAY_STRING("Child Alignment"), infoTitleConfig);
+                    CLAY({ .layout = { .layoutDirection = CLAY_LEFT_TO_RIGHT } }) {
+                        CLAY_TEXT(CLAY_STRING("{ x: "), infoTextConfig);
+                        Clay_String alignX = CLAY_STRING("LEFT");
+                        if (layoutConfig->childAlignment.x == CLAY_ALIGN_X_CENTER) {
+                            alignX = CLAY_STRING("CENTER");
+                        } else if (layoutConfig->childAlignment.x == CLAY_ALIGN_X_RIGHT) {
+                            alignX = CLAY_STRING("RIGHT");
+                        }
+                        CLAY_TEXT(alignX, infoTextConfig);
+                        CLAY_TEXT(CLAY_STRING(", y: "), infoTextConfig);
+                        Clay_String alignY = CLAY_STRING("TOP");
+                        if (layoutConfig->childAlignment.y == CLAY_ALIGN_Y_CENTER) {
+                            alignY = CLAY_STRING("CENTER");
+                        } else if (layoutConfig->childAlignment.y == CLAY_ALIGN_Y_BOTTOM) {
+                            alignY = CLAY_STRING("BOTTOM");
+                        }
+                        CLAY_TEXT(alignY, infoTextConfig);
+                        CLAY_TEXT(CLAY_STRING(" }"), infoTextConfig);
+                    }
+                }
+                for (int32_t elementConfigIndex = 0; elementConfigIndex < selectedItem->layoutElement->elementConfigs.length; ++elementConfigIndex) {
+                    Clay_ElementConfig *elementConfig = Clay__ElementConfigArraySlice_Get(&selectedItem->layoutElement->elementConfigs, elementConfigIndex);
+                    Clay__RenderDebugViewElementConfigHeader(selectedItem->elementId.stringId, elementConfig->type);
+                    switch (elementConfig->type) {
+                        case CLAY__ELEMENT_CONFIG_TYPE_SHARED: {
+                            Clay_SharedElementConfig *sharedConfig = elementConfig->config.sharedElementConfig;
+                            CLAY({ .layout = { .padding = attributeConfigPadding, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM }}) {
+                                // .backgroundColor
+                                CLAY_TEXT(CLAY_STRING("Background Color"), infoTitleConfig);
+                                Clay__RenderDebugViewColor(sharedConfig->backgroundColor, infoTextConfig);
+                                // .cornerRadius
+                                CLAY_TEXT(CLAY_STRING("Corner Radius"), infoTitleConfig);
+                                Clay__RenderDebugViewCornerRadius(sharedConfig->cornerRadius, infoTextConfig);
+                            }
+                            break;
+                        }
+                        case CLAY__ELEMENT_CONFIG_TYPE_TEXT: {
+                            Clay_TextElementConfig *textConfig = elementConfig->config.textElementConfig;
+                            CLAY({ .layout = { .padding = attributeConfigPadding, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM } }) {
+                                // .fontSize
+                                CLAY_TEXT(CLAY_STRING("Font Size"), infoTitleConfig);
+                                CLAY_TEXT(Clay__IntToString(textConfig->fontSize), infoTextConfig);
+                                // .fontId
+                                CLAY_TEXT(CLAY_STRING("Font ID"), infoTitleConfig);
+                                CLAY_TEXT(Clay__IntToString(textConfig->fontId), infoTextConfig);
+                                // .lineHeight
+                                CLAY_TEXT(CLAY_STRING("Line Height"), infoTitleConfig);
+                                CLAY_TEXT(textConfig->lineHeight == 0 ? CLAY_STRING("auto") : Clay__IntToString(textConfig->lineHeight), infoTextConfig);
+                                // .letterSpacing
+                                CLAY_TEXT(CLAY_STRING("Letter Spacing"), infoTitleConfig);
+                                CLAY_TEXT(Clay__IntToString(textConfig->letterSpacing), infoTextConfig);
+                                // .wrapMode
+                                CLAY_TEXT(CLAY_STRING("Wrap Mode"), infoTitleConfig);
+                                Clay_String wrapMode = CLAY_STRING("WORDS");
+                                if (textConfig->wrapMode == CLAY_TEXT_WRAP_NONE) {
+                                    wrapMode = CLAY_STRING("NONE");
+                                } else if (textConfig->wrapMode == CLAY_TEXT_WRAP_NEWLINES) {
+                                    wrapMode = CLAY_STRING("NEWLINES");
+                                }
+                                CLAY_TEXT(wrapMode, infoTextConfig);
+                                // .textAlignment
+                                CLAY_TEXT(CLAY_STRING("Text Alignment"), infoTitleConfig);
+                                Clay_String textAlignment = CLAY_STRING("LEFT");
+                                if (textConfig->textAlignment == CLAY_TEXT_ALIGN_CENTER) {
+                                    textAlignment = CLAY_STRING("CENTER");
+                                } else if (textConfig->textAlignment == CLAY_TEXT_ALIGN_RIGHT) {
+                                    textAlignment = CLAY_STRING("RIGHT");
+                                }
+                                CLAY_TEXT(textAlignment, infoTextConfig);
+                                // .textColor
+                                CLAY_TEXT(CLAY_STRING("Text Color"), infoTitleConfig);
+                                Clay__RenderDebugViewColor(textConfig->textColor, infoTextConfig);
+                            }
+                            break;
+                        }
+                        case CLAY__ELEMENT_CONFIG_TYPE_ASPECT: {
+                            Clay_AspectRatioElementConfig *aspectRatioConfig = elementConfig->config.aspectRatioElementConfig;
+                            CLAY({ .id = CLAY_ID("Clay__DebugViewElementInfoAspectRatioBody"), .layout = { .padding = attributeConfigPadding, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM } }) {
+                                CLAY_TEXT(CLAY_STRING("Aspect Ratio"), infoTitleConfig);
+                                // Aspect Ratio
+                                CLAY_TEXT(Clay__IntToString(aspectRatioConfig->aspectRatio), infoTextConfig);
+                            }
+                            break;
+                        }
+                        case CLAY__ELEMENT_CONFIG_TYPE_IMAGE: {
+                            Clay_ImageElementConfig *imageConfig = elementConfig->config.imageElementConfig;
+                            Clay_AspectRatioElementConfig aspectConfig = { 1 };
+                            if (Clay__ElementHasConfig(selectedItem->layoutElement, CLAY__ELEMENT_CONFIG_TYPE_ASPECT)) {
+                                aspectConfig = *Clay__FindElementConfigWithType(selectedItem->layoutElement, CLAY__ELEMENT_CONFIG_TYPE_ASPECT).aspectRatioElementConfig;
+                            }
+                            CLAY({ .id = CLAY_ID("Clay__DebugViewElementInfoImageBody"), .layout = { .padding = attributeConfigPadding, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM } }) {
+                                // Image Preview
+                                CLAY_TEXT(CLAY_STRING("Preview"), infoTitleConfig);
+                                CLAY({ .layout = { .sizing = { .width = CLAY_SIZING_GROW(64, 128), .height = CLAY_SIZING_GROW(64, 128) }}, .aspectRatio = aspectConfig, .image = *imageConfig }) {}
+                            }
+                            break;
+                        }
+                        case CLAY__ELEMENT_CONFIG_TYPE_CLIP: {
+                            Clay_ClipElementConfig *clipConfig = elementConfig->config.clipElementConfig;
+                            CLAY({ .layout = { .padding = attributeConfigPadding, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM } }) {
+                                // .vertical
+                                CLAY_TEXT(CLAY_STRING("Vertical"), infoTitleConfig);
+                                CLAY_TEXT(clipConfig->vertical ? CLAY_STRING("true") : CLAY_STRING("false") , infoTextConfig);
+                                // .horizontal
+                                CLAY_TEXT(CLAY_STRING("Horizontal"), infoTitleConfig);
+                                CLAY_TEXT(clipConfig->horizontal ? CLAY_STRING("true") : CLAY_STRING("false") , infoTextConfig);
+                            }
+                            break;
+                        }
+                        case CLAY__ELEMENT_CONFIG_TYPE_FLOATING: {
+                            Clay_FloatingElementConfig *floatingConfig = elementConfig->config.floatingElementConfig;
+                            CLAY({ .layout = { .padding = attributeConfigPadding, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM } }) {
+                                // .offset
+                                CLAY_TEXT(CLAY_STRING("Offset"), infoTitleConfig);
+                                CLAY({ .layout = { .layoutDirection = CLAY_LEFT_TO_RIGHT } }) {
+                                    CLAY_TEXT(CLAY_STRING("{ x: "), infoTextConfig);
+                                    CLAY_TEXT(Clay__IntToString(floatingConfig->offset.x), infoTextConfig);
+                                    CLAY_TEXT(CLAY_STRING(", y: "), infoTextConfig);
+                                    CLAY_TEXT(Clay__IntToString(floatingConfig->offset.y), infoTextConfig);
+                                    CLAY_TEXT(CLAY_STRING(" }"), infoTextConfig);
+                                }
+                                // .expand
+                                CLAY_TEXT(CLAY_STRING("Expand"), infoTitleConfig);
+                                CLAY({ .layout = { .layoutDirection = CLAY_LEFT_TO_RIGHT } }) {
+                                    CLAY_TEXT(CLAY_STRING("{ width: "), infoTextConfig);
+                                    CLAY_TEXT(Clay__IntToString(floatingConfig->expand.width), infoTextConfig);
+                                    CLAY_TEXT(CLAY_STRING(", height: "), infoTextConfig);
+                                    CLAY_TEXT(Clay__IntToString(floatingConfig->expand.height), infoTextConfig);
+                                    CLAY_TEXT(CLAY_STRING(" }"), infoTextConfig);
+                                }
+                                // .zIndex
+                                CLAY_TEXT(CLAY_STRING("z-index"), infoTitleConfig);
+                                CLAY_TEXT(Clay__IntToString(floatingConfig->zIndex), infoTextConfig);
+                                // .parentId
+                                CLAY_TEXT(CLAY_STRING("Parent"), infoTitleConfig);
+                                Clay_LayoutElementHashMapItem *hashItem = Clay__GetHashMapItem(floatingConfig->parentId);
+                                CLAY_TEXT(hashItem->elementId.stringId, infoTextConfig);
+                                // .attachPoints
+                                CLAY_TEXT(CLAY_STRING("Attach Points"), infoTitleConfig);
+                                CLAY({ .layout = { .layoutDirection = CLAY_LEFT_TO_RIGHT } }) {
+                                    CLAY_TEXT(CLAY_STRING("{ element: "), infoTextConfig);
+                                    Clay_String attachPointElement = CLAY_STRING("LEFT_TOP");
+                                    if (floatingConfig->attachPoints.element == CLAY_ATTACH_POINT_LEFT_CENTER) {
+                                        attachPointElement = CLAY_STRING("LEFT_CENTER");
+                                    } else if (floatingConfig->attachPoints.element == CLAY_ATTACH_POINT_LEFT_BOTTOM) {
+                                        attachPointElement = CLAY_STRING("LEFT_BOTTOM");
+                                    } else if (floatingConfig->attachPoints.element == CLAY_ATTACH_POINT_CENTER_TOP) {
+                                        attachPointElement = CLAY_STRING("CENTER_TOP");
+                                    } else if (floatingConfig->attachPoints.element == CLAY_ATTACH_POINT_CENTER_CENTER) {
+                                        attachPointElement = CLAY_STRING("CENTER_CENTER");
+                                    } else if (floatingConfig->attachPoints.element == CLAY_ATTACH_POINT_CENTER_BOTTOM) {
+                                        attachPointElement = CLAY_STRING("CENTER_BOTTOM");
+                                    } else if (floatingConfig->attachPoints.element == CLAY_ATTACH_POINT_RIGHT_TOP) {
+                                        attachPointElement = CLAY_STRING("RIGHT_TOP");
+                                    } else if (floatingConfig->attachPoints.element == CLAY_ATTACH_POINT_RIGHT_CENTER) {
+                                        attachPointElement = CLAY_STRING("RIGHT_CENTER");
+                                    } else if (floatingConfig->attachPoints.element == CLAY_ATTACH_POINT_RIGHT_BOTTOM) {
+                                        attachPointElement = CLAY_STRING("RIGHT_BOTTOM");
+                                    }
+                                    CLAY_TEXT(attachPointElement, infoTextConfig);
+                                    Clay_String attachPointParent = CLAY_STRING("LEFT_TOP");
+                                    if (floatingConfig->attachPoints.parent == CLAY_ATTACH_POINT_LEFT_CENTER) {
+                                        attachPointParent = CLAY_STRING("LEFT_CENTER");
+                                    } else if (floatingConfig->attachPoints.parent == CLAY_ATTACH_POINT_LEFT_BOTTOM) {
+                                        attachPointParent = CLAY_STRING("LEFT_BOTTOM");
+                                    } else if (floatingConfig->attachPoints.parent == CLAY_ATTACH_POINT_CENTER_TOP) {
+                                        attachPointParent = CLAY_STRING("CENTER_TOP");
+                                    } else if (floatingConfig->attachPoints.parent == CLAY_ATTACH_POINT_CENTER_CENTER) {
+                                        attachPointParent = CLAY_STRING("CENTER_CENTER");
+                                    } else if (floatingConfig->attachPoints.parent == CLAY_ATTACH_POINT_CENTER_BOTTOM) {
+                                        attachPointParent = CLAY_STRING("CENTER_BOTTOM");
+                                    } else if (floatingConfig->attachPoints.parent == CLAY_ATTACH_POINT_RIGHT_TOP) {
+                                        attachPointParent = CLAY_STRING("RIGHT_TOP");
+                                    } else if (floatingConfig->attachPoints.parent == CLAY_ATTACH_POINT_RIGHT_CENTER) {
+                                        attachPointParent = CLAY_STRING("RIGHT_CENTER");
+                                    } else if (floatingConfig->attachPoints.parent == CLAY_ATTACH_POINT_RIGHT_BOTTOM) {
+                                        attachPointParent = CLAY_STRING("RIGHT_BOTTOM");
+                                    }
+                                    CLAY_TEXT(CLAY_STRING(", parent: "), infoTextConfig);
+                                    CLAY_TEXT(attachPointParent, infoTextConfig);
+                                    CLAY_TEXT(CLAY_STRING(" }"), infoTextConfig);
+                                }
+                                // .pointerCaptureMode
+                                CLAY_TEXT(CLAY_STRING("Pointer Capture Mode"), infoTitleConfig);
+                                Clay_String pointerCaptureMode = CLAY_STRING("NONE");
+                                if (floatingConfig->pointerCaptureMode == CLAY_POINTER_CAPTURE_MODE_PASSTHROUGH) {
+                                    pointerCaptureMode = CLAY_STRING("PASSTHROUGH");
+                                }
+                                CLAY_TEXT(pointerCaptureMode, infoTextConfig);
+                                // .attachTo
+                                CLAY_TEXT(CLAY_STRING("Attach To"), infoTitleConfig);
+                                Clay_String attachTo = CLAY_STRING("NONE");
+                                if (floatingConfig->attachTo == CLAY_ATTACH_TO_PARENT) {
+                                    attachTo = CLAY_STRING("PARENT");
+                                } else if (floatingConfig->attachTo == CLAY_ATTACH_TO_ELEMENT_WITH_ID) {
+                                    attachTo = CLAY_STRING("ELEMENT_WITH_ID");
+                                } else if (floatingConfig->attachTo == CLAY_ATTACH_TO_ROOT) {
+                                    attachTo = CLAY_STRING("ROOT");
+                                }
+                                CLAY_TEXT(attachTo, infoTextConfig);
+                                // .clipTo
+                                CLAY_TEXT(CLAY_STRING("Clip To"), infoTitleConfig);
+                                Clay_String clipTo = CLAY_STRING("ATTACHED_PARENT");
+                                if (floatingConfig->clipTo == CLAY_CLIP_TO_NONE) {
+                                    clipTo = CLAY_STRING("NONE");
+                                }
+                                CLAY_TEXT(clipTo, infoTextConfig);
+                            }
+                            break;
+                        }
+                        case CLAY__ELEMENT_CONFIG_TYPE_BORDER: {
+                            Clay_BorderElementConfig *borderConfig = elementConfig->config.borderElementConfig;
+                            CLAY({ .id = CLAY_ID("Clay__DebugViewElementInfoBorderBody"), .layout = { .padding = attributeConfigPadding, .childGap = 8, .layoutDirection = CLAY_TOP_TO_BOTTOM } }) {
+                                CLAY_TEXT(CLAY_STRING("Border Widths"), infoTitleConfig);
+                                CLAY({ .layout = { .layoutDirection = CLAY_LEFT_TO_RIGHT } }) {
+                                    CLAY_TEXT(CLAY_STRING("{ left: "), infoTextConfig);
+                                    CLAY_TEXT(Clay__IntToString(borderConfig->width.left), infoTextConfig);
+                                    CLAY_TEXT(CLAY_STRING(", right: "), infoTextConfig);
+                                    CLAY_TEXT(Clay__IntToString(borderConfig->width.right), infoTextConfig);
+                                    CLAY_TEXT(CLAY_STRING(", top: "), infoTextConfig);
+                                    CLAY_TEXT(Clay__IntToString(borderConfig->width.top), infoTextConfig);
+                                    CLAY_TEXT(CLAY_STRING(", bottom: "), infoTextConfig);
+                                    CLAY_TEXT(Clay__IntToString(borderConfig->width.bottom), infoTextConfig);
+                                    CLAY_TEXT(CLAY_STRING(" }"), infoTextConfig);
+                                }
+                                // .textColor
+                                CLAY_TEXT(CLAY_STRING("Border Color"), infoTitleConfig);
+                                Clay__RenderDebugViewColor(borderConfig->color, infoTextConfig);
+                            }
+                            break;
+                        }
+                        case CLAY__ELEMENT_CONFIG_TYPE_CUSTOM:
+                        default: break;
+                    }
+                }
+            }
+        } else {
+            CLAY({ .id = CLAY_ID("Clay__DebugViewWarningsScrollPane"), .layout = { .sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_FIXED(300)}, .childGap = 6, .layoutDirection = CLAY_TOP_TO_BOTTOM }, .backgroundColor = CLAY__DEBUGVIEW_COLOR_2, .clip = { .horizontal = true, .vertical = true, .childOffset = Clay_GetScrollOffset() } }) {
+                Clay_TextElementConfig *warningConfig = CLAY_TEXT_CONFIG({ .textColor = CLAY__DEBUGVIEW_COLOR_4, .fontSize = 16, .wrapMode = CLAY_TEXT_WRAP_NONE });
+                CLAY({ .id = CLAY_ID("Clay__DebugViewWarningItemHeader"), .layout = { .sizing = {.height = CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT)}, .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, CLAY__DEBUGVIEW_OUTER_PADDING, 0, 0 }, .childGap = 8, .childAlignment = {.y = CLAY_ALIGN_Y_CENTER} } }) {
+                    CLAY_TEXT(CLAY_STRING("Warnings"), warningConfig);
+                }
+                CLAY({ .id = CLAY_ID("Clay__DebugViewWarningsTopBorder"), .layout = { .sizing = { .width = CLAY_SIZING_GROW(0), .height = CLAY_SIZING_FIXED(1)} }, .backgroundColor = {200, 200, 200, 255} }) {}
+                int32_t previousWarningsLength = context->warnings.length;
+                for (int32_t i = 0; i < previousWarningsLength; i++) {
+                    Clay__Warning warning = context->warnings.internalArray[i];
+                    CLAY({ .id = CLAY_IDI("Clay__DebugViewWarningItem", i), .layout = { .sizing = {.height = CLAY_SIZING_FIXED(CLAY__DEBUGVIEW_ROW_HEIGHT)}, .padding = {CLAY__DEBUGVIEW_OUTER_PADDING, CLAY__DEBUGVIEW_OUTER_PADDING, 0, 0 }, .childGap = 8, .childAlignment = {.y = CLAY_ALIGN_Y_CENTER} } }) {
+                        CLAY_TEXT(warning.baseMessage, warningConfig);
+                        if (warning.dynamicMessage.length > 0) {
+                            CLAY_TEXT(warning.dynamicMessage, warningConfig);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+#pragma endregion
+
+uint32_t Clay__debugViewWidth = 400;
+Clay_Color Clay__debugViewHighlightColor = { 168, 66, 28, 100 };
+
+Clay__WarningArray Clay__WarningArray_Allocate_Arena(int32_t capacity, Clay_Arena *arena) {
+    size_t totalSizeBytes = capacity * sizeof(Clay_String);
+    Clay__WarningArray array = {.capacity = capacity, .length = 0};
+    uintptr_t nextAllocOffset = arena->nextAllocation + (64 - (arena->nextAllocation % 64));
+    if (nextAllocOffset + totalSizeBytes <= arena->capacity) {
+        array.internalArray = (Clay__Warning*)((uintptr_t)arena->memory + (uintptr_t)nextAllocOffset);
+        arena->nextAllocation = nextAllocOffset + totalSizeBytes;
+    }
+    else {
+        Clay__currentContext->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
+            .errorType = CLAY_ERROR_TYPE_ARENA_CAPACITY_EXCEEDED,
+            .errorText = CLAY_STRING("Clay attempted to allocate memory in its arena, but ran out of capacity. Try increasing the capacity of the arena passed to Clay_Initialize()"),
+            .userData = Clay__currentContext->errorHandler.userData });
+    }
+    return array;
+}
+
+Clay__Warning *Clay__WarningArray_Add(Clay__WarningArray *array, Clay__Warning item)
+{
+    if (array->length < array->capacity) {
+        array->internalArray[array->length++] = item;
+        return &array->internalArray[array->length - 1];
+    }
+    return &CLAY__WARNING_DEFAULT;
+}
+
+void* Clay__Array_Allocate_Arena(int32_t capacity, uint32_t itemSize, Clay_Arena *arena)
+{
+    size_t totalSizeBytes = capacity * itemSize;
+    uintptr_t nextAllocOffset = arena->nextAllocation + (64 - (arena->nextAllocation % 64));
+    if (nextAllocOffset + totalSizeBytes <= arena->capacity) {
+        arena->nextAllocation = nextAllocOffset + totalSizeBytes;
+        return (void*)((uintptr_t)arena->memory + (uintptr_t)nextAllocOffset);
+    }
+    else {
+        Clay__currentContext->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
+                .errorType = CLAY_ERROR_TYPE_ARENA_CAPACITY_EXCEEDED,
+                .errorText = CLAY_STRING("Clay attempted to allocate memory in its arena, but ran out of capacity. Try increasing the capacity of the arena passed to Clay_Initialize()"),
+                .userData = Clay__currentContext->errorHandler.userData });
+    }
+    return CLAY__NULL;
+}
+
+bool Clay__Array_RangeCheck(int32_t index, int32_t length)
+{
+    if (index < length && index >= 0) {
+        return true;
+    }
+    Clay_Context* context = Clay_GetCurrentContext();
+    context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
+            .errorType = CLAY_ERROR_TYPE_INTERNAL_ERROR,
+            .errorText = CLAY_STRING("Clay attempted to make an out of bounds array access. This is an internal error and is likely a bug."),
+            .userData = context->errorHandler.userData });
+    return false;
+}
+
+bool Clay__Array_AddCapacityCheck(int32_t length, int32_t capacity)
+{
+    if (length < capacity) {
+        return true;
+    }
+    Clay_Context* context = Clay_GetCurrentContext();
+    context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
+        .errorType = CLAY_ERROR_TYPE_INTERNAL_ERROR,
+        .errorText = CLAY_STRING("Clay attempted to make an out of bounds array access. This is an internal error and is likely a bug."),
+        .userData = context->errorHandler.userData });
+    return false;
+}
+
+// PUBLIC API FROM HERE ---------------------------------------
+
+CLAY_WASM_EXPORT("Clay_MinMemorySize")
+uint32_t Clay_MinMemorySize(void) {
+    Clay_Context fakeContext = {
+        .maxElementCount = Clay__defaultMaxElementCount,
+        .maxMeasureTextCacheWordCount = Clay__defaultMaxMeasureTextWordCacheCount,
+        .internalArena = {
+            .capacity = SIZE_MAX,
+            .memory = NULL,
+        }
+    };
+    Clay_Context* currentContext = Clay_GetCurrentContext();
+    if (currentContext) {
+        fakeContext.maxElementCount = currentContext->maxElementCount;
+        fakeContext.maxMeasureTextCacheWordCount = currentContext->maxMeasureTextCacheWordCount;
+    }
+    // Reserve space in the arena for the context, important for calculating min memory size correctly
+    Clay__Context_Allocate_Arena(&fakeContext.internalArena);
+    Clay__InitializePersistentMemory(&fakeContext);
+    Clay__InitializeEphemeralMemory(&fakeContext);
+    return (uint32_t)fakeContext.internalArena.nextAllocation + 128;
+}
+
+CLAY_WASM_EXPORT("Clay_CreateArenaWithCapacityAndMemory")
+Clay_Arena Clay_CreateArenaWithCapacityAndMemory(size_t capacity, void *memory) {
+    Clay_Arena arena = {
+        .capacity = capacity,
+        .memory = (char *)memory
+    };
+    return arena;
+}
+
+#ifndef CLAY_WASM
+void Clay_SetMeasureTextFunction(Clay_Dimensions (*measureTextFunction)(Clay_StringSlice text, Clay_TextElementConfig *config, void *userData), void *userData) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    Clay__MeasureText = measureTextFunction;
+    context->measureTextUserData = userData;
+}
+void Clay_SetQueryScrollOffsetFunction(Clay_Vector2 (*queryScrollOffsetFunction)(uint32_t elementId, void *userData), void *userData) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    Clay__QueryScrollOffset = queryScrollOffsetFunction;
+    context->queryScrollOffsetUserData = userData;
+}
+#endif
+
+CLAY_WASM_EXPORT("Clay_SetLayoutDimensions")
+void Clay_SetLayoutDimensions(Clay_Dimensions dimensions) {
+    Clay_GetCurrentContext()->layoutDimensions = dimensions;
+}
+
+CLAY_WASM_EXPORT("Clay_SetPointerState")
+void Clay_SetPointerState(Clay_Vector2 position, bool isPointerDown) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context->booleanWarnings.maxElementsExceeded) {
+        return;
+    }
+    context->pointerInfo.position = position;
+    context->pointerOverIds.length = 0;
+    Clay__int32_tArray dfsBuffer = context->layoutElementChildrenBuffer;
+    for (int32_t rootIndex = context->layoutElementTreeRoots.length - 1; rootIndex >= 0; --rootIndex) {
+        dfsBuffer.length = 0;
+        Clay__LayoutElementTreeRoot *root = Clay__LayoutElementTreeRootArray_Get(&context->layoutElementTreeRoots, rootIndex);
+        Clay__int32_tArray_Add(&dfsBuffer, (int32_t)root->layoutElementIndex);
+        context->treeNodeVisited.internalArray[0] = false;
+        bool found = false;
+        while (dfsBuffer.length > 0) {
+            if (context->treeNodeVisited.internalArray[dfsBuffer.length - 1]) {
+                dfsBuffer.length--;
+                continue;
+            }
+            context->treeNodeVisited.internalArray[dfsBuffer.length - 1] = true;
+            Clay_LayoutElement *currentElement = Clay_LayoutElementArray_Get(&context->layoutElements, Clay__int32_tArray_GetValue(&dfsBuffer, (int)dfsBuffer.length - 1));
+            Clay_LayoutElementHashMapItem *mapItem = Clay__GetHashMapItem(currentElement->id); // TODO think of a way around this, maybe the fact that it's essentially a binary tree limits the cost, but the worst case is not great
+            int32_t clipElementId = Clay__int32_tArray_GetValue(&context->layoutElementClipElementIds, (int32_t)(currentElement - context->layoutElements.internalArray));
+            Clay_LayoutElementHashMapItem *clipItem = Clay__GetHashMapItem(clipElementId);
+            if (mapItem) {
+                Clay_BoundingBox elementBox = mapItem->boundingBox;
+                elementBox.x -= root->pointerOffset.x;
+                elementBox.y -= root->pointerOffset.y;
+                if ((Clay__PointIsInsideRect(position, elementBox)) && (clipElementId == 0 || (Clay__PointIsInsideRect(position, clipItem->boundingBox)))) {
+                    if (mapItem->onHoverFunction) {
+                        mapItem->onHoverFunction(mapItem->elementId, context->pointerInfo, mapItem->hoverFunctionUserData);
+                    }
+                    Clay_ElementIdArray_Add(&context->pointerOverIds, mapItem->elementId);
+                    found = true;
+
+                    if (mapItem->idAlias != 0) {
+                        Clay_ElementIdArray_Add(&context->pointerOverIds, CLAY__INIT(Clay_ElementId) { .id = mapItem->idAlias });
+                    }
+                }
+                if (Clay__ElementHasConfig(currentElement, CLAY__ELEMENT_CONFIG_TYPE_TEXT)) {
+                    dfsBuffer.length--;
+                    continue;
+                }
+                for (int32_t i = currentElement->childrenOrTextContent.children.length - 1; i >= 0; --i) {
+                    Clay__int32_tArray_Add(&dfsBuffer, currentElement->childrenOrTextContent.children.elements[i]);
+                    context->treeNodeVisited.internalArray[dfsBuffer.length - 1] = false; // TODO needs to be ranged checked
+                }
+            } else {
+                dfsBuffer.length--;
+            }
+        }
+
+        Clay_LayoutElement *rootElement = Clay_LayoutElementArray_Get(&context->layoutElements, root->layoutElementIndex);
+        if (found && Clay__ElementHasConfig(rootElement, CLAY__ELEMENT_CONFIG_TYPE_FLOATING) &&
+                Clay__FindElementConfigWithType(rootElement, CLAY__ELEMENT_CONFIG_TYPE_FLOATING).floatingElementConfig->pointerCaptureMode == CLAY_POINTER_CAPTURE_MODE_CAPTURE) {
+            break;
+        }
+    }
+
+    if (isPointerDown) {
+        if (context->pointerInfo.state == CLAY_POINTER_DATA_PRESSED_THIS_FRAME) {
+            context->pointerInfo.state = CLAY_POINTER_DATA_PRESSED;
+        } else if (context->pointerInfo.state != CLAY_POINTER_DATA_PRESSED) {
+            context->pointerInfo.state = CLAY_POINTER_DATA_PRESSED_THIS_FRAME;
+        }
+    } else {
+        if (context->pointerInfo.state == CLAY_POINTER_DATA_RELEASED_THIS_FRAME) {
+            context->pointerInfo.state = CLAY_POINTER_DATA_RELEASED;
+        } else if (context->pointerInfo.state != CLAY_POINTER_DATA_RELEASED)  {
+            context->pointerInfo.state = CLAY_POINTER_DATA_RELEASED_THIS_FRAME;
+        }
+    }
+}
+
+CLAY_WASM_EXPORT("Clay_Initialize")
+Clay_Context* Clay_Initialize(Clay_Arena arena, Clay_Dimensions layoutDimensions, Clay_ErrorHandler errorHandler) {
+    Clay_Context *context = Clay__Context_Allocate_Arena(&arena);
+    if (context == NULL) return NULL;
+    // DEFAULTS
+    Clay_Context *oldContext = Clay_GetCurrentContext();
+    *context = CLAY__INIT(Clay_Context) {
+        .maxElementCount = oldContext ? oldContext->maxElementCount : Clay__defaultMaxElementCount,
+        .maxMeasureTextCacheWordCount = oldContext ? oldContext->maxMeasureTextCacheWordCount : Clay__defaultMaxMeasureTextWordCacheCount,
+        .errorHandler = errorHandler.errorHandlerFunction ? errorHandler : CLAY__INIT(Clay_ErrorHandler) { Clay__ErrorHandlerFunctionDefault, 0 },
+        .layoutDimensions = layoutDimensions,
+        .internalArena = arena,
+    };
+    Clay_SetCurrentContext(context);
+    Clay__InitializePersistentMemory(context);
+    Clay__InitializeEphemeralMemory(context);
+    for (int32_t i = 0; i < context->layoutElementsHashMap.capacity; ++i) {
+        context->layoutElementsHashMap.internalArray[i] = -1;
+    }
+    for (int32_t i = 0; i < context->measureTextHashMap.capacity; ++i) {
+        context->measureTextHashMap.internalArray[i] = 0;
+    }
+    context->measureTextHashMapInternal.length = 1; // Reserve the 0 value to mean "no next element"
+    context->layoutDimensions = layoutDimensions;
+    return context;
+}
+
+CLAY_WASM_EXPORT("Clay_GetCurrentContext")
+Clay_Context* Clay_GetCurrentContext(void) {
+    return Clay__currentContext;
+}
+
+CLAY_WASM_EXPORT("Clay_SetCurrentContext")
+void Clay_SetCurrentContext(Clay_Context* context) {
+    Clay__currentContext = context;
+}
+
+CLAY_WASM_EXPORT("Clay_GetScrollOffset")
+Clay_Vector2 Clay_GetScrollOffset(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context->booleanWarnings.maxElementsExceeded) {
+        return CLAY__INIT(Clay_Vector2) CLAY__DEFAULT_STRUCT;
+    }
+    Clay_LayoutElement *openLayoutElement = Clay__GetOpenLayoutElement();
+    // If the element has no id attached at this point, we need to generate one
+    if (openLayoutElement->id == 0) {
+        Clay__GenerateIdForAnonymousElement(openLayoutElement);
+    }
+    for (int32_t i = 0; i < context->scrollContainerDatas.length; i++) {
+        Clay__ScrollContainerDataInternal *mapping = Clay__ScrollContainerDataInternalArray_Get(&context->scrollContainerDatas, i);
+        if (mapping->layoutElement == openLayoutElement) {
+            return mapping->scrollPosition;
+        }
+    }
+    return CLAY__INIT(Clay_Vector2) CLAY__DEFAULT_STRUCT;
+}
+
+CLAY_WASM_EXPORT("Clay_UpdateScrollContainers")
+void Clay_UpdateScrollContainers(bool enableDragScrolling, Clay_Vector2 scrollDelta, float deltaTime) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    bool isPointerActive = enableDragScrolling && (context->pointerInfo.state == CLAY_POINTER_DATA_PRESSED || context->pointerInfo.state == CLAY_POINTER_DATA_PRESSED_THIS_FRAME);
+    // Don't apply scroll events to ancestors of the inner element
+    int32_t highestPriorityElementIndex = -1;
+    Clay__ScrollContainerDataInternal *highestPriorityScrollData = CLAY__NULL;
+    for (int32_t i = 0; i < context->scrollContainerDatas.length; i++) {
+        Clay__ScrollContainerDataInternal *scrollData = Clay__ScrollContainerDataInternalArray_Get(&context->scrollContainerDatas, i);
+        if (!scrollData->openThisFrame) {
+            Clay__ScrollContainerDataInternalArray_RemoveSwapback(&context->scrollContainerDatas, i);
+            continue;
+        }
+        scrollData->openThisFrame = false;
+        Clay_LayoutElementHashMapItem *hashMapItem = Clay__GetHashMapItem(scrollData->elementId);
+        // Element isn't rendered this frame but scroll offset has been retained
+        if (!hashMapItem) {
+            Clay__ScrollContainerDataInternalArray_RemoveSwapback(&context->scrollContainerDatas, i);
+            continue;
+        }
+
+        // Touch / click is released
+        if (!isPointerActive && scrollData->pointerScrollActive) {
+            float xDiff = scrollData->scrollPosition.x - scrollData->scrollOrigin.x;
+            if (xDiff < -10 || xDiff > 10) {
+                scrollData->scrollMomentum.x = (scrollData->scrollPosition.x - scrollData->scrollOrigin.x) / (scrollData->momentumTime * 25);
+            }
+            float yDiff = scrollData->scrollPosition.y - scrollData->scrollOrigin.y;
+            if (yDiff < -10 || yDiff > 10) {
+                scrollData->scrollMomentum.y = (scrollData->scrollPosition.y - scrollData->scrollOrigin.y) / (scrollData->momentumTime * 25);
+            }
+            scrollData->pointerScrollActive = false;
+
+            scrollData->pointerOrigin = CLAY__INIT(Clay_Vector2){0,0};
+            scrollData->scrollOrigin = CLAY__INIT(Clay_Vector2){0,0};
+            scrollData->momentumTime = 0;
+        }
+
+        // Apply existing momentum
+        scrollData->scrollPosition.x += scrollData->scrollMomentum.x;
+        scrollData->scrollMomentum.x *= 0.95f;
+        bool scrollOccurred = scrollDelta.x != 0 || scrollDelta.y != 0;
+        if ((scrollData->scrollMomentum.x > -0.1f && scrollData->scrollMomentum.x < 0.1f) || scrollOccurred) {
+            scrollData->scrollMomentum.x = 0;
+        }
+        scrollData->scrollPosition.x = CLAY__MIN(CLAY__MAX(scrollData->scrollPosition.x, -(CLAY__MAX(scrollData->contentSize.width - scrollData->layoutElement->dimensions.width, 0))), 0);
+
+        scrollData->scrollPosition.y += scrollData->scrollMomentum.y;
+        scrollData->scrollMomentum.y *= 0.95f;
+        if ((scrollData->scrollMomentum.y > -0.1f && scrollData->scrollMomentum.y < 0.1f) || scrollOccurred) {
+            scrollData->scrollMomentum.y = 0;
+        }
+        scrollData->scrollPosition.y = CLAY__MIN(CLAY__MAX(scrollData->scrollPosition.y, -(CLAY__MAX(scrollData->contentSize.height - scrollData->layoutElement->dimensions.height, 0))), 0);
+
+        for (int32_t j = 0; j < context->pointerOverIds.length; ++j) { // TODO n & m are small here but this being n*m gives me the creeps
+            if (scrollData->layoutElement->id == Clay_ElementIdArray_Get(&context->pointerOverIds, j)->id) {
+                highestPriorityElementIndex = j;
+                highestPriorityScrollData = scrollData;
+            }
+        }
+    }
+
+    if (highestPriorityElementIndex > -1 && highestPriorityScrollData) {
+        Clay_LayoutElement *scrollElement = highestPriorityScrollData->layoutElement;
+        Clay_ClipElementConfig *clipConfig = Clay__FindElementConfigWithType(scrollElement, CLAY__ELEMENT_CONFIG_TYPE_CLIP).clipElementConfig;
+        bool canScrollVertically = clipConfig->vertical && highestPriorityScrollData->contentSize.height > scrollElement->dimensions.height;
+        bool canScrollHorizontally = clipConfig->horizontal && highestPriorityScrollData->contentSize.width > scrollElement->dimensions.width;
+        // Handle wheel scroll
+        if (canScrollVertically) {
+            highestPriorityScrollData->scrollPosition.y = highestPriorityScrollData->scrollPosition.y + scrollDelta.y * 10;
+        }
+        if (canScrollHorizontally) {
+            highestPriorityScrollData->scrollPosition.x = highestPriorityScrollData->scrollPosition.x + scrollDelta.x * 10;
+        }
+        // Handle click / touch scroll
+        if (isPointerActive) {
+            highestPriorityScrollData->scrollMomentum = CLAY__INIT(Clay_Vector2)CLAY__DEFAULT_STRUCT;
+            if (!highestPriorityScrollData->pointerScrollActive) {
+                highestPriorityScrollData->pointerOrigin = context->pointerInfo.position;
+                highestPriorityScrollData->scrollOrigin = highestPriorityScrollData->scrollPosition;
+                highestPriorityScrollData->pointerScrollActive = true;
+            } else {
+                float scrollDeltaX = 0, scrollDeltaY = 0;
+                if (canScrollHorizontally) {
+                    float oldXScrollPosition = highestPriorityScrollData->scrollPosition.x;
+                    highestPriorityScrollData->scrollPosition.x = highestPriorityScrollData->scrollOrigin.x + (context->pointerInfo.position.x - highestPriorityScrollData->pointerOrigin.x);
+                    highestPriorityScrollData->scrollPosition.x = CLAY__MAX(CLAY__MIN(highestPriorityScrollData->scrollPosition.x, 0), -(highestPriorityScrollData->contentSize.width - highestPriorityScrollData->boundingBox.width));
+                    scrollDeltaX = highestPriorityScrollData->scrollPosition.x - oldXScrollPosition;
+                }
+                if (canScrollVertically) {
+                    float oldYScrollPosition = highestPriorityScrollData->scrollPosition.y;
+                    highestPriorityScrollData->scrollPosition.y = highestPriorityScrollData->scrollOrigin.y + (context->pointerInfo.position.y - highestPriorityScrollData->pointerOrigin.y);
+                    highestPriorityScrollData->scrollPosition.y = CLAY__MAX(CLAY__MIN(highestPriorityScrollData->scrollPosition.y, 0), -(highestPriorityScrollData->contentSize.height - highestPriorityScrollData->boundingBox.height));
+                    scrollDeltaY = highestPriorityScrollData->scrollPosition.y - oldYScrollPosition;
+                }
+                if (scrollDeltaX > -0.1f && scrollDeltaX < 0.1f && scrollDeltaY > -0.1f && scrollDeltaY < 0.1f && highestPriorityScrollData->momentumTime > 0.15f) {
+                    highestPriorityScrollData->momentumTime = 0;
+                    highestPriorityScrollData->pointerOrigin = context->pointerInfo.position;
+                    highestPriorityScrollData->scrollOrigin = highestPriorityScrollData->scrollPosition;
+                } else {
+                     highestPriorityScrollData->momentumTime += deltaTime;
+                }
+            }
+        }
+        // Clamp any changes to scroll position to the maximum size of the contents
+        if (canScrollVertically) {
+            highestPriorityScrollData->scrollPosition.y = CLAY__MAX(CLAY__MIN(highestPriorityScrollData->scrollPosition.y, 0), -(highestPriorityScrollData->contentSize.height - scrollElement->dimensions.height));
+        }
+        if (canScrollHorizontally) {
+            highestPriorityScrollData->scrollPosition.x = CLAY__MAX(CLAY__MIN(highestPriorityScrollData->scrollPosition.x, 0), -(highestPriorityScrollData->contentSize.width - scrollElement->dimensions.width));
+        }
+    }
+}
+
+CLAY_WASM_EXPORT("Clay_BeginLayout")
+void Clay_BeginLayout(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    Clay__InitializeEphemeralMemory(context);
+    context->generation++;
+    context->dynamicElementIndex = 0;
+    // Set up the root container that covers the entire window
+    Clay_Dimensions rootDimensions = {context->layoutDimensions.width, context->layoutDimensions.height};
+    if (context->debugModeEnabled) {
+        rootDimensions.width -= (float)Clay__debugViewWidth;
+    }
+    context->booleanWarnings = CLAY__INIT(Clay_BooleanWarnings) CLAY__DEFAULT_STRUCT;
+    Clay__OpenElement();
+    Clay__ConfigureOpenElement(CLAY__INIT(Clay_ElementDeclaration) {
+            .id = CLAY_ID("Clay__RootContainer"),
+            .layout = { .sizing = {CLAY_SIZING_FIXED((rootDimensions.width)), CLAY_SIZING_FIXED(rootDimensions.height)} }
+    });
+    Clay__int32_tArray_Add(&context->openLayoutElementStack, 0);
+    Clay__LayoutElementTreeRootArray_Add(&context->layoutElementTreeRoots, CLAY__INIT(Clay__LayoutElementTreeRoot) { .layoutElementIndex = 0 });
+}
+
+CLAY_WASM_EXPORT("Clay_EndLayout")
+Clay_RenderCommandArray Clay_EndLayout(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    Clay__CloseElement();
+    bool elementsExceededBeforeDebugView = context->booleanWarnings.maxElementsExceeded;
+    if (context->debugModeEnabled && !elementsExceededBeforeDebugView) {
+        context->warningsEnabled = false;
+        Clay__RenderDebugView();
+        context->warningsEnabled = true;
+    }
+    if (context->booleanWarnings.maxElementsExceeded) {
+        Clay_String message;
+        if (!elementsExceededBeforeDebugView) {
+            message = CLAY_STRING("Clay Error: Layout elements exceeded Clay__maxElementCount after adding the debug-view to the layout.");
+        } else {
+            message = CLAY_STRING("Clay Error: Layout elements exceeded Clay__maxElementCount");
+        }
+        Clay__AddRenderCommand(CLAY__INIT(Clay_RenderCommand ) {
+            .boundingBox = { context->layoutDimensions.width / 2 - 59 * 4, context->layoutDimensions.height / 2, 0, 0 },
+            .renderData = { .text = { .stringContents = CLAY__INIT(Clay_StringSlice) { .length = message.length, .chars = message.chars, .baseChars = message.chars }, .textColor = {255, 0, 0, 255}, .fontSize = 16 } },
+            .commandType = CLAY_RENDER_COMMAND_TYPE_TEXT
+        });
+    } else {
+        Clay__CalculateFinalLayout();
+    }
+    return context->renderCommands;
+}
+
+CLAY_WASM_EXPORT("Clay_GetElementId")
+Clay_ElementId Clay_GetElementId(Clay_String idString) {
+    return Clay__HashString(idString, 0, 0);
+}
+
+CLAY_WASM_EXPORT("Clay_GetElementIdWithIndex")
+Clay_ElementId Clay_GetElementIdWithIndex(Clay_String idString, uint32_t index) {
+    return Clay__HashString(idString, index, 0);
+}
+
+bool Clay_Hovered(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context->booleanWarnings.maxElementsExceeded) {
+        return false;
+    }
+    Clay_LayoutElement *openLayoutElement = Clay__GetOpenLayoutElement();
+    // If the element has no id attached at this point, we need to generate one
+    if (openLayoutElement->id == 0) {
+        Clay__GenerateIdForAnonymousElement(openLayoutElement);
+    }
+    for (int32_t i = 0; i < context->pointerOverIds.length; ++i) {
+        if (Clay_ElementIdArray_Get(&context->pointerOverIds, i)->id == openLayoutElement->id) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void Clay_OnHover(void (*onHoverFunction)(Clay_ElementId elementId, Clay_PointerData pointerInfo, intptr_t userData), intptr_t userData) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context->booleanWarnings.maxElementsExceeded) {
+        return;
+    }
+    Clay_LayoutElement *openLayoutElement = Clay__GetOpenLayoutElement();
+    if (openLayoutElement->id == 0) {
+        Clay__GenerateIdForAnonymousElement(openLayoutElement);
+    }
+    Clay_LayoutElementHashMapItem *hashMapItem = Clay__GetHashMapItem(openLayoutElement->id);
+    hashMapItem->onHoverFunction = onHoverFunction;
+    hashMapItem->hoverFunctionUserData = userData;
+}
+
+CLAY_WASM_EXPORT("Clay_PointerOver")
+bool Clay_PointerOver(Clay_ElementId elementId) { // TODO return priority for separating multiple results
+    Clay_Context* context = Clay_GetCurrentContext();
+    for (int32_t i = 0; i < context->pointerOverIds.length; ++i) {
+        if (Clay_ElementIdArray_Get(&context->pointerOverIds, i)->id == elementId.id) {
+            return true;
+        }
+    }
+    return false;
+}
+
+CLAY_WASM_EXPORT("Clay_GetScrollContainerData")
+Clay_ScrollContainerData Clay_GetScrollContainerData(Clay_ElementId id) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    for (int32_t i = 0; i < context->scrollContainerDatas.length; ++i) {
+        Clay__ScrollContainerDataInternal *scrollContainerData = Clay__ScrollContainerDataInternalArray_Get(&context->scrollContainerDatas, i);
+        if (scrollContainerData->elementId == id.id) {
+            Clay_ClipElementConfig *clipElementConfig = Clay__FindElementConfigWithType(scrollContainerData->layoutElement, CLAY__ELEMENT_CONFIG_TYPE_CLIP).clipElementConfig;
+            if (!clipElementConfig) { // This can happen on the first frame before a scroll container is declared
+                return CLAY__INIT(Clay_ScrollContainerData) CLAY__DEFAULT_STRUCT;
+            }
+            return CLAY__INIT(Clay_ScrollContainerData) {
+                .scrollPosition = &scrollContainerData->scrollPosition,
+                .scrollContainerDimensions = { scrollContainerData->boundingBox.width, scrollContainerData->boundingBox.height },
+                .contentDimensions = scrollContainerData->contentSize,
+                .config = *clipElementConfig,
+                .found = true
+            };
+        }
+    }
+    return CLAY__INIT(Clay_ScrollContainerData) CLAY__DEFAULT_STRUCT;
+}
+
+CLAY_WASM_EXPORT("Clay_GetElementData")
+Clay_ElementData Clay_GetElementData(Clay_ElementId id){
+    Clay_LayoutElementHashMapItem * item = Clay__GetHashMapItem(id.id);
+    if(item == &Clay_LayoutElementHashMapItem_DEFAULT) {
+        return CLAY__INIT(Clay_ElementData) CLAY__DEFAULT_STRUCT;
+    }
+
+    return CLAY__INIT(Clay_ElementData){
+        .boundingBox = item->boundingBox,
+        .found = true
+    };
+}
+
+CLAY_WASM_EXPORT("Clay_SetDebugModeEnabled")
+void Clay_SetDebugModeEnabled(bool enabled) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    context->debugModeEnabled = enabled;
+}
+
+CLAY_WASM_EXPORT("Clay_IsDebugModeEnabled")
+bool Clay_IsDebugModeEnabled(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    return context->debugModeEnabled;
+}
+
+CLAY_WASM_EXPORT("Clay_SetCullingEnabled")
+void Clay_SetCullingEnabled(bool enabled) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    context->disableCulling = !enabled;
+}
+
+CLAY_WASM_EXPORT("Clay_SetExternalScrollHandlingEnabled")
+void Clay_SetExternalScrollHandlingEnabled(bool enabled) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    context->externalScrollHandlingEnabled = enabled;
+}
+
+CLAY_WASM_EXPORT("Clay_GetMaxElementCount")
+int32_t Clay_GetMaxElementCount(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    return context->maxElementCount;
+}
+
+CLAY_WASM_EXPORT("Clay_SetMaxElementCount")
+void Clay_SetMaxElementCount(int32_t maxElementCount) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context) {
+        context->maxElementCount = maxElementCount;
+    } else {
+        Clay__defaultMaxElementCount = maxElementCount; // TODO: Fix this
+        Clay__defaultMaxMeasureTextWordCacheCount = maxElementCount * 2;
+    }
+}
+
+CLAY_WASM_EXPORT("Clay_GetMaxMeasureTextCacheWordCount")
+int32_t Clay_GetMaxMeasureTextCacheWordCount(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    return context->maxMeasureTextCacheWordCount;
+}
+
+CLAY_WASM_EXPORT("Clay_SetMaxMeasureTextCacheWordCount")
+void Clay_SetMaxMeasureTextCacheWordCount(int32_t maxMeasureTextCacheWordCount) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    if (context) {
+        Clay__currentContext->maxMeasureTextCacheWordCount = maxMeasureTextCacheWordCount;
+    } else {
+        Clay__defaultMaxMeasureTextWordCacheCount = maxMeasureTextCacheWordCount; // TODO: Fix this
+    }
+}
+
+CLAY_WASM_EXPORT("Clay_ResetMeasureTextCache")
+void Clay_ResetMeasureTextCache(void) {
+    Clay_Context* context = Clay_GetCurrentContext();
+    context->measureTextHashMapInternal.length = 0;
+    context->measureTextHashMapInternalFreeList.length = 0;
+    context->measureTextHashMap.length = 0;
+    context->measuredWords.length = 0;
+    context->measuredWordsFreeList.length = 0;
+    
+    for (int32_t i = 0; i < context->measureTextHashMap.capacity; ++i) {
+        context->measureTextHashMap.internalArray[i] = 0;
+    }
+    context->measureTextHashMapInternal.length = 1; // Reserve the 0 value to mean "no next element"
+}
+
+#endif // CLAY_IMPLEMENTATION
+
+/*
+LICENSE
+zlib/libpng license
+
+Copyright (c) 2024 Nic Barker
+
+This software is provided 'as-is', without any express or implied warranty.
+In no event will the authors be held liable for any damages arising from the
+use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+    claim that you wrote the original software. If you use this software in a
+    product, an acknowledgment in the product documentation would be
+    appreciated but is not required.
+
+    2. Altered source versions must be plainly marked as such, and must not
+    be misrepresented as being the original software.
+
+    3. This notice may not be removed or altered from any source
+    distribution.
+*/


### PR DESCRIPTION
## Description
Vendors clay.h 0.14 into third_party/ and adds the renderer as new C files.

Widgets draw themselves with cairo today, so the widget tree is code rather than a description of the screen. Clay makes it a description and emits a command list, and this is the piece that turns that list into wlr_scene, diffing it so an unchanged frame does nothing. Nothing calls it yet, so it cannot regress a running compositor.
