### PR TITLE
2.1/flip

### DIFF
--- a/DEVIATIONS.md
+++ b/DEVIATIONS.md
@@ -149,6 +149,45 @@ Widget-layer consumers (`naughty.list`, `awful.widget.tasklist`, `awful.widget.t
 
 ---
 
+## Clay Draw Order (somewm 2.1)
+
+somewm 2.1 draws each output from one Clay layout tree. Every client, drawin and layer-shell surface is a Clay floating element with a `zIndex`. Clay sorts by `zIndex` and leaves equal values in declaration order, so clients sharing a `zIndex` draw in stack order and layer-shell surfaces oldest first.
+
+A client's `zIndex` follows `ontop`, `above`, `below` and `fullscreen`. A transient that sets none of them gets its parent's.
+
+| zIndex | draws |
+|--------|-------|
+| 10 | layer-shell background |
+| 20 | desktop clients |
+| 30 | desktop and splash drawins |
+| 40 | layer-shell bottom |
+| 50 | `below` clients |
+| 60 | normal clients |
+| 70 | drawins (wibars, popups) |
+| 80 | layer-shell top |
+| 90 | `above` clients |
+| 100 | dock drawins |
+| 105 | fullscreen backing rectangle |
+| 110 | fullscreen clients |
+| 120 | layer-shell overlay |
+| 130 | `ontop` clients |
+| 140 | `ontop` drawins |
+| 150 | override-redirect X11 windows |
+
+**Override-redirect X11 windows draw above everything.** X11 menus and tooltips set no stacking properties, so somewm gives them the top `zIndex`. AwesomeWM stacks them with the client that owns them, and somewm 2.0 left the result to scene insertion order. The lock screen is unaffected: it has its own Clay tree above this one.
+
+**A drawin's border and shadow do not accept pointer input.** Clicks fall through to whatever draws below, as in 2.0.
+
+**Clicking a client's border focuses that client.** In 2.0 the border was a separate scene rectangle that reported no client, so the click did nothing.
+
+**`border_color` set from Lua survives focus changes.** somewm recolors a client's border on focus only while the config has not set the color itself. AwesomeWM never recolors it.
+
+**xdg popups draw above the client's tiled neighbours.** A popup wider than its client is no longer covered by the next tile.
+
+**`client._scene_layer`** returns the name of the layer a client draws in. It is a test aid, not AwesomeWM API.
+
+---
+
 ## No-Op APIs
 
 These APIs exist and can be called without error, but have no effect on Wayland.

--- a/client.h
+++ b/client.h
@@ -333,12 +333,14 @@ client_send_close(Client *c)
 	wlr_xdg_toplevel_send_close(c->surface.xdg->toplevel);
 }
 
+/* Record the color; the declare pass reads it (client_border_rgba) and the
+ * border_need_update flag makes the next refresh cycle dirty the outputs. */
 static inline void
 client_set_border_color(Client *c, const float color[static 4])
 {
-	int i;
-	for (i = 0; i < 4; i++)
-		wlr_scene_rect_set_color(c->border[i], color);
+	memcpy(c->border_rgba, color, 4 * sizeof(float));
+	c->border_rgba_set = true;
+	c->border_need_update = true;
 }
 
 static inline void

--- a/declare.c
+++ b/declare.c
@@ -1,0 +1,683 @@
+/*
+ * declare.c - the per-output declare/solve boundary for the Clay tree
+ *
+ * Each output owns a Clay context sized to its effective resolution and a
+ * render_state parented into a band directly below LyrBlock, so everything
+ * the tree will declare stays under the session lock, its covers, and the
+ * drag icon. Per dirty frame the declare pass rebuilds the output's tree:
+ * every box somewm computes elsewhere enters as a fixed floating leaf
+ * attached to Clay's root, so Clay places without solving it, and the
+ * declaration order is the draw order (Clay_EndLayout's root sort is stable
+ * for equal zIndex, clay.h:2605-2615, and Clay_BeginLayout opens an implicit
+ * root container covering the window, clay.h:4170-4174).
+ *
+ * The order reproduces the scene layers stack.c maintained: per shared band,
+ * layer-shell surfaces below clients below drawins, bands stacked
+ * Bg < Bottom < Tile < Wibox < Top < FS < Overlay.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <wlr/types/wlr_fractional_scale_v1.h>
+#include <wlr/types/wlr_layer_shell_v1.h>
+#include <wlr/types/wlr_output.h>
+#include <wlr/types/wlr_scene.h>
+#include <wlr/util/log.h>
+
+#include "clay.h"
+#include "declare.h"
+#include "render.h"
+#include "somewm.h"
+#include "somewm_types.h"
+#include "globalconf.h"
+#include "client.h"
+#include "color.h"
+#include "focus.h"
+#include "somewm_api.h"
+#include "monitor.h"
+#include "stack.h"
+#include "window.h"
+#include "common/util.h"
+#include "objects/client.h"
+#include "objects/drawin.h"
+#include "objects/screen.h"
+
+/* One Clay context plus the render_state its solved commands reconcile
+ * into. Every output has a desktop band; the lua-lock band is created when
+ * the lock engages (covers and the lock surface drawin reconcile into
+ * LyrBlock, above locked_bg, below the raised external lock surface). */
+struct declare_band {
+	Clay_Context *clay;
+	void *arena;
+	struct wlr_scene_tree *tree;
+	struct render_state *render;
+};
+
+struct declare_output {
+	struct wlr_output *wlr_output;
+	struct declare_band desktop;
+	struct declare_band lock;
+	bool dirty;
+};
+
+/* Zero hooks until window.c installs the real ones at startup; the
+ * reconciler only consults them for CUSTOM commands and borrowed nodes,
+ * neither of which can exist before then. */
+static struct render_client_hooks client_hooks;
+
+void
+declare_set_client_hooks(const struct render_client_hooks *hooks)
+{
+	client_hooks = *hooks;
+}
+
+/* --- the handle registry --- */
+
+struct handle_entry {
+	void *object;
+	enum declare_kind kind;
+	uint32_t id;
+};
+
+static struct handle_entry *handles;
+static size_t handles_len, handles_cap;
+static uint32_t handle_next = 1;
+
+static uint64_t
+handle_pack(enum declare_kind kind, uint32_t id)
+{
+	return ((uint64_t)kind << 32) | id;
+}
+
+/* Chrome scale is tens of objects; linear scans are fine. */
+static uint64_t
+handle_for(void *object, enum declare_kind kind)
+{
+	for (size_t i = 0; i < handles_len; i++)
+		if (handles[i].object == object)
+			return handle_pack(handles[i].kind, handles[i].id);
+	if (handles_len == handles_cap) {
+		handles_cap = handles_cap ? handles_cap * 2 : 32;
+		p_realloc(&handles, handles_cap);
+	}
+	handles[handles_len++] = (struct handle_entry) {
+		.object = object, .kind = kind, .id = handle_next++,
+	};
+	return handle_pack(kind, handles[handles_len - 1].id);
+}
+
+void *
+declare_handle_get(uint64_t handle, enum declare_kind *kind)
+{
+	uint32_t id = (uint32_t)handle;
+
+	for (size_t i = 0; i < handles_len; i++) {
+		if (handles[i].id != id)
+			continue;
+		if (handles[i].kind != (enum declare_kind)(handle >> 32))
+			return NULL;
+		if (kind)
+			*kind = handles[i].kind;
+		return handles[i].object;
+	}
+	return NULL;
+}
+
+void
+declare_handle_drop(void *object)
+{
+	for (size_t i = 0; i < handles_len; i++) {
+		if (handles[i].object == object) {
+			handles[i] = handles[--handles_len];
+			return;
+		}
+	}
+}
+
+/* --- leaf declarations --- */
+
+static void
+declare_leaf(Clay_ElementDeclaration *decl)
+{
+	Clay__OpenElement();
+	Clay__ConfigureOpenElementPtr(decl);
+	Clay__CloseElement();
+}
+
+static Clay_ElementDeclaration
+leaf_at(Clay_String label, uint32_t index, int x, int y, int w, int h)
+{
+	return (Clay_ElementDeclaration) {
+		.id = Clay__HashString(label, index, 0),
+		.layout.sizing = {
+			.width = CLAY_SIZING_FIXED(w),
+			.height = CLAY_SIZING_FIXED(h),
+		},
+		.floating = {
+			.offset = { .x = x, .y = y },
+			.attachTo = CLAY_ATTACH_TO_ROOT,
+		},
+	};
+}
+
+/* The per-element userData word (render.h): registry id in bits 0-31, kind
+ * in 32-39, opacity byte in 40-47. A packed integer rather than a pointer,
+ * so a retained command can never dangle into freed registry state; the low
+ * 40 bits are exactly a declare handle. */
+_Static_assert(sizeof(void *) >= 8, "userData packing needs 64-bit pointers");
+
+static void *
+leaf_userdata(uint64_t handle, float opacity)
+{
+	return (void *)(uintptr_t)(handle
+		| ((uint64_t)(1 + (unsigned)(opacity * 254.0f + 0.5f)) << 40));
+}
+
+void *
+declare_output_hit(struct declare_output *dout, struct wlr_scene_node *node,
+	enum declare_kind *kind)
+{
+	void *ud = render_hit_userdata(dout->desktop.render, node);
+
+	if (!ud && dout->lock.render)
+		ud = render_hit_userdata(dout->lock.render, node);
+	if (!ud)
+		return NULL;
+	return declare_handle_get((uintptr_t)ud & 0xFFFFFFFFFFULL, kind);
+}
+
+/* somewm colors are straight-alpha 0-1 floats; Clay_Color is 0-255.
+ * The renderer premultiplies once when converting back for wlr_scene. */
+static Clay_Color
+clay_color(const float rgba[4])
+{
+	return (Clay_Color) {
+		rgba[0] * 255.0f, rgba[1] * 255.0f,
+		rgba[2] * 255.0f, rgba[3] * 255.0f,
+	};
+}
+
+static void
+client_border_rgba(Client *c, float out[4])
+{
+	if (c->border_color.initialized)
+		color_to_floats(&c->border_color, out);
+	else
+		memcpy(out, c->urgent ? get_urgentcolor() : get_bordercolor(),
+			4 * sizeof(float));
+}
+
+/* The frame box: awful.layout's geometry plus the border ring drawn around
+ * the content, positioned output-local (the render band sits at the output's
+ * layout position). One BORDER element and one CUSTOM element at the same
+ * box, border first so the borrowed tree, popups included, stacks above it,
+ * matching the popup raise in client_configure_to_box(). */
+static void
+declare_client(Client *c, Monitor *m)
+{
+	uint64_t handle = handle_for(c, DECLARE_KIND_CLIENT);
+	uint32_t id = (uint32_t)handle;
+	int bw = c->bw;
+	int fw = c->geometry.width + 2 * bw;
+	int fh = c->geometry.height + 2 * bw;
+	int x = c->geometry.x - m->m.x;
+	int y = c->geometry.y - m->m.y;
+	bool clamp = client_clamps_to_monitor(c);
+
+	/* Under a clip-offscreen layout, a fully offscreen client declares
+	 * nothing: the sweep releases its tree disabled, which is today's
+	 * visible=false hide. The test uses the geometry box, matching the
+	 * content-box test in client_configure_to_box(). */
+	if (clamp && (x + bw + c->geometry.width <= 0
+			|| y + bw + c->geometry.height <= 0
+			|| x + bw >= m->m.width
+			|| y + bw >= m->m.height))
+		return;
+
+	if (bw > 0) {
+		Clay_ElementDeclaration b = leaf_at(
+			CLAY_STRING("client.border"), id, x, y, fw, fh);
+		float rgba[4];
+
+		client_border_rgba(c, rgba);
+		b.border.color = clay_color(rgba);
+		b.border.width = (Clay_BorderWidth) {
+			bw, bw, bw, bw, 0 };
+		b.userData = leaf_userdata(handle, 1.0f);
+		if (clamp) {
+			/* The monitor scissor: a floating clip wrapper at the
+			 * output box; the border rides inside as an
+			 * attach-to-parent child inheriting the wrapper's clip
+			 * (clay.h:2077-2079, 2123), so a partially offscreen
+			 * border clips at the output edge instead of bleeding
+			 * onto the neighbor. The surface leaf stays outside:
+			 * CUSTOM is never clipped, and the surface's own clamp
+			 * lives in client_configure_to_box(). */
+			Clay_ElementDeclaration w = leaf_at(
+				CLAY_STRING("client.clip"), id,
+				0, 0, m->m.width, m->m.height);
+			w.clip = (Clay_ClipElementConfig) {
+				.horizontal = true, .vertical = true };
+			b.floating.attachTo = CLAY_ATTACH_TO_PARENT;
+			b.floating.clipTo = CLAY_CLIP_TO_ATTACHED_PARENT;
+			Clay__OpenElement();
+			Clay__ConfigureOpenElementPtr(&w);
+			declare_leaf(&b);
+			Clay__CloseElement();
+		} else {
+			declare_leaf(&b);
+		}
+	}
+
+	Clay_ElementDeclaration s = leaf_at(
+		CLAY_STRING("client.surface"), id, x, y, fw, fh);
+	s.custom.customData = (void *)(uintptr_t)handle;
+	s.userData = leaf_userdata(handle, 1.0f);
+	declare_leaf(&s);
+}
+
+static bool
+declarable_client(Client *c)
+{
+	if (!c || !c->scene || !client_surface(c)
+			|| !client_surface(c)->mapped)
+		return false;
+	/* Banning's visibility fact (tags, minimized) becomes a declare
+	 * filter: an undeclared client's tree is released disabled by the
+	 * sweep. Unmanaged clients are not tag-tracked. */
+	return client_is_unmanaged(c) || client_isvisible(c);
+}
+
+/* Transients ride their parent: declared right above it in the parent's
+ * band, mirroring stack_transients_above() (stack.c). Unmanaged children
+ * are excluded; declare_unmanaged_clients() owns every unmanaged client,
+ * and declaring one here too would hash a duplicate Clay id and abort. */
+static void
+declare_client_tree(Client *c, Monitor *m)
+{
+	declare_client(c, m);
+	foreach(node, globalconf.stack)
+		if ((*node)->transient_for == c && (*node)->mon == m
+				&& !client_is_unmanaged(*node)
+				&& declarable_client(*node))
+			declare_client_tree(*node, m);
+}
+
+/* Whether declare_client_tree() will reach c through its parent. When it
+ * will not (parent minimized, unmapped, unmanaged, or on another output),
+ * c declares as a root in its own layer instead of vanishing; the old
+ * scene path kept exactly these clients visible per-client. The immediate
+ * parent suffices: every managed declarable client on m is declared, as a
+ * root or by riding one, so a declarable parent is a declared parent. */
+static bool
+transient_rides_parent(Client *c, Monitor *m)
+{
+	Client *p = c->transient_for;
+
+	return p && p->mon == m && !client_is_unmanaged(p)
+		&& declarable_client(p);
+}
+
+static void
+declare_clients_in_layer(Monitor *m, window_layer_t want)
+{
+	foreach(node, globalconf.stack) {
+		Client *c = *node;
+		window_layer_t layer;
+
+		/* Cheap pointer filters first; the tag-visibility checks walk
+		 * Lua state and run last. Unmanaged (override-redirect) clients
+		 * bypass stacking attributes and declare at the top of the
+		 * overlay band instead. */
+		if (!c || c->mon != m || client_is_unmanaged(c))
+			continue;
+		layer = stack_client_layer(c);
+		if (layer == WINDOW_LAYER_IGNORE)
+			layer = WINDOW_LAYER_NORMAL;
+		if (layer != want)
+			continue;
+		if (c->transient_for && transient_rides_parent(c, m))
+			continue;
+		if (!declarable_client(c))
+			continue;
+		declare_client_tree(c, m);
+	}
+}
+
+/* Unmanaged clients have no c->mon assignment to trust; each declares on
+ * exactly one output, the one under its center, so two outputs never fight
+ * over borrowing the same scene tree. */
+static Monitor *
+monitor_for_unmanaged(Client *c)
+{
+	Monitor *m = xytomon(c->geometry.x + c->geometry.width / 2.0,
+		c->geometry.y + c->geometry.height / 2.0);
+
+	return m ? m : c->mon;
+}
+
+static void
+declare_unmanaged_clients(Monitor *m)
+{
+	foreach(node, globalconf.stack) {
+		Client *c = *node;
+
+		if (!c || !client_is_unmanaged(c))
+			continue;
+		if (monitor_for_unmanaged(c) != m)
+			continue;
+		if (!declarable_client(c))
+			continue;
+		declare_client(c, m);
+	}
+}
+
+static void
+declare_layer_surface(LayerSurface *l, Monitor *m)
+{
+	uint64_t handle = handle_for(l, DECLARE_KIND_LAYER);
+	struct wlr_layer_surface_v1 *ls = l->layer_surface;
+	Clay_ElementDeclaration s = leaf_at(CLAY_STRING("layer.surface"),
+		(uint32_t)handle,
+		l->scene->node.x - m->m.x, l->scene->node.y - m->m.y,
+		ls->current.actual_width, ls->current.actual_height);
+
+	s.custom.customData = (void *)(uintptr_t)handle;
+	s.userData = leaf_userdata(handle, 1.0f);
+	declare_leaf(&s);
+}
+
+static void
+declare_layer_band(Monitor *m, int band)
+{
+	LayerSurface *l;
+
+	/* protocols.c prepends new surfaces to m->layers, and scene child
+	 * order stacks newer surfaces on top; reverse iteration declares the
+	 * oldest first, at the bottom. */
+	wl_list_for_each_reverse(l, &m->layers[band], link) {
+		if (!l->mapped || !l->scene)
+			continue;
+		declare_layer_surface(l, m);
+	}
+}
+
+/* --- drawins as whole-buffer image leaves ---
+ *
+ * Shadow below border below content, all riding the drawin's own image
+ * entries (objects/drawin.c fills them; gen bumps on content change).
+ * Opacity applies to the content leaf only, matching the old scene-buffer
+ * path, which never set opacity on the border or shadow. */
+static void
+declare_drawin(drawin_t *d, Monitor *m)
+{
+	uint64_t handle = handle_for(d, DECLARE_KIND_DRAWIN);
+	uint32_t id = (uint32_t)handle;
+	int bw = d->border_width;
+	int x = d->x - m->m.x;
+	int y = d->y - m->m.y;
+	float opacity = d->opacity >= 0 ? (float)d->opacity : 1.0f;
+
+	if (d->shadow_entry.native) {
+		int r = d->shadow_entry_config.radius;
+		Clay_ElementDeclaration s = leaf_at(CLAY_STRING("drawin.shadow"),
+			id, x + d->shadow_entry_config.offset_x - r,
+			y + d->shadow_entry_config.offset_y - r,
+			d->shadow_entry.width, d->shadow_entry.height);
+		s.image.imageData = &d->shadow_entry;
+		declare_leaf(&s);
+	}
+	if (bw > 0 && d->border_entry.native) {
+		Clay_ElementDeclaration b = leaf_at(CLAY_STRING("drawin.border"),
+			id, x - bw, y - bw, d->width + 2 * bw, d->height + 2 * bw);
+		b.image.imageData = &d->border_entry;
+		b.userData = leaf_userdata(handle, 1.0f);
+		declare_leaf(&b);
+	}
+
+	Clay_ElementDeclaration c = leaf_at(CLAY_STRING("drawin.image"), id,
+		x, y, d->width, d->height);
+	c.image.imageData = &d->content_entry;
+	c.userData = leaf_userdata(handle, opacity);
+	declare_leaf(&c);
+}
+
+/* Map-then-draw: a drawin only declares once its content entry holds pixels,
+ * the same gate the old path applied by enabling the scene node after the
+ * first refresh. */
+static bool
+declarable_drawin(drawin_t *d, Monitor *m)
+{
+	return d->visible
+		&& d->content_entry.native
+		&& d->screen && d->screen->monitor == m;
+}
+
+static void
+declare_drawins_in_band(Monitor *m, int scene_layer)
+{
+	foreach(item, globalconf.drawins) {
+		drawin_t *d = *item;
+
+		if (stack_drawin_layer(d) != scene_layer)
+			continue;
+		/* Lock drawins belong to the lock pass while locked. */
+		if (session_is_locked() && some_is_lock_drawin(d))
+			continue;
+		if (!declarable_drawin(d, m))
+			continue;
+		declare_drawin(d, m);
+	}
+}
+
+/* The opaque backing the xdg protocol requires under a non-opaque
+ * fullscreen surface; replaces the per-monitor fullscreen_bg scene rect,
+ * enabled under the same condition (arrange()'s focustop check). */
+static void
+declare_fullscreen_bg(Monitor *m)
+{
+	Client *c = focustop(m);
+
+	if (!c || !c->fullscreen)
+		return;
+
+	Clay_ElementDeclaration bg = leaf_at(CLAY_STRING("fullscreen_bg"), 0,
+		0, 0, m->m.width, m->m.height);
+	bg.backgroundColor = clay_color(globalconf.appearance.fullscreen_bg);
+	declare_leaf(&bg);
+}
+
+static void
+declare_scene(Monitor *m)
+{
+	declare_layer_band(m, ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND);
+	declare_clients_in_layer(m, WINDOW_LAYER_DESKTOP);
+	declare_drawins_in_band(m, LyrBg);
+	declare_layer_band(m, ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM);
+	declare_clients_in_layer(m, WINDOW_LAYER_BELOW);
+	declare_clients_in_layer(m, WINDOW_LAYER_NORMAL);
+	declare_drawins_in_band(m, LyrWibox);
+	declare_layer_band(m, ZWLR_LAYER_SHELL_V1_LAYER_TOP);
+	declare_clients_in_layer(m, WINDOW_LAYER_ABOVE);
+	declare_drawins_in_band(m, LyrTop);
+	declare_fullscreen_bg(m);
+	declare_clients_in_layer(m, WINDOW_LAYER_FULLSCREEN);
+	declare_layer_band(m, ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY);
+	declare_clients_in_layer(m, WINDOW_LAYER_ONTOP);
+	declare_drawins_in_band(m, LyrOverlay);
+	declare_unmanaged_clients(m);
+	/* Session lock: locked_bg, the lock covers, and the lock surface stay
+	 * C-owned scene nodes in LyrBlock, above this whole band. */
+}
+
+/* --- context lifecycle and the frame entry --- */
+
+static void
+handle_clay_error(Clay_ErrorData error)
+{
+	/* A Clay error (arena exhaustion, duplicate id, command array
+	 * overflow) is a bug, not a condition to ride out. */
+	wlr_log(WLR_ERROR, "clay error %d: %.*s", error.errorType,
+		error.errorText.length, error.errorText.chars);
+	abort();
+}
+
+/* One band: an arena-backed Clay context and a render_state reconciling
+ * into a fresh tree under parent. */
+static void
+declare_band_init(struct declare_band *band, struct wlr_output *wlr_output,
+	struct wlr_scene_tree *parent)
+{
+	uint32_t arena_size = Clay_MinMemorySize();
+	int width, height;
+
+	wlr_output_effective_resolution(wlr_output, &width, &height);
+	band->arena = malloc(arena_size);
+	band->clay = Clay_Initialize(
+		Clay_CreateArenaWithCapacityAndMemory(arena_size, band->arena),
+		(Clay_Dimensions) { .width = width, .height = height },
+		(Clay_ErrorHandler) { .errorHandlerFunction = handle_clay_error });
+	band->tree = wlr_scene_tree_create(parent);
+	band->render = render_create(band->tree);
+}
+
+static void
+declare_band_wipe(struct declare_band *band)
+{
+	if (!band->clay)
+		return;
+	/* The Clay_Context lives inside the arena being freed. Clay keeps a
+	 * global current-context pointer; left dangling, the next
+	 * Clay_MinMemorySize or Clay_Initialize would read freed memory. */
+	if (Clay_GetCurrentContext() == band->clay)
+		Clay_SetCurrentContext(NULL);
+	render_destroy(band->render, &client_hooks);
+	wlr_scene_node_destroy(&band->tree->node);
+	free(band->arena);
+}
+
+/* Layout dimensions, band position, and raster scale have one owner: this
+ * function, run at band creation and on every updatemons pass. The frame
+ * entry never re-derives them. */
+static void
+declare_band_update(struct declare_band *band, struct wlr_output *wlr_output,
+	int lx, int ly)
+{
+	int width, height;
+
+	if (!band->clay)
+		return;
+	wlr_output_effective_resolution(wlr_output, &width, &height);
+	Clay_SetCurrentContext(band->clay);
+	Clay_SetLayoutDimensions(
+		(Clay_Dimensions) { .width = width, .height = height });
+	render_set_position(band->render, lx, ly);
+	render_set_scale(band->render, wlr_output->scale);
+}
+
+struct declare_output *
+declare_output_create(struct wlr_output *wlr_output)
+{
+	struct declare_output *dout = calloc(1, sizeof(*dout));
+
+	dout->wlr_output = wlr_output;
+	declare_band_init(&dout->desktop, wlr_output, &scene->tree);
+	wlr_scene_node_place_below(&dout->desktop.tree->node,
+		&layers[LyrBlock]->node);
+	dout->dirty = true;
+	return dout;
+}
+
+/* The lock scene, in some_activate_lua_lock()'s own order: the covers, then
+ * the lock surface drawin on top. */
+static void
+declare_lock_scene(Monitor *m)
+{
+	drawin_t *lock_surface = some_get_lua_lock_surface();
+	int cover_count;
+	drawin_t **covers = some_get_lua_lock_covers(&cover_count);
+
+	for (int i = 0; i < cover_count; i++)
+		if (covers[i] && declarable_drawin(covers[i], m))
+			declare_drawin(covers[i], m);
+	if (lock_surface && declarable_drawin(lock_surface, m))
+		declare_drawin(lock_surface, m);
+}
+
+void
+declare_lock_set_visible(bool on)
+{
+	Monitor *m;
+
+	wl_list_for_each(m, &mons, link) {
+		if (!m->declare)
+			continue;
+		/* Create the lock band on engage, before the caller raises the
+		 * covers and lock surface: wlroots appends new children topmost,
+		 * so a band created after the raise would land above them. */
+		if (on && !m->declare->lock.clay) {
+			declare_band_init(&m->declare->lock,
+				m->declare->wlr_output, layers[LyrBlock]);
+			declare_band_update(&m->declare->lock,
+				m->declare->wlr_output, m->m.x, m->m.y);
+		}
+		if (m->declare->lock.render)
+			render_set_enabled(m->declare->lock.render, on);
+		declare_output_mark_dirty(m->declare);
+	}
+}
+
+void
+declare_output_destroy(struct declare_output *dout)
+{
+	declare_band_wipe(&dout->desktop);
+	declare_band_wipe(&dout->lock);
+	free(dout);
+}
+
+void
+declare_output_update(struct declare_output *dout, int lx, int ly)
+{
+	declare_band_update(&dout->desktop, dout->wlr_output, lx, ly);
+	declare_band_update(&dout->lock, dout->wlr_output, lx, ly);
+	declare_output_mark_dirty(dout);
+}
+
+void
+declare_output_mark_dirty(struct declare_output *dout)
+{
+	dout->dirty = true;
+	wlr_output_schedule_frame(dout->wlr_output);
+}
+
+int
+declare_output_frame(struct declare_output *dout, Monitor *m, bool lock_active)
+{
+	struct declare_band *band;
+
+	if (!dout->dirty)
+		return -1;
+	dout->dirty = false;
+
+	/* While lua-locked, this output solves its lock scene instead; the
+	 * desktop band keeps its last scene, occluded by locked_bg. The lock
+	 * band normally exists already (declare_lock_set_visible creates it
+	 * on engage, before the lock surface is raised above it); this covers
+	 * outputs created mid-lock. */
+	if (lock_active && !dout->lock.clay) {
+		declare_band_init(&dout->lock, dout->wlr_output, layers[LyrBlock]);
+		declare_band_update(&dout->lock, dout->wlr_output, m->m.x, m->m.y);
+	}
+	band = lock_active ? &dout->lock : &dout->desktop;
+
+	Clay_SetCurrentContext(band->clay);
+	Clay_BeginLayout();
+	if (lock_active)
+		declare_lock_scene(m);
+	else
+		declare_scene(m);
+	Clay_RenderCommandArray commands = Clay_EndLayout();
+
+	return render_reconcile(band->render, commands, &client_hooks);
+}

--- a/declare.c
+++ b/declare.c
@@ -6,14 +6,11 @@
  * the tree will declare stays under the session lock, its covers, and the
  * drag icon. Per dirty frame the declare pass rebuilds the output's tree:
  * every box somewm computes elsewhere enters as a fixed floating leaf
- * attached to Clay's root, so Clay places without solving it, and the
- * declaration order is the draw order (Clay_EndLayout's root sort is stable
- * for equal zIndex, clay.h:2605-2615, and Clay_BeginLayout opens an implicit
- * root container covering the window, clay.h:4170-4174).
+ * attached to Clay's root, so Clay places without solving it.
  *
- * The order reproduces the scene layers stack.c maintained: per shared band,
- * layer-shell surfaces below clients below drawins, bands stacked
- * Bg < Bottom < Tile < Wibox < Top < FS < Overlay.
+ * Draw order is Clay's own: zIndex picks the band and declaration order
+ * breaks ties inside it. The bands are the table below; within one, clients
+ * follow the stack and layer-shell surfaces the oldest first.
  */
 
 #include <stdlib.h>
@@ -144,8 +141,44 @@ declare_leaf(Clay_ElementDeclaration *decl)
 	Clay__CloseElement();
 }
 
+/* --- the draw order ---
+ *
+ * One band per line, bottom first. Clay sorts floating tree roots by zIndex
+ * (every floating element is one, clay.h:2102-2107; the sort is at
+ * clay.h:2603-2615 and is stable), so declaration order decides only within
+ * a band. A window's band comes from its stacking attribute; a transient
+ * that sets none inherits its parent's. */
+enum {
+	Z_LAYER_BACKGROUND = 10,
+	Z_CLIENT_DESKTOP = 20,
+	Z_DRAWIN_BG = 30,
+	Z_LAYER_BOTTOM = 40,
+	Z_CLIENT_BELOW = 50,
+	Z_CLIENT_NORMAL = 60,
+	Z_DRAWIN_WIBOX = 70,
+	Z_LAYER_TOP = 80,
+	Z_CLIENT_ABOVE = 90,
+	Z_DRAWIN_TOP = 100,
+	Z_FULLSCREEN_BG = 105,
+	Z_CLIENT_FULLSCREEN = 110,
+	Z_LAYER_OVERLAY = 120,
+	Z_CLIENT_ONTOP = 130,
+	Z_DRAWIN_OVERLAY = 140,
+	/* Override-redirect X11 windows (menus, tooltips, drag icons) carry
+	 * no stacking attribute to place them and are always transient UI for
+	 * the window below, so they sit above everything. */
+	Z_CLIENT_UNMANAGED = 150,
+};
+
+/* The lock band is a separate Clay context with its own order. */
+enum {
+	Z_LOCK_COVER = 10,
+	Z_LOCK_SURFACE = 20,
+};
+
 static Clay_ElementDeclaration
-leaf_at(Clay_String label, uint32_t index, int x, int y, int w, int h)
+leaf_at(Clay_String label, uint32_t index, int16_t z,
+	int x, int y, int w, int h)
 {
 	return (Clay_ElementDeclaration) {
 		.id = Clay__HashString(label, index, 0),
@@ -156,6 +189,7 @@ leaf_at(Clay_String label, uint32_t index, int x, int y, int w, int h)
 		.floating = {
 			.offset = { .x = x, .y = y },
 			.attachTo = CLAY_ATTACH_TO_ROOT,
+			.zIndex = z,
 		},
 	};
 }
@@ -203,7 +237,7 @@ clay_color(const float rgba[4])
  * box, border first so the borrowed tree, popups included, stacks above it,
  * matching the popup raise in client_configure_to_box(). */
 static void
-declare_client(Client *c, Monitor *m)
+declare_client(Client *c, Monitor *m, int16_t z)
 {
 	uint64_t handle = handle_for(c, DECLARE_KIND_CLIENT);
 	uint32_t id = (uint32_t)handle;
@@ -226,7 +260,7 @@ declare_client(Client *c, Monitor *m)
 
 	if (bw > 0) {
 		Clay_ElementDeclaration b = leaf_at(
-			CLAY_STRING("client.border"), id, x, y, fw, fh);
+			CLAY_STRING("client.border"), id, z, x, y, fw, fh);
 		float rgba[4];
 
 		client_border_rgba(c, rgba);
@@ -244,7 +278,7 @@ declare_client(Client *c, Monitor *m)
 			 * CUSTOM is never clipped, and the surface's own clamp
 			 * lives in client_configure_to_box(). */
 			Clay_ElementDeclaration w = leaf_at(
-				CLAY_STRING("client.clip"), id,
+				CLAY_STRING("client.clip"), id, z,
 				0, 0, m->m.width, m->m.height);
 			w.clip = (Clay_ClipElementConfig) {
 				.horizontal = true, .vertical = true };
@@ -260,7 +294,7 @@ declare_client(Client *c, Monitor *m)
 	}
 
 	Clay_ElementDeclaration s = leaf_at(
-		CLAY_STRING("client.surface"), id, x, y, fw, fh);
+		CLAY_STRING("client.surface"), id, z, x, y, fw, fh);
 	s.custom.customData = (void *)(uintptr_t)handle;
 	s.userData = leaf_userdata(handle, 1.0f);
 	declare_leaf(&s);
@@ -278,55 +312,86 @@ declarable_client(Client *c)
 	return client_is_unmanaged(c) || client_isvisible(c);
 }
 
-/* Transients ride their parent: declared right above it in the parent's
- * band, mirroring stack_transients_above() (stack.c). Unmanaged children
- * are excluded; declare_unmanaged_clients() owns every unmanaged client,
- * and declaring one here too would hash a duplicate Clay id and abort. */
+/* A transient that sets no stacking attribute of its own inherits its
+ * parent's band and is declared right above it. One that sets ontop, above,
+ * below or fullscreen declares as a root in that band instead, so the
+ * attribute wins over the parent's placement, as in AwesomeWM.
+ * stack_client_layer() returns WINDOW_LAYER_IGNORE for exactly the first
+ * case, so this implies c->transient_for. */
+static bool
+transient_inherits(Client *c)
+{
+	return stack_client_layer(c) == WINDOW_LAYER_IGNORE;
+}
+
+static int16_t
+client_z(Client *c)
+{
+	if (client_is_unmanaged(c))
+		return Z_CLIENT_UNMANAGED;
+
+	switch (stack_client_effective_layer(c)) {
+	case WINDOW_LAYER_DESKTOP:
+		return Z_CLIENT_DESKTOP;
+	case WINDOW_LAYER_BELOW:
+		return Z_CLIENT_BELOW;
+	case WINDOW_LAYER_ABOVE:
+		return Z_CLIENT_ABOVE;
+	case WINDOW_LAYER_FULLSCREEN:
+		return Z_CLIENT_FULLSCREEN;
+	case WINDOW_LAYER_ONTOP:
+		return Z_CLIENT_ONTOP;
+	default:
+		return Z_CLIENT_NORMAL;
+	}
+}
+
+/* Inheriting transients ride their parent: declared right above it in the
+ * band it resolved to, mirroring stack_transients_above() (stack.c).
+ * Unmanaged children are excluded; declare_unmanaged_clients() owns every
+ * unmanaged client, and declaring one here too would hash a duplicate Clay
+ * id and abort. */
 static void
 declare_client_tree(Client *c, Monitor *m)
 {
-	declare_client(c, m);
+	declare_client(c, m, client_z(c));
 	foreach(node, globalconf.stack)
 		if ((*node)->transient_for == c && (*node)->mon == m
 				&& !client_is_unmanaged(*node)
+				&& transient_inherits(*node)
 				&& declarable_client(*node))
 			declare_client_tree(*node, m);
 }
 
 /* Whether declare_client_tree() will reach c through its parent. When it
- * will not (parent minimized, unmapped, unmanaged, or on another output),
- * c declares as a root in its own layer instead of vanishing; the old
- * scene path kept exactly these clients visible per-client. The immediate
- * parent suffices: every managed declarable client on m is declared, as a
- * root or by riding one, so a declarable parent is a declared parent. */
+ * will not (c carries a stacking attribute of its own, or the parent is
+ * minimized, unmapped, unmanaged, or on another output), c declares as a
+ * root instead of vanishing; the old scene path kept exactly these clients
+ * visible per-client. The immediate parent suffices: every managed
+ * declarable client on m is declared, as a root or by riding one, so a
+ * declarable parent is a declared parent. */
 static bool
 transient_rides_parent(Client *c, Monitor *m)
 {
 	Client *p = c->transient_for;
 
-	return p && p->mon == m && !client_is_unmanaged(p)
-		&& declarable_client(p);
+	return p && transient_inherits(c) && p->mon == m
+		&& !client_is_unmanaged(p) && declarable_client(p);
 }
 
 static void
-declare_clients_in_layer(Monitor *m, window_layer_t want)
+declare_clients(Monitor *m)
 {
 	foreach(node, globalconf.stack) {
 		Client *c = *node;
-		window_layer_t layer;
 
-		/* Cheap pointer filters first; the tag-visibility checks walk
-		 * Lua state and run last. Unmanaged (override-redirect) clients
-		 * bypass stacking attributes and declare at the top of the
-		 * overlay band instead. */
+		/* Cheap pointer filters first, then the riding test, which
+		 * skips a transient before it pays for its own tag-visibility
+		 * check. Unmanaged (override-redirect) clients are declared by
+		 * declare_unmanaged_clients() instead. */
 		if (!c || c->mon != m || client_is_unmanaged(c))
 			continue;
-		layer = stack_client_layer(c);
-		if (layer == WINDOW_LAYER_IGNORE)
-			layer = WINDOW_LAYER_NORMAL;
-		if (layer != want)
-			continue;
-		if (c->transient_for && transient_rides_parent(c, m))
+		if (transient_rides_parent(c, m))
 			continue;
 		if (!declarable_client(c))
 			continue;
@@ -358,12 +423,12 @@ declare_unmanaged_clients(Monitor *m)
 			continue;
 		if (!declarable_client(c))
 			continue;
-		declare_client(c, m);
+		declare_client(c, m, client_z(c));
 	}
 }
 
 static void
-declare_layer_surface(LayerSurface *l, Monitor *m)
+declare_layer_surface(LayerSurface *l, Monitor *m, int16_t z)
 {
 	uint64_t handle = handle_for(l, DECLARE_KIND_LAYER);
 	struct wlr_layer_surface_v1 *ls = l->layer_surface;
@@ -371,8 +436,7 @@ declare_layer_surface(LayerSurface *l, Monitor *m)
 	 * layer-shell solve; the scene node's own position belongs to the
 	 * reconciler and may hold this same value already. */
 	Clay_ElementDeclaration s = leaf_at(CLAY_STRING("layer.surface"),
-		(uint32_t)handle,
-		l->geom.x, l->geom.y,
+		(uint32_t)handle, z, l->geom.x, l->geom.y,
 		ls->current.actual_width, ls->current.actual_height);
 
 	s.custom.customData = (void *)(uintptr_t)handle;
@@ -381,17 +445,25 @@ declare_layer_surface(LayerSurface *l, Monitor *m)
 }
 
 static void
-declare_layer_band(Monitor *m, int band)
+declare_layer_surfaces(Monitor *m)
 {
+	static const int16_t band_z[] = {
+		[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND] = Z_LAYER_BACKGROUND,
+		[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM] = Z_LAYER_BOTTOM,
+		[ZWLR_LAYER_SHELL_V1_LAYER_TOP] = Z_LAYER_TOP,
+		[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY] = Z_LAYER_OVERLAY,
+	};
 	LayerSurface *l;
 
 	/* protocols.c prepends new surfaces to m->layers, and scene child
 	 * order stacks newer surfaces on top; reverse iteration declares the
 	 * oldest first, at the bottom. */
-	wl_list_for_each_reverse(l, &m->layers[band], link) {
-		if (!l->mapped || !l->scene)
-			continue;
-		declare_layer_surface(l, m);
+	for (size_t band = 0; band < LENGTH(m->layers); band++) {
+		wl_list_for_each_reverse(l, &m->layers[band], link) {
+			if (!l->mapped || !l->scene)
+				continue;
+			declare_layer_surface(l, m, band_z[band]);
+		}
 	}
 }
 
@@ -402,7 +474,7 @@ declare_layer_band(Monitor *m, int band)
  * Opacity applies to the content leaf only, matching the old scene-buffer
  * path, which never set opacity on the border or shadow. */
 static void
-declare_drawin(drawin_t *d, Monitor *m)
+declare_drawin(drawin_t *d, Monitor *m, int16_t z)
 {
 	uint64_t handle = handle_for(d, DECLARE_KIND_DRAWIN);
 	uint32_t id = (uint32_t)handle;
@@ -414,7 +486,7 @@ declare_drawin(drawin_t *d, Monitor *m)
 	if (d->shadow_entry.native) {
 		int r = d->shadow_entry_config.radius;
 		Clay_ElementDeclaration s = leaf_at(CLAY_STRING("drawin.shadow"),
-			id, x + d->shadow_entry_config.offset_x - r,
+			id, z, x + d->shadow_entry_config.offset_x - r,
 			y + d->shadow_entry_config.offset_y - r,
 			d->shadow_entry.width, d->shadow_entry.height);
 		s.image.imageData = &d->shadow_entry;
@@ -426,12 +498,13 @@ declare_drawin(drawin_t *d, Monitor *m)
 		 * old border_buffer's point_accepts_input answered, and the
 		 * shadow leaf below gets the same treatment for free. */
 		Clay_ElementDeclaration b = leaf_at(CLAY_STRING("drawin.border"),
-			id, x - bw, y - bw, d->width + 2 * bw, d->height + 2 * bw);
+			id, z, x - bw, y - bw,
+			d->width + 2 * bw, d->height + 2 * bw);
 		b.image.imageData = &d->border_entry;
 		declare_leaf(&b);
 	}
 
-	Clay_ElementDeclaration c = leaf_at(CLAY_STRING("drawin.image"), id,
+	Clay_ElementDeclaration c = leaf_at(CLAY_STRING("drawin.image"), id, z,
 		x, y, d->width, d->height);
 	c.image.imageData = &d->content_entry;
 	c.userData = leaf_userdata(handle, opacity);
@@ -449,20 +522,33 @@ declarable_drawin(drawin_t *d, Monitor *m)
 		&& d->screen && d->screen->monitor == m;
 }
 
+/* The drawin band policy (AwesomeWM compat): desktop and splash below
+ * clients like wallpaper, ontop above everything, dock above normal
+ * windows, everything else in the wibox band. */
+static int16_t
+drawin_z(drawin_t *d)
+{
+	if (d->type == WINDOW_TYPE_DESKTOP || d->type == WINDOW_TYPE_SPLASH)
+		return Z_DRAWIN_BG;
+	if (d->ontop)
+		return Z_DRAWIN_OVERLAY;
+	if (d->type == WINDOW_TYPE_DOCK)
+		return Z_DRAWIN_TOP;
+	return Z_DRAWIN_WIBOX;
+}
+
 static void
-declare_drawins_in_band(Monitor *m, int scene_layer)
+declare_drawins(Monitor *m)
 {
 	foreach(item, globalconf.drawins) {
 		drawin_t *d = *item;
 
-		if (stack_drawin_layer(d) != scene_layer)
-			continue;
 		/* Lock drawins belong to the lock pass while locked. */
 		if (session_is_locked() && some_is_lock_drawin(d))
 			continue;
 		if (!declarable_drawin(d, m))
 			continue;
-		declare_drawin(d, m);
+		declare_drawin(d, m, drawin_z(d));
 	}
 }
 
@@ -478,7 +564,7 @@ declare_fullscreen_bg(Monitor *m)
 		return;
 
 	Clay_ElementDeclaration bg = leaf_at(CLAY_STRING("fullscreen_bg"), 0,
-		0, 0, m->m.width, m->m.height);
+		Z_FULLSCREEN_BG, 0, 0, m->m.width, m->m.height);
 	bg.backgroundColor = clay_color(globalconf.appearance.fullscreen_bg);
 	declare_leaf(&bg);
 }
@@ -486,24 +572,40 @@ declare_fullscreen_bg(Monitor *m)
 static void
 declare_scene(Monitor *m)
 {
-	declare_layer_band(m, ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND);
-	declare_clients_in_layer(m, WINDOW_LAYER_DESKTOP);
-	declare_drawins_in_band(m, LyrBg);
-	declare_layer_band(m, ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM);
-	declare_clients_in_layer(m, WINDOW_LAYER_BELOW);
-	declare_clients_in_layer(m, WINDOW_LAYER_NORMAL);
-	declare_drawins_in_band(m, LyrWibox);
-	declare_layer_band(m, ZWLR_LAYER_SHELL_V1_LAYER_TOP);
-	declare_clients_in_layer(m, WINDOW_LAYER_ABOVE);
-	declare_drawins_in_band(m, LyrTop);
+	declare_layer_surfaces(m);
+	declare_clients(m);
+	declare_drawins(m);
 	declare_fullscreen_bg(m);
-	declare_clients_in_layer(m, WINDOW_LAYER_FULLSCREEN);
-	declare_layer_band(m, ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY);
-	declare_clients_in_layer(m, WINDOW_LAYER_ONTOP);
-	declare_drawins_in_band(m, LyrOverlay);
 	declare_unmanaged_clients(m);
 	/* Session lock: locked_bg, the lock covers, and the lock surface stay
 	 * C-owned scene nodes in LyrBlock, above this whole band. */
+}
+
+int
+declare_output_order(struct declare_output *dout, Monitor *m, void **objects,
+	int cap)
+{
+	int n = 0;
+
+	Clay_SetCurrentContext(dout->desktop.clay);
+	Clay_BeginLayout();
+	declare_scene(m);
+	Clay_RenderCommandArray commands = Clay_EndLayout();
+
+	for (int32_t i = 0; i < commands.length && n < cap; i++) {
+		Clay_RenderCommand *cmd = Clay_RenderCommandArray_Get(&commands, i);
+		void *object = declare_handle_get(
+			declare_userdata_handle(cmd->userData), NULL);
+
+		/* A leaf with no handle (the clip wrapper, the fullscreen
+		 * backing) is not an object. A client declares a border leaf
+		 * and a surface leaf, a drawin up to three image leaves; the
+		 * object enters the order once, at its lowest leaf. */
+		if (!object || (n > 0 && objects[n - 1] == object))
+			continue;
+		objects[n++] = object;
+	}
+	return n;
 }
 
 /* --- context lifecycle and the frame entry --- */
@@ -597,9 +699,9 @@ declare_lock_scene(Monitor *m)
 
 	for (int i = 0; i < cover_count; i++)
 		if (covers[i] && declarable_drawin(covers[i], m))
-			declare_drawin(covers[i], m);
+			declare_drawin(covers[i], m, Z_LOCK_COVER);
 	if (lock_surface && declarable_drawin(lock_surface, m))
-		declare_drawin(lock_surface, m);
+		declare_drawin(lock_surface, m, Z_LOCK_SURFACE);
 }
 
 void
@@ -652,19 +754,23 @@ declare_output_mark_dirty(struct declare_output *dout)
  * this each loop iteration: input hit-testing reads the reconciled scene,
  * and a hidden or asleep output gets no frame events to rebuild it there.
  * The frame handler keeps its own call for marks that land in between.
- * Returns whether any scene mutated, so the caller can re-evaluate what is
- * under the pointer. */
-bool
+ * Returns the scene mutations that took, so the caller can re-evaluate what
+ * is under the pointer.
+ */
+int
 declare_flush(void)
 {
 	Monitor *m;
-	bool mutated = false;
+	int mutations = 0, n;
 
-	wl_list_for_each(m, &mons, link)
-		if (m->declare && m->wlr_output->enabled)
-			mutated |= declare_output_frame(m->declare, m,
-				some_is_lua_locked()) > 0;
-	return mutated;
+	wl_list_for_each(m, &mons, link) {
+		if (!m->declare || !m->wlr_output->enabled)
+			continue;
+		n = declare_output_frame(m->declare, m, some_is_lua_locked());
+		if (n > 0)
+			mutations += n;
+	}
+	return mutations;
 }
 
 void

--- a/declare.c
+++ b/declare.c
@@ -207,17 +207,32 @@ leaf_userdata(uint64_t handle, float opacity)
 		| ((uint64_t)(1 + (unsigned)(opacity * 254.0f + 0.5f)) << 40));
 }
 
+/* The band that drew a node is the one whose render_state retains it, which
+ * is not the band under the pointer: a drawin overhanging an output edge and
+ * a floating client dragged clear of its monitor both draw on a neighbor
+ * while the band that declared them stays where it is. Every band answers,
+ * and a node belongs to at most one, so the first hit is the owner. Asking
+ * all of them also covers a point in a gap between misaligned outputs, where
+ * there is no monitor to ask. */
 void *
-declare_output_hit(struct declare_output *dout, struct wlr_scene_node *node,
-	enum declare_kind *kind)
+declare_hit(struct wlr_scene_node *node, enum declare_kind *kind)
 {
-	void *ud = render_hit_userdata(dout->desktop.render, node);
+	Monitor *m;
 
-	if (!ud && dout->lock.render)
-		ud = render_hit_userdata(dout->lock.render, node);
-	if (!ud)
-		return NULL;
-	return declare_handle_get(declare_userdata_handle(ud), kind);
+	wl_list_for_each(m, &mons, link) {
+		struct declare_output *dout = m->declare;
+		void *ud;
+
+		if (!dout)
+			continue;
+		ud = render_hit_userdata(dout->desktop.render, node);
+		if (!ud && dout->lock.render)
+			ud = render_hit_userdata(dout->lock.render, node);
+		if (ud)
+			return declare_handle_get(
+				declare_userdata_handle(ud), kind);
+	}
+	return NULL;
 }
 
 /* somewm colors are straight-alpha 0-1 floats; Clay_Color is 0-255.
@@ -635,6 +650,15 @@ declare_band_init(struct declare_band *band, struct wlr_output *wlr_output,
 		Clay_CreateArenaWithCapacityAndMemory(arena_size, band->arena),
 		(Clay_Dimensions) { .width = width, .height = height },
 		(Clay_ErrorHandler) { .errorHandlerFunction = handle_clay_error });
+	/* Clay_Initialize left this the current context. Clay drops any
+	 * element whose box lies entirely outside layoutDimensions
+	 * (clay.h:2465), which saves draw calls in immediate mode and loses
+	 * windows here. Boxes are output-local, but the nodes they reconcile
+	 * into are not confined to the output: a floating client mid-drag and
+	 * a drawin overhanging an edge render on the neighbor while their box
+	 * is still relative to the output that declared them. wlr_scene does
+	 * the per-output culling. */
+	Clay_SetCullingEnabled(false);
 	band->tree = wlr_scene_tree_create(parent);
 	band->render = render_create(band->tree);
 }

--- a/declare.c
+++ b/declare.c
@@ -32,7 +32,6 @@
 #include "somewm_types.h"
 #include "globalconf.h"
 #include "client.h"
-#include "color.h"
 #include "focus.h"
 #include "somewm_api.h"
 #include "monitor.h"
@@ -184,7 +183,7 @@ declare_output_hit(struct declare_output *dout, struct wlr_scene_node *node,
 		ud = render_hit_userdata(dout->lock.render, node);
 	if (!ud)
 		return NULL;
-	return declare_handle_get((uintptr_t)ud & 0xFFFFFFFFFFULL, kind);
+	return declare_handle_get(declare_userdata_handle(ud), kind);
 }
 
 /* somewm colors are straight-alpha 0-1 floats; Clay_Color is 0-255.
@@ -196,16 +195,6 @@ clay_color(const float rgba[4])
 		rgba[0] * 255.0f, rgba[1] * 255.0f,
 		rgba[2] * 255.0f, rgba[3] * 255.0f,
 	};
-}
-
-static void
-client_border_rgba(Client *c, float out[4])
-{
-	if (c->border_color.initialized)
-		color_to_floats(&c->border_color, out);
-	else
-		memcpy(out, c->urgent ? get_urgentcolor() : get_bordercolor(),
-			4 * sizeof(float));
 }
 
 /* The frame box: awful.layout's geometry plus the border ring drawn around
@@ -378,9 +367,12 @@ declare_layer_surface(LayerSurface *l, Monitor *m)
 {
 	uint64_t handle = handle_for(l, DECLARE_KIND_LAYER);
 	struct wlr_layer_surface_v1 *ls = l->layer_surface;
+	/* l->geom is output-local, captured by arrangelayer() from the
+	 * layer-shell solve; the scene node's own position belongs to the
+	 * reconciler and may hold this same value already. */
 	Clay_ElementDeclaration s = leaf_at(CLAY_STRING("layer.surface"),
 		(uint32_t)handle,
-		l->scene->node.x - m->m.x, l->scene->node.y - m->m.y,
+		l->geom.x, l->geom.y,
 		ls->current.actual_width, ls->current.actual_height);
 
 	s.custom.customData = (void *)(uintptr_t)handle;
@@ -429,10 +421,13 @@ declare_drawin(drawin_t *d, Monitor *m)
 		declare_leaf(&s);
 	}
 	if (bw > 0 && d->border_entry.native) {
+		/* No userData: the input filter (window.c hook_accepts_input)
+		 * reads a bare word as "never accepts input", which is what the
+		 * old border_buffer's point_accepts_input answered, and the
+		 * shadow leaf below gets the same treatment for free. */
 		Clay_ElementDeclaration b = leaf_at(CLAY_STRING("drawin.border"),
 			id, x - bw, y - bw, d->width + 2 * bw, d->height + 2 * bw);
 		b.image.imageData = &d->border_entry;
-		b.userData = leaf_userdata(handle, 1.0f);
 		declare_leaf(&b);
 	}
 
@@ -583,8 +578,10 @@ declare_output_create(struct wlr_output *wlr_output)
 
 	dout->wlr_output = wlr_output;
 	declare_band_init(&dout->desktop, wlr_output, &scene->tree);
-	wlr_scene_node_place_below(&dout->desktop.tree->node,
-		&layers[LyrBlock]->node);
+	/* Directly above the legacy layers, and below the drag icon and
+	 * LyrBlock, both placed below LyrBlock at setup before any band. */
+	wlr_scene_node_place_above(&dout->desktop.tree->node,
+		&layers[LyrOverlay]->node);
 	dout->dirty = true;
 	return dout;
 }
@@ -613,9 +610,9 @@ declare_lock_set_visible(bool on)
 	wl_list_for_each(m, &mons, link) {
 		if (!m->declare)
 			continue;
-		/* Create the lock band on engage, before the caller raises the
-		 * covers and lock surface: wlroots appends new children topmost,
-		 * so a band created after the raise would land above them. */
+		/* Create the lock band on engage: wlroots appends new children
+		 * topmost, so it lands above locked_bg and below any external
+		 * session-lock tree created after it. */
 		if (on && !m->declare->lock.clay) {
 			declare_band_init(&m->declare->lock,
 				m->declare->wlr_output, layers[LyrBlock]);
@@ -651,6 +648,35 @@ declare_output_mark_dirty(struct declare_output *dout)
 	wlr_output_schedule_frame(dout->wlr_output);
 }
 
+/* Run the declare pass for every dirty output now. The poll function calls
+ * this each loop iteration: input hit-testing reads the reconciled scene,
+ * and a hidden or asleep output gets no frame events to rebuild it there.
+ * The frame handler keeps its own call for marks that land in between.
+ * Returns whether any scene mutated, so the caller can re-evaluate what is
+ * under the pointer. */
+bool
+declare_flush(void)
+{
+	Monitor *m;
+	bool mutated = false;
+
+	wl_list_for_each(m, &mons, link)
+		if (m->declare && m->wlr_output->enabled)
+			mutated |= declare_output_frame(m->declare, m,
+				some_is_lua_locked()) > 0;
+	return mutated;
+}
+
+void
+declare_mark_all_dirty(void)
+{
+	Monitor *m;
+
+	wl_list_for_each(m, &mons, link)
+		if (m->declare)
+			declare_output_mark_dirty(m->declare);
+}
+
 int
 declare_output_frame(struct declare_output *dout, Monitor *m, bool lock_active)
 {
@@ -663,8 +689,7 @@ declare_output_frame(struct declare_output *dout, Monitor *m, bool lock_active)
 	/* While lua-locked, this output solves its lock scene instead; the
 	 * desktop band keeps its last scene, occluded by locked_bg. The lock
 	 * band normally exists already (declare_lock_set_visible creates it
-	 * on engage, before the lock surface is raised above it); this covers
-	 * outputs created mid-lock. */
+	 * on engage); this covers outputs created mid-lock. */
 	if (lock_active && !dout->lock.clay) {
 		declare_band_init(&dout->lock, dout->wlr_output, layers[LyrBlock]);
 		declare_band_update(&dout->lock, dout->wlr_output, m->m.x, m->m.y);

--- a/declare.h
+++ b/declare.h
@@ -1,0 +1,65 @@
+#ifndef SOMEWM_DECLARE_H
+#define SOMEWM_DECLARE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+struct wlr_output;
+struct Monitor;
+struct render_client_hooks;
+
+/* Per-output declare/solve state: the output's Clay context, the retained
+ * render_state its solved commands reconcile into, and the dirty flag the
+ * frame handler consumes. Inert until the frame handler runs declare, solve,
+ * reconcile; created early so the flip edits the frame path, not the output
+ * lifecycle. */
+struct declare_output;
+
+struct declare_output *declare_output_create(struct wlr_output *wlr_output);
+void declare_output_destroy(struct declare_output *dout);
+
+/* Layout position and scale, re-applied on every updatemons pass. */
+void declare_output_update(struct declare_output *dout, int lx, int ly);
+
+/* Mark the output's tree stale and schedule a frame to rebuild it. */
+void declare_output_mark_dirty(struct declare_output *dout);
+
+/* If dirty, declare the output's scene into its Clay context, solve, and
+ * reconcile into wlr_scene. Returns the mutation count, or -1 when the
+ * output was clean and nothing ran. While the lua lock is active
+ * (lock_active), the lock scene solves instead, in a second per-output
+ * context reconciling into a band in LyrBlock; the desktop band keeps its
+ * last scene, occluded by locked_bg below that band. */
+int declare_output_frame(struct declare_output *dout, struct Monitor *m,
+	bool lock_active);
+
+/* Show or hide every output's retained lock band, and dirty all outputs;
+ * called on lua lock engage and disengage. Hiding keeps the retained nodes,
+ * so re-engaging does not first flash the previous lock frame. */
+void declare_lock_set_visible(bool on);
+
+/* How the reconciler reaches surface scene trees (render.h); implemented by
+ * window.c, set once at startup, before any output declares. */
+void declare_set_client_hooks(const struct render_client_hooks *hooks);
+
+/* Renderer handles: what the declare pass stores in a CUSTOM command and the
+ * hooks get back. The kind rides the top 32 bits, a registry id the bottom.
+ * Ids are assigned lazily at first declare; declare_handle_drop at object
+ * destroy is what makes a later resolve of the dead handle return NULL. */
+enum declare_kind {
+	DECLARE_KIND_CLIENT = 1,
+	DECLARE_KIND_LAYER,
+	DECLARE_KIND_DRAWIN,
+};
+
+void *declare_handle_get(uint64_t handle, enum declare_kind *kind);
+void declare_handle_drop(void *object);
+
+/* The input backmap: the object whose leaf drew node (renderer-owned image
+ * nodes, border sides, borrowed surface trees), or NULL for a node this
+ * output's bands did not draw. Checks the desktop band, then the lock band. */
+struct wlr_scene_node;
+void *declare_output_hit(struct declare_output *dout,
+	struct wlr_scene_node *node, enum declare_kind *kind);
+
+#endif

--- a/declare.h
+++ b/declare.h
@@ -24,6 +24,16 @@ void declare_output_update(struct declare_output *dout, int lx, int ly);
 /* Mark the output's tree stale and schedule a frame to rebuild it. */
 void declare_output_mark_dirty(struct declare_output *dout);
 
+/* Mark every output dirty: for facts without one owning output (stacking
+ * order, banning, a drawin whose screen assignment may be stale). */
+void declare_mark_all_dirty(void);
+
+/* Run the declare pass for every dirty output now; called from the poll
+ * function each loop iteration so input hit-testing reads a current scene
+ * even when the backend delivers no frame events (a hidden nested output,
+ * an asleep monitor). Returns whether any scene mutated. */
+bool declare_flush(void);
+
 /* If dirty, declare the output's scene into its Clay context, solve, and
  * reconcile into wlr_scene. Returns the mutation count, or -1 when the
  * output was clean and nothing ran. While the lua lock is active
@@ -54,6 +64,14 @@ enum declare_kind {
 
 void *declare_handle_get(uint64_t handle, enum declare_kind *kind);
 void declare_handle_drop(void *object);
+
+/* The declare handle inside a retained userData word (render.h): the low 40
+ * bits are kind and registry id, the opacity byte rides above them. */
+static inline uint64_t
+declare_userdata_handle(void *userdata)
+{
+	return (uint64_t)(uintptr_t)userdata & 0xFFFFFFFFFFULL;
+}
 
 /* The input backmap: the object whose leaf drew node (renderer-owned image
  * nodes, border sides, borrowed surface trees), or NULL for a node this

--- a/declare.h
+++ b/declare.h
@@ -31,8 +31,8 @@ void declare_mark_all_dirty(void);
 /* Run the declare pass for every dirty output now; called from the poll
  * function each loop iteration so input hit-testing reads a current scene
  * even when the backend delivers no frame events (a hidden nested output,
- * an asleep monitor). Returns whether any scene mutated. */
-bool declare_flush(void);
+ * an asleep monitor). Returns the scene mutations that took. */
+int declare_flush(void);
 
 /* If dirty, declare the output's scene into its Clay context, solve, and
  * reconcile into wlr_scene. Returns the mutation count, or -1 when the
@@ -64,6 +64,14 @@ enum declare_kind {
 
 void *declare_handle_get(uint64_t handle, enum declare_kind *kind);
 void declare_handle_drop(void *object);
+
+/* Test hook (awesome._test_declare_order): the desktop band's draw order for
+ * m, bottom to top, one entry per declared object. A fresh solve of the
+ * current state with no reconcile, so it reads what the next frame would
+ * draw without touching the scene; while the lua lock is up it still reports
+ * the desktop band, which is the one it solves. Returns the entries written. */
+int declare_output_order(struct declare_output *dout, struct Monitor *m,
+	void **objects, int cap);
 
 /* The declare handle inside a retained userData word (render.h): the low 40
  * bits are kind and registry id, the opacity byte rides above them. */

--- a/declare.h
+++ b/declare.h
@@ -82,10 +82,10 @@ declare_userdata_handle(void *userdata)
 }
 
 /* The input backmap: the object whose leaf drew node (renderer-owned image
- * nodes, border sides, borrowed surface trees), or NULL for a node this
- * output's bands did not draw. Checks the desktop band, then the lock band. */
+ * nodes, border sides, borrowed surface trees), or NULL for a node no band
+ * drew. Searches every output's bands, desktop then lock, because the band
+ * that drew a node is not always the one the node is over. */
 struct wlr_scene_node;
-void *declare_output_hit(struct declare_output *dout,
-	struct wlr_scene_node *node, enum declare_kind *kind);
+void *declare_hit(struct wlr_scene_node *node, enum declare_kind *kind);
 
 #endif

--- a/focus.c
+++ b/focus.c
@@ -143,9 +143,9 @@ focusclient(Client *c, int lift)
 	globalconf.focus.client = c;
 	globalconf.focus.need_update = true;
 
-	/* Trigger stack refresh: client_layer_translator() depends on which
-	 * client has focus (e.g., fullscreen clients only get LyrFS when
-	 * focused or when the focused client is on a different screen). */
+	/* Trigger stack refresh: stack_client_layer() depends on which client
+	 * has focus (e.g. fullscreen clients only get WINDOW_LAYER_FULLSCREEN
+	 * when focused or when the focused client is on a different screen). */
 	stack_windows();
 
 	/* Activate the new client */

--- a/globalconf.h
+++ b/globalconf.h
@@ -315,13 +315,11 @@ typedef struct
 
     /** System tray state (StatusNotifierItem protocol)
      * Unlike AwesomeWM's X11 XEmbed approach, we use D-Bus SNI protocol
-     * and render icons as scene graph nodes within the parent drawin.
+     * and composite icons into the parent drawin's content pixels.
      */
     struct {
         /** Parent drawin where systray is rendered */
         drawin_t *parent;
-        /** Scene tree containing icon buffer nodes (child of drawin's scene) */
-        struct wlr_scene_tree *scene_tree;
         /** Background color (ARGB pixel value) */
         uint32_t background_pixel;
         /** Current layout parameters (cached from last render call) */

--- a/input.c
+++ b/input.c
@@ -1701,7 +1701,6 @@ xytonode(double x, double y, struct wlr_surface **psurface,
 	LayerSurface *l = NULL;
 	drawin_t *d = NULL;
 	drawable_t *titlebar_drawable = NULL;
-	Monitor *m;
 
 	if (scene)
 		node = wlr_scene_node_at(&scene->tree.node, x, y, nx, ny);
@@ -1727,11 +1726,12 @@ xytonode(double x, double y, struct wlr_surface **psurface,
 	/* Renderer-drawn chrome resolves through the band backmap: a drawin
 	 * image leaf names its drawin (its shape_input pass-through pixels
 	 * were already skipped inside the scene hit test), a client border
-	 * rect or corner tile names its client. */
-	if (node && !c && !d
-			&& (m = xytomon(x, y)) && m->declare) {
+	 * rect or corner tile names its client. The lookup is by node, not by
+	 * the monitor under the pointer: chrome declared on one output can be
+	 * drawn over its neighbor. */
+	if (node && !c && !d) {
 		enum declare_kind kind;
-		void *obj = declare_output_hit(m->declare, node, &kind);
+		void *obj = declare_hit(node, &kind);
 
 		if (obj && kind == DECLARE_KIND_DRAWIN)
 			d = obj;

--- a/input.c
+++ b/input.c
@@ -40,6 +40,7 @@
 #include "event.h"
 #include "event_queue.h"
 #include "monitor.h"
+#include "declare.h"
 #include "globalconf.h"
 #include "client.h"
 #include "common/luaobject.h"
@@ -1694,92 +1695,60 @@ void
 xytonode(double x, double y, struct wlr_surface **psurface,
 		Client **pc, LayerSurface **pl, drawin_t **pd, drawable_t **pdrawable, double *nx, double *ny)
 {
-	struct wlr_scene_node *node, *pnode;
+	struct wlr_scene_node *node = NULL, *pnode;
 	struct wlr_surface *surface = NULL;
 	Client *c = NULL;
 	LayerSurface *l = NULL;
 	drawin_t *d = NULL;
 	drawable_t *titlebar_drawable = NULL;
-	int layer;
+	Monitor *m;
 
-	/* Safety check: scene must be initialized */
-	if (!scene) {
-		if (psurface) *psurface = NULL;
-		if (pc) *pc = NULL;
-		if (pl) *pl = NULL;
-		if (pd) *pd = NULL;
-		if (pdrawable) *pdrawable = NULL;
-		return;
+	if (scene)
+		node = wlr_scene_node_at(&scene->tree.node, x, y, nx, ny);
+
+	if (node && node->type == WLR_SCENE_NODE_BUFFER) {
+		struct wlr_scene_buffer *buffer = wlr_scene_buffer_from_node(node);
+		struct wlr_scene_surface *scene_surface = wlr_scene_surface_try_from_buffer(buffer);
+
+		if (scene_surface) {
+			surface = scene_surface->surface;
+		} else if (node->data) {
+			/* A titlebar buffer inside a client's scene tree carries
+			 * its drawable (AwesomeWM pattern). */
+			drawable_t *drawable = (drawable_t *)node->data;
+
+			if (drawable->owner_type == DRAWABLE_OWNER_CLIENT) {
+				c = drawable->owner.client;
+				titlebar_drawable = drawable;
+			}
+		}
 	}
 
-	for (layer = NUM_LAYERS - 1; !surface && layer >= 0; layer--) {
-		/* Safety check: layer tree must exist */
-		if (!layers[layer])
-			continue;
-		if (!(node = wlr_scene_node_at(&layers[layer]->node, x, y, nx, ny)))
-			continue;
+	/* Renderer-drawn chrome resolves through the band backmap: a drawin
+	 * image leaf names its drawin (its shape_input pass-through pixels
+	 * were already skipped inside the scene hit test), a client border
+	 * rect or corner tile names its client. */
+	if (node && !c && !d
+			&& (m = xytomon(x, y)) && m->declare) {
+		enum declare_kind kind;
+		void *obj = declare_output_hit(m->declare, node, &kind);
 
+		if (obj && kind == DECLARE_KIND_DRAWIN)
+			d = obj;
+		else if (obj && kind == DECLARE_KIND_CLIENT)
+			c = obj;
+		else if (obj && kind == DECLARE_KIND_LAYER)
+			l = obj;
+	}
 
-		if (node->type == WLR_SCENE_NODE_BUFFER) {
-			struct wlr_scene_buffer *buffer = wlr_scene_buffer_from_node(node);
-			struct wlr_scene_surface *scene_surface = wlr_scene_surface_try_from_buffer(buffer);
-
-
-			if (scene_surface) {
-				surface = scene_surface->surface;
-			} else {
-				/* Check if this buffer belongs to a drawin or titlebar */
-
-				/* node->data now stores drawable pointer (AwesomeWM pattern) */
-				if (node->data) {
-					drawable_t *drawable = (drawable_t *)node->data;
-
-					if (drawable->owner_type == DRAWABLE_OWNER_DRAWIN) {
-						/* This is a drawin's drawable */
-						drawin_t *candidate = drawable->owner.drawin;
-						/* Check shape_input to see if input passes through */
-						if (drawin_accepts_input_at(candidate, x - candidate->x, y - candidate->y)) {
-							d = candidate;
-							/* For drawins, we found what we need - skip client check */
-							goto found;
-						}
-						/* Input passes through this drawin, continue searching */
-					} else if (drawable->owner_type == DRAWABLE_OWNER_CLIENT) {
-						/* This is a titlebar drawable - store it and set client
-						 * Matches AwesomeWM event.c:76-77 client_get_drawable_offset() */
-						c = drawable->owner.client;
-						titlebar_drawable = drawable;
-						/* Continue to found label with client and titlebar_drawable set */
-					}
-				}
-			}
-		} else {
-			/* Skip parent walk for non-buffer nodes (e.g., scene rects) -
-			 * these are background elements that shouldn't intercept input */
-			continue;
-		}
-		/* Walk the tree to find a node that knows the client */
-		for (pnode = node; pnode && !c && !d; ) {
-			/* Check if this node has a drawin */
-			if (pnode->data && layer == LyrWibox) {
-				drawin_t *candidate = (drawin_t *)pnode->data;
-				/* Check shape_input to see if input passes through */
-				if (drawin_accepts_input_at(candidate, x - candidate->x, y - candidate->y)) {
-					d = candidate;
-					break;
-				}
-				/* Input passes through, continue searching to parent (don't set c) */
-			} else {
-				/* Not a drawin - could be a client */
-				c = pnode->data;
-			}
-			/* Safely traverse to parent - stop if we reach root */
-			if (!pnode->parent)
-				break;
-			pnode = &pnode->parent->node;
-		}
-		/* Check type at offset 0 - LayerSurface has 'type' as first field,
-		 * but Client has WINDOW_OBJECT_HEADER before client_type.
+	/* Fall back to the owner walk for nodes the bands did not draw or
+	 * resolve (a surface mid-release, the drag icon, lock surfaces):
+	 * client and layer-surface trees carry their owner in node.data. */
+	if (node && !c && !l && !d) {
+		for (pnode = node; pnode && !c; pnode = pnode->parent ? &pnode->parent->node : NULL)
+			c = pnode->data;
+		/* Check type at offset 0 - LayerSurface has 'type' as first
+		 * field, but Client has WINDOW_OBJECT_HEADER before client_type.
 		 * LayerSurface.type is at offset 0 and set to LayerShell. */
 		if (c && *((unsigned int *)c) == LayerShell) {
 			l = (LayerSurface *)c;
@@ -1787,7 +1756,9 @@ xytonode(double x, double y, struct wlr_surface **psurface,
 		}
 	}
 
-found:
+	if (d && !drawin_accepts_input_at(d, x - d->x, y - d->y))
+		d = NULL;
+
 	/* Validate client pointer - ensure it's still in globalconf.clients
 	 * to avoid returning stale pointers from scene graph data fields */
 	if (c && pc) {

--- a/loop.c
+++ b/loop.c
@@ -10,6 +10,7 @@
 #include <glib.h>
 #include <wayland-server-core.h>
 
+#include "declare.h"
 #include "loop.h"
 #include "somewm.h"
 #include "somewm_api.h"
@@ -200,6 +201,16 @@ some_glib_poll(GPollFD *ufds, guint nfsd, gint timeout)
 	float length;
 	int saved_errno;
 
+	/* Apply pending declare marks before sleeping: input hit-testing reads
+	 * the reconciled scene, and a hidden or asleep output gets no frame
+	 * events to rebuild it in rendermon. Runs before the client flush so
+	 * configures the reconcile sends leave in this iteration. When the
+	 * scene changed, what sits under the stationary pointer may have too
+	 * (a surface mapped under it, a tag switch): re-evaluate pointer
+	 * focus, the way banning_refresh() does after visibility flips. */
+	if (declare_flush())
+		motionnotify(0, NULL, 0, 0, 0, 0);
+
 	/* Flush pending Wayland client data before polling
 	 * Clients won't receive data until we flush */
 	wl_display_flush_clients(dpy);
@@ -308,6 +319,9 @@ some_refresh(void)
 	/* Step 4: Update client visibility (banning) */
 	bool banning_pending = globalconf.need_lazy_banning;
 	banning_refresh();
+	/* Banning is a declare filter (declare.c): re-solve when it ran. */
+	if (banning_pending)
+		declare_mark_all_dirty();
 
 	/* Step 4.5: Re-evaluate pointer focus after visibility changes.
 	 * When scene nodes are disabled (banned) wlroots sends wl_pointer.leave,

--- a/luaa.c
+++ b/luaa.c
@@ -1252,6 +1252,47 @@ luaA_awesome_test_add_output(lua_State *L)
 	return 1;
 }
 
+/** awesome._test_redeclare: re-declare every output and report the scene
+ * mutations that took. Nothing else having changed between two calls, the
+ * second must return 0 (see tests/test-declare-zero-mutations.lua).
+ * \return Number of scene mutations
+ */
+static int
+luaA_awesome_test_redeclare(lua_State *L)
+{
+	declare_mark_all_dirty();
+	lua_pushinteger(L, declare_flush());
+	return 1;
+}
+
+/** The draw order of a screen's windows, wiboxes and layer surfaces,
+ * bottom to top.
+ * Solves the screen's Clay tree again and reports what it would draw, so a
+ * test can assert stacking directly instead of inferring it from attributes
+ * (see tests/test-declare-order.lua).
+ * \param screen The screen to solve.
+ * \return Array of the objects drawn, bottom first.
+ */
+static int
+luaA_awesome_test_declare_order(lua_State *L)
+{
+	enum { ORDER_CAP = 256 };
+	screen_t *s = luaA_checkscreen(L, 1);
+	void *objects[ORDER_CAP];
+	int n;
+
+	if (!s->monitor || !s->monitor->declare)
+		return 0;
+	n = declare_output_order(s->monitor->declare, s->monitor, objects,
+		ORDER_CAP);
+	lua_createtable(L, n, 0);
+	for (int i = 0; i < n; i++) {
+		luaA_object_push(L, objects[i]);
+		lua_rawseti(L, -2, i + 1);
+	}
+	return 1;
+}
+
 /** Reload shadow settings from beautiful theme.
  * Call this after changing beautiful.shadow_* values to apply them.
  * Regenerates shadow textures and updates all existing shadows.
@@ -2102,6 +2143,8 @@ const luaL_Reg awesome_methods[] = {
 	{ "restart", luaA_restart },
 	{ "shadow_reload", luaA_awesome_shadow_reload },
 	{ "_test_add_output", luaA_awesome_test_add_output },
+	{ "_test_redeclare", luaA_awesome_test_redeclare },
+	{ "_test_declare_order", luaA_awesome_test_declare_order },
 	/* Lock API methods */
 	{ "lock", luaA_awesome_lock },
 	{ "unlock", luaA_awesome_unlock },

--- a/luaa.c
+++ b/luaa.c
@@ -1,4 +1,5 @@
 #include "luaa.h"
+#include "declare.h"
 #include "draw.h"  /* Must be before globalconf.h to avoid type conflicts */
 #include "globalconf.h"
 
@@ -1270,13 +1271,9 @@ luaA_awesome_shadow_reload(lua_State *L)
 			(*c)->geometry.height + 2 * (*c)->bw);
 	}
 
-	/* Update all existing drawin shadows */
+	/* Drawin shadow entries rebuild through the refresh cycle */
 	foreach(d, globalconf.drawins) {
-		drawin_t *drawin = *d;
-		const shadow_config_t *config = shadow_get_effective_config(
-			drawin->shadow_config, true);
-		shadow_update_config(&drawin->shadow, drawin->scene_tree, config,
-			drawin->width, drawin->height);
+		(*d)->border_need_update = true;
 	}
 
 	return 0;
@@ -4570,30 +4567,20 @@ luaA_state_drop_object_pointers(void)
 	globalconf.mouse_under.ptr.client = NULL;
 	globalconf.primary_screen = NULL;
 
-	/* Destroy old drawin scene trees now, or they persist as duplicates
-	 * behind the ones the rebuilt state creates. */
+	/* Retire the renderer's view of the old drawins now, or their retained
+	 * leaves persist as duplicates behind the ones the rebuilt state
+	 * creates. */
 	foreach(d, globalconf.drawins) {
 		drawin_t *w = *d;
-		for (int si = 0; si < SHADOW_TEXTURE_COUNT; si++) {
-			if (w->shadow.textures[si]) {
-				wlr_buffer_drop(w->shadow.textures[si]);
-				w->shadow.textures[si] = NULL;
-			}
-		}
-		if (w->scene_tree) {
-			wlr_scene_node_destroy(&w->scene_tree->node);
-			w->scene_tree = NULL;
-			w->scene_buffer = NULL;
-			w->border_buffer = NULL;
-		}
+		declare_handle_drop(w);
+		drawin_entry_set(&w->content_entry, NULL);
+		drawin_entry_set(&w->border_entry, NULL);
+		drawin_entry_set(&w->shadow_entry, NULL);
 	}
 	globalconf.drawins.len = 0;
+	declare_mark_all_dirty();
 
-	/* The systray scene tree is a child of the parent drawin's tree, so the
-	 * loop above already destroyed it. Both pointers dangle; NULL them, or
-	 * drawin_wipe() destroys the freed scene node again at close. */
 	globalconf.systray.parent = NULL;
-	globalconf.systray.scene_tree = NULL;
 
 	/* Reset screen_refs before closing (entries become invalid) */
 	luaA_screen_refs_reset();

--- a/luaa.c
+++ b/luaa.c
@@ -1281,8 +1281,12 @@ luaA_awesome_test_declare_order(lua_State *L)
 	void *objects[ORDER_CAP];
 	int n;
 
-	if (!s->monitor || !s->monitor->declare)
-		return 0;
+	/* A screen with no monitor draws nothing. Report that as an empty
+	 * order, not nil: the caller iterates the result. */
+	if (!s->monitor || !s->monitor->declare) {
+		lua_createtable(L, 0, 0);
+		return 1;
+	}
 	n = declare_output_order(s->monitor->declare, s->monitor, objects,
 		ORDER_CAP);
 	lua_createtable(L, n, 0);

--- a/meson.build
+++ b/meson.build
@@ -433,6 +433,7 @@ somewm_sources = [
   'xwayland.c',
   'protocols.c',
   'monitor.c',
+  'declare.c',
   'input.c',
   'window.c',
   'focus.c',

--- a/monitor.c
+++ b/monitor.c
@@ -147,7 +147,6 @@ cleanupmon(struct wl_listener *listener, void *data)
 
 	closemon(m);
 	declare_output_destroy(m->declare);
-	wlr_scene_node_destroy(&m->fullscreen_bg->node);
 	free(m);
 
 	if (updatemons_pending) {
@@ -284,18 +283,6 @@ createmon(struct wl_listener *listener, void *data)
 			m->needs_output_added = 1;
 		}
 	}
-
-	/* The xdg-protocol specifies:
-	 *
-	 * If the fullscreened surface is not opaque, the compositor must make
-	 * sure that other screen content not part of the same surface tree (made
-	 * up of subsurfaces, popups or similarly coupled surfaces) are not
-	 * visible below the fullscreened surface.
-	 *
-	 */
-	/* updatemons() will resize and set correct position */
-	m->fullscreen_bg = wlr_scene_rect_create(layers[LyrFS], 0, 0, globalconf.appearance.fullscreen_bg);
-	wlr_scene_node_set_enabled(&m->fullscreen_bg->node, 0);
 
 	/* Adds this to the output layout in the order it was configured.
 	 *
@@ -533,6 +520,13 @@ rendermon(struct wl_listener *listener, void *data)
 	struct timespec bench_render_start, bench_render_end;
 	clock_gettime(CLOCK_MONOTONIC, &bench_render_start);
 #endif
+	/* The Clay frame: when the output is dirty, declare its scene, solve,
+	 * and reconcile into wlr_scene before the commit below presents it.
+	 * A clean output does zero work here. While the lua lock is engaged
+	 * the lock band solves instead of the desktop (declare.h). */
+	if (m->declare)
+		declare_output_frame(m->declare, m, some_is_lua_locked());
+
 	/* needs_frame is true only when there is something to present;
 	 * wlr_scene_output_commit() returns true without presenting otherwise, so
 	 * sample it first to count only real presents. */
@@ -700,9 +694,6 @@ updatemons(struct wl_listener *listener, void *data)
 		m->w = m->m;
 		wlr_scene_output_set_position(m->scene_output, m->m.x, m->m.y);
 		declare_output_update(m->declare, m->m.x, m->m.y);
-
-		wlr_scene_node_set_position(&m->fullscreen_bg->node, m->m.x, m->m.y);
-		wlr_scene_rect_set_size(m->fullscreen_bg, m->m.width, m->m.height);
 
 		if (m->lock_surface) {
 			struct wlr_scene_tree *scene_tree = client_surface_get_scene_tree(m->lock_surface->surface);

--- a/monitor.c
+++ b/monitor.c
@@ -25,6 +25,7 @@
 
 #include "somewm.h"
 #include "somewm_api.h"
+#include "declare.h"
 #include "monitor.h"
 #include "nested_inhibitor.h"
 #include "protocols.h"
@@ -145,6 +146,7 @@ cleanupmon(struct wl_listener *listener, void *data)
 	in_updatemons = 0;
 
 	closemon(m);
+	declare_output_destroy(m->declare);
 	wlr_scene_node_destroy(&m->fullscreen_bg->node);
 	free(m);
 
@@ -302,6 +304,7 @@ createmon(struct wl_listener *listener, void *data)
 	 * output (such as DPI, scale factor, manufacturer, etc).
 	 */
 	m->scene_output = wlr_scene_output_create(scene, wlr_output);
+	m->declare = declare_output_create(wlr_output);
 
 	/* Create screen object BEFORE adding to layout.
 	 * wlr_output_layout_add_auto() triggers updatemons() SYNCHRONOUSLY
@@ -696,6 +699,7 @@ updatemons(struct wl_listener *listener, void *data)
 		wlr_output_layout_get_box(output_layout, m->wlr_output, &m->m);
 		m->w = m->m;
 		wlr_scene_output_set_position(m->scene_output, m->m.x, m->m.y);
+		declare_output_update(m->declare, m->m.x, m->m.y);
 
 		wlr_scene_node_set_position(&m->fullscreen_bg->node, m->m.x, m->m.y);
 		wlr_scene_rect_set_size(m->fullscreen_bg, m->m.width, m->m.height);

--- a/objects/client.c
+++ b/objects/client.c
@@ -1976,9 +1976,9 @@ client_ban(client_t *c)
         if(!c->scene)
             return;
 
-        /* Wayland: hide in scene graph (equivalent to xcb_unmap_window) */
-        wlr_scene_node_set_enabled(&c->scene->node, false);
-
+        /* The reconciler hides it: banning is a declare filter
+         * (client_isvisible in declarable_client), and banning_refresh()'s
+         * caller marks every output dirty once the sweep has to run. */
         c->isbanned = true;
 
         client_ban_unfocus(c);
@@ -2553,11 +2553,9 @@ client_set_minimized(lua_State *L, int cidx, bool s)
     if(c->minimized != s)
     {
         c->minimized = s;
+        /* The reconciler hides and shows it: banning_need_update() marks
+         * every output once banning_refresh() has to run. */
         banning_need_update();
-
-        /* Wayland: Hide/show the client's scene node */
-        if(c->scene)
-            wlr_scene_node_set_enabled(&c->scene->node, !s);
 
         /* xdg state is not set here. property::minimized below reaches
          * arrange(), which calls client_set_suspended() - one configure
@@ -2879,9 +2877,7 @@ client_unban(client_t *c)
         if(!c->scene)
             return;
 
-        /* Wayland: show in scene graph (equivalent to xcb_map_window) */
-        wlr_scene_node_set_enabled(&c->scene->node, true);
-
+        /* The reconciler shows it again; see client_ban(). */
         c->isbanned = false;
 
         /* An unbanned client shouldn't be minimized or hidden */

--- a/objects/client.c
+++ b/objects/client.c
@@ -112,8 +112,10 @@
 #include "../property.h"
 #include "../screenshot_compose.h"
 
-/* Forward declaration - applies client geometry to wlroots scene graph */
-void apply_geometry_to_wlroots(client_t *c);
+#include "../declare.h"
+
+/* Forward declarations - window.c's configure-client-to-box seam */
+bool client_configure_to_box(client_t *c);
 
 #include <math.h>
 #include <stdio.h>
@@ -2140,60 +2142,43 @@ client_border_refresh(void)
         c->border_need_update = false;
 
         /* Skip if client has no scene (not yet mapped) */
-        if(!c->scene || !c->border[0])
+        if(!c->scene)
             continue;
 
         /* Sync wlroots border width (bw) with Lua-facing border_width;
-         * client_geometry_refresh() runs right after this and applies the
-         * new width to the border rects, surface offset and shadow.
+         * the dirty frame below re-declares the frame at the new width.
          * Fullscreen keeps bw at 0 (matches setfullscreen()), so a
          * border_color change while fullscreen doesn't re-grow the frame. */
         c->bw = c->fullscreen ? 0 : c->border_width;
 
-        /* Update border color if initialized (matches AwesomeWM window_border_refresh pattern) */
-        if(c->border_color.initialized) {
-            float color_floats[4];
-            int i;
-
-            color_to_floats(&c->border_color, color_floats);
-
-            /* Apply color to all 4 border rectangles */
-            for(i = 0; i < 4; i++)
-                wlr_scene_rect_set_color(c->border[i], color_floats);
-        }
+        /* Width and color both land through the declare pass, which reads
+         * c->bw and client_border_rgba() per frame. */
+        if (c->mon && c->mon->declare)
+            declare_output_mark_dirty(c->mon->declare);
     }
 }
 
-/** Apply pending geometry changes to wlroots scene graph.
- *
- * This is the Wayland equivalent of AwesomeWM's X11 client_geometry_refresh().
- * Lua layout code calculates positions via c:geometry({...}), which updates
- * c->geometry in the C struct. This function applies those changes to the
- * actual wlroots scene nodes.
- *
- * Called from client_refresh() during the refresh cycle.
+/** The border color the declare pass draws for c: the Lua border_color
+ * property when set, else the C-side focus recolor, else the theme default
+ * (urgent-aware). Straight-alpha 0-1 floats.
  */
-static void
-client_geometry_refresh(void)
+void
+client_border_rgba(client_t *c, float out[4])
 {
-    foreach(_c, globalconf.clients)
-    {
-        client_t *c = *_c;
-
-        if (!c || !c->mon)
-            continue;
-
-        /* Apply c->geometry to wlroots scene graph */
-        apply_geometry_to_wlroots(c);
-    }
+    if (c->border_color.initialized)
+        color_to_floats(&c->border_color, out);
+    else if (c->border_rgba_set)
+        memcpy(out, c->border_rgba, 4 * sizeof(float));
+    else
+        memcpy(out, c->urgent ? globalconf.appearance.urgentcolor
+                              : globalconf.appearance.bordercolor,
+               4 * sizeof(float));
 }
 
 void
 client_refresh(void)
 {
-    /* Border refresh first: it syncs c->bw, which the geometry pass reads */
     client_border_refresh();
-    client_geometry_refresh();
     client_focus_refresh();
 }
 
@@ -2484,10 +2469,14 @@ client_resize_do(client_t *c, area_t geometry, bool silent)
         lua_pop(L, 2);
     }
 
-    /* Geometry will be applied to wlroots in the deferred refresh cycle.
-     * This matches AwesomeWM's pattern: client_resize_do() only updates state,
-     * and client_geometry_refresh() applies to the window system.
-     */
+    /* The frame around the client (position, borders, shadow) follows
+     * c->geometry at the next dirty frame; the configure leg runs now so
+     * the client learns its size in this cycle (titlebar-only changes
+     * shift the surface without moving the declared box, so the
+     * reconciler's configure hook alone would miss them). */
+    client_configure_to_box(c);
+    if (c->mon && c->mon->declare)
+        declare_output_mark_dirty(c->mon->declare);
 }
 
 /** Resize client window.
@@ -2751,7 +2740,7 @@ client_set_maximized_common(lua_State *L, int cidx, bool s, const char* type, co
             luaA_object_emit_signal(L, abs_cidx, "property::maximized", 0);
             if(c->toplevel_handle)
                 wlr_foreign_toplevel_handle_v1_set_maximized(c->toplevel_handle, c->maximized);
-            /* xdg-shell state is not written here. apply_geometry_to_wlroots()
+            /* xdg-shell state is not written here. client_configure_to_box()
              * reconciles it, so it batches into the same configure as the
              * size change (same as fullscreen). */
         }
@@ -3435,37 +3424,52 @@ luaA_client_get_first_tag(lua_State *L, client_t *c)
     return 0;
 }
 
-/** Get the wlroots scene-graph layer the client currently lives in.
+/** Get the stacking layer the client currently draws in.
  * Returns the layer name as a string, or nil if the client has no scene
- * node or its parent is not one of the known top-level layers. Intended
- * for integration tests that verify stacking behavior.
+ * node. Intended for integration tests that verify stacking behavior; the
+ * names are the pre-Clay scene layers, now derived from the same
+ * classification the declare pass orders bands by.
  */
 static int
 luaA_client_get__scene_layer(lua_State *L, client_t *c)
 {
-    static const char *const layer_names[NUM_LAYERS] = {
-        [LyrBg]      = "background",
-        [LyrBottom]  = "bottom",
-        [LyrTile]    = "tile",
-        [LyrFloat]   = "float",
-        [LyrWibox]   = "wibox",
-        [LyrTop]     = "top",
-        [LyrFS]      = "fullscreen",
-        [LyrOverlay] = "overlay",
-        [LyrBlock]   = "block",
+    static const char *const layer_names[WINDOW_LAYER_COUNT] = {
+        [WINDOW_LAYER_DESKTOP]    = "background",
+        [WINDOW_LAYER_BELOW]      = "bottom",
+        [WINDOW_LAYER_NORMAL]     = "tile",
+        [WINDOW_LAYER_ABOVE]      = "top",
+        [WINDOW_LAYER_FULLSCREEN] = "fullscreen",
+        [WINDOW_LAYER_ONTOP]      = "overlay",
     };
+    window_layer_t layer;
 
-    if (!c->scene || !c->scene->node.parent)
+    if (!c->scene)
         return 0;
 
-    for (int i = 0; i < NUM_LAYERS; i++) {
-        if ((void *)c->scene->node.parent == (void *)layers[i]) {
-            lua_pushstring(L, layer_names[i]);
-            return 1;
+    /* Unmanaged (override-redirect) clients draw at the top of the overlay
+     * band (declare_unmanaged_clients); transients ride their parent. */
+#ifdef XWAYLAND
+    if (c->client_type == X11 && c->surface.xwayland
+            && c->surface.xwayland->override_redirect) {
+        lua_pushstring(L, "overlay");
+        return 1;
+    }
+#endif
+    {
+        client_t *p = c;
+
+        layer = stack_client_layer(p);
+        while (layer == WINDOW_LAYER_IGNORE && p->transient_for) {
+            p = p->transient_for;
+            layer = stack_client_layer(p);
         }
     }
-
-    return 0;
+    if (layer == WINDOW_LAYER_IGNORE)
+        layer = WINDOW_LAYER_NORMAL;
+    if (!layer_names[layer])
+        return 0;
+    lua_pushstring(L, layer_names[layer]);
+    return 1;
 }
 
 /** Raise a client on top of others which are on the same layer.
@@ -3776,7 +3780,7 @@ titlebar_resize(lua_State *L, int cidx, client_t *c, client_titlebar_t bar, int 
 }
 
 /** Update all titlebar scene buffer positions based on current geometry.
- * Called from apply_geometry_to_wlroots() when client geometry changes.
+ * Called from client_configure_to_box() when client geometry changes.
  * In X11, drawable_set_geometry() implicitly repositions windows.
  * In Wayland, we must explicitly update scene_buffer positions.
  */
@@ -4972,20 +4976,21 @@ luaA_client_set_xproperty(lua_State *L)
 /** client:_border_is_focus_color() -> boolean
  *
  * Returns true if the client's rendered border color matches the
- * compositor's focus color. Reads directly from wlr_scene_rect.
+ * compositor's focus color. Reads the same color the declare pass draws.
  */
 static int
 luaA_client_border_is_focus_color(lua_State *L)
 {
     client_t *c = luaA_checkudata(L, 1, &client_class);
-    if (!c || !c->border[0]) {
+    if (!c || !c->scene) {
         lua_pushboolean(L, 0);
         return 1;
     }
 
     const float *focus = globalconf.appearance.focuscolor;
-    const float *actual = c->border[0]->color;
+    float actual[4];
 
+    client_border_rgba(c, actual);
     int matches = (actual[0] == focus[0] && actual[1] == focus[1] &&
                    actual[2] == focus[2] && actual[3] == focus[3]);
 
@@ -5002,14 +5007,15 @@ static int
 luaA_client_border_is_normal_color(lua_State *L)
 {
     client_t *c = luaA_checkudata(L, 1, &client_class);
-    if (!c || !c->border[0]) {
+    if (!c || !c->scene) {
         lua_pushboolean(L, 0);
         return 1;
     }
 
     const float *normal = globalconf.appearance.bordercolor;
-    const float *actual = c->border[0]->color;
+    float actual[4];
 
+    client_border_rgba(c, actual);
     int matches = (actual[0] == normal[0] && actual[1] == normal[1] &&
                    actual[2] == normal[2] && actual[3] == normal[3]);
 

--- a/objects/client.c
+++ b/objects/client.c
@@ -3446,8 +3446,9 @@ luaA_client_get__scene_layer(lua_State *L, client_t *c)
     if (!c->scene)
         return 0;
 
-    /* Unmanaged (override-redirect) clients draw at the top of the overlay
-     * band (declare_unmanaged_clients); transients ride their parent. */
+    /* Unmanaged (override-redirect) clients draw above everything
+     * (declare.c's z table); every other client draws in the layer
+     * stack_client_effective_layer() names. */
 #ifdef XWAYLAND
     if (c->client_type == X11 && c->surface.xwayland
             && c->surface.xwayland->override_redirect) {
@@ -3455,17 +3456,7 @@ luaA_client_get__scene_layer(lua_State *L, client_t *c)
         return 1;
     }
 #endif
-    {
-        client_t *p = c;
-
-        layer = stack_client_layer(p);
-        while (layer == WINDOW_LAYER_IGNORE && p->transient_for) {
-            p = p->transient_for;
-            layer = stack_client_layer(p);
-        }
-    }
-    if (layer == WINDOW_LAYER_IGNORE)
-        layer = WINDOW_LAYER_NORMAL;
+    layer = stack_client_effective_layer(c);
     if (!layer_names[layer])
         return 0;
     lua_pushstring(L, layer_names[layer]);

--- a/objects/client.h
+++ b/objects/client.h
@@ -156,6 +156,8 @@ struct client_t
     } surface;
     /** Scene tree for this client */
     struct wlr_scene_tree *scene;
+    /** The render_state currently borrowing scene (render.h owner token) */
+    void *render_owner;
     /** Scene surface node */
     struct wlr_scene_tree *scene_surface;
     /** Popup parent tree: tracks scene_surface's position but is exempt

--- a/objects/client.h
+++ b/objects/client.h
@@ -164,8 +164,10 @@ struct client_t
      * from client_get_clip()'s content clip (mirrors LayerSurface::popups),
      * since context menus routinely extend beyond the parent's bounds. */
     struct wlr_scene_tree *popups;
-    /** Border rectangles */
-    struct wlr_scene_rect *border[4];
+    /** C-side border recolor (focus tracking): the declare pass reads this
+     * when the Lua border_color property was never set. */
+    float border_rgba[4];
+    bool border_rgba_set;
     /** Shadow configuration (NULL = use defaults) */
     shadow_config_t *shadow_config;
     /** Shadow scene nodes */
@@ -408,6 +410,7 @@ void client_focus(client_t *);
 bool client_focus_update(client_t *);
 void client_focus_refresh(void);
 void client_refresh(void);
+void client_border_rgba(client_t *, float out[4]);
 void client_destroy_later(void);
 bool client_hasproto(client_t *, uint32_t);  /* Changed from xcb_atom_t */
 void client_ignore_enterleave_events(void);

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -11,6 +11,7 @@
 #include "common/util.h"
 #include "../globalconf.h"
 #include "../shadow.h"
+#include "../declare.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -390,6 +391,45 @@ drawin_apply_shape_mask(cairo_surface_t *src, cairo_surface_t *shape)
 	return dst;
 }
 
+static cairo_surface_t *drawin_copy_surface(cairo_surface_t *src);
+
+/* Hand an entry a new owned surface (destroying the previous one) and bump
+ * its generation so the renderer re-rasters. NULL clears the entry; a no-op
+ * clear does not bump. */
+static void
+drawin_entry_set(struct image_entry *entry, cairo_surface_t *owned)
+{
+	if (!entry->native && !owned)
+		return;
+	if (entry->native)
+		cairo_surface_destroy(entry->native);
+	entry->native = owned;
+	entry->width = owned ? cairo_image_surface_get_width(owned) : 0;
+	entry->height = owned ? cairo_image_surface_get_height(owned) : 0;
+	entry->gen++;
+}
+
+/* Rebuild the shadow composite entry when its inputs changed; the memo
+ * (entry size vs drawin size plus radius, and the stored config) makes
+ * redundant calls free. */
+static void
+drawin_update_shadow_entry(drawin_t *d, const shadow_config_t *config)
+{
+	if (!config || !config->enabled) {
+		drawin_entry_set(&d->shadow_entry, NULL);
+		return;
+	}
+	if (d->shadow_entry.native
+			&& d->shadow_entry.width == d->width + 2 * config->radius
+			&& d->shadow_entry.height == d->height + 2 * config->radius
+			&& memcmp(&d->shadow_entry_config, config, sizeof(*config)) == 0)
+		return;
+
+	drawin_entry_set(&d->shadow_entry,
+		shadow_render_composite(config, d->width, d->height));
+	d->shadow_entry_config = *config;
+}
+
 static void
 drawin_refresh_drawable(drawin_t *drawin)
 {
@@ -453,11 +493,33 @@ drawin_refresh_drawable(drawin_t *drawin)
 		buffer = drawable_create_buffer(d);
 	}
 
-	/* Clean up temporary surfaces */
-	if (clipped_surface)
-		cairo_surface_destroy(clipped_surface);
-	if (masked_surface)
-		cairo_surface_destroy(masked_surface);
+	/* Feed the renderer's content entry the same pixels: the final masked
+	 * copy when masks applied (its ownership moves to the entry), else an
+	 * owned copy of the drawable surface. The scene-buffer upload above is
+	 * the half the Clay flip deletes; the entry is the surviving half. */
+	if (work_surface != d->surface) {
+		if (clipped_surface && clipped_surface != work_surface)
+			cairo_surface_destroy(clipped_surface);
+		drawin_entry_set(&drawin->content_entry, work_surface);
+	} else {
+		struct image_entry *entry = &drawin->content_entry;
+		int cw = cairo_image_surface_get_width(d->surface);
+		int ch = cairo_image_surface_get_height(d->surface);
+
+		if (entry->native && entry->width == cw && entry->height == ch) {
+			/* Same size: repaint the owned copy in place instead of
+			 * reallocating a full surface every refresh. */
+			cairo_t *cr = cairo_create(entry->native);
+			cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+			cairo_set_source_surface(cr, d->surface, 0, 0);
+			cairo_paint(cr);
+			cairo_destroy(cr);
+			cairo_surface_flush(entry->native);
+			entry->gen++;
+		} else {
+			drawin_entry_set(entry, drawin_copy_surface(d->surface));
+		}
+	}
 
 	if (!buffer) {
 		return;
@@ -673,6 +735,13 @@ drawin_wipe(drawin_t *w)
 
 	/* Clear any lock surface/cover pointers referencing this drawin (EDGE-2) */
 	some_notify_drawin_destroyed(w);
+
+	/* Retire the renderer's view: the handle so a later resolve answers
+	 * NULL, and the entry surfaces the declare pass hands out. */
+	declare_handle_drop(w);
+	drawin_entry_set(&w->content_entry, NULL);
+	drawin_entry_set(&w->border_entry, NULL);
+	drawin_entry_set(&w->shadow_entry, NULL);
 
 	/* Note: drawable reference cleanup handled by class system */
 	w->drawable = NULL;
@@ -1411,6 +1480,7 @@ drawin_border_refresh_single(drawin_t *d)
 					d->width, d->height);
 			}
 		}
+		drawin_update_shadow_entry(d, shadow_config);
 	}
 
 	bw = d->border_width;
@@ -1418,6 +1488,7 @@ drawin_border_refresh_single(drawin_t *d)
 	/* If no border width, hide the border buffer */
 	if (bw <= 0) {
 		wlr_scene_buffer_set_buffer(d->border_buffer, NULL);
+		drawin_entry_set(&d->border_entry, NULL);
 		return;
 	}
 
@@ -1425,12 +1496,14 @@ drawin_border_refresh_single(drawin_t *d)
 	border_surface = drawin_render_border(d);
 	if (!border_surface) {
 		wlr_scene_buffer_set_buffer(d->border_buffer, NULL);
+		drawin_entry_set(&d->border_entry, NULL);
 		return;
 	}
 
 	/* Convert Cairo surface to wlr_buffer */
 	wlr_buf = border_buffer_from_cairo(border_surface);
-	cairo_surface_destroy(border_surface);
+	/* border_surface's ownership moves to the renderer's border entry */
+	drawin_entry_set(&d->border_entry, border_surface);
 
 	if (!wlr_buf) {
 		wlr_scene_buffer_set_buffer(d->border_buffer, NULL);

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -291,6 +291,25 @@ drawin_apply_shape_mask(cairo_surface_t *src, cairo_surface_t *shape)
 
 static cairo_surface_t *drawin_copy_surface(cairo_surface_t *src);
 
+/* Paint src onto cr's target one pixel to one pixel. A drawable surface
+ * carries a device scale (set below so Lua draws in logical coordinates) and
+ * cairo honours it on the source pattern, which would land a HiDPI surface in
+ * the top-left 1/scale of the destination and drop the rest. Undoing it on the
+ * context makes this the plain pixel copy an image_entry is expected to hold,
+ * matching what drawin_apply_shape_mask already produces. */
+static void
+drawin_paint_pixels(cairo_t *cr, cairo_surface_t *src)
+{
+	double sx = 1.0, sy = 1.0;
+
+	cairo_surface_get_device_scale(src, &sx, &sy);
+	if (sx > 0.0 && sy > 0.0)
+		cairo_scale(cr, sx, sy);
+	cairo_set_source_surface(cr, src, 0, 0);
+	cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+	cairo_paint(cr);
+}
+
 /* Hand an entry a new owned surface (destroying the previous one) and bump
  * its generation so the renderer re-rasters. NULL clears the entry; a no-op
  * clear does not bump. */
@@ -394,9 +413,7 @@ drawin_refresh_drawable(drawin_t *drawin)
 			/* Same size: repaint the owned copy in place instead of
 			 * reallocating a full surface every refresh. */
 			cairo_t *cr = cairo_create(entry->native);
-			cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
-			cairo_set_source_surface(cr, d->surface, 0, 0);
-			cairo_paint(cr);
+			drawin_paint_pixels(cr, d->surface);
 			cairo_destroy(cr);
 			entry->gen++;
 		} else {
@@ -1615,9 +1632,7 @@ drawin_copy_surface(cairo_surface_t *src)
 
 	/* Copy the content */
 	cr = cairo_create(dst);
-	cairo_set_source_surface(cr, src, 0, 0);
-	cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
-	cairo_paint(cr);
+	drawin_paint_pixels(cr, src);
 	cairo_destroy(cr);
 
 	return dst;

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -434,6 +434,7 @@ static void
 drawin_refresh_drawable(drawin_t *drawin)
 {
 	drawable_t *d;
+	struct image_entry *entry;
 	struct wlr_buffer *buffer;
 	cairo_surface_t *clipped_surface = NULL;
 	cairo_surface_t *masked_surface = NULL;
@@ -480,29 +481,15 @@ drawin_refresh_drawable(drawin_t *drawin)
 			work_surface = masked_surface;
 	}
 
-	/* Create SHM buffer from the final surface
-	 * This uses the shared buffer implementation in drawable.c */
-	if (work_surface != d->surface) {
-		cairo_surface_flush(work_surface);
-		buffer = drawable_create_buffer_from_data(
-			cairo_image_surface_get_width(work_surface),
-			cairo_image_surface_get_height(work_surface),
-			cairo_image_surface_get_data(work_surface),
-			cairo_image_surface_get_stride(work_surface));
-	} else {
-		buffer = drawable_create_buffer(d);
-	}
-
-	/* Feed the renderer's content entry the same pixels: the final masked
-	 * copy when masks applied (its ownership moves to the entry), else an
-	 * owned copy of the drawable surface. The scene-buffer upload above is
-	 * the half the Clay flip deletes; the entry is the surviving half. */
+	/* Feed the renderer's content entry the final pixels: the masked copy
+	 * when masks applied (its ownership moves to the entry), else an owned
+	 * copy of the drawable surface, repainted in place when sizes match. */
+	entry = &drawin->content_entry;
 	if (work_surface != d->surface) {
 		if (clipped_surface && clipped_surface != work_surface)
 			cairo_surface_destroy(clipped_surface);
-		drawin_entry_set(&drawin->content_entry, work_surface);
+		drawin_entry_set(entry, work_surface);
 	} else {
-		struct image_entry *entry = &drawin->content_entry;
 		int cw = cairo_image_surface_get_width(d->surface);
 		int ch = cairo_image_surface_get_height(d->surface);
 
@@ -514,13 +501,25 @@ drawin_refresh_drawable(drawin_t *drawin)
 			cairo_set_source_surface(cr, d->surface, 0, 0);
 			cairo_paint(cr);
 			cairo_destroy(cr);
-			cairo_surface_flush(entry->native);
 			entry->gen++;
 		} else {
 			drawin_entry_set(entry, drawin_copy_surface(d->surface));
 		}
 	}
+	if (!entry->native)
+		return;
+	cairo_surface_flush(entry->native);
 
+	/* Wake the frame path: the gen bump above changed declared content. */
+	if (drawin->screen && drawin->screen->monitor
+			&& drawin->screen->monitor->declare)
+		declare_output_mark_dirty(drawin->screen->monitor->declare);
+
+	/* The scene-buffer upload, reading the entry's pixels: the half the
+	 * Clay flip deletes. Everything above is the surviving half. */
+	buffer = drawable_create_buffer_from_data(entry->width, entry->height,
+		cairo_image_surface_get_data(entry->native),
+		cairo_image_surface_get_stride(entry->native));
 	if (!buffer) {
 		return;
 	}
@@ -549,13 +548,6 @@ drawin_refresh_drawable(drawin_t *drawin)
 		/* Show shadow too */
 		shadow_set_visible(&drawin->shadow, true);
 	}
-
-	/* Schedule a frame render on the output to ensure content is displayed
-	 * immediately, not waiting for the next external event. This mirrors
-	 * AwesomeWM's xcb_flush() which sends pending X requests immediately.
-	 * In Wayland, we request the compositor to render a new frame. */
-	if (drawin->screen && drawin->screen->monitor && drawin->screen->monitor->wlr_output)
-		wlr_output_schedule_frame(drawin->screen->monitor->wlr_output);
 }
 
 /** Assign screen to drawin based on its position

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -45,7 +45,6 @@ extern void signal_array_wipe(signal_array_t *arr);
 extern void screen_update_workarea(screen_t *screen);
 
 /* Forward declaration for drawable refresh callback */
-static void drawin_refresh_drawable(drawin_t *drawin);
 
 /** Get the effective scale for a drawin's drawable surface.
  * Returns scale_override if set (>0), otherwise the output scale.
@@ -347,7 +346,7 @@ drawin_update_shadow_entry(drawin_t *d, const shadow_config_t *config)
 	d->shadow_entry_config = *config;
 }
 
-static void
+void
 drawin_refresh_drawable(drawin_t *drawin)
 {
 	drawable_t *d;

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -12,6 +12,7 @@
 #include "../globalconf.h"
 #include "../shadow.h"
 #include "../declare.h"
+#include "../systray.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -58,109 +59,6 @@ drawin_get_effective_scale(drawin_t *d)
 	if (d->screen && d->screen->monitor && d->screen->monitor->wlr_output)
 		return d->screen->monitor->wlr_output->scale;
 	return 1.0f;
-}
-
-/* ========================================================================
- * Border Buffer Implementation (for shaped borders)
- * ========================================================================
- * Same pattern as shadow_buffer in shadow.c - wraps Cairo data for wlr_buffer.
- */
-
-struct border_buffer {
-	struct wlr_buffer base;
-	void *data;
-	int width;
-	int height;
-	size_t stride;
-};
-
-static void border_buffer_destroy(struct wlr_buffer *wlr_buffer)
-{
-	struct border_buffer *buffer = wl_container_of(wlr_buffer, buffer, base);
-	free(buffer->data);
-	free(buffer);
-}
-
-static bool border_buffer_begin_data_ptr_access(
-	struct wlr_buffer *wlr_buffer, uint32_t flags, void **data,
-	uint32_t *format, size_t *stride)
-{
-	struct border_buffer *buffer = wl_container_of(wlr_buffer, buffer, base);
-	*data = buffer->data;
-	*format = DRM_FORMAT_ARGB8888;
-	*stride = buffer->stride;
-	return true;
-}
-
-static void border_buffer_end_data_ptr_access(struct wlr_buffer *wlr_buffer)
-{
-	/* Nothing to do */
-}
-
-static const struct wlr_buffer_impl border_buffer_impl = {
-	.destroy = border_buffer_destroy,
-	.begin_data_ptr_access = border_buffer_begin_data_ptr_access,
-	.end_data_ptr_access = border_buffer_end_data_ptr_access,
-};
-
-/**
- * Create a wlr_buffer from a cairo surface.
- * Caller must destroy the cairo surface separately.
- */
-static struct wlr_buffer *
-border_buffer_from_cairo(cairo_surface_t *surface)
-{
-	struct border_buffer *buffer;
-	int width, height;
-	size_t stride, size;
-	unsigned char *src_data;
-
-	if (!surface || cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS)
-		return NULL;
-
-	if (cairo_image_surface_get_format(surface) != CAIRO_FORMAT_ARGB32)
-		return NULL;
-
-	width = cairo_image_surface_get_width(surface);
-	height = cairo_image_surface_get_height(surface);
-	stride = (size_t)cairo_image_surface_get_stride(surface);
-	src_data = cairo_image_surface_get_data(surface);
-
-	if (width <= 0 || height <= 0 || !src_data)
-		return NULL;
-
-	buffer = calloc(1, sizeof(*buffer));
-	if (!buffer)
-		return NULL;
-
-	size = stride * (size_t)height;
-	buffer->data = malloc(size);
-	if (!buffer->data) {
-		free(buffer);
-		return NULL;
-	}
-
-	memcpy(buffer->data, src_data, size);
-	buffer->width = width;
-	buffer->height = height;
-	buffer->stride = stride;
-
-	wlr_buffer_init(&buffer->base, &border_buffer_impl, width, height);
-
-	return &buffer->base;
-}
-
-/**
- * Border buffers never accept input - they are purely visual decoration.
- * This callback ensures input events pass through to the content beneath.
- */
-static bool border_point_accepts_input(struct wlr_scene_buffer *buffer,
-                                       double *sx, double *sy)
-{
-	(void)buffer;
-	(void)sx;
-	(void)sy;
-	return false;
 }
 
 /**
@@ -396,7 +294,7 @@ static cairo_surface_t *drawin_copy_surface(cairo_surface_t *src);
 /* Hand an entry a new owned surface (destroying the previous one) and bump
  * its generation so the renderer re-rasters. NULL clears the entry; a no-op
  * clear does not bump. */
-static void
+void
 drawin_entry_set(struct image_entry *entry, cairo_surface_t *owned)
 {
 	if (!entry->native && !owned)
@@ -435,12 +333,11 @@ drawin_refresh_drawable(drawin_t *drawin)
 {
 	drawable_t *d;
 	struct image_entry *entry;
-	struct wlr_buffer *buffer;
 	cairo_surface_t *clipped_surface = NULL;
 	cairo_surface_t *masked_surface = NULL;
 	cairo_surface_t *work_surface = NULL;
 
-	if (!drawin || !drawin->scene_buffer || !drawin->drawable) {
+	if (!drawin || !drawin->drawable) {
 		return;
 	}
 
@@ -508,46 +405,18 @@ drawin_refresh_drawable(drawin_t *drawin)
 	}
 	if (!entry->native)
 		return;
+	/* Tray icons draw into the entry, over the widget pixels, exactly
+	 * where the old scene overlay stacked them. A no-op unless this
+	 * drawin hosts the systray. */
+	systray_composite(drawin, entry->native);
 	cairo_surface_flush(entry->native);
 
-	/* Wake the frame path: the gen bump above changed declared content. */
+	/* Wake the frame path: the gen bump above changed declared content.
+	 * Map-then-draw holds through the declare filter, which skips a
+	 * drawin until its entry has pixels. */
 	if (drawin->screen && drawin->screen->monitor
 			&& drawin->screen->monitor->declare)
 		declare_output_mark_dirty(drawin->screen->monitor->declare);
-
-	/* The scene-buffer upload, reading the entry's pixels: the half the
-	 * Clay flip deletes. Everything above is the surviving half. */
-	buffer = drawable_create_buffer_from_data(entry->width, entry->height,
-		cairo_image_surface_get_data(entry->native),
-		cairo_image_surface_get_stride(entry->native));
-	if (!buffer) {
-		return;
-	}
-
-	/* Update scene buffer with new content
-	 * NULL damage region means entire buffer is new */
-	wlr_scene_buffer_set_buffer_with_damage(drawin->scene_buffer, buffer, NULL);
-
-	/* Set the destination size to match drawin geometry for proper hit-testing
-	 * Without this, wlroots uses the buffer's intrinsic size for hit detection,
-	 * which breaks mouse input on the wibox */
-	wlr_scene_buffer_set_dest_size(drawin->scene_buffer, drawin->width, drawin->height);
-
-	/* Apply opacity if set (native Wayland compositing - no picom needed) */
-	if (drawin->opacity >= 0)
-		wlr_scene_buffer_set_opacity(drawin->scene_buffer, (float)drawin->opacity);
-
-	/* Drop our reference - scene buffer holds its own reference */
-	wlr_buffer_drop(buffer);
-
-	/* Enable scene node now that we have valid content.
-	 * This is the Wayland equivalent of X11's map-then-draw pattern:
-	 * we only show the drawin once content is ready, avoiding smearing. */
-	if (drawin->visible && drawin->scene_tree) {
-		wlr_scene_node_set_enabled(&drawin->scene_tree->node, true);
-		/* Show shadow too */
-		shadow_set_visible(&drawin->shadow, true);
-	}
 }
 
 /** Assign screen to drawin based on its position
@@ -641,48 +510,10 @@ drawin_allocator(lua_State *L)
 	signal_array_init(&drawin->signals);
 	button_array_init(&drawin->buttons);
 
-	/* Create scene graph nodes for rendering (Wayland-specific)
-	 * This replaces AwesomeWM's X11 window creation */
-	drawin->scene_tree = wlr_scene_tree_create(layers[LyrWibox]);
-	drawin->scene_buffer = wlr_scene_buffer_create(drawin->scene_tree, NULL);
-	drawin->scene_tree->node.data = drawin;
-
-	/* Set initial position */
-	wlr_scene_node_set_position(&drawin->scene_tree->node, drawin->x, drawin->y);
-
-	/* Start disabled (not visible until visible=true) */
-	wlr_scene_node_set_enabled(&drawin->scene_tree->node, false);
-
-	/* Create border scene buffer (shaped border support)
-	 * Border is rendered as a single Cairo surface that respects shape_bounding */
-	drawin->border_buffer = wlr_scene_buffer_create(drawin->scene_tree, NULL);
-	if (drawin->border_buffer) {
-		drawin->border_buffer->node.data = drawin;
-		/* Position border at (-border_width, -border_width) relative to content */
-		wlr_scene_node_set_position(&drawin->border_buffer->node, 0, 0);
-		/* Border renders below content (has 1px overlap for AA seam coverage) */
-		wlr_scene_node_lower_to_bottom(&drawin->border_buffer->node);
-		/* Border never accepts input - purely visual decoration */
-		drawin->border_buffer->point_accepts_input = border_point_accepts_input;
-		/* Use bilinear filtering for smooth rendering at fractional scales */
-		wlr_scene_buffer_set_filter_mode(drawin->border_buffer,
-			WLR_SCALE_FILTER_BILINEAR);
-	}
+	/* No scene nodes: the renderer draws a drawin from its image entries
+	 * (shadow, border, content), which the declare pass hands out. */
 	drawin->border_need_update = true;
 	drawin->border_color_parsed.initialized = false;
-
-	/* Create shadow (compositor-level, replaces picom shadows)
-	 * Shadow is created initially but disabled - enabled when visible=true */
-	{
-		const shadow_config_t *shadow_config = shadow_get_effective_config(
-			drawin->shadow_config, true);
-		if (shadow_config && shadow_config->enabled) {
-			shadow_create(drawin->scene_tree, &drawin->shadow, shadow_config,
-				drawin->width, drawin->height);
-			/* Shadow starts hidden like the rest of the drawin */
-			shadow_set_visible(&drawin->shadow, false);
-		}
-	}
 
 	/* Create drawable object for rendering (AwesomeWM pattern)
 	 * Stack: [drawin] */
@@ -694,9 +525,6 @@ drawin_allocator(lua_State *L)
 	drawin->drawable = luaA_object_ref_item(L, -2, -1);
 	/* Stack: [drawin] */
 
-	/* Store drawable pointer (not drawin!) and set owner (AwesomeWM pattern)
-	 * MUST happen AFTER drawable is created */
-	drawin->scene_buffer->node.data = drawin->drawable;
 	drawin->drawable->owner_type = DRAWABLE_OWNER_DRAWIN;
 	drawin->drawable->owner.drawin = drawin;
 
@@ -717,13 +545,8 @@ drawin_wipe(drawin_t *w)
 		return;
 
 	/* If this drawin was hosting the systray, clean it up */
-	if (globalconf.systray.parent == w) {
-		if (globalconf.systray.scene_tree) {
-			wlr_scene_node_destroy(&globalconf.systray.scene_tree->node);
-			globalconf.systray.scene_tree = NULL;
-		}
+	if (globalconf.systray.parent == w)
 		globalconf.systray.parent = NULL;
-	}
 
 	/* Clear any lock surface/cover pointers referencing this drawin (EDGE-2) */
 	some_notify_drawin_destroyed(w);
@@ -766,27 +589,9 @@ drawin_wipe(drawin_t *w)
 		w->shape_border = NULL;
 	}
 
-	/* Shadow scene nodes are children of scene_tree and destroyed with it.
-	 * We own the texture buffers though and must free them. */
-	for (int i = 0; i < SHADOW_TEXTURE_COUNT; i++) {
-		if (w->shadow.textures[i]) {
-			wlr_buffer_drop(w->shadow.textures[i]);
-			w->shadow.textures[i] = NULL;
-		}
-	}
-	w->shadow.tree = NULL;
-	memset(w->shadow.slice, 0, sizeof(w->shadow.slice));
 	if (w->shadow_config) {
 		free(w->shadow_config);
 		w->shadow_config = NULL;
-	}
-
-	/* Destroy scene graph nodes */
-	if (w->scene_tree) {
-		wlr_scene_node_destroy(&w->scene_tree->node);
-		w->scene_tree = NULL;
-		w->scene_buffer = NULL;  /* Child node destroyed with parent */
-		w->border_buffer = NULL; /* Child node destroyed with parent */
 	}
 }
 
@@ -1251,17 +1056,15 @@ drawin_moveresize(lua_State *L, int udx, int x, int y, int width, int height)
 		screen_update_workarea(drawin->screen);
 	}
 
-	/* Update scene graph node position if position changed */
-	if (drawin->scene_tree && (old_x != drawin->x || old_y != drawin->y))
-		wlr_scene_node_set_position(&drawin->scene_tree->node, drawin->x, drawin->y);
-
-	/* Update scene buffer destination size if size changed */
-	if (drawin->scene_buffer && (old_width != drawin->width || old_height != drawin->height))
-		wlr_scene_buffer_set_dest_size(drawin->scene_buffer, drawin->width, drawin->height);
-
-	/* Size change requires border + shadow refresh */
+	/* Size change requires border + shadow entry refresh */
 	if (old_width != drawin->width || old_height != drawin->height)
 		drawin->border_need_update = true;
+
+	/* Any geometry change re-declares the drawin; all outputs, because a
+	 * move can also change which screen it sits on. */
+	if (old_x != drawin->x || old_y != drawin->y
+			|| old_width != drawin->width || old_height != drawin->height)
+		declare_mark_all_dirty();
 }
 
 /** Set drawin geometry (wrapper for external callers)
@@ -1370,28 +1173,19 @@ drawin_set_visible(lua_State *L, int udx, bool v)
 		screen_update_workarea(drawin->screen);
 	}
 
-	/* Scene node visibility - differs from AwesomeWM's X11 approach:
-	 * In X11, xcb_map_window() maps immediately and content shows when ready.
-	 * In Wayland, we MUST have content before showing, otherwise we get smearing.
-	 *
-	 * When becoming visible: don't enable scene node yet. Let drawin_refresh_drawable()
-	 * enable it when content is actually ready.
-	 * When becoming invisible: disable scene node immediately. */
-	if (drawin->scene_tree) {
-		if (!v) {
-			/* Hiding: disable immediately */
-			wlr_scene_node_set_enabled(&drawin->scene_tree->node, false);
-		} else {
-			/* Showing: if content is already ready, refresh and enable.
-			 * Otherwise, wait for Lua's drawable:refresh() callback to enable. */
-			if (drawin->drawable) {
-				drawable_t *d = drawin->drawable;
-				if (d->surface && d->refreshed) {
-					drawin_refresh_drawable(drawin);
-					/* drawin_refresh_drawable will enable the node */
-				}
-			}
-		}
+	/* Map-then-draw, through the declare filter: a hidden drawin drops out
+	 * of the next declare; a shown one enters it once its content entry
+	 * has pixels, so a not-yet-drawn popup cannot smear. */
+	if (!v) {
+		declare_mark_all_dirty();
+	} else if (drawin->drawable) {
+		drawable_t *d = drawin->drawable;
+
+		/* Content already drawn: re-feed the entry (it may have been
+		 * dropped) and dirty the output in one step. Otherwise Lua's
+		 * drawable:refresh() callback does the same when it draws. */
+		if (d->surface && d->refreshed)
+			drawin_refresh_drawable(drawin);
 	}
 }
 
@@ -1419,34 +1213,21 @@ luaA_drawin_set_strut(lua_State *L, drawin_t *drawin, strut_t strut)
 	}
 }
 
-/** Apply pending geometry changes
- * TODO: This will update wlr_scene_node position when rendering is implemented
- */
+/** Apply pending geometry changes */
 void
 luaA_drawin_apply_geometry(drawin_t *drawin)
 {
-	if (!drawin->geometry_dirty)
-		return;
-
 	drawin->geometry_dirty = false;
-
-	/* TODO: Update scene graph position when rendering is implemented */
-	/* if (drawin->scene_tree) {
-		wlr_scene_node_set_position(&drawin->scene_tree->node,
-		                             drawin->x, drawin->y);
-	} */
 }
 
-/** Refresh a single drawin's border visuals
- * Renders border as a Cairo surface with shape_bounding mask applied.
- * Borders are positioned OUTSIDE the content area.
- */
+/** Refresh a single drawin's border and shadow entries.
+ * Rebuilds the image entries the declare pass hands the renderer; the leaf
+ * boxes (border outside the content area, shadow around it) are declared in
+ * declare.c. */
 static void
 drawin_border_refresh_single(drawin_t *d)
 {
-	int bw;
 	cairo_surface_t *border_surface;
-	struct wlr_buffer *wlr_buf;
 
 	/* Skip if no update needed */
 	if (!d->border_need_update) {
@@ -1455,74 +1236,22 @@ drawin_border_refresh_single(drawin_t *d)
 
 	d->border_need_update = false;
 
-	/* Skip if no scene tree (not yet created) */
-	if (!d->scene_tree || !d->border_buffer)
-		return;
+	drawin_update_shadow_entry(d,
+		shadow_get_effective_config(d->shadow_config, true));
 
-	/* Update shadow geometry (independent of border width) */
-	{
-		const shadow_config_t *shadow_config = shadow_get_effective_config(
-			d->shadow_config, true);
-		if (shadow_config && shadow_config->enabled) {
-			if (d->shadow.tree) {
-				shadow_update_geometry(&d->shadow, shadow_config,
-					d->width, d->height);
-			} else {
-				shadow_create(d->scene_tree, &d->shadow, shadow_config,
-					d->width, d->height);
-			}
-		}
-		drawin_update_shadow_entry(d, shadow_config);
-	}
-
-	bw = d->border_width;
-
-	/* If no border width, hide the border buffer */
-	if (bw <= 0) {
-		wlr_scene_buffer_set_buffer(d->border_buffer, NULL);
-		drawin_entry_set(&d->border_entry, NULL);
-		return;
-	}
-
-	/* Render the border as a Cairo surface with shape mask applied */
-	border_surface = drawin_render_border(d);
-	if (!border_surface) {
-		wlr_scene_buffer_set_buffer(d->border_buffer, NULL);
-		drawin_entry_set(&d->border_entry, NULL);
-		return;
-	}
-
-	/* Convert Cairo surface to wlr_buffer */
-	wlr_buf = border_buffer_from_cairo(border_surface);
-	/* border_surface's ownership moves to the renderer's border entry */
+	/* border_surface's ownership moves to the renderer's border entry;
+	 * without a border there is no entry and no leaf. */
+	border_surface = d->border_width > 0 ? drawin_render_border(d) : NULL;
 	drawin_entry_set(&d->border_entry, border_surface);
 
-	if (!wlr_buf) {
-		wlr_scene_buffer_set_buffer(d->border_buffer, NULL);
-		return;
-	}
-
-	/* Update the scene buffer with new border content */
-	wlr_scene_buffer_set_buffer(d->border_buffer, wlr_buf);
-	wlr_buffer_drop(wlr_buf);  /* Scene buffer holds its own reference */
-
-	/* Set destination size (required for wlr_scene to know buffer dimensions) */
-	int total_w = d->width + 2 * bw;
-	int total_h = d->height + 2 * bw;
-	wlr_scene_buffer_set_dest_size(d->border_buffer, total_w, total_h);
-
-	/* Position border so it surrounds the content
-	 * Border surface origin is at top-left corner of border area */
-	wlr_scene_node_set_position(&d->border_buffer->node, -bw, -bw);
+	if (d->screen && d->screen->monitor && d->screen->monitor->declare)
+		declare_output_mark_dirty(d->screen->monitor->declare);
 }
 
 /** Refresh all visible drawins (AwesomeWM compatibility)
- * Applies pending geometry changes for all visible drawins.
- * Called from some_refresh() main loop.
- *
- * In AwesomeWM this does xcb_configure_window and border refresh.
- * In Wayland, geometry is already applied via wlr_scene_node_set_position
- * in luaA_drawin_set_geometry(), borders use wlr_scene_rect.
+ * Called from some_refresh() main loop. Geometry was already recorded by
+ * drawin_moveresize() (the declare pass reads it per frame); what applies
+ * here is the pending border and shadow entry rebuild.
  */
 void
 drawin_refresh(void)
@@ -1531,10 +1260,6 @@ drawin_refresh(void)
 	{
 		drawin_t *d = *item;
 
-		/* Apply pending geometry changes
-		 * In AwesomeWM this does xcb_configure_window
-		 * In Wayland, geometry already applied via wlr_scene_node_set_position
-		 * in luaA_drawin_set_geometry(), so just clear the flag */
 		if (d->geometry_dirty) {
 			d->geometry_dirty = false;
 		}
@@ -1625,12 +1350,13 @@ luaA_drawin_gc(lua_State *L)
 		/* Wipe button array */
 		button_array_wipe(&drawin->buttons);
 
-		/* Destroy scene graph nodes */
-		if (drawin->scene_tree) {
-			wlr_scene_node_destroy(&drawin->scene_tree->node);
-			drawin->scene_tree = NULL;
-			drawin->scene_buffer = NULL;  /* Child node destroyed with parent */
-		}
+		/* Retire the renderer's view and drop the retained leaves at the
+		 * next frame */
+		declare_handle_drop(drawin);
+		drawin_entry_set(&drawin->content_entry, NULL);
+		drawin_entry_set(&drawin->border_entry, NULL);
+		drawin_entry_set(&drawin->shadow_entry, NULL);
+		declare_mark_all_dirty();
 	}
 	return 0;
 }
@@ -1794,10 +1520,8 @@ luaA_drawin_set_opacity(lua_State *L, drawin_t *drawin)
 	if(drawin->opacity != opacity)
 	{
 		drawin->opacity = opacity;
-		/* Wayland: apply opacity via scene buffer */
-		if (drawin->scene_buffer)
-			wlr_scene_buffer_set_opacity(drawin->scene_buffer,
-				opacity >= 0 ? (float)opacity : 1.0f);
+		/* Opacity rides the content leaf's userData word (declare.c) */
+		declare_mark_all_dirty();
 		luaA_object_emit_signal(L, -3, "property::opacity", 0);
 	}
 	return 0;
@@ -1811,7 +1535,7 @@ luaA_drawin_get_shadow(lua_State *L, drawin_t *drawin)
 		shadow_config_to_lua(L, drawin->shadow_config);
 	} else {
 		const shadow_config_t *eff = shadow_get_effective_config(NULL, true);
-		if (eff->enabled && drawin->shadow.tree) {
+		if (eff->enabled && drawin->shadow_entry.native) {
 			shadow_config_to_lua(L, eff);
 		} else {
 			lua_pushboolean(L, false);
@@ -1838,15 +1562,7 @@ luaA_drawin_set_shadow(lua_State *L, drawin_t *drawin)
 	}
 	*drawin->shadow_config = new_config;
 
-	/* Update shadow if scene tree exists */
-	if (drawin->scene_tree) {
-		shadow_update_config(&drawin->shadow, drawin->scene_tree, &new_config,
-			drawin->width, drawin->height);
-		/* Match drawin visibility */
-		shadow_set_visible(&drawin->shadow, drawin->visible);
-	}
-
-	/* Ensure shadow gets refreshed with correct geometry on next cycle */
+	/* The shadow entry rebuilds on the next refresh cycle */
 	drawin->border_need_update = true;
 
 	luaA_object_emit_signal(L, -3, "property::shadow", 0);

--- a/objects/drawin.h
+++ b/objects/drawin.h
@@ -123,6 +123,12 @@ void drawin_entry_set(struct image_entry *entry, cairo_surface_t *owned);
 /* Drawin refresh cycle (called from main event loop) */
 void drawin_refresh(void);
 
+/* Re-feed the content entry from the drawable's pixels. Callers outside
+ * the widget path need it for state composited into the entry rather than
+ * drawn into it, which the systray is: dropping the tray has to repaint
+ * the host, or its icons stay baked in until something else redraws. */
+void drawin_refresh_drawable(drawin_t *drawin);
+
 /* Apply an A1 or ARGB32 shape mask to a surface.
  * Returns a new surface scaled by the mask's coverage.
  * Caller must destroy the returned surface.

--- a/objects/drawin.h
+++ b/objects/drawin.h
@@ -11,6 +11,7 @@
 #include "common/luaclass.h"  /* For lua_class_t */
 #include "common/luaobject.h"  /* For LUA_OBJECT_FUNCS macro */
 #include "shadow.h"           /* For shadow_config_t, shadow_nodes_t */
+#include "../render_image.h"  /* For struct image_entry */
 
 /* Forward declarations */
 struct screen_t;
@@ -78,6 +79,17 @@ typedef struct drawin_t {
 	cairo_surface_t *shape_clip;            /* Drawing clip region */
 	cairo_surface_t *shape_input;           /* Input hit-test region (click-through) */
 	cairo_surface_t *shape_border;          /* Pre-rendered anti-aliased border (ARGB32) */
+
+	/* Renderer leaves (the Clay flip): stable image entries the declare
+	 * pass hands to the renderer as imageData. Each native surface is a
+	 * drawin-owned copy (masks applied), so a drawable resize can never
+	 * dangle the renderer's source; gen bumps whenever content changes.
+	 * shadow_entry_config is the memoized config the composite was built
+	 * from; the leaf's origin and the memo's size derive from it. */
+	struct image_entry content_entry;
+	struct image_entry border_entry;
+	struct image_entry shadow_entry;
+	shadow_config_t shadow_entry_config;
 } drawin_t;
 
 /* Metatable name for drawin userdata */

--- a/objects/drawin.h
+++ b/objects/drawin.h
@@ -59,17 +59,10 @@ typedef struct drawin_t {
 	 * Pointer retrieved via luaA_object_ref_item, pushed via luaA_object_push_item */
 	struct drawable_t *drawable;   /* Direct C pointer for callback access */
 
-	/* Scene graph integration for rendering (Wayland-specific) */
-	struct wlr_scene_tree *scene_tree;      /* Container node for positioning */
-	struct wlr_scene_buffer *scene_buffer;  /* The actual rendered surface */
-
-	/* Border rendering (Wayland-specific, shaped border support) */
-	struct wlr_scene_buffer *border_buffer; /* Single buffer for shaped border */
 	color_t border_color_parsed;            /* Cached parsed color for efficient refresh */
 
 	/* Shadow support (compositor-level, replaces picom shadows) */
 	shadow_config_t *shadow_config;         /* Per-drawin override (NULL = use defaults) */
-	shadow_nodes_t shadow;                  /* Shadow scene nodes */
 
 	/* Shape properties (AwesomeWM compatibility)
 	 * These are cairo_surface_t* alpha masks, either A1 (AwesomeWM's
@@ -124,6 +117,8 @@ void luaA_drawin_set_strut(lua_State *L, drawin_t *drawin, strut_t strut);
 
 /* Drawin geometry synchronization */
 void luaA_drawin_apply_geometry(drawin_t *drawin);
+/* Hand a renderer image entry a new owned surface (NULL clears it) */
+void drawin_entry_set(struct image_entry *entry, cairo_surface_t *owned);
 
 /* Drawin refresh cycle (called from main event loop) */
 void drawin_refresh(void);

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -2283,9 +2283,6 @@ screen_client_moveto(client_t *c, screen_t *new_screen, bool doresize)
 	area_t new_geometry;
 	bool had_focus = false;
 
-	/* Forward declare apply_geometry_to_wlroots from somewm.c */
-	extern void apply_geometry_to_wlroots(client_t *c);
-
 	if (new_screen == c->screen)
 		return;
 
@@ -2359,12 +2356,9 @@ screen_client_moveto(client_t *c, screen_t *new_screen, bool doresize)
 		new_geometry.y = to.y;
 	}
 
-	/* move / resize the client */
+	/* move / resize the client; the next dirty frame declares it on the
+	 * new screen's band */
 	client_resize(c, new_geometry, false, false);
-
-	/* Force immediate scene node position update (bypass deferred refresh)
-	 * This ensures the window appears on the new screen immediately */
-	apply_geometry_to_wlroots(c);
 
 	/* emit signal */
 	luaA_object_push(L, c);

--- a/protocols.c
+++ b/protocols.c
@@ -98,8 +98,16 @@ arrangelayer(Monitor *m, struct wl_list *list, struct wlr_box *usable_area, int 
 		if (exclusive != (layer_surface->current.exclusive_zone > 0))
 			continue;
 
+		/* The layer-shell solve writes a layout-absolute position into
+		 * the scene node (it assumes a parent at the layout origin).
+		 * Capture it output-local as the declare pass's geometry fact,
+		 * then rewrite the node to that same value: the tree lives in
+		 * the output's band (or the parked tree), and the reconciler
+		 * will keep it at exactly this box. */
 		wlr_scene_layer_surface_v1_configure(l->scene_layer, &full_area, usable_area);
-		wlr_scene_node_set_position(&l->popups->node, l->scene->node.x, l->scene->node.y);
+		l->geom.x = l->scene->node.x - m->m.x;
+		l->geom.y = l->scene->node.y - m->m.y;
+		wlr_scene_node_set_position(&l->scene->node, l->geom.x, l->geom.y);
 	}
 }
 
@@ -180,7 +188,6 @@ commitlayersurfacenotify(struct wl_listener *listener, void *data)
 {
 	LayerSurface *l = wl_container_of(listener, l, surface_commit);
 	struct wlr_layer_surface_v1 *layer_surface = l->layer_surface;
-	struct wlr_scene_tree *scene_layer = layers[layermap[layer_surface->current.layer]];
 	struct wlr_layer_surface_v1_state old_state;
 	int was_mapped;
 
@@ -210,15 +217,17 @@ commitlayersurfacenotify(struct wl_listener *listener, void *data)
 		layer_surface_emit_manage(ls, "new");
 	}
 
-	if (scene_layer != l->scene->node.parent) {
-		wlr_scene_node_reparent(&l->scene->node, scene_layer);
+	/* A layer change moves the surface between declare bands; the scene
+	 * tree itself stays wherever the reconciler put it. */
+	if (l->band != layer_surface->current.layer) {
+		l->band = layer_surface->current.layer;
 		wl_list_remove(&l->link);
-		wl_list_insert(&l->mon->layers[layer_surface->current.layer], &l->link);
-		wlr_scene_node_reparent(&l->popups->node, (layer_surface->current.layer
-				< ZWLR_LAYER_SHELL_V1_LAYER_TOP ? layers[LyrTop] : scene_layer));
+		wl_list_insert(&l->mon->layers[l->band], &l->link);
 	}
 
 	arrangelayers(l->mon);
+	if (l->mon && l->mon->declare)
+		declare_output_mark_dirty(l->mon->declare);
 
 	/* When a layer surface maps, re-evaluate pointer focus so that
 	 * wl_pointer.enter is delivered if the cursor is already over it.
@@ -258,7 +267,6 @@ createlayersurface(struct wl_listener *listener, void *data)
 	struct wlr_layer_surface_v1 *layer_surface = data;
 	LayerSurface *l;
 	struct wlr_surface *surface = layer_surface->surface;
-	struct wlr_scene_tree *scene_layer = layers[layermap[layer_surface->pending.layer]];
 
 	if (!layer_surface->output
 			&& !(layer_surface->output = selmon ? selmon->wlr_output : NULL)) {
@@ -273,18 +281,24 @@ createlayersurface(struct wl_listener *listener, void *data)
 
 	l->layer_surface = layer_surface;
 	l->mon = layer_surface->output->data;
-	l->scene_layer = wlr_scene_layer_surface_v1_create(scene_layer, layer_surface);
+	l->band = layer_surface->pending.layer;
+	/* Born parked; the reconciler borrows the tree into the output's band
+	 * once the declare pass sees the surface mapped. */
+	l->scene_layer = wlr_scene_layer_surface_v1_create(window_parked_tree(),
+			layer_surface);
 	/* Register commit listener AFTER wlr_scene_layer_surface_v1_create() so our
 	 * listener fires AFTER wlroots' internal scene commit handler. This lets
 	 * the scene graph reflect the new buffer before the commit handler calls
 	 * motionnotify(0, ...) to re-evaluate pointer focus on map. */
 	LISTEN(&surface->events.commit, &l->surface_commit, commitlayersurfacenotify);
 	l->scene = l->scene_layer->tree;
-	l->popups = surface->data = wlr_scene_tree_create(layer_surface->current.layer
-			< ZWLR_LAYER_SHELL_V1_LAYER_TOP ? layers[LyrTop] : scene_layer);
+	/* Popups ride the borrowed tree at the surface origin, like a client's
+	 * popup tree; the reconciler folds a surface with a live popup to the
+	 * top of its band, so a bottom-layer panel's menu is not occluded. */
+	l->popups = surface->data = wlr_scene_tree_create(l->scene);
 	l->scene->node.data = l->popups->node.data = l;
 
-	wl_list_insert(&l->mon->layers[layer_surface->pending.layer],&l->link);
+	wl_list_insert(&l->mon->layers[l->band], &l->link);
 	wlr_surface_send_enter(surface, layer_surface->output);
 }
 
@@ -303,8 +317,9 @@ destroylayersurfacenotify(struct wl_listener *listener, void *data)
 	wl_list_remove(&l->unmap.link);
 	wl_list_remove(&l->surface_commit.link);
 	declare_handle_drop(l);
+	/* popups is a child of scene and dies with it */
 	wlr_scene_node_destroy(&l->scene->node);
-	wlr_scene_node_destroy(&l->popups->node);
+	declare_mark_all_dirty();
 	free(l);
 }
 
@@ -324,8 +339,11 @@ unmaplayersurfacenotify(struct wl_listener *listener, void *data)
 			wlr_surface_send_leave(l->layer_surface->surface, l->layer_surface->output);
 
 		l->mon = l->layer_surface->output->data;
-		if (l->mon)
+		if (l->mon) {
 			arrangelayers(l->mon);
+			if (l->mon->declare)
+				declare_output_mark_dirty(l->mon->declare);
+		}
 	}
 
 	/* Emit request::unmanage signal if we have a Lua object */

--- a/protocols.c
+++ b/protocols.c
@@ -47,6 +47,7 @@
 struct wlr_input_device;
 
 #include "window.h"
+#include "declare.h"
 #include "focus.h"
 #include "input.h"
 #include "somewm_internal.h"
@@ -301,6 +302,7 @@ destroylayersurfacenotify(struct wl_listener *listener, void *data)
 	wl_list_remove(&l->destroy.link);
 	wl_list_remove(&l->unmap.link);
 	wl_list_remove(&l->surface_commit.link);
+	declare_handle_drop(l);
 	wlr_scene_node_destroy(&l->scene->node);
 	wlr_scene_node_destroy(&l->popups->node);
 	free(l);

--- a/render.c
+++ b/render.c
@@ -138,6 +138,10 @@ struct rnode {
 	bool borrowed;
 	uint64_t handle;
 	uint64_t gen;
+	/* The command's userData word (render.h), retained for the input
+	 * backmap; and the opacity last applied to an IMAGE node's buffer. */
+	void *user_data;
+	float opacity;
 };
 
 /* An open-addressing slot mapping a command key to its index in nodes. */
@@ -286,6 +290,9 @@ static struct rnode *rnode_add(struct render_state *rs, uint64_t key) {
 	p_grow(&rs->nodes, rs->len + 1, &rs->cap);
 	struct rnode *n = &rs->nodes[rs->len++];
 	memset(n, 0, sizeof(*n));
+	/* Matches wlroots' default: a fresh scene buffer is opaque, so a
+	 * declared opacity of 0.0 must not compare equal to the sentinel. */
+	n->opacity = 1.0f;
 	n->key = key;
 	return n;
 }
@@ -1144,6 +1151,15 @@ static int reconcile_image(struct render_state *rs, struct rnode *n,
 		muts++;
 	}
 
+	float opacity = render_userdata_opacity(cmd->userData);
+	if (opacity != n->opacity) {
+		wlr_scene_buffer_set_opacity(sb, opacity);
+		n->opacity = opacity;
+		if (!is_new) {
+			muts++;
+		}
+	}
+
 	/* Crop to the clip, exactly as reconcile_text does (buffer is ceil(box)
 	 * sized, so the source box is in box pixels). */
 	muts += rnode_apply_clip(n, sb, cmd, rbox, rs->scale, raster_changed);
@@ -1316,39 +1332,53 @@ static void verify_order(struct render_state *rs) {
 
 /* --- the scene-node-to-Clay-id backmap --- */
 
-uint32_t render_hit_id(struct render_state *rs, struct wlr_scene_node *node) {
+/* The retained node that drew a scene node: the hit node is the retained
+ * node itself (rect, buffer) or a descendant of it (a square border's side
+ * rect under its tree). */
+static struct rnode *rnode_for_scene_node(struct render_state *rs,
+		struct wlr_scene_node *node) {
 	if (node == NULL) {
-		return 0;
+		return NULL;
 	}
 	for (size_t i = 0; i < rs->len; i++) {
 		struct rnode *n = &rs->nodes[i];
 		if (n->node == NULL) {
 			continue;
 		}
-		/* The hit node is the retained node itself (rect, buffer) or a
-		 * descendant of it (a square border's side rect under its tree). */
 		for (struct wlr_scene_node *c = node; c != NULL;
 				c = c->parent != NULL ? &c->parent->node : NULL) {
 			if (c == n->node) {
-				/* RECTANGLE, IMAGE, and CUSTOM commands carry the element id
-				 * directly (comparable to Clay_GetPointerOverIds). TEXT and
-				 * BORDER commands carry a Clay-derived per-line / per-side
-				 * hash, not the element id, so they are not comparable; report
-				 * 0 for them (the structural checks cover their order and
-				 * clipping). */
-				uint32_t type = (uint32_t)(n->key >> 32);
-				if (type == CLAY_RENDER_COMMAND_TYPE_TEXT ||
-						type == CLAY_RENDER_COMMAND_TYPE_BORDER) {
-					return 0;
-				}
-				return (uint32_t)(n->key & 0xFFFFFFFF);
+				return n;
 			}
 			if (c == &rs->tree->node) {
 				break;
 			}
 		}
 	}
-	return 0;
+	return NULL;
+}
+
+void *render_hit_userdata(struct render_state *rs, struct wlr_scene_node *node) {
+	struct rnode *n = rnode_for_scene_node(rs, node);
+	return n != NULL ? n->user_data : NULL;
+}
+
+uint32_t render_hit_id(struct render_state *rs, struct wlr_scene_node *node) {
+	struct rnode *n = rnode_for_scene_node(rs, node);
+	if (n == NULL) {
+		return 0;
+	}
+	/* RECTANGLE, IMAGE, and CUSTOM commands carry the element id directly
+	 * (comparable to Clay_GetPointerOverIds). TEXT and BORDER commands
+	 * carry a Clay-derived per-line / per-side hash, not the element id,
+	 * so they are not comparable; report 0 for them (the structural checks
+	 * cover their order and clipping). */
+	uint32_t type = (uint32_t)(n->key >> 32);
+	if (type == CLAY_RENDER_COMMAND_TYPE_TEXT ||
+			type == CLAY_RENDER_COMMAND_TYPE_BORDER) {
+		return 0;
+	}
+	return (uint32_t)(n->key & 0xFFFFFFFF);
 }
 
 /* --- the reconcile pass --- */
@@ -1392,6 +1422,7 @@ int render_reconcile(struct render_state *rs, Clay_RenderCommandArray commands,
 		}
 		bool is_new = n->node == NULL;
 		n->gen = rs->gen;
+		n->user_data = cmd->userData;
 
 		/* The clip that applies to this command reflects every START/END
 		 * already crossed; this command's own START (below) affects only its

--- a/render.c
+++ b/render.c
@@ -180,6 +180,9 @@ struct render_state {
 	 * identity: every device_len below reduces to the logical length, so a
 	 * non-HiDPI output rasters exactly as before. */
 	float scale;
+	/* The hooks of the last reconcile pass, for input callbacks that fire
+	 * between passes (accepts_input). The declarer passes a stable struct. */
+	const struct render_client_hooks *hooks;
 	struct render_state *next;
 };
 
@@ -1114,6 +1117,29 @@ static struct cairo_buffer *rasterize_image(Clay_RenderCommand *cmd,
 	return cb;
 }
 
+/* The input filter on image leaves: find the owning rnode across the live
+ * render_states (same scan as border_point_accepts_input) and ask the
+ * declarer's hook with the retained userData word and the node-local point.
+ * This is what lets a shaped drawin's pass-through pixels fall through
+ * wlr_scene_node_at to whatever draws below. */
+static bool image_point_accepts_input(struct wlr_scene_buffer *sb,
+		double *sx, double *sy) {
+	for (struct render_state *rs = render_states; rs != NULL; rs = rs->next) {
+		for (size_t i = 0; i < rs->len; i++) {
+			struct rnode *n = &rs->nodes[i];
+			if (n->node != &sb->node) {
+				continue;
+			}
+			if (rs->hooks == NULL || rs->hooks->accepts_input == NULL) {
+				return true;
+			}
+			return rs->hooks->accepts_input(rs->hooks->data,
+				n->user_data, *sx, *sy);
+		}
+	}
+	return false;
+}
+
 static bool image_data_equal(Clay_ImageRenderData *a, Clay_ImageRenderData *b) {
 	return a->imageData == b->imageData &&
 		memcmp(&a->backgroundColor, &b->backgroundColor,
@@ -1131,6 +1157,7 @@ static int reconcile_image(struct render_state *rs, struct rnode *n,
 	bool is_new = n->node == NULL;
 	if (is_new) {
 		struct wlr_scene_buffer *sb = wlr_scene_buffer_create(rs->tree, NULL);
+		sb->point_accepts_input = image_point_accepts_input;
 		n->node = &sb->node;
 	}
 	struct wlr_scene_buffer *sb = wlr_scene_buffer_from_node(n->node);
@@ -1388,6 +1415,7 @@ int render_reconcile(struct render_state *rs, Clay_RenderCommandArray commands,
 	rs->gen++;
 	rs->buffers_created = 0;
 	rs->node_recreated = false;
+	rs->hooks = hooks;
 	int muts = 0;
 
 	/* Map reflects the pre-pass nodes; new nodes appended below get unique

--- a/render.h
+++ b/render.h
@@ -69,6 +69,27 @@ void render_set_position(struct render_state *rs, int x, int y);
  * this output's nodes (scale joins the raster cache key). */
 void render_set_scale(struct render_state *rs, float scale);
 
+/* The userData channel: Clay carries each element's userData word into its
+ * render commands untouched, and the renderer retains it per node. The word
+ * is a packed integer, never a pointer, so a retained command can never
+ * dangle into freed declarer state. The renderer itself reads only the
+ * opacity byte (bits 40-47, IMAGE commands; 0 means unset, fully opaque,
+ * else 1 + opacity * 254); everything else in the word is the declarer's to
+ * encode and to get back from render_hit_userdata(). */
+static inline float
+render_userdata_opacity(void *ud)
+{
+	unsigned byte = ((uintptr_t)ud >> 40) & 0xff;
+	return byte ? (float)(byte - 1) / 254.0f : 1.0f;
+}
+
+/* The retained userData word of the command that drew node (the node itself,
+ * or an ancestor for a border's side rects), or 0 for a node this
+ * render_state did not draw. Works for every command type, which is what
+ * makes it the input backmap: BORDER and TEXT nodes carry no element id
+ * (render_hit_id below) but do carry their element's word. */
+void *render_hit_userdata(struct render_state *rs, struct wlr_scene_node *node);
+
 /* The scene-node-to-Clay-id backmap: given a scene node the scene hit test
  * returned, find the retained chrome node that drew it (the node itself, or an
  * ancestor for a square border's side rects) and return that command's Clay

--- a/render.h
+++ b/render.h
@@ -40,6 +40,13 @@ struct render_client_hooks {
 	 * neighbor tile, is not occluded by that sibling. C to C, never Lua;
 	 * optional (a NULL has_popup means no client is ever folded up). */
 	bool (*has_popup)(void *data, uint64_t handle);
+	/* Whether the IMAGE leaf carrying userdata (the retained userData word)
+	 * accepts pointer input at node-local logical (x, y). A false lets the
+	 * scene hit test fall through to whatever draws below, which is how a
+	 * drawin's shape_input pass-through reaches wlr_scene_node_at. Called
+	 * from the scene's input path, never during reconcile; optional (a NULL
+	 * accepts_input accepts everywhere). */
+	bool (*accepts_input)(void *data, void *userdata, double x, double y);
 	void *data;
 };
 

--- a/shadow.c
+++ b/shadow.c
@@ -283,6 +283,23 @@ shadow_get_effective_config(const shadow_config_t *override, bool is_drawin)
 /**
  * Free owned textures in a shadow_nodes_t.
  */
+/* Which sides a directional shadow shows (all four when clip_directional is
+ * off). The one statement of the rule, shared by the 9-slice scene path and
+ * shadow_render_composite(). Order: top, bottom, left, right. */
+static void
+shadow_slice_visibility(const shadow_config_t *config,
+                        bool *show_top, bool *show_bottom,
+                        bool *show_left, bool *show_right)
+{
+    *show_top = *show_bottom = *show_left = *show_right = true;
+    if (!config->clip_directional)
+        return;
+    *show_top = config->offset_y <= 0;
+    *show_bottom = config->offset_y >= 0;
+    *show_left = config->offset_x <= 0;
+    *show_right = config->offset_x >= 0;
+}
+
 static void
 shadow_free_textures(shadow_nodes_t *shadow)
 {
@@ -406,10 +423,10 @@ shadow_create(struct wlr_scene_tree *parent,
     if (config->clip_directional) {
         int ox = config->offset_x;
         int oy = config->offset_y;
-        bool show_top = (oy <= 0);
-        bool show_bottom = (oy >= 0);
-        bool show_left = (ox <= 0);
-        bool show_right = (ox >= 0);
+        bool show_top, show_bottom, show_left, show_right;
+
+        shadow_slice_visibility(config, &show_top, &show_bottom,
+            &show_left, &show_right);
 
         if (shadow->slice[SHADOW_CORNER_TL])
             wlr_scene_node_set_enabled(&shadow->slice[SHADOW_CORNER_TL]->node,
@@ -477,21 +494,10 @@ shadow_update_geometry(shadow_nodes_t *shadow,
     /* Visibility is determined by clip_directional and offset direction.
      * These are constant for the lifetime of the shadow, so only update
      * slices that are actually visible — skip disabled ones entirely. */
-    bool show_top = true, show_bottom = true;
-    bool show_left = true, show_right = true;
+    bool show_top, show_bottom, show_left, show_right;
 
-    if (config->clip_directional) {
-        show_top = (oy < 0);
-        show_bottom = (oy > 0);
-        show_left = (ox < 0);
-        show_right = (ox > 0);
-        if (ox == 0 && oy == 0)
-            show_top = show_bottom = show_left = show_right = true;
-        if (ox == 0)
-            show_left = show_right = true;
-        if (oy == 0)
-            show_top = show_bottom = true;
-    }
+    shadow_slice_visibility(config, &show_top, &show_bottom,
+        &show_left, &show_right);
 
     /* Position corners — only touch visible ones */
     if (shadow->slice[SHADOW_CORNER_TL] && show_top && show_left)
@@ -598,6 +604,139 @@ shadow_destroy(shadow_nodes_t *shadow)
 
     memset(shadow->slice, 0, sizeof(shadow->slice));
     shadow_free_textures(shadow);
+}
+
+/* src OVER dst, both premultiplied ARGB32. */
+static uint32_t
+shadow_blend_over(uint32_t src, uint32_t dst)
+{
+    uint32_t inv = 255 - (src >> 24);
+    uint32_t out = 0;
+
+    for (int shift = 0; shift < 32; shift += 8)
+        out |= (((src >> shift) & 0xff)
+            + (((dst >> shift) & 0xff) * inv + 127) / 255) << shift;
+    return out;
+}
+
+/* Write one gradient region into the composite. sx/sy are surface-local;
+ * horiz/vert pick the falloff axis (both = radial corner, from the inner
+ * corner at icx/icy; neither = solid fill). Regions normally tile the
+ * slice layout without touching, but an offset larger than the frame
+ * pushes a fill strip into an edge gradient; the scene path rendered
+ * that overlap as two alpha-blended nodes, so blend here too. */
+static void
+shadow_composite_region(uint32_t *pixels, int stride_px, int surf_w, int surf_h,
+                        int sx, int sy, int w, int h,
+                        bool horiz, bool vert, int icx, int icy,
+                        int radius, const float color[4], float opacity)
+{
+    float inv_radius = (radius > 1) ? 1.0f / (float)(radius - 1) : 1.0f;
+
+    for (int y = 0; y < h; y++) {
+        int py = sy + y;
+        if (py < 0 || py >= surf_h)
+            continue;
+        for (int x = 0; x < w; x++) {
+            int px = sx + x;
+            if (px < 0 || px >= surf_w)
+                continue;
+            float t;
+            if (horiz && vert) {
+                float dx = (float)(x - icx);
+                float dy = (float)(y - icy);
+                t = sqrtf(dx * dx + dy * dy) * inv_radius;
+            } else if (vert) {
+                t = (float)(icy >= 0 ? h - 1 - y : y) * inv_radius;
+            } else if (horiz) {
+                t = (float)(icx >= 0 ? w - 1 - x : x) * inv_radius;
+            } else {
+                t = 0.0f;
+            }
+            uint32_t *dst = &pixels[py * stride_px + px];
+            uint32_t src = shadow_pixel(color, opacity, shadow_falloff(t));
+            *dst = *dst ? shadow_blend_over(src, *dst) : src;
+        }
+    }
+}
+
+cairo_surface_t *
+shadow_render_composite(const shadow_config_t *config,
+                        int width, int height)
+{
+    if (!config || !config->enabled || config->radius <= 0
+            || width <= 0 || height <= 0)
+        return NULL;
+
+    int r = config->radius;
+    int ox = config->offset_x;
+    int oy = config->offset_y;
+    const float *col = config->color;
+    float op = config->opacity;
+
+    bool show_top, show_bottom, show_left, show_right;
+    shadow_slice_visibility(config, &show_top, &show_bottom,
+        &show_left, &show_right);
+
+    int surf_w = width + 2 * r;
+    int surf_h = height + 2 * r;
+    cairo_surface_t *surface = cairo_image_surface_create(
+        CAIRO_FORMAT_ARGB32, surf_w, surf_h);
+    if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) {
+        cairo_surface_destroy(surface);
+        return NULL;
+    }
+
+    cairo_surface_flush(surface);
+    uint32_t *pixels = (uint32_t *)cairo_image_surface_get_data(surface);
+    int stride_px = cairo_image_surface_get_stride(surface) / 4;
+
+    /* Surface origin sits at (ox - r, oy - r) in frame coordinates, so a
+     * slice at frame position (fx, fy) lands at (fx - ox + r, fy - oy + r).
+     * Inner-corner coordinates mirror shadow_render_corner(): TL's inner
+     * corner is its bottom-right pixel, and the icx/icy signs double as the
+     * edge-direction flags in shadow_composite_region(). */
+    if (show_top && show_left)
+        shadow_composite_region(pixels, stride_px, surf_w, surf_h,
+            0, 0, r, r, true, true, r - 1, r - 1, r, col, op);
+    if (show_top && show_right)
+        shadow_composite_region(pixels, stride_px, surf_w, surf_h,
+            r + width, 0, r, r, true, true, 0, r - 1, r, col, op);
+    if (show_bottom && show_left)
+        shadow_composite_region(pixels, stride_px, surf_w, surf_h,
+            0, r + height, r, r, true, true, r - 1, 0, r, col, op);
+    if (show_bottom && show_right)
+        shadow_composite_region(pixels, stride_px, surf_w, surf_h,
+            r + width, r + height, r, r, true, true, 0, 0, r, col, op);
+    if (show_top)
+        shadow_composite_region(pixels, stride_px, surf_w, surf_h,
+            r, 0, width, r, false, true, 0, 1, r, col, op);
+    if (show_bottom)
+        shadow_composite_region(pixels, stride_px, surf_w, surf_h,
+            r, r + height, width, r, false, true, 0, -1, r, col, op);
+    if (show_left)
+        shadow_composite_region(pixels, stride_px, surf_w, surf_h,
+            0, r, r, height, true, false, 1, 0, r, col, op);
+    if (show_right)
+        shadow_composite_region(pixels, stride_px, surf_w, surf_h,
+            r + width, r, r, height, true, false, -1, 0, r, col, op);
+
+    /* Fill strips bridging the offset gap (shadow_update_geometry()). */
+    if (oy != 0 && (oy > 0 ? show_bottom : show_top)) {
+        int abs_oy = oy > 0 ? oy : -oy;
+        int fy = oy > 0 ? height : oy;
+        shadow_composite_region(pixels, stride_px, surf_w, surf_h,
+            r, fy - oy + r, width, abs_oy, false, false, 0, 0, r, col, op);
+    }
+    if (ox != 0 && (ox > 0 ? show_right : show_left)) {
+        int abs_ox = ox > 0 ? ox : -ox;
+        int fx = ox > 0 ? width : ox;
+        shadow_composite_region(pixels, stride_px, surf_w, surf_h,
+            fx - ox + r, r, abs_ox, height, false, false, 0, 0, r, col, op);
+    }
+
+    cairo_surface_mark_dirty(surface);
+    return surface;
 }
 
 /* ========== Lua Integration ========== */

--- a/shadow.h
+++ b/shadow.h
@@ -21,6 +21,7 @@
 #ifndef SOMEWM_SHADOW_H
 #define SOMEWM_SHADOW_H
 
+#include <cairo.h>
 #include <lua.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -174,6 +175,18 @@ void shadow_update_config(shadow_nodes_t *shadow,
  * @param visible true to show, false to hide
  */
 void shadow_set_visible(shadow_nodes_t *shadow, bool visible);
+
+/**
+ * Render the whole shadow into one ARGB32 cairo surface, for the Clay
+ * declare pass (a drawin's shadow rides as a single image leaf). A faithful
+ * transcription of the 9-slice layout in shadow_update_geometry(): same
+ * falloff, same visibility rules, same fill strips. The surface spans
+ * (width + 2 * radius) x (height + 2 * radius), its origin at
+ * (offset - radius) relative to the object's frame origin. Caller owns the
+ * surface. NULL when the config renders nothing.
+ */
+cairo_surface_t *shadow_render_composite(const shadow_config_t *config,
+                                         int width, int height);
 
 /**
  * Destroy shadow nodes and free owned textures.

--- a/somewm.c
+++ b/somewm.c
@@ -94,6 +94,7 @@
 #include "monitor.h"
 #include "input.h"
 #include "window.h"
+#include "declare.h"
 #include "focus.h"
 #include "loop.h"
 #include "version.h"
@@ -403,6 +404,11 @@ some_activate_lua_lock(void)
 	 * Lua-created cover wibox (e.g. hotplugged monitors). */
 	wlr_scene_node_set_enabled(&locked_bg->node, 1);
 
+	/* Show the retained lock bands and dirty every output, so the lock
+	 * scene solves this frame (declare.c). Runs before the promotions
+	 * below so a band created now sits under the raised trees. */
+	declare_lock_set_visible(true);
+
 	/* Promote all cover surfaces to LyrBlock so they hide desktop content
 	 * on secondary monitors */
 	for (int i = 0; i < cover_count; i++)
@@ -440,6 +446,10 @@ lua_lock_scene_restore(void)
 
 	/* Let stack_refresh() sort everything back to proper layers */
 	stack_refresh();
+
+	/* Hide the retained lock bands (nodes kept, so a re-engage does not
+	 * flash the previous lock frame) and re-solve the desktop. */
+	declare_lock_set_visible(false);
 }
 
 /** Deactivate Lua-controlled lock mode
@@ -838,6 +848,7 @@ setup(void)
 		layers[i] = wlr_scene_tree_create(&scene->tree);
 	drag_icon = wlr_scene_tree_create(&scene->tree);
 	wlr_scene_node_place_below(&drag_icon->node, &layers[LyrBlock]->node);
+	window_setup_render_hooks();
 
 	/* Autocreates a renderer, either Pixman, GLES2 or Vulkan for us. The user
 	 * can also specify a renderer using the WLR_RENDERER env var.

--- a/somewm.c
+++ b/somewm.c
@@ -126,8 +126,6 @@ struct wlr_scene *scene;
 struct wlr_scene_tree *layers[NUM_LAYERS];
 struct wlr_scene_tree *drag_icon;
 Client *drag_source_client;
-/* Map from ZWLR_LAYER_SHELL_* constants to Lyr* enum */
-const int layermap[] = { LyrBg, LyrBottom, LyrTop, LyrOverlay };
 struct wlr_renderer *drw;
 struct wlr_allocator *alloc;
 struct wlr_compositor *compositor;
@@ -375,16 +373,12 @@ cleanuplisteners(void)
 static Client *pre_lock_focused_client = NULL;
 
 /** Activate Lua-controlled lock mode
- * - Promotes lock surface and cover surfaces to LyrBlock
+ * - Solves the lock scene (covers + lock surface) into LyrBlock
  * - Gives keyboard focus to lock surface
  */
 void
 some_activate_lua_lock(void)
 {
-	drawin_t *lock_surface = some_get_lua_lock_surface();
-	int cover_count;
-	drawin_t **covers = some_get_lua_lock_covers(&cover_count);
-
 	/* Save currently focused client for restoration on unlock. */
 	pre_lock_focused_client = globalconf.focus.client;
 
@@ -405,50 +399,22 @@ some_activate_lua_lock(void)
 	wlr_scene_node_set_enabled(&locked_bg->node, 1);
 
 	/* Show the retained lock bands and dirty every output, so the lock
-	 * scene solves this frame (declare.c). Runs before the promotions
-	 * below so a band created now sits under the raised trees. */
+	 * scene (the covers, then the lock surface on top) solves this frame
+	 * into LyrBlock, above locked_bg (declare.c). */
 	declare_lock_set_visible(true);
-
-	/* Promote all cover surfaces to LyrBlock so they hide desktop content
-	 * on secondary monitors */
-	for (int i = 0; i < cover_count; i++)
-		some_promote_lock_cover(covers[i]);
-
-	/* Promote lock surface to LyrBlock and raise above covers */
-	if (lock_surface && lock_surface->scene_tree) {
-		wlr_scene_node_reparent(&lock_surface->scene_tree->node, layers[LyrBlock]);
-		wlr_scene_node_raise_to_top(&lock_surface->scene_tree->node);
-	}
 }
 
 /** The scene half of deactivating the lock: layers only, no Lua. */
 static void
 lua_lock_scene_restore(void)
 {
-	drawin_t *lock_surface = some_get_lua_lock_surface();
-	int cover_count;
-	drawin_t **covers = some_get_lua_lock_covers(&cover_count);
-
 	/* Disable compositor-level lock background */
 	wlr_scene_node_set_enabled(&locked_bg->node, 0);
 
-	/* Move lock surface back to normal layer (LyrWibox) */
-	if (lock_surface && lock_surface->scene_tree) {
-		wlr_scene_node_reparent(&lock_surface->scene_tree->node, layers[LyrWibox]);
-	}
-
-	/* Move cover surfaces back to normal layers via stack_refresh() */
-	for (int i = 0; i < cover_count; i++) {
-		if (covers[i] && covers[i]->scene_tree) {
-			wlr_scene_node_reparent(&covers[i]->scene_tree->node, layers[LyrWibox]);
-		}
-	}
-
-	/* Let stack_refresh() sort everything back to proper layers */
-	stack_refresh();
-
 	/* Hide the retained lock bands (nodes kept, so a re-engage does not
-	 * flash the previous lock frame) and re-solve the desktop. */
+	 * flash the previous lock frame) and re-solve the desktop; the lock
+	 * drawins rejoin the desktop declaration through the normal band
+	 * policy on that same solve. */
 	declare_lock_set_visible(false);
 }
 
@@ -486,19 +452,13 @@ some_deactivate_lua_lock_no_focus(void)
 	pre_lock_focused_client = NULL;
 }
 
-/** Promote a single cover to LyrBlock during an active lock.
- * Re-raises the interactive lock surface above the new cover so it
- * stays on top of all covers. */
+/** A cover registered during an active lock: re-solve the lock scene so it
+ * joins, still under the lock surface (declare_lock_scene's order). */
 void
 some_promote_lock_cover(drawin_t *d)
 {
-	if (d && d->scene_tree) {
-		wlr_scene_node_reparent(&d->scene_tree->node, layers[LyrBlock]);
-		wlr_scene_node_raise_to_top(&d->scene_tree->node);
-		drawin_t *lock_surface = some_get_lua_lock_surface();
-		if (lock_surface && lock_surface->scene_tree)
-			wlr_scene_node_raise_to_top(&lock_surface->scene_tree->node);
-	}
+	if (d)
+		declare_mark_all_dirty();
 }
 
 /** Clear pre_lock_focused_client if it matches the given client.
@@ -582,7 +542,7 @@ void
 cursor_to_client_coordinates(Client *client, double *sx, double *sy) {
 	double bw = client->bw;
 	/* The content surface is positioned inside the frame at (bw + titlebar_left,
-	 * bw + titlebar_top) (see apply_geometry_to_wlroots), so content-local
+	 * bw + titlebar_top) (see client_configure_to_box), so content-local
 	 * coordinates must subtract the titlebars too, not just the border. Without
 	 * this the values stay positive over a titlebar and leak onto the client's
 	 * top content rows; with it they go negative there (= pointer not in content).

--- a/somewm.h
+++ b/somewm.h
@@ -125,7 +125,6 @@ extern uint32_t next_client_id;
 extern int new_client_placement;
 
 /* Layer mapping (ZWLR_LAYER_SHELL_* -> Lyr* enum) */
-extern const int layermap[];
 
 #ifdef XWAYLAND
 extern struct wlr_xwayland *xwayland;

--- a/somewm_types.h
+++ b/somewm_types.h
@@ -99,7 +99,6 @@ struct Monitor {
 	struct wl_list link;
 	struct wlr_output *wlr_output;
 	struct wlr_scene_output *scene_output;
-	struct wlr_scene_rect *fullscreen_bg; /* See createmon() for info */
 	struct wl_listener frame;
 	struct wl_listener destroy;
 	struct wl_listener request_state;
@@ -146,6 +145,12 @@ typedef struct LayerSurface {
 	struct wlr_scene_tree *scene;
 	/* The render_state currently borrowing scene (render.h owner token) */
 	void *render_owner;
+	/* Output-local position from the last layer-shell arrange; the declare
+	 * pass reads this, never the scene node the reconciler owns. */
+	struct { int x, y; } geom;
+	/* The zwlr layer this surface last committed to, keyed to the
+	 * m->layers list holding it (= its declare band). */
+	uint32_t band;
 	struct wlr_scene_tree *popups;
 	struct wlr_scene_layer_surface_v1 *scene_layer;
 	struct wl_list link;

--- a/somewm_types.h
+++ b/somewm_types.h
@@ -29,7 +29,7 @@
  * (awful.mouse.client.move/resize) instead of C-level cursor_mode state machine */
 enum { CurNormal, CurPressed }; /* cursor */
 enum { XDGShell, LayerShell, X11 }; /* client types */
-enum { LyrBg, LyrBottom, LyrTile, LyrFloat, LyrWibox, LyrTop, LyrFS, LyrOverlay, LyrBlock, NUM_LAYERS }; /* scene layers */
+enum { LyrBg, LyrWibox, LyrTop, LyrOverlay, LyrBlock, NUM_LAYERS }; /* scene layers */
 
 /* Window types (for stacking and EWMH) - AwesomeWM compatibility */
 typedef enum {

--- a/somewm_types.h
+++ b/somewm_types.h
@@ -115,6 +115,7 @@ struct Monitor {
 	int needs_screen_added; /* Set in createmon, cleared by updatemons after geometry is ready */
 	int needs_output_added; /* Set in createmon, cleared by updatemons after screen is ready */
 	output_t *output; /* Lua output object (persists across enable/disable) */
+	struct declare_output *declare; /* Per-output Clay context and render_state (declare.h) */
 };
 
 /* KeyboardGroup structure */
@@ -143,6 +144,8 @@ typedef struct LayerSurface {
 
 	Monitor *mon;
 	struct wlr_scene_tree *scene;
+	/* The render_state currently borrowing scene (render.h owner token) */
+	void *render_owner;
 	struct wlr_scene_tree *popups;
 	struct wlr_scene_layer_surface_v1 *scene_layer;
 	struct wl_list link;

--- a/stack.c
+++ b/stack.c
@@ -80,8 +80,8 @@ stack_windows(void)
  * \param c The client
  * \return The layer this client belongs in
  */
-static window_layer_t
-client_layer_translator(Client *c)
+window_layer_t
+stack_client_layer(Client *c)
 {
 	Client *focused;
 
@@ -119,6 +119,21 @@ client_layer_translator(Client *c)
 	}
 
 	return WINDOW_LAYER_NORMAL;
+}
+
+/* The drawin band policy (AwesomeWM compat): desktop/splash below clients
+ * like wallpaper, ontop above everything but fullscreen, dock above normal
+ * windows, everything else in the wibox layer. */
+int
+stack_drawin_layer(struct drawin_t *d)
+{
+	if (d->type == WINDOW_TYPE_DESKTOP || d->type == WINDOW_TYPE_SPLASH)
+		return LyrBg;
+	if (d->ontop)
+		return LyrOverlay;
+	if (d->type == WINDOW_TYPE_DOCK)
+		return LyrTop;
+	return LyrWibox;
 }
 
 /*
@@ -232,7 +247,7 @@ stack_refresh(void)
 
 		/* Unmanaged (override_redirect) X11 clients bypass the window
 		 * manager; they have no stacking attributes, so running them
-		 * through client_layer_translator() returns LyrTile and drops
+		 * through stack_client_layer() returns LyrTile and drops
 		 * Wine/Qt popups below their floating parents. mapnotify()
 		 * placed them in LyrOverlay; skip them here so the placement
 		 * survives. */
@@ -242,7 +257,7 @@ stack_refresh(void)
 			continue;
 #endif
 
-		layer = client_layer_translator(*node);
+		layer = stack_client_layer(*node);
 
 		/* Skip IGNORE layer (transients are handled with their parents) */
 		if (layer == WINDOW_LAYER_IGNORE)
@@ -258,12 +273,7 @@ stack_refresh(void)
 		prev_in_layer[layer] = stack_transients_above(*node, prev_in_layer[layer]);
 	}
 
-	/* Stack drawins (wiboxes) - AwesomeWM stacks these after clients
-	 * Layer is determined by: ontop property AND type property (AwesomeWM compat)
-	 * - type="desktop" → LyrBg (below everything, like wallpaper)
-	 * - type="dock" → LyrTop (above normal windows, like panels)
-	 * - ontop=true → LyrOverlay (above everything except fullscreen)
-	 * - otherwise → LyrTile (same as normal clients) */
+	/* Stack drawins (wiboxes) - AwesomeWM stacks these after clients */
 	foreach(drawin, globalconf.drawins) {
 		if (!(*drawin)->scene_tree)
 			continue;
@@ -275,21 +285,7 @@ stack_refresh(void)
 		if (session_is_locked() && some_is_lock_drawin(*drawin))
 			continue;
 
-		/* Determine layer based on type and ontop (AwesomeWM compatibility) */
-		if ((*drawin)->type == WINDOW_TYPE_DESKTOP ||
-		    (*drawin)->type == WINDOW_TYPE_SPLASH) {
-			/* Desktop/splash type goes to background layer (below clients) */
-			scene_layer = LyrBg;
-		} else if ((*drawin)->ontop) {
-			/* ontop drawins go to overlay layer */
-			scene_layer = LyrOverlay;
-		} else if ((*drawin)->type == WINDOW_TYPE_DOCK) {
-			/* Dock type goes above normal windows */
-			scene_layer = LyrTop;
-		} else {
-			/* Normal drawins go to wibox layer (above clients but below ontop) */
-			scene_layer = LyrWibox;
-		}
+		scene_layer = stack_drawin_layer(*drawin);
 
 		/* Reparent to correct layer if needed */
 		if ((void *)(*drawin)->scene_tree->node.parent != (void *)layers[scene_layer]) {

--- a/stack.c
+++ b/stack.c
@@ -1,14 +1,14 @@
 /*
  * stack.c - client stack management for somewm
  *
- * Manages Z-order (stacking) of windows using wlroots scene graph layers.
- * Ported from AwesomeWM's stack.c, adapted for Wayland.
- *
- * Key differences from AwesomeWM:
- * - Uses wlroots scene graph layers instead of XCB stacking
+ * Maintains globalconf.stack (bottom to top) and the layer classification.
+ * The declare pass (declare.c) walks both per dirty frame and expresses the
+ * order as declaration order, so a stacking change is just a dirty mark;
+ * ported from AwesomeWM's stack.c.
  */
 
 #include "stack.h"
+#include "declare.h"
 #include "ewmh.h"
 #include "somewm_types.h"
 #include "objects/client.h"  /* For complete client_t definition */
@@ -16,16 +16,9 @@
 #include "globalconf.h"      /* For globalconf.stack and globalconf.drawins */
 #include "somewm_api.h"
 #include <stdbool.h>
-#include <wlr/types/wlr_scene.h>
-#ifdef XWAYLAND
-#include <wlr/xwayland.h>
-#endif
 
 /* Flag to mark stack as needing refresh */
 static bool need_stack_refresh = false;
-
-/* External references */
-extern struct wlr_scene_tree *layers[NUM_LAYERS];
 
 /*
  * Stack management - uses globalconf.stack (matches AwesomeWM)
@@ -94,8 +87,9 @@ stack_client_layer(Client *c)
 
 	/* Fullscreen windows only get their own layer when they have focus.
 	 * On Wayland, we also keep the fullscreen layer when the focused client
-	 * is on a different screen, since the scene graph uses separate layers
-	 * (unlike X11's flat stacking model where wibars are below all clients). */
+	 * is on a different screen, since the declare pass keeps per-band
+	 * ordering (unlike X11's flat stacking model where wibars are below all
+	 * clients). */
 	focused = some_get_focused_client();
 	if (c->fullscreen && (focused == c || !focused || focused->screen != c->screen))
 		return WINDOW_LAYER_FULLSCREEN;
@@ -136,166 +130,18 @@ stack_drawin_layer(struct drawin_t *d)
 	return LyrWibox;
 }
 
-/*
- * Scene graph integration
- */
-
-/** Get the wlroots scene layer for a window layer
- * Maps our logical layers to wlroots scene graph layers
- * \param layer Window layer
- * \return Scene graph layer index
- */
-static int
-get_scene_layer(window_layer_t layer)
-{
-	switch (layer) {
-	case WINDOW_LAYER_DESKTOP:
-		return LyrBg;
-	case WINDOW_LAYER_BELOW:
-		return LyrBottom;
-	case WINDOW_LAYER_NORMAL:
-		return LyrTile;
-	case WINDOW_LAYER_ABOVE:
-		return LyrTop;
-	case WINDOW_LAYER_FULLSCREEN:
-		return LyrFS;
-	case WINDOW_LAYER_ONTOP:
-		return LyrOverlay;
-	case WINDOW_LAYER_IGNORE:
-	case WINDOW_LAYER_COUNT:
-	default:
-		return LyrTile;
-	}
-}
-
-/** Stack a client relative to another within the same scene layer
- * \param c Client to stack
- * \param previous Previous client (stack above this one), or NULL
- */
-static void
-stack_client_relative(Client *c, Client *previous)
-{
-	if (!c || !c->scene)
-		return;
-
-	if (previous && previous->scene) {
-		/* Ensure both nodes share the same scene parent.
-		 * In X11, stacking is flat (xcb_configure_window works on any two windows).
-		 * In wlroots, wlr_scene_node_place_above requires shared parents.
-		 * Transients should visually stack with their parent regardless of
-		 * which layer they were initially placed in. */
-		if (c->scene->node.parent != previous->scene->node.parent) {
-			wlr_scene_node_reparent(&c->scene->node, previous->scene->node.parent);
-		}
-		wlr_scene_node_place_above(&c->scene->node, &previous->scene->node);
-	} else {
-		/* No previous client, raise to top of layer */
-		wlr_scene_node_raise_to_top(&c->scene->node);
-	}
-}
-
-/** Stack transient windows above their parent
- * Recursively stacks all transients above c
- * \param c Parent client
- * \param previous Last stacked window
- * \return Last stacked transient (or c if no transients)
- */
-static Client *
-stack_transients_above(Client *c, Client *previous)
-{
-	if (!c)
-		return previous;
-
-	/* Stack this client first */
-	stack_client_relative(c, previous);
-	previous = c;
-
-	/* Then stack all transients above it */
-	foreach(node, globalconf.stack) {
-		if ((*node)->transient_for == c) {
-			/* Recursively stack this transient and its transients */
-			previous = stack_transients_above(*node, previous);
-		}
-	}
-
-	return previous;
-}
-
 /** Refresh stacking order
- * Ported from AwesomeWM stack.c:stack_refresh (lines 162-199)
- * Applies computed stack order to wlroots scene graph
+ * The declare pass reads globalconf.stack per dirty frame and the
+ * reconciler restacks the scene from declaration order, so applying a stack
+ * change is a dirty mark on every output plus the EWMH mirror.
  */
 void
 stack_refresh(void)
 {
-	window_layer_t layer;
-	Client *prev_in_layer[WINDOW_LAYER_COUNT];
-	int scene_layer;
-
 	if (!need_stack_refresh)
 		return;
 
-	/* Initialize previous pointers for each layer */
-	for (layer = 0; layer < WINDOW_LAYER_COUNT; layer++) {
-		prev_in_layer[layer] = NULL;
-	}
-
-	/* Process stack from bottom to top, organizing by layer */
-	foreach(node, globalconf.stack) {
-		if (!(*node) || !(*node)->scene)
-			continue;
-
-		/* Unmanaged (override_redirect) X11 clients bypass the window
-		 * manager; they have no stacking attributes, so running them
-		 * through stack_client_layer() returns LyrTile and drops
-		 * Wine/Qt popups below their floating parents. mapnotify()
-		 * placed them in LyrOverlay; skip them here so the placement
-		 * survives. */
-#ifdef XWAYLAND
-		if ((*node)->client_type == X11 &&
-		    (*node)->surface.xwayland->override_redirect)
-			continue;
-#endif
-
-		layer = stack_client_layer(*node);
-
-		/* Skip IGNORE layer (transients are handled with their parents) */
-		if (layer == WINDOW_LAYER_IGNORE)
-			continue;
-
-		/* Move client to correct scene graph layer if needed */
-		scene_layer = get_scene_layer(layer);
-		if ((void *)(*node)->scene->node.parent != (void *)layers[scene_layer]) {
-			wlr_scene_node_reparent(&(*node)->scene->node, layers[scene_layer]);
-		}
-
-		/* Stack client and its transients */
-		prev_in_layer[layer] = stack_transients_above(*node, prev_in_layer[layer]);
-	}
-
-	/* Stack drawins (wiboxes) - AwesomeWM stacks these after clients */
-	foreach(drawin, globalconf.drawins) {
-		if (!(*drawin)->scene_tree)
-			continue;
-
-		/* Lock drawins are managed by some_activate_lua_lock() /
-		 * some_promote_lock_cover() and must stay in LyrBlock while the
-		 * session is locked. Without this skip, the normal ontop/type
-		 * logic below would reparent them out of LyrBlock. */
-		if (session_is_locked() && some_is_lock_drawin(*drawin))
-			continue;
-
-		scene_layer = stack_drawin_layer(*drawin);
-
-		/* Reparent to correct layer if needed */
-		if ((void *)(*drawin)->scene_tree->node.parent != (void *)layers[scene_layer]) {
-			wlr_scene_node_reparent(&(*drawin)->scene_tree->node, layers[scene_layer]);
-		}
-
-		/* Raise to top of its layer (drawins stack above clients in same layer) */
-		wlr_scene_node_raise_to_top(&(*drawin)->scene_tree->node);
-	}
-
+	declare_mark_all_dirty();
 	ewmh_update_net_client_list_stacking();
 
 	need_stack_refresh = false;

--- a/stack.c
+++ b/stack.c
@@ -115,19 +115,20 @@ stack_client_layer(Client *c)
 	return WINDOW_LAYER_NORMAL;
 }
 
-/* The drawin band policy (AwesomeWM compat): desktop/splash below clients
- * like wallpaper, ontop above everything but fullscreen, dock above normal
- * windows, everything else in the wibox layer. */
-int
-stack_drawin_layer(struct drawin_t *d)
+/* A transient that sets no stacking attribute of its own inherits its
+ * parent's layer, so a dialog stays with its parent while ontop on the
+ * dialog itself still wins. WINDOW_LAYER_IGNORE means exactly the first
+ * case, so the walk ends at the first client that set something. */
+window_layer_t
+stack_client_effective_layer(Client *c)
 {
-	if (d->type == WINDOW_TYPE_DESKTOP || d->type == WINDOW_TYPE_SPLASH)
-		return LyrBg;
-	if (d->ontop)
-		return LyrOverlay;
-	if (d->type == WINDOW_TYPE_DOCK)
-		return LyrTop;
-	return LyrWibox;
+	window_layer_t layer = stack_client_layer(c);
+
+	while (layer == WINDOW_LAYER_IGNORE && c->transient_for) {
+		c = c->transient_for;
+		layer = stack_client_layer(c);
+	}
+	return layer == WINDOW_LAYER_IGNORE ? WINDOW_LAYER_NORMAL : layer;
 }
 
 /** Refresh stacking order

--- a/stack.h
+++ b/stack.h
@@ -13,6 +13,10 @@
  * Order from bottom to top:
  * DESKTOP -> BELOW -> NORMAL -> ABOVE -> FULLSCREEN -> ONTOP
  *
+ * These name a client's stacking class, not the draw order: declare.c's
+ * z table is the order of record, and it interleaves drawins and
+ * layer-shell surfaces between these layers.
+ *
  * Note: Floating is a LAYOUT concept, not a STACKING concept.
  * Floating windows go to NORMAL layer. Use c.above/c.ontop for Z-order.
  */
@@ -55,15 +59,13 @@ void stack_windows(void);
  */
 void stack_refresh(void);
 
-/** The stacking layer a client's attributes place it in.
- * Also consumed by the declare pass, which expresses the same order as
- * Clay declaration order. */
+/** The stacking layer a client's own attributes place it in.
+ * WINDOW_LAYER_IGNORE for a transient that sets none of its own. */
 window_layer_t stack_client_layer(Client *c);
 
-/** The scene layer (Lyr*) a drawin's type and ontop place it in.
- * The one statement of the drawin band policy, shared with the declare
- * pass like stack_client_layer(). */
-struct drawin_t;
-int stack_drawin_layer(struct drawin_t *d);
+/** The layer a client draws in: its own if it sets one, else the nearest
+ * one up the transient chain. The one statement of the inherit rule, read
+ * by the declare pass and by client._scene_layer. */
+window_layer_t stack_client_effective_layer(Client *c);
 
 #endif /* STACK_H */

--- a/stack.h
+++ b/stack.h
@@ -55,4 +55,15 @@ void stack_windows(void);
  */
 void stack_refresh(void);
 
+/** The stacking layer a client's attributes place it in.
+ * Also consumed by the declare pass, which expresses the same order as
+ * Clay declaration order. */
+window_layer_t stack_client_layer(Client *c);
+
+/** The scene layer (Lyr*) a drawin's type and ontop place it in.
+ * The one statement of the drawin band policy, shared with the declare
+ * pass like stack_client_layer(). */
+struct drawin_t;
+int stack_drawin_layer(struct drawin_t *d);
+
 #endif /* STACK_H */

--- a/systray.c
+++ b/systray.c
@@ -24,6 +24,7 @@
 #include "globalconf.h"
 #include "color.h"
 #include "objects/drawin.h"
+#include "objects/drawable.h"
 #include "objects/systray.h"
 #include "common/luaobject.h"
 
@@ -102,112 +103,27 @@ systray_count_visible(void)
 	return count;
 }
 
-/* Systray icon buffer wrapper for wlr_scene_buffer */
-struct systray_icon_buffer {
-	struct wlr_buffer base;
-	void *data;
-	int width;
-	int height;
-	size_t stride;
-};
-
-static void systray_icon_buffer_destroy(struct wlr_buffer *wlr_buffer)
-{
-	struct systray_icon_buffer *buffer =
-		wl_container_of(wlr_buffer, buffer, base);
-	free(buffer->data);
-	free(buffer);
-}
-
-static bool systray_icon_buffer_begin_data_ptr_access(
-	struct wlr_buffer *wlr_buffer, uint32_t flags, void **data,
-	uint32_t *format, size_t *stride)
-{
-	struct systray_icon_buffer *buffer =
-		wl_container_of(wlr_buffer, buffer, base);
-	*data = buffer->data;
-	*format = DRM_FORMAT_ARGB8888;
-	*stride = buffer->stride;
-	return true;
-}
-
-static void systray_icon_buffer_end_data_ptr_access(struct wlr_buffer *wlr_buffer)
-{
-	/* Nothing to do */
-}
-
-static const struct wlr_buffer_impl systray_icon_buffer_impl = {
-	.destroy = systray_icon_buffer_destroy,
-	.begin_data_ptr_access = systray_icon_buffer_begin_data_ptr_access,
-	.end_data_ptr_access = systray_icon_buffer_end_data_ptr_access,
-};
-
-/** Create a wlr_buffer from a cairo surface */
-static struct wlr_buffer *
-systray_buffer_from_cairo(cairo_surface_t *surface)
-{
-	struct systray_icon_buffer *buffer;
-	int width, height;
-	size_t stride, size;
-	unsigned char *src_data;
-
-	if (!surface || cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS)
-		return NULL;
-
-	if (cairo_image_surface_get_format(surface) != CAIRO_FORMAT_ARGB32)
-		return NULL;
-
-	width = cairo_image_surface_get_width(surface);
-	height = cairo_image_surface_get_height(surface);
-	stride = (size_t)cairo_image_surface_get_stride(surface);
-	src_data = cairo_image_surface_get_data(surface);
-
-	if (width <= 0 || height <= 0 || !src_data)
-		return NULL;
-
-	buffer = calloc(1, sizeof(*buffer));
-	if (!buffer)
-		return NULL;
-
-	size = stride * (size_t)height;
-	buffer->data = malloc(size);
-	if (!buffer->data) {
-		free(buffer);
-		return NULL;
-	}
-
-	memcpy(buffer->data, src_data, size);
-	buffer->width = width;
-	buffer->height = height;
-	buffer->stride = stride;
-
-	wlr_buffer_init(&buffer->base, &systray_icon_buffer_impl, width, height);
-
-	return &buffer->base;
-}
-
-/** Render systray icons to scene graph */
-static void
-systray_render_icons(drawin_t *drawin)
+/** Paint the visible tray icons into the hosting drawin's content pixels.
+ * Called from drawin_refresh_drawable() after the widget pixels landed in
+ * the content entry, so the icons sit on top exactly where the old scene
+ * overlay stacked them. target holds device pixels with no device scale
+ * set, so every coordinate scales by the drawable's surface scale. */
+void
+systray_composite(drawin_t *drawin, cairo_surface_t *target)
 {
 	systray_item_array_t *items;
-	int i, pos_x, pos_y, idx;
+	cairo_t *cr;
+	int i, idx;
 	int base_size, spacing, rows;
 	bool horizontal;
+	float scale;
 
-	if (!drawin || !drawin->scene_tree)
+	if (!drawin || drawin != globalconf.systray.parent)
 		return;
 
 	items = systray_get_items();
 	if (!items || items->len == 0)
 		return;
-
-	if (!globalconf.systray.scene_tree) {
-		globalconf.systray.scene_tree = wlr_scene_tree_create(drawin->scene_tree);
-		if (!globalconf.systray.scene_tree)
-			return;
-		globalconf.systray.scene_tree->node.data = drawin;
-	}
 
 	base_size = globalconf.systray.layout.base_size;
 	spacing = globalconf.systray.layout.spacing;
@@ -218,22 +134,18 @@ systray_render_icons(drawin_t *drawin)
 		base_size = 24;
 	if (rows <= 0)
 		rows = 1;
+	scale = drawin->drawable && drawin->drawable->surface_scale > 0
+		? drawin->drawable->surface_scale : 1.0f;
 
-	wlr_scene_node_set_position(&globalconf.systray.scene_tree->node,
-	                            globalconf.systray.layout.x,
-	                            globalconf.systray.layout.y);
-
-	{
-		struct wlr_scene_node *child, *tmp;
-		wl_list_for_each_safe(child, tmp, &globalconf.systray.scene_tree->children, link) {
-			wlr_scene_node_destroy(child);
-		}
-	}
+	cr = cairo_create(target);
+	cairo_scale(cr, scale, scale);
+	cairo_translate(cr, globalconf.systray.layout.x,
+	                globalconf.systray.layout.y);
 
 	idx = 0;
 	for (i = 0; i < items->len; i++) {
 		systray_item_t *item = items->tab[i];
-		int row, col;
+		int row, col, pos_x, pos_y;
 
 		if (!item || !item->is_valid)
 			continue;
@@ -243,43 +155,33 @@ systray_render_icons(drawin_t *drawin)
 		if (horizontal) {
 			col = idx / rows;
 			row = idx % rows;
-			pos_x = col * (base_size + spacing);
-			pos_y = row * (base_size + spacing);
 		} else {
 			row = idx / rows;
 			col = idx % rows;
-			pos_x = col * (base_size + spacing);
-			pos_y = row * (base_size + spacing);
 		}
+		pos_x = col * (base_size + spacing);
+		pos_y = row * (base_size + spacing);
 
-		if (item->icon) {
-			struct wlr_buffer *icon_buffer = systray_buffer_from_cairo(item->icon);
-			if (icon_buffer) {
-				struct wlr_scene_buffer *scene_buf;
-				scene_buf = wlr_scene_buffer_create(globalconf.systray.scene_tree,
-				                                    icon_buffer);
-				if (scene_buf) {
-					wlr_scene_node_set_position(&scene_buf->node, pos_x, pos_y);
-					scene_buf->node.data = drawin->drawable;
-					if (item->icon_width != base_size || item->icon_height != base_size) {
-						wlr_scene_buffer_set_dest_size(scene_buf, base_size, base_size);
-					}
-				}
-				wlr_buffer_drop(icon_buffer);
-			}
+		cairo_save(cr);
+		cairo_translate(cr, pos_x, pos_y);
+		if (item->icon
+				&& cairo_surface_status(item->icon) == CAIRO_STATUS_SUCCESS
+				&& item->icon_width > 0 && item->icon_height > 0) {
+			cairo_scale(cr, (double)base_size / item->icon_width,
+			            (double)base_size / item->icon_height);
+			cairo_set_source_surface(cr, item->icon, 0, 0);
+			cairo_paint(cr);
 		} else {
-			float color[4] = {0.5f, 0.5f, 0.8f, 1.0f};
-			struct wlr_scene_rect *rect;
-			rect = wlr_scene_rect_create(globalconf.systray.scene_tree,
-			                             base_size, base_size, color);
-			if (rect) {
-				wlr_scene_node_set_position(&rect->node, pos_x, pos_y);
-				rect->node.data = drawin->drawable;
-			}
+			/* No icon yet: the old path's placeholder tile */
+			cairo_set_source_rgba(cr, 0.5, 0.5, 0.8, 1.0);
+			cairo_rectangle(cr, 0, 0, base_size, base_size);
+			cairo_fill(cr);
 		}
+		cairo_restore(cr);
 
 		idx++;
 	}
+	cairo_destroy(cr);
 }
 
 /** Systray kickout - remove systray from a drawin */
@@ -289,12 +191,9 @@ systray_kickout(drawin_t *drawin)
 	if (globalconf.systray.parent != drawin)
 		return;
 
-	if (globalconf.systray.scene_tree) {
-		wlr_scene_node_destroy(&globalconf.systray.scene_tree->node);
-		globalconf.systray.scene_tree = NULL;
-	}
-
 	globalconf.systray.parent = NULL;
+	/* The old parent's entry still has the icons baked in; its next
+	 * redraw re-feeds the entry without them. */
 }
 
 /** awesome.systray() - Manage the system tray */
@@ -362,7 +261,9 @@ luaA_systray(lua_State *L)
 	globalconf.systray.layout.spacing = spacing;
 	globalconf.systray.layout.rows = rows > 0 ? rows : 1;
 
-	systray_render_icons(drawin);
+	/* Layout recorded; the icons composite into the drawin content entry
+	 * on its next drawable refresh, which the widget draw that called us
+	 * triggers. */
 
 	lua_pushinteger(L, systray_count_visible());
 	luaA_object_push(L, drawin);

--- a/systray.c
+++ b/systray.c
@@ -192,8 +192,11 @@ systray_kickout(drawin_t *drawin)
 		return;
 
 	globalconf.systray.parent = NULL;
-	/* The old parent's entry still has the icons baked in; its next
-	 * redraw re-feeds the entry without them. */
+	/* The icons are baked into the old parent's content entry. Repaint it
+	 * now: systray_composite() is a no-op for it from here, so the widget
+	 * pixels land without them. Waiting for an unrelated redraw leaves the
+	 * tray drawn in two places. */
+	drawin_refresh_drawable(drawin);
 }
 
 /** awesome.systray() - Manage the system tray */

--- a/systray.h
+++ b/systray.h
@@ -26,9 +26,14 @@
 #include <stdbool.h>
 #include <xcb/xcb.h>
 #include <lua.h>
+#include <cairo/cairo.h>
 
 void systray_init(void);
 void systray_cleanup(void);
+/* Paint the tray icons into the hosting drawin's content pixels; no-op for
+ * any other drawin. Called from drawin_refresh_drawable(). */
+struct drawin_t;
+void systray_composite(struct drawin_t *drawin, cairo_surface_t *target);
 int systray_process_client_message(xcb_client_message_event_t*);
 int xembed_process_client_message(xcb_client_message_event_t*);
 int luaA_systray(lua_State*);

--- a/tests/test-declare-dirty-mark.lua
+++ b/tests/test-declare-dirty-mark.lua
@@ -1,0 +1,90 @@
+---------------------------------------------------------------------------
+-- Test: a bare dirty mark on an idle session produces a frame
+--
+-- The Clay frame loop only rebuilds an output's tree inside the
+-- wlr_output.events.frame handler, and only when the output was marked
+-- dirty. A geometry change that redraws no drawable (moving a wibox) is a
+-- pure declare_output_mark_dirty(); the mark must wake the poll and reach a
+-- presented frame with no input and no client traffic, or the move is
+-- invisible until unrelated fd activity wakes the loop.
+--
+-- Presents are observed via awesome._test_frame_count, the same hook as
+-- tests/test-widget-idle-repaint.lua, and the same quiescence discipline
+-- applies: measure only after the frame loop has gone quiet.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local awful  = require("awful")
+local wibox  = require("wibox")
+
+local wb
+local baseline
+
+local last_count, stable_samples = nil, 0
+
+local steps = {
+    -- Step 1: show a wibox, then wait for the frame loop to go idle (frame
+    -- count unchanged across several 0.1s samples).
+    function(count)
+        if count == 1 then
+            wb = wibox {
+                x = 0, y = 0, width = 120, height = 24,
+                bg = "#000000", visible = true,
+                screen = awful.screen.focused(),
+            }
+            last_count, stable_samples = nil, 0
+            return nil
+        end
+
+        local now = awesome._test_frame_count
+        if last_count ~= nil and now == last_count then
+            stable_samples = stable_samples + 1
+        else
+            stable_samples = 0
+        end
+        last_count = now
+
+        if stable_samples >= 3 and now > 0 then
+            return true
+        end
+        return nil
+    end,
+
+    -- Step 2: move the wibox. This redraws nothing; it only marks the
+    -- output dirty. The next frames must present the move.
+    function(count)
+        if count == 1 then
+            baseline = awesome._test_frame_count
+            wb.x = wb.x + 10
+            return nil
+        end
+
+        if awesome._test_frame_count > baseline then
+            io.stderr:write("[PASS] dirty mark on an idle session presented a frame\n")
+            return true
+        end
+        return nil
+    end,
+
+    -- Cleanup.
+    function()
+        if wb then
+            wb.visible = false
+            wb = nil
+        end
+        return true
+    end,
+}
+
+-- Meaningful only on the headless backend: a nested parent compositor keeps
+-- the Wayland fd busy and would drain a stranded frame idle, masking the
+-- bug (same reasoning as test-widget-idle-repaint.lua).
+if not (os.getenv("WLR_BACKENDS") or ""):find("headless", 1, true) then
+    runner.run_direct()
+    io.stderr:write("[SKIP] test-declare-dirty-mark: needs the headless backend "
+        .. "(HEADLESS=1); a nested parent compositor masks the bug under test.\n")
+    runner.done()
+    return
+end
+
+runner.run_steps(steps)

--- a/tests/test-declare-hit-cross-output.lua
+++ b/tests/test-declare-hit-cross-output.lua
@@ -1,0 +1,103 @@
+---------------------------------------------------------------------------
+-- Test: chrome drawn across an output edge is still clickable there
+--
+-- A wibox declares on the output its top-left sits on, and the node it
+-- reconciles into is free to overhang onto the neighbor. The input backmap
+-- has to find the band that drew the node, not the band the pointer happens
+-- to be over, or every click on the overhanging half falls through.
+--
+-- mouse.object_under_pointer() runs the real xytonode() path, so this reads
+-- the backmap rather than a test hook.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local wibox = require("wibox")
+
+if not awesome._test_add_output then
+    io.stderr:write("SKIP: awesome._test_add_output not available\n")
+    io.stderr:write("Test finished successfully.\n")
+    awesome.quit()
+    return
+end
+
+local initial_count = screen.count()
+local left, right, w
+local probe_x, probe_y
+
+local steps = {
+    function()
+        assert(awesome._test_add_output(800, 600), "_test_add_output failed")
+        return true
+    end,
+
+    function()
+        return screen.count() > initial_count or nil
+    end,
+
+    -- wlr_output_layout_add_auto() lays outputs out left to right, but read
+    -- the geometry rather than assume which screen ended up where.
+    function()
+        for s in screen do
+            local g = s.geometry
+            if not left or g.x < left.geometry.x then left = s end
+            if not right or g.x > right.geometry.x then right = s end
+        end
+        assert(left ~= right, "the two outputs share an x origin")
+        assert(right.geometry.x == left.geometry.x + left.geometry.width,
+            "outputs are not adjacent: cannot straddle the edge")
+        return true
+    end,
+
+    -- 40px on the left output, 80px over the right one. The top-left stays
+    -- on the left output, so that is the screen it is assigned and the band
+    -- that declares it.
+    function()
+        w = wibox({
+            x = right.geometry.x - 40,
+            y = left.geometry.y + 10,
+            width = 120, height = 30,
+            bg = "#00ff00", visible = true,
+        })
+        w:setup({ widget = wibox.widget.textbox, text = "edge" })
+        assert(w.screen == left, "wibox was not assigned to the left output")
+        probe_x = right.geometry.x + 20
+        probe_y = left.geometry.y + 25
+        return true
+    end,
+
+    -- A drawin only draws once its content entry holds pixels.
+    function()
+        for _, o in ipairs(awesome._test_declare_order(left)) do
+            if o == w.drawin then
+                return true
+            end
+        end
+    end,
+
+    -- capi.mouse.coords() warps; assigning mouse.coords replaces the
+    -- function with a table and warps nothing.
+    function()
+        local c = mouse.coords({ x = probe_x, y = probe_y })
+        assert(c.x == probe_x and c.y == probe_y, "pointer did not warp")
+        return true
+    end,
+
+    function()
+        local obj = mouse.object_under_pointer()
+        assert(obj == w.drawin, string.format(
+            "nothing found under (%d,%d), the part of the wibox on screen %d",
+            probe_x, probe_y, right.index))
+        io.stderr:write("[PASS] overhanging wibox is hit on the neighbor\n")
+        return true
+    end,
+
+    function()
+        w.visible = false
+        w = nil
+        return true
+    end,
+}
+
+runner.run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-declare-offscreen.lua
+++ b/tests/test-declare-offscreen.lua
@@ -1,0 +1,111 @@
+---------------------------------------------------------------------------
+-- Test: a box that has moved off its output is still declared
+--
+-- Boxes enter the Clay tree output-local, but the nodes they reconcile into
+-- are not confined to the output: a floating client mid-drag and a wibox
+-- overhanging an edge both render on the neighbor while their box is still
+-- relative to the output that declared them. Clay's own culling drops any
+-- element whose box lies entirely outside the layout dimensions, which would
+-- delete both instead of drawing them, so the bands run with culling off.
+--
+-- awesome._test_declare_order(screen) solves the screen's tree again and
+-- returns what it would draw, so absence here is exactly the vanishing.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local utils = require("_utils")
+local awful = require("awful")
+local wibox = require("wibox")
+
+local TEST_CLIENT = utils.binary_or_skip("./build-test/test-transient-client")
+if not TEST_CLIENT then
+    return
+end
+
+local s = screen[1]
+local geo = s.geometry
+local bar
+local c
+
+local function declared(object)
+    for _, o in ipairs(awesome._test_declare_order(s)) do
+        if o == object then
+            return true
+        end
+    end
+    return false
+end
+
+local function assert_declared(object, what)
+    assert(declared(object), what .. ": not declared")
+    io.stderr:write("[PASS] " .. what .. "\n")
+end
+
+local steps = {
+    -- A wibox only declares once it has drawn, so wait for it to appear.
+    function(count)
+        if count == 1 then
+            local w = wibox({
+                x = geo.x, y = geo.y, width = 100, height = 20,
+                bg = "#000000", visible = true, screen = s,
+            })
+            w:setup({ widget = wibox.widget.textbox, text = "bar" })
+            bar = w.drawin
+        end
+        return declared(bar) or nil
+    end,
+
+    -- Past the right edge, then past the left: still drawn, because the
+    -- neighbor output is where those pixels belong.
+    function()
+        bar.x = geo.x + geo.width + 200
+        assert_declared(bar, "wibox past the right edge")
+        bar.x = geo.x - bar.width - 200
+        assert_declared(bar, "wibox past the left edge")
+        return true
+    end,
+
+    function(count)
+        if count == 1 then
+            awful.spawn(TEST_CLIENT)
+        end
+        c = utils.find_client_by_class("transient_test_parent")
+        return c and true or nil
+    end,
+
+    -- A floating client carries user-authoritative geometry and does not
+    -- clamp to its monitor, so dragging it clear of the output must not
+    -- delete it before c.screen catches up.
+    function()
+        c.floating = true
+        c:geometry({
+            x = geo.x + geo.width + 200, y = geo.y,
+            width = 200, height = 200,
+        })
+        assert_declared(c, "floating client past the right edge")
+        return true
+    end,
+
+    -- The wibox must not outlive the test: a visible drawin left behind
+    -- hangs the quit, and test-transient-client needs the same kill dance
+    -- as tests/test-declare-order.lua.
+    function(count)
+        if count == 1 then
+            bar.visible = false
+            for _, cl in ipairs(client.get()) do
+                cl:kill()
+            end
+        end
+        if #client.get() == 0 then
+            return true
+        end
+        if count >= 10 then
+            os.execute("pkill -9 test-transient-client 2>/dev/null")
+            return true
+        end
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-declare-order.lua
+++ b/tests/test-declare-order.lua
@@ -1,0 +1,129 @@
+-- Test: the declare pass draws windows in the band their stacking attribute
+-- names, and a transient that sets none inherits its parent's.
+--
+-- awesome._test_declare_order(screen) solves the screen's Clay tree again and
+-- returns the clients and drawins it would draw, bottom first, so the
+-- assertions read the real draw order rather than inferring it from
+-- attributes.
+
+local runner = require("_runner")
+local utils = require("_utils")
+local awful = require("awful")
+local wibox = require("wibox")
+
+local TEST_TRANSIENT_CLIENT =
+    utils.binary_or_skip("./build-test/test-transient-client")
+if not TEST_TRANSIENT_CLIENT then
+    return
+end
+
+local s = screen[1]
+local bar
+local parent_client
+local child_client
+local proc_pid
+
+-- Position in the draw order, bottom first.
+local function order_index(object)
+    local order = awesome._test_declare_order(s)
+    for i, o in ipairs(order) do
+        if o == object then
+            return i
+        end
+    end
+    return nil
+end
+
+local function assert_above(a, b, what)
+    local ia, ib = order_index(a), order_index(b)
+    assert(ia and ib, what .. ": not everything is declared")
+    assert(ia > ib, string.format("%s: expected above (%d vs %d)",
+        what, ia, ib))
+    io.stderr:write("[PASS] " .. what .. "\n")
+end
+
+local steps = {
+    -- A plain wibox sits in the wibox band, above normal clients. It only
+    -- declares once it has drawn, so wait for it to enter the order.
+    function(count)
+        if count == 1 then
+            local w = wibox({
+                x = 0, y = 0, width = 100, height = 20,
+                visible = true,
+                screen = s,
+            })
+            w:setup({ widget = wibox.widget.textbox, text = "bar" })
+            bar = w.drawin
+        end
+        if order_index(bar) then
+            return true
+        end
+    end,
+
+    function(count)
+        if count == 1 then
+            proc_pid = awful.spawn(TEST_TRANSIENT_CLIENT)
+        end
+        parent_client = utils.find_client_by_class("transient_test_parent")
+        if parent_client then
+            return true
+        end
+    end,
+
+    function(count)
+        if count == 1 then
+            awesome.kill(proc_pid, 10) -- SIGUSR1: create the transient child
+        end
+        for _, c in ipairs(client.get()) do
+            if c.transient_for == parent_client then
+                child_client = c
+                return true
+            end
+        end
+    end,
+
+    -- With no stacking attribute of its own, the child inherits its parent's
+    -- normal band: above the parent, below the wibox.
+    function()
+        assert_above(child_client, parent_client, "plain transient above parent")
+        assert_above(bar, child_client, "wibox above plain transient")
+        return true
+    end,
+
+    -- ontop on the child wins over the parent's placement, as in AwesomeWM.
+    function()
+        child_client.ontop = true
+        assert_above(child_client, bar, "ontop transient above wibox")
+        return true
+    end,
+
+    -- Back to inheriting, and now the parent is the one that is ontop: the
+    -- child follows it above the wibox without setting anything itself.
+    function()
+        child_client.ontop = false
+        parent_client.ontop = true
+        assert_above(child_client, parent_client, "inheriting child above parent")
+        assert_above(child_client, bar, "inheriting child above wibox")
+        return true
+    end,
+
+    function(count)
+        if count == 1 then
+            bar.visible = false
+            if proc_pid then
+                awful.spawn("kill " .. proc_pid)
+            end
+        end
+        if #client.get() == 0 then
+            return true
+        end
+        if count >= 10 then
+            os.execute("pkill -9 test-transient-client 2>/dev/null")
+            return true
+        end
+    end,
+}
+
+runner.run_steps(steps, { kill_clients = false })
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-declare-zero-mutations.lua
+++ b/tests/test-declare-zero-mutations.lua
@@ -1,0 +1,89 @@
+---------------------------------------------------------------------------
+-- Test: re-declaring an unchanged scene mutates nothing
+--
+-- The Clay frame loop earns its keep only if a frame that declares the same
+-- thing twice reconciles to zero scene mutations. Anything that churns per
+-- declare (an element id derived from a counter, a raster redone because a
+-- generation bumps unconditionally, a node reparented every pass) shows up
+-- here as a non-zero second count while the screen looks perfectly fine.
+--
+-- awesome._test_redeclare() marks every output dirty and runs the declare,
+-- solve and reconcile pass synchronously, returning the mutation count. Two
+-- calls back to back have nothing in between that could change the scene, so
+-- the second must be 0.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local awful  = require("awful")
+local wibox  = require("wibox")
+
+local wb
+local last_count, stable_samples = nil, 0
+
+-- Re-declare twice: the first call absorbs whatever was genuinely pending,
+-- the second must find the scene already correct.
+local function second_pass_mutations()
+    awesome._test_redeclare()
+    return awesome._test_redeclare()
+end
+
+local function assert_zero(what)
+    local n = second_pass_mutations()
+    assert(n == 0, what .. ": re-declare mutated " .. n .. " nodes")
+    io.stderr:write("[PASS] " .. what .. ": 0 mutations\n")
+end
+
+local steps = {
+    -- Step 1: a wibox with a border and a textbox, then wait for the frame
+    -- loop to go quiet so no genuine redraw is still in flight.
+    function(count)
+        if count == 1 then
+            wb = wibox {
+                x = 10, y = 10, width = 200, height = 30,
+                bg = "#202020", border_width = 2, border_color = "#ff0000",
+                visible = true,
+                screen = awful.screen.focused(),
+            }
+            wb:setup { text = "declare", widget = wibox.widget.textbox }
+            return nil
+        end
+
+        local now = awesome._test_frame_count
+        stable_samples = (last_count ~= nil and now == last_count)
+            and stable_samples + 1 or 0
+        last_count = now
+        return stable_samples >= 3 or nil
+    end,
+
+    -- Step 2: the settled scene re-declares to nothing.
+    function()
+        assert_zero("settled wibox scene")
+        return true
+    end,
+
+    -- Step 3: a real change mutates, and the scene is stable again after it.
+    function()
+        wb.x = wb.x + 25
+        assert(awesome._test_redeclare() > 0,
+            "moving the wibox mutated nothing")
+        assert_zero("after a wibox move")
+        return true
+    end,
+
+    -- Step 4: same across a tag switch, which rebuilds every band.
+    function()
+        local s = awful.screen.focused()
+        local other = s.tags[2] or s.tags[1]
+        other:view_only()
+        assert_zero("after a tag switch")
+        s.tags[1]:view_only()
+        return true
+    end,
+
+    function()
+        wb.visible = false
+        return true
+    end,
+}
+
+runner.run_steps(steps)

--- a/tests/test-shape-input-gc.lua
+++ b/tests/test-shape-input-gc.lua
@@ -81,34 +81,39 @@ local steps = {
         end
     end,
 
-    -- Step 3: Move mouse over the wibox to trigger drawin_accepts_input_at()
-    -- This will crash if the surface backing data was freed (use-after-free)
+    -- Step 3: capi.mouse.coords() only warps; object_under_pointer() is what
+    -- runs xytonode() and with it drawin_accepts_input_at(), the read of the
+    -- finished surface that used to crash. Assigning mouse.coords instead
+    -- warps nothing: awful.mouse has no set_coords, so the assignment lands
+    -- in its props table and shadows this function.
     function()
-        -- Position mouse inside the wibox
-        mouse.coords = { x = BOX_X + BOX_W / 2, y = BOX_Y + BOX_H / 2 }
-        io.stderr:write("[TEST] Mouse moved to center of wibox\n")
+        mouse.coords({ x = BOX_X + BOX_W / 2, y = BOX_Y + BOX_H / 2 })
+        assert(mouse.object_under_pointer() == test_wibox.drawin,
+            "center of the shape did not accept input")
+        io.stderr:write("[TEST] center of the wibox accepts input\n")
         return true
     end,
 
-    -- Step 4: Move mouse to corner (transparent region in rounded rect)
-    -- This tests the actual pixel lookup in drawin_accepts_input_at()
+    -- Step 4: The corners fall outside the rounded rect, so the mask reads 0
+    -- there. A mask whose backing data was freed and overwritten answers
+    -- these wrong (or crashes) instead.
     function()
-        -- Position mouse at corner where shape has transparency
-        mouse.coords = { x = BOX_X + 5, y = BOX_Y + 5 }
-        io.stderr:write("[TEST] Mouse moved to corner - shape_input check passed\n")
+        for _, corner in ipairs({
+            { BOX_X + 5, BOX_Y + 5 },
+            { BOX_X + BOX_W - 5, BOX_Y + 5 },
+            { BOX_X + BOX_W - 5, BOX_Y + BOX_H - 5 },
+            { BOX_X + 5, BOX_Y + BOX_H - 5 },
+        }) do
+            mouse.coords({ x = corner[1], y = corner[2] })
+            assert(mouse.object_under_pointer() ~= test_wibox.drawin,
+                string.format("corner (%d,%d) accepted input", corner[1],
+                    corner[2]))
+        end
+        io.stderr:write("[TEST] all four corners pass input through\n")
         return true
     end,
 
-    -- Step 5: Move mouse around more to stress test
-    function()
-        mouse.coords = { x = BOX_X + BOX_W - 5, y = BOX_Y + 5 }
-        mouse.coords = { x = BOX_X + BOX_W - 5, y = BOX_Y + BOX_H - 5 }
-        mouse.coords = { x = BOX_X + 5, y = BOX_Y + BOX_H - 5 }
-        io.stderr:write("[TEST] Mouse moved to all corners - no crash!\n")
-        return true
-    end,
-
-    -- Step 6: Cleanup
+    -- Step 5: Cleanup
     function()
         if test_wibox then
             test_wibox.visible = false

--- a/tests/test-systray-handoff.lua
+++ b/tests/test-systray-handoff.lua
@@ -1,0 +1,79 @@
+---------------------------------------------------------------------------
+-- Test: moving the systray repaints the host it left
+--
+-- The icons composite into the host drawin's content entry rather than
+-- living in their own scene tree, so dropping the tray has to repaint the
+-- old host. awesome.systray() reports the current parent, and the kickout
+-- path runs drawin_refresh_drawable() on the drawin it left.
+--
+-- With no tray client connected systray_composite() paints nothing, so this
+-- covers the ownership handoff and the repaint call, not the pixels.
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+local wibox = require("wibox")
+
+local a, b
+
+local function parent()
+    local _, p = awesome.systray()
+    return p
+end
+
+local steps = {
+    function()
+        a = wibox({ x = 0, y = 0, width = 200, height = 24,
+                    bg = "#111111", visible = true })
+        a:setup({ widget = wibox.widget.textbox, text = "a" })
+        b = wibox({ x = 0, y = 40, width = 200, height = 24,
+                    bg = "#222222", visible = true })
+        b:setup({ widget = wibox.widget.textbox, text = "b" })
+        return true
+    end,
+
+    -- Both need pixels before the kickout repaint has anything to re-feed.
+    function()
+        local order = awesome._test_declare_order(screen[1])
+        local seen = {}
+        for _, o in ipairs(order) do seen[o] = true end
+        return (seen[a.drawin] and seen[b.drawin]) or nil
+    end,
+
+    function()
+        awesome.systray(a.drawin, 0, 0, 16, true, "#000000", false, 0, 1)
+        assert(parent() == a.drawin, "systray did not land on a")
+        return true
+    end,
+
+    -- The handoff kicks a out, which repaints it.
+    function()
+        awesome.systray(b.drawin, 0, 0, 16, true, "#000000", false, 0, 1)
+        assert(parent() == b.drawin, "systray did not move to b")
+        return true
+    end,
+
+    -- The one-argument form is a bare kickout.
+    function()
+        awesome.systray(b.drawin)
+        assert(parent() == nil, "systray still has a parent after kickout")
+        return true
+    end,
+
+    -- Kicking out a drawin that does not host the tray is a no-op.
+    function()
+        awesome.systray(a.drawin)
+        assert(parent() == nil, "kickout of a non-host set a parent")
+        io.stderr:write("[PASS] systray handoff and kickout\n")
+        return true
+    end,
+
+    function()
+        a.visible = false
+        b.visible = false
+        return true
+    end,
+}
+
+runner.run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/window.c
+++ b/window.c
@@ -227,10 +227,10 @@ arrange(Monitor *m)
 fallback:
 	/* Scene node visibility already updated at function start (Wayland-specific requirement) */
 
-	/* Update fullscreen background */
-	c = focustop(m);
-	wlr_scene_node_set_enabled(&m->fullscreen_bg->node,
-		c && c->fullscreen);
+	/* Everything arrange changed (visibility, geometry, the fullscreen_bg
+	 * condition) lands through the declare pass at the next frame. */
+	if (m->declare)
+		declare_output_mark_dirty(m->declare);
 
 	motionnotify(0, NULL, 0, 0, 0, 0);
 	some_recompute_idle_inhibit();
@@ -260,7 +260,7 @@ initialcommitnotify(struct wl_listener *listener, void *data)
 			WLR_XDG_TOPLEVEL_WM_CAPABILITIES_MINIMIZE);
 
 	/* A set_maximized that arrived before this commit already ran through
-	 * maximizenotify() into c->maximized; apply_geometry_to_wlroots() puts
+	 * maximizenotify() into c->maximized; client_configure_to_box() puts
 	 * it on the wire once the client is mapped. Nothing to fold in here. */
 
 	if (c->decoration)
@@ -296,9 +296,9 @@ commitnotify(struct wl_listener *listener, void *data)
 	 * Tiled clients have their geometry managed by the Lua layout engine,
 	 * which may intentionally position clients offscreen (e.g. carousel
 	 * layout). resize() calls applybounds() which would clamp offscreen
-	 * clients back to the monitor workarea. For tiled clients, call
-	 * apply_geometry_to_wlroots() directly to update clip, borders, scene
-	 * position, and re-send the configure event without clamping. */
+	 * clients back to the monitor workarea. For tiled clients, run the
+	 * configure leg directly to update clip and re-send the configure
+	 * event without clamping. */
 	if (some_client_get_floating(c) || c->fullscreen) {
 		resize(c, c->geometry, (some_client_get_floating(c) && !c->fullscreen));
 	} else {
@@ -307,7 +307,7 @@ commitnotify(struct wl_listener *listener, void *data)
 		 * (e.g. Ghostty) may never get a re-configure after a screen
 		 * change because client_set_size() is gated by !c->resize. */
 		client_set_bounds(c, c->geometry.width, c->geometry.height);
-		apply_geometry_to_wlroots(c);
+		client_configure_to_box(c);
 	}
 
 	/* mark a pending resize as completed */
@@ -830,8 +830,11 @@ mapnotify(struct wl_listener *listener, void *data)
 	lua_State *L;
 	tag_t *tag;
 
-	/* Create scene tree for this client and its border */
-	c->scene = wlr_scene_tree_create(layers[LyrTile]);
+	/* Create scene tree for this client, parked until the first frame that
+	 * declares it borrows the tree into an output's band; being created in
+	 * the disabled parked tree means an enable below cannot flash the
+	 * surface at 0,0 before the reconciler places it. */
+	c->scene = wlr_scene_tree_create(window_parked_tree());
 	/* Enabled later by a call to arrange() */
 	wlr_scene_node_set_enabled(&c->scene->node, client_is_unmanaged(c));
 	c->scene_surface = c->client_type == XDGShell
@@ -889,16 +892,14 @@ mapnotify(struct wl_listener *listener, void *data)
 	}
 #endif
 
-	/* Handle unmanaged clients first so we can return prior create borders */
+	/* Handle unmanaged clients first: they skip the manage machinery */
 	if (client_is_unmanaged(c)) {
 		/* Unmanaged (override_redirect) X11 surfaces bypass the window
-		 * manager and must display above all managed windows. Place
-		 * them in LyrOverlay to match X11 semantics; LyrBlock (session
-		 * lock) still covers them. stack_refresh() skips unmanaged
-		 * clients so this placement is preserved. */
-		wlr_scene_node_reparent(&c->scene->node, layers[LyrOverlay]);
-		wlr_scene_node_set_position(&c->scene->node, c->geometry.x, c->geometry.y);
+		 * manager and must display above all managed windows. The
+		 * declare pass draws them at the top of the overlay band
+		 * (declare_unmanaged_clients); LyrBlock still covers them. */
 		client_set_size(c, c->geometry.width, c->geometry.height);
+		declare_mark_all_dirty();
 		if (client_wants_focus(c)) {
 			focusclient(c, 1);
 			exclusive_focus = c;
@@ -906,14 +907,8 @@ mapnotify(struct wl_listener *listener, void *data)
 		goto unset_fullscreen;
 	}
 
-	for (i = 0; i < 4; i++) {
-		c->border[i] = wlr_scene_rect_create(c->scene, 0, 0,
-				c->urgent ? get_urgentcolor() : get_bordercolor());
-		c->border[i]->node.data = c;
-	}
-
-	/* Shadow is lazily created by apply_geometry_to_wlroots() on the first
-	 * refresh cycle after the map */
+	/* Border and shadow are drawn by the declare pass; the client shadow's
+	 * scene nodes are lazily created by the configure hook. */
 
 	/* Create foreign toplevel handle for external tools (rofi, taskbars, etc.) */
 	if (foreign_toplevel_mgr) {
@@ -1014,7 +1009,7 @@ mapnotify(struct wl_listener *listener, void *data)
 		 * above and trip-zip/somewm#530 for why this can't run synchronously
 		 * here. */
 		c->resize = 0;
-		apply_geometry_to_wlroots(c);
+		client_configure_to_box(c);
 		schedule_flush_clients(dpy);
 
 		/* Enable scene node for transient client */
@@ -1138,7 +1133,7 @@ mapnotify(struct wl_listener *listener, void *data)
 		 * Fixes Firefox tiling issue (#10). Reset c->resize to force re-send
 		 * configure even if setmon()->resize() already queued one. */
 		c->resize = 0;
-		apply_geometry_to_wlroots(c);
+		client_configure_to_box(c);
 
 		/* Schedule a flush so the encoded configure leaves the kernel buffer
 		 * at the next event-loop idle, before the loop blocks in poll(). The
@@ -1250,9 +1245,9 @@ maximizenotify(struct wl_listener *listener, void *data)
 	}
 
 	/* xdg-shell owes a configure for every request. When the state changed,
-	 * apply_geometry_to_wlroots() sends one next frame carrying the new
-	 * maximized flag and the new size together; acking here too would land
-	 * first, with stale state. So only ack what we ignored or no-opped. */
+	 * client_configure_to_box() sends one carrying the new maximized flag
+	 * and the new size together; acking here too would land first, with
+	 * stale state. So only ack what we ignored or no-opped. */
 	if (c->surface.xdg->initialized && before == (bool)c->maximized)
 		wlr_xdg_surface_schedule_configure(c->surface.xdg);
 }
@@ -1334,11 +1329,12 @@ client_layout_clips_offscreen(Client *c)
 
 /* Released trees park here, disabled, outside every band: a tree no output
  * declares (banned tag, unmapped, mid-migration) must not linger in a band
- * it no longer belongs to. */
+ * it no longer belongs to. New client and layer-surface trees are also born
+ * here, so nothing shows before the reconciler places it. */
 static struct wlr_scene_tree *render_parked;
 
-static struct wlr_scene_tree *
-parked_tree(void)
+struct wlr_scene_tree *
+window_parked_tree(void)
 {
 	if (!render_parked) {
 		render_parked = wlr_scene_tree_create(&scene->tree);
@@ -1348,8 +1344,7 @@ parked_tree(void)
 }
 
 /* The client shadow is parented inside c->scene and rides the borrowed
- * tree; only its geometry update needs a home once
- * apply_geometry_to_wlroots() is gone, and that home is the configure leg. */
+ * tree; its geometry update lives on the configure leg. */
 static void
 client_update_shadow(Client *c)
 {
@@ -1460,7 +1455,7 @@ hook_release(void *data, uint64_t handle, void *owner_token)
 	if (*owner != owner_token)
 		return;
 	*owner = NULL;
-	wlr_scene_node_reparent(&stree->node, parked_tree());
+	wlr_scene_node_reparent(&stree->node, window_parked_tree());
 	wlr_scene_node_set_enabled(&stree->node, false);
 }
 
@@ -1475,6 +1470,22 @@ hook_has_popup(void *data, uint64_t handle)
 	return ptree && !wl_list_empty(&ptree->children);
 }
 
+/* The input filter for image leaves (render.h). Only a drawin's content
+ * leaf carries a handle; its shape_input decides per pixel, and node-local
+ * coordinates are drawin-local because the leaf sits exactly at the drawin
+ * box. The border and shadow leaves carry no userData word and never take
+ * input, matching the old border_buffer's point_accepts_input. */
+static bool
+hook_accepts_input(void *data, void *userdata, double x, double y)
+{
+	enum declare_kind kind;
+	void *obj = declare_handle_get(declare_userdata_handle(userdata), &kind);
+
+	if (!obj || kind != DECLARE_KIND_DRAWIN)
+		return false;
+	return drawin_accepts_input_at(obj, x, y);
+}
+
 void
 window_setup_render_hooks(void)
 {
@@ -1485,6 +1496,7 @@ window_setup_render_hooks(void)
 		.release = hook_release,
 		.reposition = hook_reposition,
 		.has_popup = hook_has_popup,
+		.accepts_input = hook_accepts_input,
 	};
 
 	declare_set_client_hooks(&hooks);
@@ -1510,12 +1522,11 @@ client_clamps_to_monitor(Client *c)
 /* The configure-client-to-box seam: the client-facing half of geometry
  * application. Positions and clips nodes inside the client's scene tree and
  * sends the state-batched configure, but never touches the frame somewm
- * draws around the client (c->scene position, borders, shadow). At the Clay
- * flip the render_client_hooks calls (render.h) land here and the frame
- * half is replaced by the reconciler; paths that force a configure re-send
- * (c->resize = 0, then a re-apply) keep calling this directly. Returns
- * whether the client content is at least partially visible on its monitor,
- * so the caller can toggle the frame nodes it owns to match. */
+ * draws around the client (c->scene position, borders), which the
+ * reconciler owns. The render_client_hooks configure and reposition legs
+ * land here; paths that force a configure re-send (c->resize = 0, then a
+ * re-apply) call this directly. Returns whether the client content is at
+ * least partially visible on its monitor. */
 bool
 client_configure_to_box(Client *c)
 {
@@ -1649,55 +1660,6 @@ client_configure_to_box(Client *c)
 	return visible;
 }
 
-/* Apply geometry to wlroots scene graph - Wayland-specific rendering layer.
- * This function ONLY updates wlroots; it does NOT modify c->geometry or emit signals.
- * Called by resize() for interactive resize and client_resize_do() for Lua-initiated resize.
- */
-void
-apply_geometry_to_wlroots(Client *c)
-{
-	if (!c->scene || !client_surface(c) || !client_surface(c)->mapped)
-		return;
-
-	/* The frame footprint is the geometry plus the border drawn outside it */
-	int frame_w = c->geometry.width + 2 * c->bw;
-	int frame_h = c->geometry.height + 2 * c->bw;
-
-	/* Update scene-graph position and borders */
-	wlr_scene_node_set_position(&c->scene->node, c->geometry.x, c->geometry.y);
-	wlr_scene_rect_set_size(c->border[0], frame_w, c->bw);
-	wlr_scene_rect_set_size(c->border[1], frame_w, c->bw);
-	wlr_scene_rect_set_size(c->border[2], c->bw, c->geometry.height);
-	wlr_scene_rect_set_size(c->border[3], c->bw, c->geometry.height);
-	wlr_scene_node_set_position(&c->border[1]->node, 0, frame_h - c->bw);
-	wlr_scene_node_set_position(&c->border[2]->node, 0, c->bw);
-	wlr_scene_node_set_position(&c->border[3]->node, frame_w - c->bw, c->bw);
-
-	/* Update shadow geometry (lazy creation if needed) */
-	{
-		const shadow_config_t *shadow_config = shadow_get_effective_config(
-			c->shadow_config, false);
-		if (shadow_config && shadow_config->enabled) {
-			if (c->shadow.tree) {
-				shadow_update_geometry(&c->shadow, shadow_config,
-					frame_w, frame_h);
-			} else {
-				shadow_create(c->scene, &c->shadow, shadow_config,
-					frame_w, frame_h);
-			}
-		}
-	}
-
-	/* Frame decorations follow the surface's monitor-clamp visibility;
-	 * wlr_scene_rect/buffer have no clip API, so a partially offscreen
-	 * frame stays fully shown and only a fully offscreen one hides. */
-	bool visible = client_configure_to_box(c);
-	for (int i = 0; i < 4; i++)
-		wlr_scene_node_set_enabled(&c->border[i]->node, visible);
-	if (c->shadow.tree)
-		wlr_scene_node_set_enabled(&c->shadow.tree->node, visible);
-}
-
 void
 resize(Client *c, struct wlr_box geo, int interact)
 {
@@ -1732,8 +1694,10 @@ resize(Client *c, struct wlr_box geo, int interact)
 		}
 	}
 
-	/* Apply to wlroots rendering */
-	apply_geometry_to_wlroots(c);
+	/* The new box lands through the declare pass: the reconciler moves the
+	 * frame and runs the configure leg when the solved box changed. */
+	if (c->mon->declare)
+		declare_output_mark_dirty(c->mon->declare);
 
 	/* Queue per-instance geometry signals so every C-side geometry change
 	 * reaches Lua subscribers the same way Lua-side client_resize_do does
@@ -1789,7 +1753,6 @@ setfullscreen(Client *c, int fullscreen)
 	 * would send a fullscreen configure to every client setmon() touches. */
 	if (was_fullscreen != fullscreen)
 		client_set_fullscreen_internal(c, fullscreen);
-	wlr_scene_node_reparent(&c->scene->node, layers[c->fullscreen ? LyrFS : LyrTile]);
 
 	/* c->prev is the pre-fullscreen restore point: capture only on the
 	 * non-FS -> FS edge, consume only on FS -> non-FS. setmon() and

--- a/window.c
+++ b/window.c
@@ -55,6 +55,8 @@
 #include "ewmh.h"
 #include "property.h"
 #include "shadow.h"
+#include "declare.h"
+#include "render.h"
 #include "animation.h"
 #include "event.h"
 #include "systray.h"
@@ -100,7 +102,9 @@ client_scene_node_destroy(Client *c)
 		client_surface_clear_scene_data(surface, c->popups);
 	}
 	/* c->popups and c->scene_surface are both descendants of c->scene,
-	 * destroyed recursively along with it. */
+	 * destroyed recursively along with it. Drop the render handle first so
+	 * a later resolve answers NULL instead of the dead tree. */
+	declare_handle_drop(c);
 	wlr_scene_node_destroy(&c->scene->node);
 	c->scene = NULL;
 	c->popups = NULL;
@@ -1326,6 +1330,183 @@ client_layout_clips_offscreen(Client *c)
 	return result;
 }
 
+/* --- render_client_hooks: how the reconciler reaches surface trees --- */
+
+/* Released trees park here, disabled, outside every band: a tree no output
+ * declares (banned tag, unmapped, mid-migration) must not linger in a band
+ * it no longer belongs to. */
+static struct wlr_scene_tree *render_parked;
+
+static struct wlr_scene_tree *
+parked_tree(void)
+{
+	if (!render_parked) {
+		render_parked = wlr_scene_tree_create(&scene->tree);
+		wlr_scene_node_set_enabled(&render_parked->node, false);
+	}
+	return render_parked;
+}
+
+/* The client shadow is parented inside c->scene and rides the borrowed
+ * tree; only its geometry update needs a home once
+ * apply_geometry_to_wlroots() is gone, and that home is the configure leg. */
+static void
+client_update_shadow(Client *c)
+{
+	const shadow_config_t *config = shadow_get_effective_config(
+		c->shadow_config, false);
+	int frame_w = c->geometry.width + 2 * c->bw;
+	int frame_h = c->geometry.height + 2 * c->bw;
+
+	if (!config || !config->enabled)
+		return;
+	if (c->shadow.tree)
+		shadow_update_geometry(&c->shadow, config, frame_w, frame_h);
+	else
+		shadow_create(c->scene, &c->shadow, config, frame_w, frame_h);
+}
+
+/* The scene tree, popups tree, and owner slot behind a handle. Clients and
+ * layer surfaces both borrow; anything else (a dead handle, a drawin) has
+ * no borrowed tree and returns false. */
+static bool
+handle_window(uint64_t handle, struct wlr_scene_tree **stree,
+	struct wlr_scene_tree **ptree, void ***owner)
+{
+	enum declare_kind kind;
+	void *obj = declare_handle_get(handle, &kind);
+
+	if (!obj)
+		return false;
+	if (kind == DECLARE_KIND_CLIENT) {
+		Client *c = obj;
+		*stree = c->scene;
+		*ptree = c->popups;
+		*owner = &c->render_owner;
+		return true;
+	}
+	if (kind == DECLARE_KIND_LAYER) {
+		LayerSurface *l = obj;
+		*stree = l->scene;
+		*ptree = l->popups;
+		*owner = &l->render_owner;
+		return true;
+	}
+	return false;
+}
+
+static Client *
+handle_client(uint64_t handle)
+{
+	enum declare_kind kind;
+	Client *c = declare_handle_get(handle, &kind);
+
+	return (c && kind == DECLARE_KIND_CLIENT) ? c : NULL;
+}
+
+static struct wlr_scene_tree *
+hook_resolve(void *data, uint64_t handle)
+{
+	struct wlr_scene_tree *stree, *ptree;
+	void **owner;
+
+	return handle_window(handle, &stree, &ptree, &owner) ? stree : NULL;
+}
+
+/* Both configure legs run client_configure_to_box(): the state-batched
+ * configure covers X11's position-carrying re-send (position-only moves
+ * included, client_set_size()), and the monitor-clamp clip inside is
+ * position-keyed. Layer surfaces have no C-driven configure; their only
+ * sizing path is the layer-shell arrange. */
+static void
+hook_configure(void *data, uint64_t handle, int width, int height)
+{
+	Client *c = handle_client(handle);
+
+	if (!c)
+		return;
+	client_configure_to_box(c);
+	client_update_shadow(c);
+}
+
+static void
+hook_reposition(void *data, uint64_t handle)
+{
+	Client *c = handle_client(handle);
+
+	if (c)
+		client_configure_to_box(c);
+}
+
+static void
+hook_borrow(void *data, uint64_t handle, void *owner_token)
+{
+	struct wlr_scene_tree *stree, *ptree;
+	void **owner;
+
+	if (handle_window(handle, &stree, &ptree, &owner))
+		*owner = owner_token;
+}
+
+static void
+hook_release(void *data, uint64_t handle, void *owner_token)
+{
+	struct wlr_scene_tree *stree, *ptree;
+	void **owner;
+
+	if (!handle_window(handle, &stree, &ptree, &owner))
+		return;
+	/* Another output owns the tree now: leave it be. */
+	if (*owner != owner_token)
+		return;
+	*owner = NULL;
+	wlr_scene_node_reparent(&stree->node, parked_tree());
+	wlr_scene_node_set_enabled(&stree->node, false);
+}
+
+static bool
+hook_has_popup(void *data, uint64_t handle)
+{
+	struct wlr_scene_tree *stree, *ptree;
+	void **owner;
+
+	if (!handle_window(handle, &stree, &ptree, &owner))
+		return false;
+	return ptree && !wl_list_empty(&ptree->children);
+}
+
+void
+window_setup_render_hooks(void)
+{
+	static const struct render_client_hooks hooks = {
+		.resolve = hook_resolve,
+		.configure = hook_configure,
+		.borrow = hook_borrow,
+		.release = hook_release,
+		.reposition = hook_reposition,
+		.has_popup = hook_has_popup,
+	};
+
+	declare_set_client_hooks(&hooks);
+}
+
+/* Clamp to the assigned monitor only for layouts that intentionally
+ * position tiled clients offscreen (carousel). For floating or unmanaged
+ * clients (user-authoritative geometry) and for layouts that keep clients
+ * within their workarea, skip the clamp so the scene graph can render the
+ * surface on whichever outputs it overlaps, e.g. during a cross-monitor
+ * drag where c->mon stays on the source monitor until the pointer crosses.
+ * Shared with the declare pass, which expresses the same fact as a monitor
+ * scissor around the client's border command. */
+bool
+client_clamps_to_monitor(Client *c)
+{
+	return c->mon
+		&& !client_is_unmanaged(c)
+		&& !some_client_get_floating(c)
+		&& client_layout_clips_offscreen(c);
+}
+
 /* The configure-client-to-box seam: the client-facing half of geometry
  * application. Positions and clips nodes inside the client's scene tree and
  * sends the state-batched configure, but never touches the frame somewm
@@ -1398,17 +1579,7 @@ client_configure_to_box(Client *c)
 	}
 	client_get_clip(c, &clip);
 
-	/* Clip the surface to its assigned monitor only for layouts that
-	 * intentionally position tiled clients offscreen (carousel). For
-	 * floating or unmanaged clients (user-authoritative geometry) and
-	 * for layouts that keep clients within their workarea, skip the
-	 * clamp so the scene graph can render the surface on whichever
-	 * outputs it overlaps, e.g. during a cross-monitor drag where
-	 * c->mon stays on the source monitor until the pointer crosses. */
-	bool clamp_to_mon = c->mon
-		&& !client_is_unmanaged(c)
-		&& !some_client_get_floating(c)
-		&& client_layout_clips_offscreen(c);
+	bool clamp_to_mon = client_clamps_to_monitor(c);
 
 	/* Clip client content to its assigned monitor bounds so offscreen
 	 * clients (e.g. carousel scrolling layout) don't render on adjacent

--- a/window.c
+++ b/window.c
@@ -169,21 +169,25 @@ arrange(Monitor *m)
 	if (!L)
 		return;
 
-	/* WAYLAND-SPECIFIC: Always update scene node visibility, even during initialization.
-	 * Unlike X11 where windows are visible by default, Wayland scene nodes start disabled.
-	 * This MUST run before any early returns to ensure clients become visible. */
+	/* Suspend the surfaces this monitor is no longer showing. Node
+	 * visibility is not set here: the reconciler owns the enabled bit, and
+	 * the mark below is what makes it re-derive one. */
 	foreach(client, globalconf.clients) {
-		bool visible;
 		c = *client;
 		if (!c->mon || c->mon != m || !c->scene)
 			continue;
 
-		visible = client_isvisible(c);
-		wlr_scene_node_set_enabled(&c->scene->node, visible);
-		client_set_suspended(c, !visible);
+		client_set_suspended(c, !client_isvisible(c));
 	}
 
-	/* Safety check: if not initialized yet, skip Lua arrange but scene nodes are already updated */
+	/* Everything arrange changes (visibility, geometry, the fullscreen_bg
+	 * condition) lands through the declare pass at the next frame. Marked
+	 * before the early returns below, which would otherwise leave a
+	 * visibility change with nothing to apply it. */
+	if (m->declare)
+		declare_output_mark_dirty(m->declare);
+
+	/* Safety check: if not initialized yet, skip Lua arrange */
 	if (!globalconf.screens.tab) {
 		return;
 	}
@@ -225,13 +229,6 @@ arrange(Monitor *m)
 	lua_pop(L, 2);  /* Pop layout and awful */
 
 fallback:
-	/* Scene node visibility already updated at function start (Wayland-specific requirement) */
-
-	/* Everything arrange changed (visibility, geometry, the fullscreen_bg
-	 * condition) lands through the declare pass at the next frame. */
-	if (m->declare)
-		declare_output_mark_dirty(m->declare);
-
 	motionnotify(0, NULL, 0, 0, 0, 0);
 	some_recompute_idle_inhibit();
 }
@@ -831,12 +828,10 @@ mapnotify(struct wl_listener *listener, void *data)
 	tag_t *tag;
 
 	/* Create scene tree for this client, parked until the first frame that
-	 * declares it borrows the tree into an output's band; being created in
-	 * the disabled parked tree means an enable below cannot flash the
-	 * surface at 0,0 before the reconciler places it. */
+	 * declares it borrows the tree into an output's band. The parked tree is
+	 * disabled, so nothing here can flash the surface at 0,0 before the
+	 * reconciler places it, and the borrow is what enables it. */
 	c->scene = wlr_scene_tree_create(window_parked_tree());
-	/* Enabled later by a call to arrange() */
-	wlr_scene_node_set_enabled(&c->scene->node, client_is_unmanaged(c));
 	c->scene_surface = c->client_type == XDGShell
 			? wlr_scene_xdg_surface_create(c->scene, c->surface.xdg)
 			: wlr_scene_subsurface_tree_create(c->scene, client_surface(c));
@@ -899,7 +894,6 @@ mapnotify(struct wl_listener *listener, void *data)
 		 * declare pass draws them at the top of the overlay band
 		 * (declare_unmanaged_clients); LyrBlock still covers them. */
 		client_set_size(c, c->geometry.width, c->geometry.height);
-		declare_mark_all_dirty();
 		if (client_wants_focus(c)) {
 			focusclient(c, 1);
 			exclusive_focus = c;
@@ -1011,11 +1005,6 @@ mapnotify(struct wl_listener *listener, void *data)
 		c->resize = 0;
 		client_configure_to_box(c);
 		schedule_flush_clients(dpy);
-
-		/* Enable scene node for transient client */
-		if (client_on_selected_tags(c)) {
-			wlr_scene_node_set_enabled(&c->scene->node, true);
-		}
 	} else {
 		Monitor *target_mon;
 		screen_t *target_screen;
@@ -1148,10 +1137,10 @@ mapnotify(struct wl_listener *listener, void *data)
 		 * We only need to make the client visible in the scene graph.
 		 * AwesomeWM's client_manage() (objects/client.c:2278-2294) does NOT call arrange()
 		 * after request::manage - layout is handled by the Lua signal system.
-		 * Calling arrange() here would overwrite geometry set by Lua placement code. */
-		if (client_on_selected_tags(c)) {
-			wlr_scene_node_set_enabled(&c->scene->node, true);
-		}
+		 * Calling arrange() here would overwrite geometry set by Lua placement code.
+		 * Showing the client is the reconciler's: the mark at the end of
+		 * this function is what gets the declare pass to borrow the tree
+		 * in and enable it. */
 	}
 	printstatus();
 
@@ -1197,6 +1186,13 @@ unset_fullscreen:
 	}
 
 	some_event_queue_global(SIG_CLIENT_MAP);
+
+	/* A newly mapped client has to reach the declare pass to be drawn at
+	 * all. setmon() above usually marks on the way through arrange(), but
+	 * it returns early when c->mon was already the target, which would
+	 * leave the client undeclared until unrelated activity marked. Mapping
+	 * also reorders the stack, which is not one output's fact. */
+	declare_mark_all_dirty();
 
 	/* If the cursor is over this new client's CONTENT, set pointer focus directly.
 	 * Don't use motionnotify(0,...) because xytonode may not find the surface yet

--- a/window.h
+++ b/window.h
@@ -42,6 +42,8 @@ void apply_geometry_to_wlroots(Client *c);
  * flip's render_client_hooks land here; forced configure re-sends keep
  * calling it directly. */
 bool client_configure_to_box(Client *c);
+bool client_clamps_to_monitor(Client *c);
+void window_setup_render_hooks(void);
 void resize(Client *c, struct wlr_box geo, int interact);
 void applybounds(Client *c, struct wlr_box *bbox);
 

--- a/window.h
+++ b/window.h
@@ -35,8 +35,7 @@ void minimizenotify(struct wl_listener *listener, void *data);
 void fullscreennotify(struct wl_listener *listener, void *data);
 
 /* Geometry */
-void apply_geometry_to_wlroots(Client *c);
-/* The client-facing half of apply_geometry_to_wlroots(): surface inset,
+/* The client-facing half of geometry application: surface inset,
  * titlebars, the configure send, and the surface clip. Returns whether the
  * client content is at least partially visible on its monitor. The Clay
  * flip's render_client_hooks land here; forced configure re-sends keep
@@ -44,6 +43,9 @@ void apply_geometry_to_wlroots(Client *c);
 bool client_configure_to_box(Client *c);
 bool client_clamps_to_monitor(Client *c);
 void window_setup_render_hooks(void);
+/* The disabled parking tree new and released surface trees live in until
+ * the reconciler borrows them into a band. */
+struct wlr_scene_tree *window_parked_tree(void);
 void resize(Client *c, struct wlr_box geo, int interact);
 void applybounds(Client *c, struct wlr_box *bbox);
 

--- a/xwayland.c
+++ b/xwayland.c
@@ -25,6 +25,7 @@
 #include "wlr_compat.h"
 #include "event_queue.h"
 #include "xwayland.h"
+#include "declare.h"
 #include "globalconf.h"
 #include "common/luaobject.h"
 #include "objects/signal.h"
@@ -106,7 +107,11 @@ configurex11(struct wl_listener *listener, void *data)
 		return;
 	}
 	if (client_is_unmanaged(c)) {
-		wlr_scene_node_set_position(&c->scene->node, event->x, event->y);
+		/* Unmanaged geometry is the client's own; record it and let the
+		 * next frame declare the tree at the new box. */
+		c->geometry = (struct wlr_box){.x = event->x, .y = event->y,
+				.width = event->width, .height = event->height};
+		declare_mark_all_dirty();
 		wlr_xwayland_surface_configure(c->surface.xwayland,
 				event->x, event->y, event->width, event->height);
 		return;


### PR DESCRIPTION
Renders each output from one Clay layout tree instead of driving wlr_scene directly. 
Every window, wibox and layer-shell surface is declared as a Clay element on each dirty frame, solved, and reconciled into the scene. 
A zIndex picks the draw order and declaration order breaks ties.