### PR TITLE
Feature/2.1 widget containers

### DIFF
--- a/DEVIATIONS.md
+++ b/DEVIATIONS.md
@@ -188,6 +188,26 @@ A client's `zIndex` follows `ontop`, `above`, `below` and `fullscreen`. A transi
 
 ---
 
+## Converted Widget Containers (somewm 2.1)
+
+A drawable's widget tree is compiled to Clay declarations from the root down, and the first widget the compile step cannot express keeps drawing itself with cairo into the drawable's surface, which the renderer shows as one image on top of the converted containers. `wibox.container.margin` and `wibox.container.background` convert; everything else, for now, does not. Widget code, signals and boxes are unchanged either way, and so is what a wibar looks like.
+
+A container stays on the cairo path when it carries something a Clay declaration does not say:
+
+- a subclass that overrides `:fit`, `:layout`, `:draw`, `before_draw_children` or `after_draw_children`
+- `visible = false`, an `opacity` other than 1, or a forced width or height
+- a background gradient, surface pattern or `bgimage`
+- a shape other than `gears.shape.rectangle` or `gears.shape.rounded_rect`, and a rounded shape together with a border width
+- a margin with `draw_empty = false`
+
+The whole drawable stays on the cairo path when its own background is not a solid color, when it has a background image, or when the drawin is shaped (`shape_bounding`, `shape_clip` or `shape_input`): those masks apply to the drawable's own pixels, which a converted container is no longer part of.
+
+**A margin's `color` draws above its child instead of below it.** The ring is the margin band, and the child is placed inside it, so the two do not overlap unless a widget draws outside its own box.
+
+**Screenshots include what the renderer draws as a flat color.** `root.content()` and `screen.content` now walk the scene for rectangles as well as buffers, so a converted container's background is in the capture. The same walk replaced `screen.content`'s own buffer pass, which ignored a scene buffer's destination size and scaled HiDPI captures wrong.
+
+---
+
 ## No-Op APIs
 
 These APIs exist and can be called without error, but have no effect on Wayland.

--- a/declare.c
+++ b/declare.c
@@ -33,6 +33,7 @@
 #include "somewm_api.h"
 #include "monitor.h"
 #include "stack.h"
+#include "widget.h"
 #include "window.h"
 #include "common/util.h"
 #include "objects/client.h"
@@ -517,6 +518,16 @@ declare_drawin(drawin_t *d, Monitor *m, int16_t z)
 			d->width + 2 * bw, d->height + 2 * bw);
 		b.image.imageData = &d->border_entry;
 		declare_leaf(&b);
+	}
+
+	/* A converted widget chain declares the content leaf itself, inside the
+	 * containers lua/wibox/clay.lua peeled off it (widget.c). Those draw
+	 * below the leaf, which still covers the whole drawin and is
+	 * transparent wherever they show through. */
+	if (widget_nodes_len(d) > 0) {
+		widget_declare(d, id, z, x, y,
+			leaf_userdata(handle, opacity));
+		return;
 	}
 
 	Clay_ElementDeclaration c = leaf_at(CLAY_STRING("drawin.image"), id, z,

--- a/declare.c
+++ b/declare.c
@@ -13,6 +13,7 @@
  * follow the stack and layer-shell surfaces the oldest first.
  */
 
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/wait.h>
@@ -177,22 +178,30 @@ enum {
 	Z_LOCK_SURFACE = 20,
 };
 
+/* The placement every box somewm computes elsewhere enters with: a fixed
+ * size at an explicit offset from the root, so Clay places it without
+ * solving for it. */
+static void
+place_fixed(Clay_ElementDeclaration *decl, int16_t z, int x, int y,
+	int w, int h)
+{
+	decl->layout.sizing.width = CLAY_SIZING_FIXED(w);
+	decl->layout.sizing.height = CLAY_SIZING_FIXED(h);
+	decl->floating.offset = (Clay_Vector2) { x, y };
+	decl->floating.attachTo = CLAY_ATTACH_TO_ROOT;
+	decl->floating.zIndex = z;
+}
+
 static Clay_ElementDeclaration
 leaf_at(Clay_String label, uint32_t index, int16_t z,
 	int x, int y, int w, int h)
 {
-	return (Clay_ElementDeclaration) {
+	Clay_ElementDeclaration decl = {
 		.id = Clay__HashString(label, index, 0),
-		.layout.sizing = {
-			.width = CLAY_SIZING_FIXED(w),
-			.height = CLAY_SIZING_FIXED(h),
-		},
-		.floating = {
-			.offset = { .x = x, .y = y },
-			.attachTo = CLAY_ATTACH_TO_ROOT,
-			.zIndex = z,
-		},
 	};
+
+	place_fixed(&decl, z, x, y, w, h);
+	return decl;
 }
 
 /* The per-element userData word (render.h): registry id in bits 0-31, kind
@@ -483,6 +492,75 @@ declare_layer_surfaces(Monitor *m)
 	}
 }
 
+/* --- the converted widget chain (widget.h) ---
+ *
+ * One element per node, each the previous one's only child, so the chain
+ * nests exactly as lua/wibox/clay.lua walked it. The outermost is the
+ * drawin's own box, fixed and floating like any other leaf here; the rest
+ * grow into whatever their parent's padding leaves them, which is the
+ * layout wibox's :fit and :layout used to compute.
+ *
+ * The id mixes the drawin's registry id with the node's depth, so a chain
+ * that grows or shrinks renames nothing above the change and the reconciler
+ * keeps the nodes it already has.
+ */
+static Clay_ElementId
+widget_node_id(uint32_t id, size_t depth)
+{
+	return Clay__HashString(CLAY_STRING("drawin.widget"), id,
+		(uint32_t)depth);
+}
+
+static Clay_ElementDeclaration
+widget_node_decl(const struct widget_node *n, uint32_t id, size_t depth)
+{
+	Clay_ElementDeclaration e = {
+		.id = widget_node_id(id, depth),
+		.layout = {
+			.sizing = {
+				.width = CLAY_SIZING_GROW(0),
+				.height = CLAY_SIZING_GROW(0),
+			},
+			.padding = { n->pad[0], n->pad[1], n->pad[2], n->pad[3] },
+		},
+		.cornerRadius = { n->radius, n->radius, n->radius, n->radius },
+	};
+
+	if (n->bg[3] > 0)
+		e.backgroundColor = clay_color(n->bg);
+	if (n->border[3] > 0) {
+		e.border.color = clay_color(n->border);
+		e.border.width = (Clay_BorderWidth) {
+			n->bw[0], n->bw[1], n->bw[2], n->bw[3], 0 };
+	}
+	return e;
+}
+
+static void
+declare_widget_chain(drawin_t *d, uint32_t id, int16_t z, int x, int y,
+	void *leaf_userdata)
+{
+	size_t len = d->widget_nodes_len;
+
+	d->widget_nodes_declared = true;
+
+	for (size_t i = 0; i < len; i++) {
+		const struct widget_node *n = &d->widget_nodes[i];
+		Clay_ElementDeclaration e = widget_node_decl(n, id, i);
+
+		if (i == 0)
+			place_fixed(&e, z, x, y, d->width, d->height);
+		if (n->raster) {
+			e.image.imageData = &d->content_entry;
+			e.userData = leaf_userdata;
+		}
+		Clay__OpenElement();
+		Clay__ConfigureOpenElementPtr(&e);
+	}
+	while (len-- > 0)
+		Clay__CloseElement();
+}
+
 /* --- drawins as whole-buffer image leaves ---
  *
  * Shadow below border below content, all riding the drawin's own image
@@ -521,11 +599,11 @@ declare_drawin(drawin_t *d, Monitor *m, int16_t z)
 	}
 
 	/* A converted widget chain declares the content leaf itself, inside the
-	 * containers lua/wibox/clay.lua peeled off it (widget.c). Those draw
-	 * below the leaf, which still covers the whole drawin and is
-	 * transparent wherever they show through. */
-	if (widget_nodes_len(d) > 0) {
-		widget_declare(d, id, z, x, y,
+	 * containers lua/wibox/clay.lua peeled off it. Those draw below the
+	 * leaf, which still covers the whole drawin and is transparent wherever
+	 * they show through. */
+	if (d->widget_nodes_len > 0) {
+		declare_widget_chain(d, id, z, x, y,
 			leaf_userdata(handle, opacity));
 		return;
 	}
@@ -605,6 +683,50 @@ declare_scene(Monitor *m)
 	declare_unmanaged_clients(m);
 	/* Session lock: locked_bg, the lock covers, and the lock surface stay
 	 * C-owned scene nodes in LyrBlock, above this whole band. */
+}
+
+int
+declare_widget_boxes(drawin_t *d, int (*boxes)[4])
+{
+	Monitor *m = d->screen ? d->screen->monitor : NULL;
+	struct declare_output *dout = m ? m->declare : NULL;
+	Clay_Context *previous;
+	Clay_BoundingBox root = { 0 };
+	uint32_t id;
+	int n = 0;
+
+	/* Clay's hashmap answers with the last box an id ever had, so a chain
+	 * the declare pass has not reached yet would read back the boxes of
+	 * the one it replaced. Report nothing until it has. */
+	if (!dout || !d->widget_nodes_declared)
+		return 0;
+
+	/* What the last frame solved, not a second solve of its own: Clay
+	 * keeps every element's box in the context's hashmap, so the readback
+	 * is one lookup per node against the boxes the output drew. */
+	previous = Clay_GetCurrentContext();
+	Clay_SetCurrentContext(dout->desktop.clay);
+	id = (uint32_t)handle_for(d, DECLARE_KIND_DRAWIN);
+
+	for (size_t i = 0; i < d->widget_nodes_len && n < WIDGET_NODES_MAX; i++) {
+		Clay_ElementData data = Clay_GetElementData(widget_node_id(id, i));
+
+		if (!data.found)
+			break;
+		if (i == 0)
+			root = data.boundingBox;
+		/* Clay solves float32; round here, and against the chain's own
+		 * root, so a box crossing into Lua is the whole drawin-local
+		 * pixel the old layout would have placed. */
+		boxes[n][0] = (int)floorf(data.boundingBox.x - root.x + 0.5f);
+		boxes[n][1] = (int)floorf(data.boundingBox.y - root.y + 0.5f);
+		boxes[n][2] = (int)floorf(data.boundingBox.width + 0.5f);
+		boxes[n][3] = (int)floorf(data.boundingBox.height + 0.5f);
+		n++;
+	}
+
+	Clay_SetCurrentContext(previous);
+	return n;
 }
 
 int

--- a/declare.h
+++ b/declare.h
@@ -7,6 +7,7 @@
 struct wlr_output;
 struct Monitor;
 struct render_client_hooks;
+typedef struct drawin_t drawin_t;
 
 /* Per-output declare/solve state: the output's Clay context, the retained
  * render_state its solved commands reconcile into, and the dirty flag the
@@ -64,6 +65,14 @@ enum declare_kind {
 
 void *declare_handle_get(uint64_t handle, enum declare_kind *kind);
 void declare_handle_drop(void *object);
+
+/* Test hook (awesome._test_widget_boxes): the boxes the last solve gave a
+ * drawin's converted widget chain (widget.h), outermost first, drawin-local
+ * and rounded. Reads the output's own context, so it reports what the frame
+ * drew rather than a second solve of its own, and reports nothing until the
+ * declare pass has put the current chain in front of Clay. Writes at most
+ * WIDGET_NODES_MAX entries and returns how many. */
+int declare_widget_boxes(drawin_t *d, int (*boxes)[4]);
 
 /* Test hook (awesome._test_declare_order): the desktop band's draw order for
  * m, bottom to top, one entry per declared object. A fresh solve of the

--- a/lua/wibox/clay.lua
+++ b/lua/wibox/clay.lua
@@ -1,0 +1,268 @@
+---------------------------------------------------------------------------
+--- Compile a drawable's widget tree into Clay declarations.
+--
+-- The declare pass (declare.c) draws a drawin as one image leaf holding the
+-- whole drawable surface. This module peels containers off the front of that
+-- leaf: walking down from the root widget, every node whose class and
+-- properties map onto a Clay declaration becomes one, and the first node that
+-- does not stops the walk. Whatever is left rasters into the same drawable
+-- surface it always did and rides as the leaf, now declared inside the
+-- converted chain instead of alone.
+--
+-- A node is pure description. Nothing here draws, measures, or reads a box:
+-- Clay solves the chain, and `compile` only says what the chain is.
+--
+-- @module wibox.clay
+---------------------------------------------------------------------------
+
+local beautiful = require("beautiful")
+local gcolor = require("gears.color")
+local gshape = require("gears.shape")
+local margin_class = require("wibox.container.margin")
+local background_class = require("wibox.container.background")
+
+local clay = {}
+
+--- The straight-alpha components of a solid color pattern, or nil for a
+-- gradient, a surface pattern, or no color at all. A Clay color is one flat
+-- fill; anything else has to keep painting itself.
+local function solid_rgba(col)
+    if not col then
+        return nil
+    end
+
+    local pattern = gcolor(col)
+
+    if pattern:get_type() ~= "SOLID" then
+        return nil
+    end
+
+    local status, r, g, b, a = pattern:get_rgba()
+
+    if status ~= "SUCCESS" then
+        return nil
+    end
+
+    return { r, g, b, a }
+end
+
+--- Clay pads and border widths are whole uint16 pixels.
+local function whole(v)
+    return type(v) == "number" and v >= 0 and v <= 65535 and v % 1 == 0
+end
+
+local function padded(node)
+    local pad = node.pad
+
+    return pad ~= nil
+        and (pad[1] > 0 or pad[2] > 0 or pad[3] > 0 or pad[4] > 0)
+end
+
+--- Properties every widget carries that a converted node cannot express.
+--
+-- `visible` and `opacity` are applied by `wibox.hierarchy`, which a converted
+-- node no longer passes through, and a forced size is a `:fit` answer, which
+-- a chain of grow-sized elements never asks for. Each stops the walk, so the
+-- widget keeps drawing itself.
+local function common_convertible(w)
+    local p = w._private
+
+    return p.visible ~= false
+        and (p.opacity == nil or p.opacity == 1)
+        and p.forced_width == nil
+        and p.forced_height == nil
+end
+
+--- The corner radius a shape function stands for, or nil for one Clay cannot
+-- name. A shape is an arbitrary painter, so identity against the two shapes
+-- that are rectangles is the whole test; `rounded_bar` and the rest keep
+-- drawing themselves.
+local function shape_radius(shape, args)
+    if shape == nil or shape == gshape.rectangle then
+        return 0
+    end
+    if shape == gshape.rounded_rect then
+        local r = args and args[1] or 10
+
+        return (type(r) == "number" and r >= 0) and r or nil
+    end
+    return nil
+end
+
+--- wibox.container.margin -> Clay padding, and the margin color -> a Clay
+-- border of the same widths, which covers exactly the ring `margin:draw`
+-- fills with the even-odd rule.
+local function describe_margin(w)
+    local p = w._private
+
+    if w.layout ~= margin_class.layout or w.draw ~= margin_class.draw then
+        return nil
+    end
+    -- draw_empty=false makes the margin's own size depend on what the child
+    -- fits to. The chain grows instead of fitting, so it has no answer.
+    if p.draw_empty == false then
+        return nil
+    end
+
+    local pad = { p.left or 0, p.right or 0, p.top or 0, p.bottom or 0 }
+
+    for _, v in ipairs(pad) do
+        if not whole(v) then
+            return nil
+        end
+    end
+
+    local node = { pad = pad }
+
+    if p.color then
+        local rgba = solid_rgba(p.color)
+
+        if not rgba then
+            return nil
+        end
+        node.border, node.bw = rgba, pad
+    end
+
+    return node
+end
+
+--- wibox.container.background -> a rectangle color, a corner radius and a
+-- border.
+--
+-- Clay draws a border inside the element box without moving its children,
+-- which is what `border_strategy = "none"` does; "inner" adds the padding
+-- that shrinks them.
+local function describe_background(w)
+    local p = w._private
+
+    if w.layout ~= background_class.layout
+            or w.before_draw_children ~= background_class.before_draw_children
+            or w.after_draw_children ~= background_class.after_draw_children then
+        return nil
+    end
+    -- A background image is a painter over the whole box, with no Clay
+    -- equivalent short of rastering it, which is what the leaf already does.
+    if p.bgimage then
+        return nil
+    end
+
+    local bw = p.shape_border_width or 0
+
+    if not whole(bw) then
+        return nil
+    end
+
+    local radius = shape_radius(p.shape, p.shape_args)
+
+    if not radius then
+        return nil
+    end
+    -- A rounded shape and a border together do not draw the ring Clay draws:
+    -- the cairo path is inset by the border width, so the visible outer
+    -- corner is rounder than the shape names. Rather than approximate it,
+    -- the container keeps drawing itself.
+    if radius > 0 and bw > 0 then
+        return nil
+    end
+
+    local node = { radius = radius }
+
+    if p.background then
+        node.bg = solid_rgba(p.background)
+        if not node.bg then
+            return nil
+        end
+    end
+
+    if bw > 0 then
+        node.border = solid_rgba(p.shape_border_color or p.foreground
+            or beautiful.fg_normal)
+        if not node.border then
+            return nil
+        end
+        node.bw = { bw, bw, bw, bw }
+        if p.border_strategy == "inner" then
+            node.pad = { bw, bw, bw, bw }
+        end
+    end
+
+    return node
+end
+
+--- Compile the widget tree `root` under a drawable painted with `bg`.
+--
+-- Returns the node chain outermost first, always ending in the raster leaf,
+-- plus the widget the leaf draws (nil when the chain consumed the whole tree)
+-- and the foreground color in force where the leaf starts. Returns nil when
+-- nothing converts, which leaves the drawable on the path it has always
+-- taken: one leaf, painted whole.
+--
+-- A node is a table with any of `pad`, `bg`, `border`, `bw`, `radius`; the
+-- last one is `{ raster = true }`, the leaf.
+--
+-- @tparam cairo.Pattern|nil bg The drawable's own background.
+-- @tparam widget|nil root The drawable's widget.
+-- @tparam cairo.Pattern|nil fg The drawable's own foreground.
+-- @treturn[1] table The node chain.
+-- @treturn[1] widget|nil The widget the raster leaf draws.
+-- @treturn[1] cairo.Pattern|nil The foreground in force at the leaf.
+-- @treturn[2] nil Nothing converted.
+function clay.compile(bg, root, fg)
+    local base = solid_rgba(bg)
+
+    -- The drawable's own background becomes the outermost rectangle, so it
+    -- has to be one Clay can name before anything inside it can convert.
+    if not base then
+        return nil
+    end
+
+    local chain, w = { { bg = base, radius = 0 } }, root
+    -- A rounded background clips its children to its shape. The leaf carries
+    -- that radius instead, which is the same clip only while the leaf's box
+    -- is the rounded element's box, so padding on either side of one ends the
+    -- walk.
+    local radius, padding = 0, false
+
+    while w and common_convertible(w) do
+        local node
+
+        if w.fit == margin_class.fit then
+            node = describe_margin(w)
+        elseif w.fit == background_class.fit then
+            node = describe_background(w)
+        end
+
+        if not node then
+            break
+        end
+        if radius > 0 and padded(node) then
+            break
+        end
+        if (node.radius or 0) > 0 and padding then
+            break
+        end
+
+        padding = padding or padded(node)
+        radius = math.max(radius, node.radius or 0)
+        chain[#chain + 1] = node
+        if w.fit == background_class.fit and w._private.foreground then
+            fg = w._private.foreground
+        end
+        w = w._private.widget
+    end
+
+    -- Only the drawable's own background converted: the leaf still covers
+    -- every pixel it did, so there is nothing to gain and a whole path to
+    -- keep off.
+    if #chain == 1 then
+        return nil
+    end
+
+    chain[#chain + 1] = { raster = true, radius = radius }
+
+    return chain, w, fg
+end
+
+return clay
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/lua/wibox/clay.lua
+++ b/lua/wibox/clay.lua
@@ -3,14 +3,16 @@
 --
 -- The declare pass (declare.c) draws a drawin as one image leaf holding the
 -- whole drawable surface. This module peels containers off the front of that
--- leaf: walking down from the root widget, every node whose class and
--- properties map onto a Clay declaration becomes one, and the first node that
--- does not stops the walk. Whatever is left rasters into the same drawable
--- surface it always did and rides as the leaf, now declared inside the
--- converted chain instead of alone.
+-- leaf: walking down from the root, every widget whose class and properties
+-- map onto a Clay declaration becomes one, and the first widget that does not
+-- stops the walk. Whatever is left rasters into the same drawable surface it
+-- always did and rides as the leaf, now declared inside the converted chain
+-- instead of alone.
 --
--- A node is pure description. Nothing here draws, measures, or reads a box:
--- Clay solves the chain, and `compile` only says what the chain is.
+-- The walk descends the drawable's `wibox.hierarchy`, which is the structure
+-- that will draw the leaf, so the chain can never name a widget the drawing
+-- does not reach. It reads no box from it: a node is pure description, Clay
+-- solves the chain, and `compile` only says what the chain is.
 --
 -- @module wibox.clay
 ---------------------------------------------------------------------------
@@ -186,81 +188,101 @@ local function describe_background(w)
         end
     end
 
-    return node
+    -- A background's fg is the source its children draw with, so it rides
+    -- alongside the node rather than in it: the leaf takes the innermost one.
+    return node, p.foreground
 end
 
---- Compile the widget tree `root` under a drawable painted with `bg`.
+--- Whether a widget is one of the classes the chain knows at all. Cheap, and
+-- separate from `describe` so a tree that can never convert costs two table
+-- lookups rather than a walk.
+local function convertible_class(w)
+    return w.fit == margin_class.fit or w.fit == background_class.fit
+end
+
+--- The node a widget compiles to, plus any foreground it puts in force, or
+-- nil for a widget that keeps drawing itself.
+local function describe(w)
+    if not common_convertible(w) then
+        return nil
+    end
+    if w.fit == margin_class.fit then
+        return describe_margin(w)
+    end
+    return describe_background(w)
+end
+
+--- Compile the front of a drawable's laid-out widget tree.
 --
 -- Returns the node chain outermost first, always ending in the raster leaf,
--- plus the widget the leaf draws (nil when the chain consumed the whole tree)
--- and the foreground color in force where the leaf starts. Returns nil when
--- nothing converts, which leaves the drawable on the path it has always
--- taken: one leaf, painted whole.
+-- plus the hierarchy the leaf draws (nil when the chain consumed the whole
+-- tree), that hierarchy's parent, and the foreground in force where the leaf
+-- starts. Returns nil when nothing converts, which leaves the drawable on the
+-- path it has always taken: one leaf, painted whole.
 --
 -- A node is a table with any of `pad`, `bg`, `border`, `bw`, `radius`; the
 -- last one is `{ raster = true }`, the leaf.
 --
--- @tparam cairo.Pattern|nil bg The drawable's own background.
--- @tparam widget|nil root The drawable's widget.
--- @tparam cairo.Pattern|nil fg The drawable's own foreground.
+-- @tparam table self The drawable, for its own background, background image
+--  and foreground.
+-- @tparam wibox.hierarchy|nil root The drawable's laid-out widget tree.
 -- @treturn[1] table The node chain.
--- @treturn[1] widget|nil The widget the raster leaf draws.
--- @treturn[1] cairo.Pattern|nil The foreground in force at the leaf.
+-- @treturn[1] wibox.hierarchy The hierarchy the raster leaf draws.
+-- @treturn[1] wibox.hierarchy The leaf's parent, whose transform places it.
+-- @treturn[1] cairo.Pattern The foreground in force at the leaf.
 -- @treturn[2] nil Nothing converted.
-function clay.compile(bg, root, fg)
-    local base = solid_rgba(bg)
+function clay.compile(self, root)
+    -- A background image is a painter over the whole drawable, with no Clay
+    -- equivalent short of rastering it, which is what the leaf already does.
+    if not root or self.background_image
+            or not convertible_class(root:get_widget()) then
+        return nil
+    end
 
     -- The drawable's own background becomes the outermost rectangle, so it
     -- has to be one Clay can name before anything inside it can convert.
+    local base = solid_rgba(self.background_color)
+
     if not base then
         return nil
     end
 
-    local chain, w = { { bg = base, radius = 0 } }, root
+    local chain, h, parent = { { bg = base, radius = 0 } }, root, nil
+    local fg = self.foreground_color
     -- A rounded background clips its children to its shape. The leaf carries
     -- that radius instead, which is the same clip only while the leaf's box
     -- is the rounded element's box, so padding on either side of one ends the
     -- walk.
     local radius, padding = 0, false
 
-    while w and common_convertible(w) do
-        local node
-
-        if w.fit == margin_class.fit then
-            node = describe_margin(w)
-        elseif w.fit == background_class.fit then
-            node = describe_background(w)
-        end
+    while h do
+        local node, node_fg = describe(h:get_widget())
 
         if not node then
             break
         end
-        if radius > 0 and padded(node) then
-            break
-        end
-        if (node.radius or 0) > 0 and padding then
+        if (radius > 0 and padded(node))
+                or ((node.radius or 0) > 0 and padding) then
             break
         end
 
         padding = padding or padded(node)
         radius = math.max(radius, node.radius or 0)
+        fg = node_fg or fg
         chain[#chain + 1] = node
-        if w.fit == background_class.fit and w._private.foreground then
-            fg = w._private.foreground
-        end
-        w = w._private.widget
+        parent, h = h, h:get_children()[1]
     end
 
-    -- Only the drawable's own background converted: the leaf still covers
-    -- every pixel it did, so there is nothing to gain and a whole path to
-    -- keep off.
+    -- The root's class matched but its properties did not: the leaf still
+    -- covers every pixel it did, so there is nothing to gain and a whole
+    -- path to keep off.
     if #chain == 1 then
         return nil
     end
 
     chain[#chain + 1] = { raster = true, radius = radius }
 
-    return chain, w, fg
+    return chain, h, parent, fg
 end
 
 return clay

--- a/lua/wibox/drawable.lua
+++ b/lua/wibox/drawable.lua
@@ -123,31 +123,6 @@ local function do_redraw(self)
         end
     end
 
-    -- Compile the front of the widget tree into Clay declarations. The
-    -- renderer draws what converted; the rest keeps painting into this
-    -- surface, which rides as the chain's innermost leaf.
-    local chain, leaf_widget, leaf_fg, leaf, leaf_parent
-    if not self.background_image then
-        chain, leaf_widget, leaf_fg = wclay.compile(self.background_color,
-            self._widget, self.foreground_color)
-    end
-    local converted = self.drawable:_clay_nodes(chain)
-
-    if converted then
-        -- The leaf draws the first widget the chain did not reach, so walk
-        -- down to it. A hierarchy that does not end where the chain says it
-        -- does is a compile bug: give up on the chain rather than draw the
-        -- tree in the wrong place.
-        leaf = self._widget_hierarchy
-        for _ = 1, #chain - 2 do
-            leaf_parent, leaf = leaf, leaf and leaf:get_children()[1]
-        end
-        if (leaf and leaf:get_widget()) ~= leaf_widget then
-            converted = false
-            self.drawable:_clay_nodes(nil)
-        end
-    end
-
     -- Clip to the dirty area
     if self._dirty_area:is_empty() then
         return
@@ -158,6 +133,15 @@ local function do_redraw(self)
     end
     self._dirty_area = cairo.Region.create()
     cr:clip()
+
+    -- Compile the front of the widget tree into Clay declarations. The
+    -- renderer draws what converted; the rest keeps painting into this
+    -- surface, which rides as the chain's innermost leaf. Below the empty
+    -- region check because every property that feeds a node dirties the
+    -- region on its way here.
+    local chain, leaf, leaf_parent, leaf_fg =
+        wclay.compile(self, self._widget_hierarchy)
+    local converted = self.drawable:_clay_nodes(chain)
 
     -- Draw the background
     cr:save()

--- a/lua/wibox/drawable.lua
+++ b/lua/wibox/drawable.lua
@@ -22,6 +22,7 @@ local timer = require("gears.timer")
 local grect =  require("gears.geometry").rectangle
 local matrix = require("gears.matrix")
 local whierarchy = require("wibox.hierarchy")
+local wclay = require("wibox.clay")
 local unpack = unpack or table.unpack -- luacheck: globals unpack (compatibility with Lua 5.1)
 
 local visible_drawables = {}
@@ -122,6 +123,31 @@ local function do_redraw(self)
         end
     end
 
+    -- Compile the front of the widget tree into Clay declarations. The
+    -- renderer draws what converted; the rest keeps painting into this
+    -- surface, which rides as the chain's innermost leaf.
+    local chain, leaf_widget, leaf_fg, leaf, leaf_parent
+    if not self.background_image then
+        chain, leaf_widget, leaf_fg = wclay.compile(self.background_color,
+            self._widget, self.foreground_color)
+    end
+    local converted = self.drawable:_clay_nodes(chain)
+
+    if converted then
+        -- The leaf draws the first widget the chain did not reach, so walk
+        -- down to it. A hierarchy that does not end where the chain says it
+        -- does is a compile bug: give up on the chain rather than draw the
+        -- tree in the wrong place.
+        leaf = self._widget_hierarchy
+        for _ = 1, #chain - 2 do
+            leaf_parent, leaf = leaf, leaf and leaf:get_children()[1]
+        end
+        if (leaf and leaf:get_widget()) ~= leaf_widget then
+            converted = false
+            self.drawable:_clay_nodes(nil)
+        end
+    end
+
     -- Clip to the dirty area
     if self._dirty_area:is_empty() then
         return
@@ -136,7 +162,13 @@ local function do_redraw(self)
     -- Draw the background
     cr:save()
 
-    if not capi.awesome.composite_manager_running then
+    if converted then
+        -- The chain's outermost node is this background, drawn by the
+        -- renderer. What is left here is the leaf, so the surface starts
+        -- empty and shows the chain through wherever the leaf does not draw.
+        cr.operator = cairo.Operator.SOURCE
+        cr:set_source_rgba(0, 0, 0, 0)
+    elseif not capi.awesome.composite_manager_running then
         -- This is pseudo-transparency: We draw the wallpaper in the background
         local wallpaper = surface.load_silently(capi.root.wallpaper(), false)
         cr.operator = cairo.Operator.SOURCE
@@ -147,12 +179,13 @@ local function do_redraw(self)
         end
         cr:paint()
         cr.operator = cairo.Operator.OVER
+        cr:set_source(self.background_color)
     else
         -- This is true transparency: We draw a translucent background
         cr.operator = cairo.Operator.SOURCE
+        cr:set_source(self.background_color)
     end
 
-    cr:set_source(self.background_color)
     cr:paint()
 
     cr:restore()
@@ -171,7 +204,18 @@ local function do_redraw(self)
     end
 
     -- Draw the widget
-    if self._widget_hierarchy then
+    if converted then
+        -- Only the leaf: every container above it is a Clay declaration now.
+        -- The leaf's own matrix is relative to its parent, so the parent's
+        -- matrix to the surface goes on first.
+        if leaf then
+            cr:save()
+            cr:set_source(leaf_fg)
+            cr:transform(leaf_parent:get_matrix_to_device():to_cairo_matrix())
+            leaf:draw(context, cr)
+            cr:restore()
+        end
+    elseif self._widget_hierarchy then
         cr:set_source(self.foreground_color)
         self._widget_hierarchy:draw(context, cr)
     end

--- a/lua/wibox/init.lua
+++ b/lua/wibox/init.lua
@@ -406,6 +406,24 @@ local function new(args)
     -- Make sure the wibox is drawn at least once
     ret.draw()
 
+    -- A shaped drawin keeps its whole surface: the masks apply to those
+    -- pixels, so the renderer refuses a converted widget chain for one
+    -- (widget.c) and the drawable has to paint every pixel itself again.
+    -- Only gaining or losing a mask moves that line, and _apply_shape resets
+    -- these on every geometry change.
+    local was_shaped = false
+    local function shape_changed()
+        local shaped = (w.shape_bounding or w.shape_clip or w.shape_input) ~= nil
+
+        if shaped ~= was_shaped then
+            was_shaped = shaped
+            ret._drawable._do_complete_repaint()
+        end
+    end
+    for _, prop in ipairs { "shape_bounding", "shape_clip", "shape_input" } do
+        w:connect_signal("property::" .. prop, shape_changed)
+    end
+
     ret:connect_signal("property::geometry", ret._apply_shape)
     ret:connect_signal("property::border_width", ret._apply_shape)
     ret:connect_signal("property::border_color", ret._apply_shape)

--- a/lua/wibox/init.lua
+++ b/lua/wibox/init.lua
@@ -406,11 +406,11 @@ local function new(args)
     -- Make sure the wibox is drawn at least once
     ret.draw()
 
-    -- A shaped drawin keeps its whole surface: the masks apply to those
-    -- pixels, so the renderer refuses a converted widget chain for one
-    -- (widget.c) and the drawable has to paint every pixel itself again.
-    -- Only gaining or losing a mask moves that line, and _apply_shape resets
-    -- these on every geometry change.
+    -- Gaining or losing a shape is the one thing that changes whether the
+    -- renderer takes a converted widget chain (widget.c) without also
+    -- redrawing a widget, so it has to ask for the repaint itself. The test
+    -- is on the masks rather than the signal because _apply_shape re-sets
+    -- them on every geometry change, unchanged.
     local was_shaped = false
     local function shape_changed()
         local shaped = (w.shape_bounding or w.shape_clip or w.shape_input) ~= nil

--- a/luaa.c
+++ b/luaa.c
@@ -1300,8 +1300,8 @@ luaA_awesome_test_declare_order(lua_State *L)
 
 /** The boxes Clay solves for a drawin's converted widget chain, outermost
  * first, drawin-local.
- * Solves the chain alone, so a test can compare Clay's boxes against the
- * ones wibox's own :fit/:layout protocol places (see
+ * What the last frame solved, so a test can compare Clay's boxes against
+ * the ones wibox's own :fit/:layout protocol places (see
  * tests/test-clay-widget-containers.lua). Empty for a drawin whose widget
  * tree did not convert.
  * \param drawin The drawin to solve.
@@ -1312,10 +1312,7 @@ luaA_awesome_test_widget_boxes(lua_State *L)
 {
 	drawin_t *d = luaA_checkdrawin(L, 1);
 	int boxes[WIDGET_NODES_MAX][4];
-	int n = 0;
-
-	if (widget_nodes_len(d) > 0)
-		n = widget_solve_boxes(d, boxes, WIDGET_NODES_MAX);
+	int n = declare_widget_boxes(d, boxes);
 
 	lua_createtable(L, n, 0);
 	for (int i = 0; i < n; i++) {

--- a/luaa.c
+++ b/luaa.c
@@ -1,5 +1,6 @@
 #include "luaa.h"
 #include "declare.h"
+#include "widget.h"
 #include "draw.h"  /* Must be before globalconf.h to avoid type conflicts */
 #include "globalconf.h"
 
@@ -1297,6 +1298,39 @@ luaA_awesome_test_declare_order(lua_State *L)
 	return 1;
 }
 
+/** The boxes Clay solves for a drawin's converted widget chain, outermost
+ * first, drawin-local.
+ * Solves the chain alone, so a test can compare Clay's boxes against the
+ * ones wibox's own :fit/:layout protocol places (see
+ * tests/test-clay-widget-containers.lua). Empty for a drawin whose widget
+ * tree did not convert.
+ * \param drawin The drawin to solve.
+ * \return Array of { x, y, width, height } tables.
+ */
+static int
+luaA_awesome_test_widget_boxes(lua_State *L)
+{
+	drawin_t *d = luaA_checkdrawin(L, 1);
+	int boxes[WIDGET_NODES_MAX][4];
+	int n = 0;
+
+	if (widget_nodes_len(d) > 0)
+		n = widget_solve_boxes(d, boxes, WIDGET_NODES_MAX);
+
+	lua_createtable(L, n, 0);
+	for (int i = 0; i < n; i++) {
+		static const char *keys[] = { "x", "y", "width", "height" };
+
+		lua_createtable(L, 0, 4);
+		for (int k = 0; k < 4; k++) {
+			lua_pushinteger(L, boxes[i][k]);
+			lua_setfield(L, -2, keys[k]);
+		}
+		lua_rawseti(L, -2, i + 1);
+	}
+	return 1;
+}
+
 /** Reload shadow settings from beautiful theme.
  * Call this after changing beautiful.shadow_* values to apply them.
  * Regenerates shadow textures and updates all existing shadows.
@@ -2149,6 +2183,7 @@ const luaL_Reg awesome_methods[] = {
 	{ "_test_add_output", luaA_awesome_test_add_output },
 	{ "_test_redeclare", luaA_awesome_test_redeclare },
 	{ "_test_declare_order", luaA_awesome_test_declare_order },
+	{ "_test_widget_boxes", luaA_awesome_test_widget_boxes },
 	/* Lock API methods */
 	{ "lock", luaA_awesome_lock },
 	{ "unlock", luaA_awesome_unlock },

--- a/meson.build
+++ b/meson.build
@@ -434,6 +434,7 @@ somewm_sources = [
   'protocols.c',
   'monitor.c',
   'declare.c',
+  'widget.c',
   'input.c',
   'window.c',
   'focus.c',

--- a/objects/client.c
+++ b/objects/client.c
@@ -4391,7 +4391,7 @@ luaA_client_get_content(lua_State *L, client_t *c)
     cairo_t *cr;
     int dst_width  = c->geometry.width;
     int dst_height = c->geometry.height;
-    struct screenshot_render_data rdata;
+    struct screenshot_render_data rdata = { 0 };
 
     /* Logical client size without decorations - what we return to Lua. */
     dst_width  -= c->titlebar[CLIENT_TITLEBAR_LEFT].size + c->titlebar[CLIENT_TITLEBAR_RIGHT].size;

--- a/objects/drawable.c
+++ b/objects/drawable.c
@@ -15,6 +15,7 @@
 #include "luaa.h"
 #include "common/util.h"
 #include "../x11_compat.h"
+#include "../widget.h"
 #include "common/luaclass.h"
 #include "common/luaobject.h"
 
@@ -659,6 +660,43 @@ luaA_drawable_refresh(lua_State *L)
 	return 0;
 }
 
+/** Hand the drawable's compiled widget chain to the renderer.
+ *
+ * lua/wibox/drawable.lua calls this once per redraw with what
+ * lua/wibox/clay.lua compiled, or with nil when nothing converted. A false
+ * return means the chain was refused (this drawable has no drawin, or the
+ * drawin is shaped), and the caller has to paint every pixel itself, which
+ * is the path every drawable took before any container converted.
+ *
+ * \param L The Lua VM state.
+ * \param nodes The node chain, or nil.
+ * \return true when the renderer took the chain.
+ */
+static int
+luaA_drawable_clay_nodes(lua_State *L)
+{
+	drawable_t *d = (drawable_t *)lua_touserdata(L, 1);
+	drawin_t *drawin;
+
+	if (!d) {
+		return luaL_error(L, "expected drawable, got %s",
+			lua_typename(L, lua_type(L, 1)));
+	}
+
+	drawin = d->owner_type == DRAWABLE_OWNER_DRAWIN ? d->owner.drawin : NULL;
+	if (!drawin) {
+		lua_pushboolean(L, false);
+		return 1;
+	}
+	if (lua_isnoneornil(L, 2)) {
+		widget_nodes_clear(drawin);
+		lua_pushboolean(L, false);
+		return 1;
+	}
+	lua_pushboolean(L, widget_nodes_set(L, drawin, 2));
+	return 1;
+}
+
 /* ============================================================================
  * Lua Class Setup
  * ============================================================================ */
@@ -762,6 +800,7 @@ drawable_class_setup(lua_State *L)
 		{ "__newindex", luaA_drawable_newindex },
 		{ "refresh", luaA_drawable_refresh },
 		{ "geometry", luaA_drawable_geometry },
+		{ "_clay_nodes", luaA_drawable_clay_nodes },
 		LUA_OBJECT_META(drawable)
 		{ NULL, NULL }
 	};

--- a/objects/drawable.c
+++ b/objects/drawable.c
@@ -688,11 +688,8 @@ luaA_drawable_clay_nodes(lua_State *L)
 		lua_pushboolean(L, false);
 		return 1;
 	}
-	if (lua_isnoneornil(L, 2)) {
-		widget_nodes_clear(drawin);
-		lua_pushboolean(L, false);
-		return 1;
-	}
+	/* nil is not a chain, so widget_nodes_set drops whatever was stored
+	 * and answers false, which is the whole of "paint it yourself". */
 	lua_pushboolean(L, widget_nodes_set(L, drawin, 2));
 	return 1;
 }

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -13,6 +13,7 @@
 #include "../shadow.h"
 #include "../declare.h"
 #include "../systray.h"
+#include "../widget.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -570,6 +571,7 @@ drawin_wipe(drawin_t *w)
 	/* Retire the renderer's view: the handle so a later resolve answers
 	 * NULL, and the entry surfaces the declare pass hands out. */
 	declare_handle_drop(w);
+	widget_nodes_clear(w);
 	drawin_entry_set(&w->content_entry, NULL);
 	drawin_entry_set(&w->border_entry, NULL);
 	drawin_entry_set(&w->shadow_entry, NULL);
@@ -1369,6 +1371,7 @@ luaA_drawin_gc(lua_State *L)
 		/* Retire the renderer's view and drop the retained leaves at the
 		 * next frame */
 		declare_handle_drop(drawin);
+		widget_nodes_clear(drawin);
 		drawin_entry_set(&drawin->content_entry, NULL);
 		drawin_entry_set(&drawin->border_entry, NULL);
 		drawin_entry_set(&drawin->shadow_entry, NULL);

--- a/objects/drawin.h
+++ b/objects/drawin.h
@@ -16,6 +16,7 @@
 /* Forward declarations */
 struct screen_t;
 struct drawable_t;
+struct widget_node;
 
 /* Drawin object structure - represents a drawable window (wibox/panel/popup)
  *
@@ -83,6 +84,13 @@ typedef struct drawin_t {
 	struct image_entry border_entry;
 	struct image_entry shadow_entry;
 	shadow_config_t shadow_entry_config;
+
+	/* The converted widget chain (widget.h), outermost first and always
+	 * ending in the raster leaf that carries content_entry. NULL while the
+	 * drawable paints itself whole, which is every drawin lua/wibox/clay.lua
+	 * finds nothing to convert in. */
+	struct widget_node *widget_nodes;
+	size_t widget_nodes_len;
 } drawin_t;
 
 /* Metatable name for drawin userdata */

--- a/objects/drawin.h
+++ b/objects/drawin.h
@@ -91,6 +91,11 @@ typedef struct drawin_t {
 	 * finds nothing to convert in. */
 	struct widget_node *widget_nodes;
 	size_t widget_nodes_len;
+	/* Whether the declare pass has put this chain in front of Clay yet.
+	 * Clay's element hashmap is persistent and answers a lookup with the
+	 * last box an id ever had, so without this a chain that changed since
+	 * the last frame would read back the boxes of the one it replaced. */
+	bool widget_nodes_declared;
 } drawin_t;
 
 /* Metatable name for drawin userdata */

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -1242,7 +1242,7 @@ luaA_screen_get_content(lua_State *L, screen_t *s)
 {
 	cairo_surface_t *surface;
 	cairo_t *cr;
-	struct screenshot_render_data rdata;
+	struct screenshot_render_data rdata = { 0 };
 	int width, height;
 
 	if (!s || !s->valid)
@@ -1270,6 +1270,10 @@ luaA_screen_get_content(lua_State *L, screen_t *s)
 	rdata.renderer = drw;
 	rdata.offset_x = -s->geometry.x;
 	rdata.offset_y = -s->geometry.y;
+	rdata.bound_x = s->geometry.x;
+	rdata.bound_y = s->geometry.y;
+	rdata.bound_w = width;
+	rdata.bound_h = height;
 
 	/* First, composite wallpaper (cropped to screen area) */
 	if (globalconf.wallpaper) {

--- a/objects/screen.c
+++ b/objects/screen.c
@@ -12,6 +12,7 @@
 #include "../event_queue.h"
 #include "common/util.h"
 #include "../x11_compat.h"
+#include "../screenshot_compose.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1115,14 +1116,6 @@ luaA_screen_get_managed(lua_State *L)
 
 /* ========== SCREEN CONTENT (SCREENSHOT) SUPPORT ========== */
 
-/** Callback data for scene buffer iteration during screenshot */
-struct screen_screenshot_data {
-	cairo_t *cr;
-	struct wlr_renderer *renderer;
-	int screen_x, screen_y;  /* Screen offset to subtract */
-	int screen_w, screen_h;  /* Screen bounds */
-};
-
 /** Composite a Cairo surface onto the screenshot at the given position */
 static void
 screen_composite_cairo_surface(cairo_t *cr, cairo_surface_t *surface,
@@ -1145,87 +1138,6 @@ box_intersects_screen(int x, int y, int w, int h,
                       int sx, int sy, int sw, int sh)
 {
 	return !(x + w <= sx || x >= sx + sw || y + h <= sy || y >= sy + sh);
-}
-
-/** Composite a scene buffer to Cairo surface (for screen screenshot) */
-static void
-screen_composite_scene_buffer(struct wlr_scene_buffer *buffer,
-                              int sx, int sy, void *data)
-{
-	struct screen_screenshot_data *sdata = data;
-	struct wlr_buffer *wlr_buf;
-	struct wlr_texture *texture;
-	void *shm_data;
-	uint32_t shm_format;
-	size_t shm_stride;
-	int rel_x, rel_y;
-	size_t stride;
-	void *pixels;
-
-	if (!buffer->buffer)
-		return;
-
-	wlr_buf = buffer->buffer;
-
-	/* Check if buffer intersects with screen */
-	if (!box_intersects_screen(sx, sy, wlr_buf->width, wlr_buf->height,
-	                           sdata->screen_x, sdata->screen_y,
-	                           sdata->screen_w, sdata->screen_h))
-		return;
-
-	/* Offset position relative to screen origin */
-	rel_x = sx - sdata->screen_x;
-	rel_y = sy - sdata->screen_y;
-
-	/* Try SHM buffer access first */
-	if (wlr_buffer_begin_data_ptr_access(wlr_buf, WLR_BUFFER_DATA_PTR_ACCESS_READ,
-	                                     &shm_data, &shm_format, &shm_stride)) {
-		if (shm_format == DRM_FORMAT_ARGB8888 || shm_format == DRM_FORMAT_XRGB8888) {
-			cairo_format_t fmt = (shm_format == DRM_FORMAT_ARGB8888) ?
-			                     CAIRO_FORMAT_ARGB32 : CAIRO_FORMAT_RGB24;
-			cairo_surface_t *tmp = cairo_image_surface_create_for_data(
-				shm_data, fmt, wlr_buf->width, wlr_buf->height, shm_stride);
-			if (cairo_surface_status(tmp) == CAIRO_STATUS_SUCCESS) {
-				screen_composite_cairo_surface(sdata->cr, tmp,
-				                               rel_x, rel_y,
-				                               wlr_buf->width, wlr_buf->height);
-			}
-			cairo_surface_destroy(tmp);
-		}
-		wlr_buffer_end_data_ptr_access(wlr_buf);
-		return;
-	}
-
-	/* Fall back to GPU texture path */
-	texture = wlr_texture_from_buffer(sdata->renderer, wlr_buf);
-	if (!texture)
-		return;
-
-	stride = wlr_buf->width * 4;
-	pixels = malloc(stride * wlr_buf->height);
-	if (!pixels) {
-		wlr_texture_destroy(texture);
-		return;
-	}
-
-	if (wlr_texture_read_pixels(texture, &(struct wlr_texture_read_pixels_options){
-	    .data = pixels,
-	    .format = DRM_FORMAT_ARGB8888,
-	    .stride = stride,
-	    .src_box = { .x = 0, .y = 0, .width = wlr_buf->width, .height = wlr_buf->height },
-	})) {
-		cairo_surface_t *tmp = cairo_image_surface_create_for_data(
-			pixels, CAIRO_FORMAT_ARGB32, wlr_buf->width, wlr_buf->height, stride);
-		if (cairo_surface_status(tmp) == CAIRO_STATUS_SUCCESS) {
-			screen_composite_cairo_surface(sdata->cr, tmp,
-			                               rel_x, rel_y,
-			                               wlr_buf->width, wlr_buf->height);
-		}
-		cairo_surface_destroy(tmp);
-	}
-
-	free(pixels);
-	wlr_texture_destroy(texture);
 }
 
 /** Composite widgets within the screen bounds, filtered by ontop state */
@@ -1330,7 +1242,7 @@ luaA_screen_get_content(lua_State *L, screen_t *s)
 {
 	cairo_surface_t *surface;
 	cairo_t *cr;
-	struct screen_screenshot_data sdata;
+	struct screenshot_render_data rdata;
 	int width, height;
 
 	if (!s || !s->valid)
@@ -1353,13 +1265,11 @@ luaA_screen_get_content(lua_State *L, screen_t *s)
 	cairo_set_source_rgb(cr, 0, 0, 0);
 	cairo_paint(cr);
 
-	/* Set up screenshot data */
-	sdata.cr = cr;
-	sdata.renderer = drw;
-	sdata.screen_x = s->geometry.x;
-	sdata.screen_y = s->geometry.y;
-	sdata.screen_w = width;
-	sdata.screen_h = height;
+	/* Scene coordinates are the layout's; this target is the screen's. */
+	rdata.cr = cr;
+	rdata.renderer = drw;
+	rdata.offset_x = -s->geometry.x;
+	rdata.offset_y = -s->geometry.y;
 
 	/* First, composite wallpaper (cropped to screen area) */
 	if (globalconf.wallpaper) {
@@ -1369,9 +1279,8 @@ luaA_screen_get_content(lua_State *L, screen_t *s)
 		                               cairo_image_surface_get_height(globalconf.wallpaper));
 	}
 
-	/* Then iterate scene buffers for client content */
-	wlr_scene_node_for_each_buffer(&scene->tree.node,
-		screen_composite_scene_buffer, &sdata);
+	/* Then walk the scene for client content and drawn chrome */
+	composite_scene_node_to_cairo(&scene->tree.node, &rdata);
 
 	/* Composite widgets in z-order: normal first, then ontop */
 	screen_composite_widgets(cr, s->geometry.x, s->geometry.y, width, height, false);

--- a/root.c
+++ b/root.c
@@ -1124,6 +1124,58 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 		free(pixels);
 }
 
+
+/** Composite one scene node and its children onto a cairo target.
+ *
+ * wlr_scene_node_for_each_buffer only reaches buffers, and the renderer draws
+ * a flat color as a wlr_scene_rect (render.c): a converted widget container's
+ * background is a rectangle and nothing else, and so is the backing behind a
+ * non-opaque fullscreen surface. Walking once covers both kinds, in the order
+ * the compositor stacks them.
+ *
+ * Shared with objects/screen.c via screenshot_compose.h.
+ */
+void
+composite_scene_node_to_cairo(struct wlr_scene_node *node, void *data)
+{
+	struct screenshot_render_data *rdata = data;
+	struct wlr_scene_node *child;
+	int lx, ly;
+
+	if (!node->enabled)
+		return;
+
+	switch (node->type) {
+	case WLR_SCENE_NODE_BUFFER:
+		if (wlr_scene_node_coords(node, &lx, &ly))
+			composite_scene_buffer_to_cairo(
+				wlr_scene_buffer_from_node(node), lx, ly, rdata);
+		return;
+	case WLR_SCENE_NODE_RECT: {
+		struct wlr_scene_rect *rect = wlr_scene_rect_from_node(node);
+		float a = rect->color[3];
+
+		if (!wlr_scene_node_coords(node, &lx, &ly))
+			return;
+		/* Scene rect colors are premultiplied; cairo wants straight. */
+		cairo_save(rdata->cr);
+		cairo_set_source_rgba(rdata->cr,
+		                      a > 0 ? rect->color[0] / a : 0,
+		                      a > 0 ? rect->color[1] / a : 0,
+		                      a > 0 ? rect->color[2] / a : 0, a);
+		cairo_rectangle(rdata->cr, lx + rdata->offset_x, ly + rdata->offset_y,
+		                rect->width, rect->height);
+		cairo_fill(rdata->cr);
+		cairo_restore(rdata->cr);
+		return;
+	}
+	case WLR_SCENE_NODE_TREE:
+		wl_list_for_each(child, &wlr_scene_tree_from_node(node)->children, link)
+			composite_scene_node_to_cairo(child, rdata);
+		return;
+	}
+}
+
 /** root.content([preserve_alpha]) - Get screenshot of entire desktop
  *
  * Returns a Cairo surface containing the current desktop content.
@@ -1185,9 +1237,8 @@ luaA_root_get_content(lua_State *L)
 	rdata.offset_x = 0;
 	rdata.offset_y = 0;
 
-	/* Iterate scene buffers for client content (GPU-rendered surfaces) */
-	wlr_scene_node_for_each_buffer(&scene->tree.node,
-		composite_scene_buffer_to_cairo, &rdata);
+	/* Walk the scene for client content and the chrome the renderer drew */
+	composite_scene_node_to_cairo(&scene->tree.node, &rdata);
 
 	/* Composite widgets in z-order: normal first, then ontop.
 	 * This ensures correct layering where ontop popups appear above titlebars. */

--- a/root.c
+++ b/root.c
@@ -1135,6 +1135,17 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
  *
  * Shared with objects/screen.c via screenshot_compose.h.
  */
+/* Whether a node's layout box reaches the target at all. */
+static bool
+within_bounds(const struct screenshot_render_data *rdata, int x, int y,
+              int w, int h)
+{
+	if (rdata->bound_w <= 0 || rdata->bound_h <= 0)
+		return true;
+	return !(x + w <= rdata->bound_x || x >= rdata->bound_x + rdata->bound_w
+		|| y + h <= rdata->bound_y || y >= rdata->bound_y + rdata->bound_h);
+}
+
 void
 composite_scene_node_to_cairo(struct wlr_scene_node *node, void *data)
 {
@@ -1146,16 +1157,29 @@ composite_scene_node_to_cairo(struct wlr_scene_node *node, void *data)
 		return;
 
 	switch (node->type) {
-	case WLR_SCENE_NODE_BUFFER:
-		if (wlr_scene_node_coords(node, &lx, &ly))
-			composite_scene_buffer_to_cairo(
-				wlr_scene_buffer_from_node(node), lx, ly, rdata);
+	case WLR_SCENE_NODE_BUFFER: {
+		struct wlr_scene_buffer *buffer = wlr_scene_buffer_from_node(node);
+		int w, h;
+
+		if (!wlr_scene_node_coords(node, &lx, &ly) || !buffer->buffer)
+			return;
+		/* The size it draws at, not the size of its pixels: a shadow
+		 * edge is a one-pixel texture stretched the length of a client,
+		 * and culling on the texture would drop it. */
+		w = buffer->dst_width > 0 ? buffer->dst_width : buffer->buffer->width;
+		h = buffer->dst_height > 0 ? buffer->dst_height : buffer->buffer->height;
+		if (!within_bounds(rdata, lx, ly, w, h))
+			return;
+		composite_scene_buffer_to_cairo(buffer, lx, ly, rdata);
 		return;
+	}
 	case WLR_SCENE_NODE_RECT: {
 		struct wlr_scene_rect *rect = wlr_scene_rect_from_node(node);
 		float a = rect->color[3];
 
 		if (!wlr_scene_node_coords(node, &lx, &ly))
+			return;
+		if (!within_bounds(rdata, lx, ly, rect->width, rect->height))
 			return;
 		/* Scene rect colors are premultiplied; cairo wants straight. */
 		cairo_save(rdata->cr);
@@ -1193,7 +1217,7 @@ luaA_root_get_content(lua_State *L)
 	cairo_surface_t *surface;
 	cairo_t *cr;
 	int width, height;
-	struct screenshot_render_data rdata;
+	struct screenshot_render_data rdata = { 0 };
 	bool preserve_alpha = false;
 
 	/* Check for optional preserve_alpha parameter */
@@ -1236,6 +1260,7 @@ luaA_root_get_content(lua_State *L)
 	rdata.renderer = drw;
 	rdata.offset_x = 0;
 	rdata.offset_y = 0;
+	/* bound_w stays zero: the whole layout is the target. */
 
 	/* Walk the scene for client content and the chrome the renderer drew */
 	composite_scene_node_to_cairo(&scene->tree.node, &rdata);

--- a/screenshot_compose.h
+++ b/screenshot_compose.h
@@ -18,10 +18,15 @@
  * starting node down INCLUDING the starting node's own position. Callers
  * that start from a non-root node must pass offset_x/y = -node->x/-node->y
  * to get subtree-relative coordinates. */
+/* bound_w or bound_h of zero means unbounded; anything else is the layout
+ * box the target covers, and a node that misses it is skipped before its
+ * pixels are touched. That skip is what keeps a one-output capture from
+ * reading back every client on the other outputs. */
 struct screenshot_render_data {
 	cairo_t *cr;
 	struct wlr_renderer *renderer;
 	int offset_x, offset_y;
+	int bound_x, bound_y, bound_w, bound_h;
 };
 
 void composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,

--- a/screenshot_compose.h
+++ b/screenshot_compose.h
@@ -27,4 +27,11 @@ struct screenshot_render_data {
 void composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
                                      int sx, int sy, void *data);
 
+/* The whole subtree, buffers and rectangles alike, in stacking order. Reaches
+ * what the renderer draws as a flat color, which for_each_buffer never sees: a
+ * converted widget container's background, and the fullscreen backing. Unlike
+ * for_each_buffer this reads each node's position from the scene root, so a
+ * caller starting below the root still gets layout coordinates. */
+void composite_scene_node_to_cairo(struct wlr_scene_node *node, void *data);
+
 #endif

--- a/spec/wibox/clay_spec.lua
+++ b/spec/wibox/clay_spec.lua
@@ -4,10 +4,11 @@
 
 local gcolor = require("gears.color")
 local gshape = require("gears.shape")
-local base = require("wibox.widget.base")
+local hierarchy = require("wibox.hierarchy")
 local background = require("wibox.container.background")
 local margin = require("wibox.container.margin")
 local constraint = require("wibox.container.constraint")
+local utils = require("wibox.test_utils")
 local wclay = require("wibox.clay")
 
 local BG = gcolor("#102030")
@@ -15,39 +16,61 @@ local BG_RGBA = { 0x10/255, 0x20/255, 0x30/255, 1 }
 
 -- A widget the chain can never convert, so it always ends up on the leaf.
 local function leaf_widget()
-    local w = base.make_widget()
+    return utils.widget_stub(10, 10)
+end
 
-    rawset(w, "fit", function() return 10, 10 end)
-    return w
+-- compile() walks the laid-out tree, so lay one out. hierarchy.new updates
+-- synchronously, which is all this needs: no drawable, no drawin, no screen.
+local function compile(bg, root, fg)
+    local drawable = {
+        background_color = bg,
+        foreground_color = fg,
+        background_image = nil,
+    }
+    local h = root and hierarchy.new({ dpi = 96 }, root, 100, 100,
+        function() end, function() end, {})
+
+    return wclay.compile(drawable, h)
 end
 
 describe("wibox.clay", function()
     it("refuses a drawable whose own background is not a solid color", function()
-        assert.is_nil(wclay.compile(nil, margin(leaf_widget(), 1), BG))
-        assert.is_nil(wclay.compile(
+        assert.is_nil(compile(nil, margin(leaf_widget(), 1, 1, 1, 1), BG))
+        assert.is_nil(compile(
             gcolor("linear:0,0:10,0:0,#000000:1,#ffffff"),
-            margin(leaf_widget(), 1), BG))
+            margin(leaf_widget(), 1, 1, 1, 1), BG))
+    end)
+
+    it("refuses a drawable with a background image", function()
+        local h = hierarchy.new({ dpi = 96 }, margin(leaf_widget(), 1, 1, 1, 1),
+            100, 100, function() end, function() end, {})
+
+        assert.is_nil(wclay.compile({
+            background_color = BG,
+            foreground_color = BG,
+            background_image = "anything",
+        }, h))
     end)
 
     it("refuses a tree whose root converts nothing", function()
-        assert.is_nil(wclay.compile(BG, leaf_widget(), BG))
-        assert.is_nil(wclay.compile(BG, nil, BG))
+        assert.is_nil(compile(BG, leaf_widget(), BG))
+        assert.is_nil(compile(BG, nil, BG))
     end)
 
     it("maps margins onto padding", function()
         local w = leaf_widget()
-        local chain, rest = wclay.compile(BG, margin(w, 1, 2, 3, 4), BG)
+        local chain, rest = compile(BG, margin(w, 1, 2, 3, 4), BG)
 
         assert.is_equal(3, #chain)
         assert.is_same(BG_RGBA, chain[1].bg)
         assert.is_same({ 1, 2, 3, 4 }, chain[2].pad)
         assert.is_nil(chain[2].border)
         assert.is_true(chain[3].raster)
-        assert.is_equal(w, rest)
+        assert.is_equal(w, rest:get_widget())
     end)
 
     it("maps a margin color onto a border of the same widths", function()
-        local chain = wclay.compile(BG,
+        local chain = compile(BG,
             margin(leaf_widget(), 1, 2, 3, 4, "#ff0000"), BG)
 
         assert.is_same({ 1, 2, 3, 4 }, chain[2].pad)
@@ -61,7 +84,7 @@ describe("wibox.clay", function()
         w.border_width = 2
         w.border_color = "#0000ff"
 
-        local chain = wclay.compile(BG, w, BG)
+        local chain = compile(BG, w, BG)
 
         assert.is_same({ 0, 1, 0, 1 }, chain[2].bg)
         assert.is_same({ 0, 0, 1, 1 }, chain[2].border)
@@ -77,13 +100,13 @@ describe("wibox.clay", function()
         w.border_color = "#0000ff"
         w.border_strategy = "inner"
 
-        local chain = wclay.compile(BG, w, BG)
+        local chain = compile(BG, w, BG)
 
         assert.is_same({ 2, 2, 2, 2 }, chain[2].pad)
     end)
 
     it("maps a rounded rectangle onto a corner radius the leaf shares", function()
-        local chain = wclay.compile(BG,
+        local chain = compile(BG,
             background(leaf_widget(), "#00ff00", function(cr, cw, ch)
                 return gshape.rounded_rect(cr, cw, ch)
             end), BG)
@@ -95,7 +118,7 @@ describe("wibox.clay", function()
         local w = background(leaf_widget(), "#00ff00")
 
         w:set_shape(gshape.rounded_rect, 8)
-        chain = wclay.compile(BG, w, BG)
+        chain = compile(BG, w, BG)
 
         assert.is_equal(8, chain[2].radius)
         assert.is_equal(8, chain[3].radius)
@@ -107,7 +130,7 @@ describe("wibox.clay", function()
 
         w:set_shape(gshape.rounded_rect, 8)
 
-        local chain = wclay.compile(BG, margin(w, 5, 5, 5, 5), BG)
+        local chain = compile(BG, margin(w, 5, 5, 5, 5), BG)
 
         -- The margin converts; the rounded background under it would clip its
         -- children to a box the leaf no longer shares, so it stops the walk.
@@ -123,13 +146,13 @@ describe("wibox.clay", function()
         w.border_width = 1
         w.border_color = "#0000ff"
 
-        assert.is_nil(wclay.compile(BG, w, BG))
+        assert.is_nil(compile(BG, w, BG))
     end)
 
     it("converts a chain of containers down to the first it cannot", function()
         local w = leaf_widget()
         local stopper = constraint(margin(w, 2, 2, 2, 2))
-        local chain, rest = wclay.compile(BG,
+        local chain, rest = compile(BG,
             background(margin(stopper, 4, 4, 4, 4), "#00ff00"), BG)
 
         -- background, margin, then the constraint stops the walk; the margin
@@ -138,7 +161,7 @@ describe("wibox.clay", function()
         assert.is_same({ 0, 1, 0, 1 }, chain[2].bg)
         assert.is_same({ 4, 4, 4, 4 }, chain[3].pad)
         assert.is_true(chain[4].raster)
-        assert.is_equal(stopper, rest)
+        assert.is_equal(stopper, rest:get_widget())
     end)
 
     it("carries the innermost background foreground to the leaf", function()
@@ -147,7 +170,7 @@ describe("wibox.clay", function()
 
         w.fg = fg
 
-        local _, _, leaf_fg = wclay.compile(BG, w, BG)
+        local _, _, _, leaf_fg = compile(BG, w, BG)
 
         assert.is_equal(fg, leaf_fg)
     end)
@@ -159,7 +182,7 @@ describe("wibox.clay", function()
             local w = margin(leaf_widget(), 3, 3, 3, 3)
 
             w[prop] = value
-            assert.is_nil(wclay.compile(BG, w, BG), prop)
+            assert.is_nil(compile(BG, w, BG), prop)
         end
     end)
 
@@ -167,14 +190,14 @@ describe("wibox.clay", function()
         local w = margin(leaf_widget(), 3, 3, 3, 3)
 
         rawset(w, "layout", function() return {} end)
-        assert.is_nil(wclay.compile(BG, w, BG))
+        assert.is_nil(compile(BG, w, BG))
     end)
 
     it("stops at a margin that shrinks away with its child", function()
         local w = margin(leaf_widget(), 3, 3, 3, 3)
 
         w.draw_empty = false
-        assert.is_nil(wclay.compile(BG, w, BG))
+        assert.is_nil(compile(BG, w, BG))
     end)
 end)
 

--- a/spec/wibox/clay_spec.lua
+++ b/spec/wibox/clay_spec.lua
@@ -1,0 +1,181 @@
+---------------------------------------------------------------------------
+-- Tests for wibox.clay, the widget-tree-to-Clay compile step.
+---------------------------------------------------------------------------
+
+local gcolor = require("gears.color")
+local gshape = require("gears.shape")
+local base = require("wibox.widget.base")
+local background = require("wibox.container.background")
+local margin = require("wibox.container.margin")
+local constraint = require("wibox.container.constraint")
+local wclay = require("wibox.clay")
+
+local BG = gcolor("#102030")
+local BG_RGBA = { 0x10/255, 0x20/255, 0x30/255, 1 }
+
+-- A widget the chain can never convert, so it always ends up on the leaf.
+local function leaf_widget()
+    local w = base.make_widget()
+
+    rawset(w, "fit", function() return 10, 10 end)
+    return w
+end
+
+describe("wibox.clay", function()
+    it("refuses a drawable whose own background is not a solid color", function()
+        assert.is_nil(wclay.compile(nil, margin(leaf_widget(), 1), BG))
+        assert.is_nil(wclay.compile(
+            gcolor("linear:0,0:10,0:0,#000000:1,#ffffff"),
+            margin(leaf_widget(), 1), BG))
+    end)
+
+    it("refuses a tree whose root converts nothing", function()
+        assert.is_nil(wclay.compile(BG, leaf_widget(), BG))
+        assert.is_nil(wclay.compile(BG, nil, BG))
+    end)
+
+    it("maps margins onto padding", function()
+        local w = leaf_widget()
+        local chain, rest = wclay.compile(BG, margin(w, 1, 2, 3, 4), BG)
+
+        assert.is_equal(3, #chain)
+        assert.is_same(BG_RGBA, chain[1].bg)
+        assert.is_same({ 1, 2, 3, 4 }, chain[2].pad)
+        assert.is_nil(chain[2].border)
+        assert.is_true(chain[3].raster)
+        assert.is_equal(w, rest)
+    end)
+
+    it("maps a margin color onto a border of the same widths", function()
+        local chain = wclay.compile(BG,
+            margin(leaf_widget(), 1, 2, 3, 4, "#ff0000"), BG)
+
+        assert.is_same({ 1, 2, 3, 4 }, chain[2].pad)
+        assert.is_same({ 1, 2, 3, 4 }, chain[2].bw)
+        assert.is_same({ 1, 0, 0, 1 }, chain[2].border)
+    end)
+
+    it("maps a background color and a square border", function()
+        local w = background(leaf_widget(), "#00ff00")
+
+        w.border_width = 2
+        w.border_color = "#0000ff"
+
+        local chain = wclay.compile(BG, w, BG)
+
+        assert.is_same({ 0, 1, 0, 1 }, chain[2].bg)
+        assert.is_same({ 0, 0, 1, 1 }, chain[2].border)
+        assert.is_same({ 2, 2, 2, 2 }, chain[2].bw)
+        assert.is_equal(0, chain[2].radius)
+        assert.is_nil(chain[2].pad)
+    end)
+
+    it("pads a background whose border strategy shrinks its child", function()
+        local w = background(leaf_widget(), "#00ff00")
+
+        w.border_width = 2
+        w.border_color = "#0000ff"
+        w.border_strategy = "inner"
+
+        local chain = wclay.compile(BG, w, BG)
+
+        assert.is_same({ 2, 2, 2, 2 }, chain[2].pad)
+    end)
+
+    it("maps a rounded rectangle onto a corner radius the leaf shares", function()
+        local chain = wclay.compile(BG,
+            background(leaf_widget(), "#00ff00", function(cr, cw, ch)
+                return gshape.rounded_rect(cr, cw, ch)
+            end), BG)
+
+        -- An inline shape function is not gears.shape.rounded_rect, so it
+        -- draws itself: nothing above the leaf converted.
+        assert.is_nil(chain)
+
+        local w = background(leaf_widget(), "#00ff00")
+
+        w:set_shape(gshape.rounded_rect, 8)
+        chain = wclay.compile(BG, w, BG)
+
+        assert.is_equal(8, chain[2].radius)
+        assert.is_equal(8, chain[3].radius)
+        assert.is_true(chain[3].raster)
+    end)
+
+    it("keeps a rounded background off the chain once a box comes between", function()
+        local w = background(leaf_widget(), "#00ff00")
+
+        w:set_shape(gshape.rounded_rect, 8)
+
+        local chain = wclay.compile(BG, margin(w, 5, 5, 5, 5), BG)
+
+        -- The margin converts; the rounded background under it would clip its
+        -- children to a box the leaf no longer shares, so it stops the walk.
+        assert.is_equal(3, #chain)
+        assert.is_same({ 5, 5, 5, 5 }, chain[2].pad)
+        assert.is_equal(0, chain[3].radius)
+    end)
+
+    it("refuses a rounded background that also has a border", function()
+        local w = background(leaf_widget(), "#00ff00")
+
+        w:set_shape(gshape.rounded_rect, 8)
+        w.border_width = 1
+        w.border_color = "#0000ff"
+
+        assert.is_nil(wclay.compile(BG, w, BG))
+    end)
+
+    it("converts a chain of containers down to the first it cannot", function()
+        local w = leaf_widget()
+        local stopper = constraint(margin(w, 2, 2, 2, 2))
+        local chain, rest = wclay.compile(BG,
+            background(margin(stopper, 4, 4, 4, 4), "#00ff00"), BG)
+
+        -- background, margin, then the constraint stops the walk; the margin
+        -- inside it stays on the leaf with everything below.
+        assert.is_equal(4, #chain)
+        assert.is_same({ 0, 1, 0, 1 }, chain[2].bg)
+        assert.is_same({ 4, 4, 4, 4 }, chain[3].pad)
+        assert.is_true(chain[4].raster)
+        assert.is_equal(stopper, rest)
+    end)
+
+    it("carries the innermost background foreground to the leaf", function()
+        local fg = gcolor("#ff00ff")
+        local w = background(leaf_widget(), "#00ff00")
+
+        w.fg = fg
+
+        local _, _, leaf_fg = wclay.compile(BG, w, BG)
+
+        assert.is_equal(fg, leaf_fg)
+    end)
+
+    it("stops at a widget whose drawing the chain does not carry", function()
+        for prop, value in pairs {
+            visible = false, opacity = 0.5, forced_width = 20, forced_height = 20,
+        } do
+            local w = margin(leaf_widget(), 3, 3, 3, 3)
+
+            w[prop] = value
+            assert.is_nil(wclay.compile(BG, w, BG), prop)
+        end
+    end)
+
+    it("stops at a subclass that overrides the layout it converted", function()
+        local w = margin(leaf_widget(), 3, 3, 3, 3)
+
+        rawset(w, "layout", function() return {} end)
+        assert.is_nil(wclay.compile(BG, w, BG))
+    end)
+
+    it("stops at a margin that shrinks away with its child", function()
+        local w = margin(leaf_widget(), 3, 3, 3, 3)
+
+        w.draw_empty = false
+        assert.is_nil(wclay.compile(BG, w, BG))
+    end)
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-clay-widget-containers.lua
+++ b/tests/test-clay-widget-containers.lua
@@ -1,0 +1,265 @@
+-- Test: margin and background containers convert to Clay declarations, and a
+-- wibar drawn that way is pixel-identical to the same wibar painted whole.
+--
+-- Two things are checked. First, that the boxes Clay solves for the converted
+-- chain are the boxes wibox's own :fit/:layout protocol places, read back
+-- through awesome._test_widget_boxes(). Second, that the screen looks the
+-- same either way: setting a bgimage puts the drawable back on the path where
+-- cairo paints every pixel (lua/wibox/clay.lua refuses a background image),
+-- so the same tree renders twice, once converted and once whole, and the two
+-- captures have to agree.
+--
+-- Run: make test-one TEST=tests/test-clay-widget-containers.lua
+
+local ffi = require("ffi")
+local runner = require("_runner")
+local wibox = require("wibox")
+local base = require("wibox.widget.base")
+local cairo = require("lgi").cairo
+local gshape = require("gears.shape")
+local matrix = require("gears.matrix")
+
+ffi.cdef [[
+    void cairo_surface_flush(void *surface);
+    unsigned char *cairo_image_surface_get_data(void *surface);
+    int cairo_image_surface_get_stride(void *surface);
+]]
+
+local s = screen[1]
+local BX, BY, BW, BH = 0, 0, 200, 40
+local OUTER, INNER, BORDER = 4, 6, 2
+local BAR_BG, BOX_BG, BORDER_COLOR = "#101010", "#204080", "#ff8000"
+
+local bar, captured
+
+-- A widget the compile step can never convert, so the chain always ends here.
+local function leaf_widget()
+    local w = base.make_widget()
+
+    rawset(w, "fit", function(_, _, width, height) return width, height end)
+    rawset(w, "draw", function(_, _, cr, width, height)
+        cr:set_source_rgb(1, 0, 0)
+        cr:rectangle(0, 0, width, height)
+        cr:fill()
+    end)
+    return w
+end
+
+-- Every widget box in the drawable's hierarchy, outermost first, in drawable
+-- coordinates. This is what the old layout engine places, and what Clay has
+-- to agree with.
+local function hierarchy_boxes()
+    local boxes, h = {}, bar._drawable._widget_hierarchy
+
+    while h do
+        local x, y, w, hh = matrix.transform_rectangle(
+            h:get_matrix_to_device(), 0, 0, h:get_size())
+
+        boxes[#boxes + 1] = { x = x, y = y, width = w, height = hh }
+        h = h:get_children()[1]
+    end
+    return boxes
+end
+
+local function box_string(b)
+    return string.format("%dx%d+%d+%d", b.width, b.height, b.x, b.y)
+end
+
+local function assert_box(got, want, what)
+    assert(got and got.x == want.x and got.y == want.y
+        and got.width == want.width and got.height == want.height,
+        string.format("%s: got %s, want %s", what,
+            got and box_string(got) or "nothing", box_string(want)))
+end
+
+-- The wibar's pixels out of a screen capture, as one string.
+local function capture()
+    local surface = s.content
+
+    assert(surface, "screen.content returned nothing")
+
+    -- screen.content comes back as an lgi record; the FFI wants the pointer.
+    local raw = surface._native or surface
+
+    ffi.C.cairo_surface_flush(raw)
+
+    local data = ffi.C.cairo_image_surface_get_data(raw)
+    local stride = ffi.C.cairo_image_surface_get_stride(raw)
+    local rows = {}
+
+    for y = BY, BY + BH - 1 do
+        rows[#rows + 1] = ffi.string(data + y * stride + BX * 4, BW * 4)
+    end
+    return table.concat(rows)
+end
+
+-- R, G, B of one pixel of a capture, drawable-local.
+local function pixel(shot, x, y)
+    local off = (y * BW + x) * 4
+
+    return shot:byte(off + 3), shot:byte(off + 2), shot:byte(off + 1)
+end
+
+local function assert_pixel(shot, x, y, hex, what)
+    local r, g, b = pixel(shot, x, y)
+    local want_r = tonumber(hex:sub(2, 3), 16)
+    local want_g = tonumber(hex:sub(4, 5), 16)
+    local want_b = tonumber(hex:sub(6, 7), 16)
+
+    assert(math.abs(r - want_r) <= 1 and math.abs(g - want_g) <= 1
+        and math.abs(b - want_b) <= 1,
+        string.format("%s at %d,%d: got #%02x%02x%02x, want %s",
+            what, x, y, r, g, b, hex))
+end
+
+-- The wibar looks the same painted whole as it does converted. Retried
+-- because the repaint the fallback needs lands a frame or two later.
+local function compare(count, what)
+    local shot = capture()
+
+    if shot == captured then
+        io.stderr:write("[PASS] " .. what .. " draws what the chain drew\n")
+        return true
+    end
+    if count < 20 then
+        return
+    end
+    for y = 0, BH - 1 do
+        for x = 0, BW - 1 do
+            local r, g, b = pixel(shot, x, y)
+            local wr, wg, wb = pixel(captured, x, y)
+
+            assert(r == wr and g == wg and b == wb, string.format(
+                "%s differs at %d,%d: #%02x%02x%02x, converted #%02x%02x%02x",
+                what, x, y, r, g, b, wr, wg, wb))
+        end
+    end
+    error(what .. " differs outside the compared channels")
+end
+
+local steps = {
+    function(count)
+        if count == 1 then
+            bar = wibox {
+                x = BX, y = BY, width = BW, height = BH,
+                visible = true, screen = s, bg = BAR_BG,
+            }
+            bar:setup {
+                widget = wibox.container.margin,
+                margins = OUTER,
+                {
+                    widget = wibox.container.background,
+                    bg = BOX_BG,
+                    border_width = BORDER,
+                    border_color = BORDER_COLOR,
+                    {
+                        widget = wibox.container.margin,
+                        margins = INNER,
+                        leaf_widget(),
+                    },
+                },
+            }
+        end
+        if #awesome._test_widget_boxes(bar.drawin) > 0 then
+            return true
+        end
+        assert(count < 20, "the widget tree never converted")
+    end,
+
+    -- Clay's boxes for the chain, against wibox's own.
+    function()
+        local boxes = awesome._test_widget_boxes(bar.drawin)
+
+        assert(#boxes == 5, "expected five nodes, got " .. #boxes)
+        assert_box(boxes[1], { x = 0, y = 0, width = BW, height = BH },
+            "the drawable's own background")
+        assert_box(boxes[2], { x = 0, y = 0, width = BW, height = BH },
+            "the outer margin")
+        assert_box(boxes[3], { x = OUTER, y = OUTER,
+            width = BW - 2 * OUTER, height = BH - 2 * OUTER }, "the background")
+        assert_box(boxes[4], { x = OUTER, y = OUTER,
+            width = BW - 2 * OUTER, height = BH - 2 * OUTER },
+            "the inner margin")
+        assert_box(boxes[5], { x = OUTER + INNER, y = OUTER + INNER,
+            width = BW - 2 * (OUTER + INNER),
+            height = BH - 2 * (OUTER + INNER) }, "the raster leaf")
+
+        -- The chain's widget nodes are boxes 2 to 5; the hierarchy holds the
+        -- same widgets, starting at the outer margin.
+        local want = hierarchy_boxes()
+
+        for i = 1, #want do
+            assert_box(boxes[i + 1], want[i],
+                "Clay and wibox disagree at hierarchy depth " .. i)
+        end
+        io.stderr:write("[PASS] Clay solves the boxes wibox places\n")
+        return true
+    end,
+
+    -- What the converted chain draws.
+    function()
+        local shot = capture()
+
+        assert_pixel(shot, 1, 1, BAR_BG, "the drawable's own background")
+        assert_pixel(shot, OUTER + 1, OUTER + 1, BORDER_COLOR,
+            "the background's border")
+        assert_pixel(shot, OUTER + BORDER + 2, OUTER + BORDER + 2, BOX_BG,
+            "the background's fill")
+        assert_pixel(shot, math.floor(BW / 2), math.floor(BH / 2), "#ff0000",
+            "the raster leaf")
+        captured = shot
+        io.stderr:write("[PASS] the converted chain draws where it should\n")
+        return true
+    end,
+
+    -- The same tree painted whole. A shape puts the drawable back on the
+    -- path where cairo paints every pixel, because the mask applies to those
+    -- pixels; a full-rectangle shape masks nothing away.
+    function(count)
+        if count == 1 then
+            bar.shape = gshape.rectangle
+        end
+        if #awesome._test_widget_boxes(bar.drawin) == 0 then
+            return true
+        end
+        assert(count < 20, "a shape did not put the drawable back on cairo")
+    end,
+
+    function(count)
+        return compare(count, "a shaped drawable")
+    end,
+
+    -- And a background image, the other thing the chain cannot carry.
+    function(count)
+        if count == 1 then
+            bar.shape = nil
+        end
+        if #awesome._test_widget_boxes(bar.drawin) > 0 then
+            return true
+        end
+        assert(count < 20, "dropping the shape did not convert the tree again")
+    end,
+
+    function(count)
+        if count == 1 then
+            bar.bgimage = cairo.ImageSurface(cairo.Format.ARGB32, 1, 1)
+        end
+        if #awesome._test_widget_boxes(bar.drawin) == 0 then
+            return true
+        end
+        assert(count < 20, "a background image did not put the drawable back")
+    end,
+
+    function(count)
+        return compare(count, "a background image")
+    end,
+
+    function()
+        bar.visible = false
+        return true
+    end,
+}
+
+runner.run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-clay-widget-containers.lua
+++ b/tests/test-clay-widget-containers.lua
@@ -13,6 +13,7 @@
 
 local ffi = require("ffi")
 local runner = require("_runner")
+local utils = require("_utils")
 local wibox = require("wibox")
 local base = require("wibox.widget.base")
 local cairo = require("lgi").cairo
@@ -61,15 +62,12 @@ local function hierarchy_boxes()
     return boxes
 end
 
-local function box_string(b)
-    return string.format("%dx%d+%d+%d", b.width, b.height, b.x, b.y)
-end
-
 local function assert_box(got, want, what)
-    assert(got and got.x == want.x and got.y == want.y
-        and got.width == want.width and got.height == want.height,
-        string.format("%s: got %s, want %s", what,
-            got and box_string(got) or "nothing", box_string(want)))
+    assert(got, what .. ": no box")
+
+    local ok, err = pcall(utils.assert_geometry, got, want)
+
+    assert(ok, what .. ": " .. tostring(err))
 end
 
 -- The wibar's pixels out of a screen capture, as one string.
@@ -135,6 +133,21 @@ local function compare(count, what)
         end
     end
     error(what .. " differs outside the compared channels")
+end
+
+-- A step that runs `setup` once and then waits for the readback to say the
+-- tree did or did not convert. The fallbacks repaint a frame or two later,
+-- so every one of these polls.
+local function step_until(converted, setup, what)
+    return function(count)
+        if count == 1 then
+            setup()
+        end
+        if (#awesome._test_widget_boxes(bar.drawin) > 0) == converted then
+            return true
+        end
+        assert(count < 20, what)
+    end
 end
 
 local steps = {
@@ -215,40 +228,20 @@ local steps = {
     -- The same tree painted whole. A shape puts the drawable back on the
     -- path where cairo paints every pixel, because the mask applies to those
     -- pixels; a full-rectangle shape masks nothing away.
-    function(count)
-        if count == 1 then
-            bar.shape = gshape.rectangle
-        end
-        if #awesome._test_widget_boxes(bar.drawin) == 0 then
-            return true
-        end
-        assert(count < 20, "a shape did not put the drawable back on cairo")
-    end,
+    step_until(false, function() bar.shape = gshape.rectangle end,
+        "a shape did not put the drawable back on cairo"),
 
     function(count)
         return compare(count, "a shaped drawable")
     end,
 
     -- And a background image, the other thing the chain cannot carry.
-    function(count)
-        if count == 1 then
-            bar.shape = nil
-        end
-        if #awesome._test_widget_boxes(bar.drawin) > 0 then
-            return true
-        end
-        assert(count < 20, "dropping the shape did not convert the tree again")
-    end,
+    step_until(true, function() bar.shape = nil end,
+        "dropping the shape did not convert the tree again"),
 
-    function(count)
-        if count == 1 then
-            bar.bgimage = cairo.ImageSurface(cairo.Format.ARGB32, 1, 1)
-        end
-        if #awesome._test_widget_boxes(bar.drawin) == 0 then
-            return true
-        end
-        assert(count < 20, "a background image did not put the drawable back")
-    end,
+    step_until(false, function()
+        bar.bgimage = cairo.ImageSurface(cairo.Format.ARGB32, 1, 1)
+    end, "a background image did not put the drawable back"),
 
     function(count)
         return compare(count, "a background image")

--- a/widget.c
+++ b/widget.c
@@ -1,0 +1,282 @@
+/*
+ * widget.c - the widget-tree-to-Clay compile step's C half
+ *
+ * lua/wibox/clay.lua walks a drawable's widget tree and describes the front
+ * of it as a chain of containers Clay can solve. This file stores that
+ * description on the drawin, declares it into the output's tree, and answers
+ * the test readback. It never draws and never measures: a node is pure
+ * description, and what the chain does not reach stays on the drawable's own
+ * surface, declared as the chain's innermost leaf.
+ */
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <lauxlib.h>
+
+#include "luaa.h"
+
+#include "clay.h"
+#include "widget.h"
+#include "common/util.h"
+#include "declare.h"
+#include "monitor.h"
+#include "objects/drawin.h"
+#include "objects/screen.h"
+
+/* somewm colors are straight-alpha 0-1 floats; Clay_Color is 0-255. */
+static Clay_Color
+clay_color(const float rgba[4])
+{
+	return (Clay_Color) {
+		rgba[0] * 255.0f, rgba[1] * 255.0f,
+		rgba[2] * 255.0f, rgba[3] * 255.0f,
+	};
+}
+
+/* --- reading a chain off the Lua stack --- */
+
+/* A four-number array field (pad, bw, bg, border), or all zeroes when the
+ * field is absent. False for a field that is present but not four numbers,
+ * which is a compile-step bug rather than a config the walk should ride out. */
+static bool
+read_quad(lua_State *L, int idx, const char *name, float *out)
+{
+	bool ok = true;
+
+	lua_getfield(L, idx, name);
+	if (lua_isnil(L, -1)) {
+		lua_pop(L, 1);
+		return true;
+	}
+	if (!lua_istable(L, -1)) {
+		lua_pop(L, 1);
+		return false;
+	}
+	for (int i = 0; i < 4; i++) {
+		lua_rawgeti(L, -1, i + 1);
+		if (lua_isnumber(L, -1))
+			out[i] = (float)lua_tonumber(L, -1);
+		else
+			ok = false;
+		lua_pop(L, 1);
+	}
+	lua_pop(L, 1);
+	return ok;
+}
+
+static bool
+read_node(lua_State *L, int idx, struct widget_node *n)
+{
+	float pad[4] = { 0 }, bw[4] = { 0 };
+
+	if (!lua_istable(L, idx))
+		return false;
+	if (!read_quad(L, idx, "pad", pad) || !read_quad(L, idx, "bw", bw)
+			|| !read_quad(L, idx, "bg", n->bg)
+			|| !read_quad(L, idx, "border", n->border))
+		return false;
+	for (int i = 0; i < 4; i++) {
+		if (pad[i] < 0 || pad[i] > UINT16_MAX
+				|| bw[i] < 0 || bw[i] > UINT16_MAX)
+			return false;
+		n->pad[i] = (uint16_t)pad[i];
+		n->bw[i] = (uint16_t)bw[i];
+	}
+
+	lua_getfield(L, idx, "radius");
+	n->radius = lua_isnumber(L, -1) ? (float)lua_tonumber(L, -1) : 0.0f;
+	lua_pop(L, 1);
+
+	lua_getfield(L, idx, "raster");
+	n->raster = lua_toboolean(L, -1);
+	lua_pop(L, 1);
+
+	return n->radius >= 0;
+}
+
+void
+widget_nodes_clear(drawin_t *d)
+{
+	p_delete(&d->widget_nodes);
+	d->widget_nodes_len = 0;
+}
+
+size_t
+widget_nodes_len(const drawin_t *d)
+{
+	return d->widget_nodes_len;
+}
+
+bool
+widget_nodes_set(lua_State *L, drawin_t *d, int idx)
+{
+	struct widget_node nodes[WIDGET_NODES_MAX];
+	size_t len;
+
+	/* A shape is applied to the drawable's own pixels, and a converted
+	 * container is no longer among them. */
+	if (d->shape_bounding || d->shape_clip || d->shape_input) {
+		widget_nodes_clear(d);
+		return false;
+	}
+
+	if (idx < 0)
+		idx = lua_gettop(L) + 1 + idx;
+	if (!lua_istable(L, idx)) {
+		widget_nodes_clear(d);
+		return false;
+	}
+
+	len = luaA_rawlen(L, idx);
+	if (len < 2 || len > WIDGET_NODES_MAX) {
+		widget_nodes_clear(d);
+		return false;
+	}
+
+	memset(nodes, 0, sizeof(nodes));
+	for (size_t i = 0; i < len; i++) {
+		bool ok;
+
+		lua_rawgeti(L, idx, (int)i + 1);
+		ok = read_node(L, lua_gettop(L), &nodes[i]);
+		lua_pop(L, 1);
+		if (!ok) {
+			widget_nodes_clear(d);
+			return false;
+		}
+	}
+	/* The leaf is the chain's whole point: without it the drawable's
+	 * pixels would have nowhere to land. */
+	if (!nodes[len - 1].raster) {
+		widget_nodes_clear(d);
+		return false;
+	}
+
+	if (d->widget_nodes_len == len
+			&& memcmp(d->widget_nodes, nodes, len * sizeof(*nodes)) == 0)
+		return true;
+
+	widget_nodes_clear(d);
+	d->widget_nodes = p_new(struct widget_node, len);
+	memcpy(d->widget_nodes, nodes, len * sizeof(*nodes));
+	d->widget_nodes_len = len;
+	/* A container's color or margin can change with no pixel in the
+	 * drawable's surface changing, so the chain has to wake the frame path
+	 * on its own; drawable:refresh() only speaks for the leaf. */
+	if (d->screen && d->screen->monitor && d->screen->monitor->declare)
+		declare_output_mark_dirty(d->screen->monitor->declare);
+	return true;
+}
+
+/* --- declaring the chain --- */
+
+/* The parts every node shares. The id mixes the drawin's registry id with
+ * the node's depth, so a chain that grows or shrinks renames nothing above
+ * the change and the reconciler keeps the nodes it already has. */
+static Clay_ElementDeclaration
+node_decl(const struct widget_node *n, uint32_t id, size_t depth)
+{
+	Clay_ElementDeclaration e = {
+		.id = Clay__HashString(CLAY_STRING("drawin.widget"), id,
+			(uint32_t)depth),
+		.layout = {
+			.sizing = {
+				.width = CLAY_SIZING_GROW(0),
+				.height = CLAY_SIZING_GROW(0),
+			},
+			.padding = { n->pad[0], n->pad[1], n->pad[2], n->pad[3] },
+		},
+		.cornerRadius = { n->radius, n->radius, n->radius, n->radius },
+	};
+
+	if (n->bg[3] > 0)
+		e.backgroundColor = clay_color(n->bg);
+	if (n->border[3] > 0) {
+		e.border.color = clay_color(n->border);
+		e.border.width = (Clay_BorderWidth) {
+			n->bw[0], n->bw[1], n->bw[2], n->bw[3], 0 };
+	}
+	return e;
+}
+
+/* Open every node, then close them all: the chain is a list, so each node is
+ * the previous one's only child. */
+void
+widget_declare(drawin_t *d, uint32_t id, int16_t z, int x, int y,
+	void *leaf_userdata)
+{
+	size_t len = d->widget_nodes_len;
+
+	for (size_t i = 0; i < len; i++) {
+		const struct widget_node *n = &d->widget_nodes[i];
+		Clay_ElementDeclaration e = node_decl(n, id, i);
+
+		if (i == 0) {
+			/* The drawin's box is somewm's, not Clay's: a fixed
+			 * floating leaf at the geometry rc.lua set, so Clay
+			 * places the chain without solving for it. */
+			e.layout.sizing.width = CLAY_SIZING_FIXED(d->width);
+			e.layout.sizing.height = CLAY_SIZING_FIXED(d->height);
+			e.floating.offset = (Clay_Vector2) { x, y };
+			e.floating.attachTo = CLAY_ATTACH_TO_ROOT;
+			e.floating.zIndex = z;
+		}
+		if (n->raster) {
+			e.image.imageData = &d->content_entry;
+			e.userData = leaf_userdata;
+		}
+		Clay__OpenElement();
+		Clay__ConfigureOpenElementPtr(&e);
+	}
+	while (len-- > 0)
+		Clay__CloseElement();
+}
+
+/* --- the test readback --- */
+
+static void
+solve_error(Clay_ErrorData error)
+{
+	fatal("clay error %d: %.*s", error.errorType, error.errorText.length,
+		error.errorText.chars);
+}
+
+int
+widget_solve_boxes(drawin_t *d, int (*boxes)[4], int cap)
+{
+	Clay_Context *previous = Clay_GetCurrentContext();
+	uint32_t arena_size = Clay_MinMemorySize();
+	void *arena = p_new(char, arena_size);
+	int n = 0;
+
+	Clay_Initialize(Clay_CreateArenaWithCapacityAndMemory(arena_size, arena),
+		(Clay_Dimensions) { d->width, d->height },
+		(Clay_ErrorHandler) { .errorHandlerFunction = solve_error });
+	Clay_SetCullingEnabled(false);
+
+	Clay_BeginLayout();
+	widget_declare(d, 1, 0, 0, 0, NULL);
+	Clay_EndLayout();
+
+	for (size_t i = 0; i < d->widget_nodes_len && n < cap; i++) {
+		Clay_ElementData data = Clay_GetElementData(
+			Clay__HashString(CLAY_STRING("drawin.widget"), 1,
+				(uint32_t)i));
+
+		if (!data.found)
+			continue;
+		/* Clay solves float32; round here so a box crossing into Lua
+		 * is the whole pixel the old layout would have placed. */
+		boxes[n][0] = (int)floorf(data.boundingBox.x + 0.5f);
+		boxes[n][1] = (int)floorf(data.boundingBox.y + 0.5f);
+		boxes[n][2] = (int)floorf(data.boundingBox.width + 0.5f);
+		boxes[n][3] = (int)floorf(data.boundingBox.height + 0.5f);
+		n++;
+	}
+
+	Clay_SetCurrentContext(previous);
+	p_delete(&arena);
+	return n;
+}

--- a/widget.c
+++ b/widget.c
@@ -1,23 +1,19 @@
 /*
- * widget.c - the widget-tree-to-Clay compile step's C half
+ * widget.c - the widget chain lua/wibox/clay.lua compiles
  *
  * lua/wibox/clay.lua walks a drawable's widget tree and describes the front
- * of it as a chain of containers Clay can solve. This file stores that
- * description on the drawin, declares it into the output's tree, and answers
- * the test readback. It never draws and never measures: a node is pure
- * description, and what the chain does not reach stays on the drawable's own
- * surface, declared as the chain's innermost leaf.
+ * of it as a chain of containers Clay can solve. This file reads that
+ * description off the Lua stack and stores it on the drawin. It holds no
+ * Clay: declaring the chain is declare.c's and drawing it is the renderer's,
+ * so a node here is nothing but the numbers Lua handed over.
  */
 
-#include <math.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include <lauxlib.h>
 
 #include "luaa.h"
 
-#include "clay.h"
 #include "widget.h"
 #include "common/util.h"
 #include "declare.h"
@@ -25,21 +21,9 @@
 #include "objects/drawin.h"
 #include "objects/screen.h"
 
-/* somewm colors are straight-alpha 0-1 floats; Clay_Color is 0-255. */
-static Clay_Color
-clay_color(const float rgba[4])
-{
-	return (Clay_Color) {
-		rgba[0] * 255.0f, rgba[1] * 255.0f,
-		rgba[2] * 255.0f, rgba[3] * 255.0f,
-	};
-}
-
-/* --- reading a chain off the Lua stack --- */
-
-/* A four-number array field (pad, bw, bg, border), or all zeroes when the
+/* A four-number array field (pad, bw, bg, border), left at zero when the
  * field is absent. False for a field that is present but not four numbers,
- * which is a compile-step bug rather than a config the walk should ride out. */
+ * which is a compile-step bug rather than a config to ride out. */
 static bool
 read_quad(lua_State *L, int idx, const char *name, float *out)
 {
@@ -96,17 +80,44 @@ read_node(lua_State *L, int idx, struct widget_node *n)
 	return n->radius >= 0;
 }
 
+/* The whole array at idx into nodes, or false for anything that is not a
+ * chain: a chain holds at least a root and the raster leaf that carries the
+ * drawable's own pixels, and the leaf is always last. */
+static bool
+read_chain(lua_State *L, int idx, struct widget_node *nodes, size_t *out_len)
+{
+	size_t len;
+
+	if (!lua_istable(L, idx))
+		return false;
+
+	len = luaA_rawlen(L, idx);
+	if (len < 2 || len > WIDGET_NODES_MAX)
+		return false;
+
+	memset(nodes, 0, len * sizeof(*nodes));
+	for (size_t i = 0; i < len; i++) {
+		bool ok;
+
+		lua_rawgeti(L, idx, (int)i + 1);
+		ok = read_node(L, lua_gettop(L), &nodes[i]);
+		lua_pop(L, 1);
+		if (!ok)
+			return false;
+	}
+	if (!nodes[len - 1].raster)
+		return false;
+
+	*out_len = len;
+	return true;
+}
+
 void
 widget_nodes_clear(drawin_t *d)
 {
 	p_delete(&d->widget_nodes);
 	d->widget_nodes_len = 0;
-}
-
-size_t
-widget_nodes_len(const drawin_t *d)
-{
-	return d->widget_nodes_len;
+	d->widget_nodes_declared = false;
 }
 
 bool
@@ -117,39 +128,8 @@ widget_nodes_set(lua_State *L, drawin_t *d, int idx)
 
 	/* A shape is applied to the drawable's own pixels, and a converted
 	 * container is no longer among them. */
-	if (d->shape_bounding || d->shape_clip || d->shape_input) {
-		widget_nodes_clear(d);
-		return false;
-	}
-
-	if (idx < 0)
-		idx = lua_gettop(L) + 1 + idx;
-	if (!lua_istable(L, idx)) {
-		widget_nodes_clear(d);
-		return false;
-	}
-
-	len = luaA_rawlen(L, idx);
-	if (len < 2 || len > WIDGET_NODES_MAX) {
-		widget_nodes_clear(d);
-		return false;
-	}
-
-	memset(nodes, 0, sizeof(nodes));
-	for (size_t i = 0; i < len; i++) {
-		bool ok;
-
-		lua_rawgeti(L, idx, (int)i + 1);
-		ok = read_node(L, lua_gettop(L), &nodes[i]);
-		lua_pop(L, 1);
-		if (!ok) {
-			widget_nodes_clear(d);
-			return false;
-		}
-	}
-	/* The leaf is the chain's whole point: without it the drawable's
-	 * pixels would have nowhere to land. */
-	if (!nodes[len - 1].raster) {
+	if (d->shape_bounding || d->shape_clip || d->shape_input
+			|| !read_chain(L, idx, nodes, &len)) {
 		widget_nodes_clear(d);
 		return false;
 	}
@@ -168,115 +148,4 @@ widget_nodes_set(lua_State *L, drawin_t *d, int idx)
 	if (d->screen && d->screen->monitor && d->screen->monitor->declare)
 		declare_output_mark_dirty(d->screen->monitor->declare);
 	return true;
-}
-
-/* --- declaring the chain --- */
-
-/* The parts every node shares. The id mixes the drawin's registry id with
- * the node's depth, so a chain that grows or shrinks renames nothing above
- * the change and the reconciler keeps the nodes it already has. */
-static Clay_ElementDeclaration
-node_decl(const struct widget_node *n, uint32_t id, size_t depth)
-{
-	Clay_ElementDeclaration e = {
-		.id = Clay__HashString(CLAY_STRING("drawin.widget"), id,
-			(uint32_t)depth),
-		.layout = {
-			.sizing = {
-				.width = CLAY_SIZING_GROW(0),
-				.height = CLAY_SIZING_GROW(0),
-			},
-			.padding = { n->pad[0], n->pad[1], n->pad[2], n->pad[3] },
-		},
-		.cornerRadius = { n->radius, n->radius, n->radius, n->radius },
-	};
-
-	if (n->bg[3] > 0)
-		e.backgroundColor = clay_color(n->bg);
-	if (n->border[3] > 0) {
-		e.border.color = clay_color(n->border);
-		e.border.width = (Clay_BorderWidth) {
-			n->bw[0], n->bw[1], n->bw[2], n->bw[3], 0 };
-	}
-	return e;
-}
-
-/* Open every node, then close them all: the chain is a list, so each node is
- * the previous one's only child. */
-void
-widget_declare(drawin_t *d, uint32_t id, int16_t z, int x, int y,
-	void *leaf_userdata)
-{
-	size_t len = d->widget_nodes_len;
-
-	for (size_t i = 0; i < len; i++) {
-		const struct widget_node *n = &d->widget_nodes[i];
-		Clay_ElementDeclaration e = node_decl(n, id, i);
-
-		if (i == 0) {
-			/* The drawin's box is somewm's, not Clay's: a fixed
-			 * floating leaf at the geometry rc.lua set, so Clay
-			 * places the chain without solving for it. */
-			e.layout.sizing.width = CLAY_SIZING_FIXED(d->width);
-			e.layout.sizing.height = CLAY_SIZING_FIXED(d->height);
-			e.floating.offset = (Clay_Vector2) { x, y };
-			e.floating.attachTo = CLAY_ATTACH_TO_ROOT;
-			e.floating.zIndex = z;
-		}
-		if (n->raster) {
-			e.image.imageData = &d->content_entry;
-			e.userData = leaf_userdata;
-		}
-		Clay__OpenElement();
-		Clay__ConfigureOpenElementPtr(&e);
-	}
-	while (len-- > 0)
-		Clay__CloseElement();
-}
-
-/* --- the test readback --- */
-
-static void
-solve_error(Clay_ErrorData error)
-{
-	fatal("clay error %d: %.*s", error.errorType, error.errorText.length,
-		error.errorText.chars);
-}
-
-int
-widget_solve_boxes(drawin_t *d, int (*boxes)[4], int cap)
-{
-	Clay_Context *previous = Clay_GetCurrentContext();
-	uint32_t arena_size = Clay_MinMemorySize();
-	void *arena = p_new(char, arena_size);
-	int n = 0;
-
-	Clay_Initialize(Clay_CreateArenaWithCapacityAndMemory(arena_size, arena),
-		(Clay_Dimensions) { d->width, d->height },
-		(Clay_ErrorHandler) { .errorHandlerFunction = solve_error });
-	Clay_SetCullingEnabled(false);
-
-	Clay_BeginLayout();
-	widget_declare(d, 1, 0, 0, 0, NULL);
-	Clay_EndLayout();
-
-	for (size_t i = 0; i < d->widget_nodes_len && n < cap; i++) {
-		Clay_ElementData data = Clay_GetElementData(
-			Clay__HashString(CLAY_STRING("drawin.widget"), 1,
-				(uint32_t)i));
-
-		if (!data.found)
-			continue;
-		/* Clay solves float32; round here so a box crossing into Lua
-		 * is the whole pixel the old layout would have placed. */
-		boxes[n][0] = (int)floorf(data.boundingBox.x + 0.5f);
-		boxes[n][1] = (int)floorf(data.boundingBox.y + 0.5f);
-		boxes[n][2] = (int)floorf(data.boundingBox.width + 0.5f);
-		boxes[n][3] = (int)floorf(data.boundingBox.height + 0.5f);
-		n++;
-	}
-
-	Clay_SetCurrentContext(previous);
-	p_delete(&arena);
-	return n;
 }

--- a/widget.h
+++ b/widget.h
@@ -1,0 +1,60 @@
+#ifndef SOMEWM_WIDGET_H
+#define SOMEWM_WIDGET_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <lua.h>
+
+typedef struct drawin_t drawin_t;
+
+/* One converted widget container, as lua/wibox/clay.lua describes it.
+ *
+ * The chain is a list, not a tree: conversion walks down from the drawable's
+ * root widget and stops at the first node it cannot express, so every node
+ * has exactly one child and the last node is always the raster leaf, the
+ * drawable's own surface holding whatever the walk did not reach.
+ *
+ * Colors are straight alpha, 0-1, as everywhere else on this side; an alpha
+ * of zero means the node draws no fill or no ring. */
+struct widget_node {
+	uint16_t pad[4];     /* left, right, top, bottom */
+	uint16_t bw[4];      /* border widths, same order */
+	float bg[4];
+	float border[4];
+	float radius;
+	bool raster;
+};
+
+/* A chain longer than this is refused rather than truncated. Deep enough
+ * that no real config reaches it, and it bounds the per-drawin element
+ * count the output's Clay arena has to hold. */
+#define WIDGET_NODES_MAX 32
+
+/* Read a chain off the top of the Lua stack (the array lua/wibox/clay.lua
+ * returns) and store it on d, replacing whatever was there. Returns false
+ * and stores nothing when the chain is malformed or the drawin cannot take
+ * one, which is Lua's signal to paint the whole drawable itself.
+ *
+ * A shaped drawin is refused: shape_bounding and shape_clip are applied to
+ * the drawable's own pixels (objects/drawin.c), which a converted container
+ * is no longer part of, and shape_input's pass-through would be swallowed by
+ * the converted node's scene rect, which takes input everywhere it draws. */
+bool widget_nodes_set(lua_State *L, drawin_t *d, int idx);
+void widget_nodes_clear(drawin_t *d);
+size_t widget_nodes_len(const drawin_t *d);
+
+/* Declare d's chain into the current Clay context: one fixed floating
+ * element at the drawin's output-local box, each further node growing into
+ * its parent, and the leaf carrying the drawable's image entry. */
+void widget_declare(drawin_t *d, uint32_t id, int16_t z, int x, int y,
+	void *leaf_userdata);
+
+/* Test readback (awesome._test_widget_boxes): solve the chain alone at the
+ * drawin's size and report each node's box, drawin-local and rounded, so a
+ * test can compare what Clay solves against what wibox's own layout would
+ * have placed. Returns the number of boxes written. */
+int widget_solve_boxes(drawin_t *d, int (*boxes)[4], int cap);
+
+#endif

--- a/widget.h
+++ b/widget.h
@@ -32,8 +32,9 @@ struct widget_node {
  * count the output's Clay arena has to hold. */
 #define WIDGET_NODES_MAX 32
 
-/* Read a chain off the top of the Lua stack (the array lua/wibox/clay.lua
- * returns) and store it on d, replacing whatever was there. Returns false
+/* Read a chain from the array at absolute stack index idx (what
+ * lua/wibox/clay.lua returns) and store it on d, replacing whatever was
+ * there. Returns false
  * and stores nothing when the chain is malformed or the drawin cannot take
  * one, which is Lua's signal to paint the whole drawable itself.
  *
@@ -43,18 +44,5 @@ struct widget_node {
  * the converted node's scene rect, which takes input everywhere it draws. */
 bool widget_nodes_set(lua_State *L, drawin_t *d, int idx);
 void widget_nodes_clear(drawin_t *d);
-size_t widget_nodes_len(const drawin_t *d);
-
-/* Declare d's chain into the current Clay context: one fixed floating
- * element at the drawin's output-local box, each further node growing into
- * its parent, and the leaf carrying the drawable's image entry. */
-void widget_declare(drawin_t *d, uint32_t id, int16_t z, int x, int y,
-	void *leaf_userdata);
-
-/* Test readback (awesome._test_widget_boxes): solve the chain alone at the
- * drawin's size and report each node's box, drawin-local and rounded, so a
- * test can compare what Clay solves against what wibox's own layout would
- * have placed. Returns the number of boxes written. */
-int widget_solve_boxes(drawin_t *d, int (*boxes)[4], int cap);
 
 #endif


### PR DESCRIPTION
## Description
wibox.container.margin and wibox.container.background compile to Clay declarations. The walk starts at the drawable's root widget and stops at the first one it cannot express; that widget and everything under it keeps painting into the drawable's surface, which is declared as the innermost leaf. Screenshot capture now walks the scene for rectangles as well as buffers, or a converted background would be missing from it.