### PR TITLE
fix(check): report each finding once, and name the right tool

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -3223,10 +3223,17 @@ static const x11_pattern_t x11_patterns[] = {
 	 "Xresources are X11-only. Use beautiful.xresources or your terminal's own config", SEVERITY_WARNING},
 	{"'xrdb", "xrdb Xresources loading",
 	 "Xresources are X11-only. Use beautiful.xresources or your terminal's own config", SEVERITY_WARNING},
-	{"\"xset", "xset display settings",
+	/* Trailing space: bare "xset matches "xsettingsd, a different program. */
+	{"\"xset ", "xset display settings",
 	 "Most settings are handled by compositor or wlr-randr", SEVERITY_WARNING},
-	{"'xset", "xset display settings",
+	{"'xset ", "xset display settings",
 	 "Most settings are handled by compositor or wlr-randr", SEVERITY_WARNING},
+	/* XSETTINGS is an X11 protocol, so the daemon has nothing to talk to.
+	 * Trailing space to catch the spawn, not a path or a local of that name. */
+	{"\"xsettingsd ", "xsettingsd XSETTINGS daemon",
+	 "XSETTINGS is X11-only. Use gsettings or gtk config files", SEVERITY_WARNING},
+	{"'xsettingsd ", "xsettingsd XSETTINGS daemon",
+	 "XSETTINGS is X11-only. Use gsettings or gtk config files", SEVERITY_WARNING},
 	{"\"xinput", "xinput device settings",
 	 "Use compositor input settings or libinput config", SEVERITY_WARNING},
 	{"'xinput", "xinput device settings",
@@ -3395,7 +3402,7 @@ prescan_module_is_external(const char *name)
  */
 static bool
 prescan_next_require(const char **pos, const char *content,
-                     char *out, size_t outlen)
+                     char *out, size_t outlen, int *line_out)
 {
 	const char *p = *pos;
 
@@ -3413,6 +3420,13 @@ prescan_next_require(const char **pos, const char *content,
 		line = p;
 		while (line > content && *(line - 1) != '\n')
 			line--;
+		if (line_out) {
+			const char *c;
+			*line_out = 1;
+			for (c = content; c < line; c++)
+				if (*c == '\n')
+					(*line_out)++;
+		}
 		for (indent = line; indent < p && (*indent == ' ' || *indent == '\t'); indent++)
 			;
 		if (indent[0] == '-' && indent[1] == '-') {
@@ -3435,6 +3449,16 @@ prescan_next_require(const char **pos, const char *content,
 		len = end - start;
 		memcpy(out, start, len);
 		out[len] = '\0';
+
+		/* require("pkg.mod." .. name) leaves a trailing dot, which becomes a
+		 * trailing slash and resolves to the same file twice. A concatenated
+		 * name cannot be resolved statically, so skip it. */
+		if (len == 0 || out[0] == '.' || out[len - 1] == '.' ||
+		    strstr(out, "..") != NULL) {
+			p = end + 1;
+			continue;
+		}
+
 		*pos = end + 1;
 		return true;
 	}
@@ -3493,11 +3517,13 @@ luaA_prescan_requires(const char *content, const char *config_dir, int depth)
 	const char *pos = content;
 	char module_name[256];
 	char path[PATH_MAX], try1[PATH_MAX], try2[PATH_MAX];
+	int require_line = 0;
 
 	if (depth >= PRESCAN_MAX_DEPTH || !config_dir)
 		return;
 
-	while (prescan_next_require(&pos, content, module_name, sizeof(module_name))) {
+	while (prescan_next_require(&pos, content, module_name, sizeof(module_name),
+	                            &require_line)) {
 		if (prescan_module_is_external(module_name))
 			continue;
 
@@ -3721,9 +3747,20 @@ check_mode_add_issue(const char *file_path, int line_num, const char *line_conte
                      const x11_pattern_t *pattern)
 {
 	check_issue_t *issue;
+	int i;
 
 	if (check_issue_count >= CHECK_MAX_ISSUES)
 		return;
+
+	/* Several patterns describe the same tool ("xclip, 'xclip, | xclip), so one
+	 * line can match more than once. Report it once. */
+	for (i = 0; i < check_issue_count; i++) {
+		if (check_issues[i].line_number == line_num &&
+		    !check_issues[i].is_syntax_error &&
+		    !strcmp(check_issues[i].pattern_desc, pattern->description) &&
+		    !strcmp(check_issues[i].file_path, file_path))
+			return;
+	}
 
 	issue = &check_issues[check_issue_count++];
 	issue->file_path = strdup(file_path);
@@ -3774,7 +3811,8 @@ check_mode_add_syntax_error(const char *file_path, const char *error_msg)
 
 /** Store a missing module error found during check mode */
 static void
-check_mode_add_missing_module(const char *source_file, const char *module_name,
+check_mode_add_missing_module(const char *source_file, int line_num,
+                              const char *module_name,
                               const char *tried_path1, const char *tried_path2)
 {
 	check_issue_t *issue;
@@ -3787,7 +3825,7 @@ check_mode_add_missing_module(const char *source_file, const char *module_name,
 
 	issue = &check_issues[check_issue_count++];
 	issue->file_path = strdup(source_file);
-	issue->line_number = 0;
+	issue->line_number = line_num;
 	issue->line_content = strdup("");
 	issue->pattern_desc = strdup(desc);
 	issue->suggestion = "Check module path or install missing dependency";
@@ -4082,11 +4120,13 @@ check_mode_scan_requires(const char *content, const char *config_dir,
 	const char *pos = content;
 	char module_name[256];
 	char path[PATH_MAX], try1[PATH_MAX], try2[PATH_MAX];
+	int require_line = 0;
 
 	if (depth >= PRESCAN_MAX_DEPTH || !config_dir)
 		return;
 
-	while (prescan_next_require(&pos, content, module_name, sizeof(module_name))) {
+	while (prescan_next_require(&pos, content, module_name, sizeof(module_name),
+	                            &require_line)) {
 		if (prescan_module_is_external(module_name))
 			continue;
 
@@ -4094,7 +4134,8 @@ check_mode_scan_requires(const char *content, const char *config_dir,
 		                           try1, sizeof(try1), try2, sizeof(try2)))
 			check_mode_scan_file(path, config_dir, depth + 1);
 		else
-			check_mode_add_missing_module(source_file, module_name, try1, try2);
+			check_mode_add_missing_module(source_file, require_line,
+			                              module_name, try1, try2);
 	}
 }
 

--- a/tests/restart/configs/prescan/rc.lua
+++ b/tests/restart/configs/prescan/rc.lua
@@ -5,10 +5,12 @@
 -- past its rc.lua. The module carries somewm's one CRITICAL pattern, and this
 -- config still has to load: the scanner warns, it does not refuse.
 
--- A path that only looks like an X11 tool: the scanner matches its xset
--- pattern inside this name. Refusing a config over that is what warn-only
--- fixes. Keep the pattern out of this comment: only the first occurrence
--- of a pattern in a file is examined, so a comment above would mask it.
+-- A genuine X11 call. It is reported, and the config still loads: the
+-- scanner warns, it does not refuse.
+local x11_call = "xset s off"
+
+-- A different program whose name starts the same way. It must not be
+-- reported as the one above.
 local x11_lookalike = "xsettingsd"
 
 dofile(assert(os.getenv("SOMEWM_TEST_BASE_RC"),
@@ -16,4 +18,4 @@ dofile(assert(os.getenv("SOMEWM_TEST_BASE_RC"),
 
 require("deepmod")
 
-return x11_lookalike
+return x11_call, x11_lookalike

--- a/tests/restart/prescan-warns-without-blocking.sh
+++ b/tests/restart/prescan-warns-without-blocking.sh
@@ -5,8 +5,7 @@
 # Two faults used to compound here. Any require() whose name had no dot was
 # treated as a standard library and skipped, so a config split across modules
 # was never read past its rc.lua. And any pattern that did match refused the
-# whole config, which cost valid configs over substring matches such as "xset
-# matching a path named xsettingsd.
+# whole config, so one reported call was enough to lose the config.
 #
 # A config that genuinely hangs is caught by the load alarm instead.
 
@@ -19,8 +18,9 @@ check_eval hr-prescan "the module behind the dotless require ran" \
 check_eval hr-prescan "and the compositor serves the API" \
     'return tostring(screen.count())' 1
 
-check_log hr-prescan "the substring match in rc.lua was reported" \
+check_log hr-prescan "the X11 call in rc.lua was reported" \
     "xset display settings"
+check_log_count hr-prescan "but the lookalike name was not" "xsettingsd" 0
 check_log hr-prescan "the scanner reached the required module" "deepmod.lua"
 check_log hr-prescan "and reported the pattern it found there" \
     "GDK initialization deadlock"

--- a/tests/test-check-mode.sh
+++ b/tests/test-check-mode.sh
@@ -591,6 +591,93 @@ end)')
 }
 test_client_icon_info
 
+# Four patterns describe xclip ("xclip, 'xclip, | xclip, " xclip "), and more
+# than one can match the same line. The report should name it once.
+test_overlapping_patterns_report_once() {
+    local name="overlapping_patterns_report_once"
+    local cfg
+    cfg=$(write_config "dupe.lua" 'local cmd = "xclip -selection clipboard | xclip -i"')
+    run_check "$cfg"
+    local hits
+    hits=$(echo "$CHECK_STDOUT" | grep -c "xclip clipboard tool")
+    if [ "$hits" -ne 1 ]; then
+        fail "$name" "expected 1 xclip finding, got $hits"
+        return
+    fi
+    pass "$name"
+}
+test_overlapping_patterns_report_once
+
+# require("pkg.mod." .. name) yields a trailing dot, which used to resolve to
+# <dir>/pkg/mod//init.lua and scan the same file a second time.
+test_dynamic_require_not_scanned_twice() {
+    local name="dynamic_require_not_scanned_twice"
+    local cfg
+    mkdir -p "$TMP_DIR/widgets"
+    printf '%s\n' 'local cmd = "maim -s"' > "$TMP_DIR/widgets/init.lua"
+    cfg=$(write_config "dyn.lua" 'local w = require("widgets")
+for _, k in ipairs({"a"}) do w[k] = require("widgets." .. k) end')
+    run_check "$cfg"
+    assert_not_contains "$name" "//init.lua" || return
+    local hits
+    hits=$(echo "$CHECK_STDOUT" | grep -c "maim screenshot tool")
+    if [ "$hits" -ne 1 ]; then
+        fail "$name" "expected 1 maim finding, got $hits"
+        return
+    fi
+    pass "$name"
+}
+test_dynamic_require_not_scanned_twice
+
+# xsettingsd is a different program from xset, and needs different advice.
+test_xsettingsd_is_not_xset() {
+    local name="xsettingsd_is_not_xset"
+    local cfg
+    cfg=$(write_config "xsd.lua" 'os.execute("xsettingsd --config /etc/xsettingsd &")')
+    run_check "$cfg"
+    assert_contains "$name" "xsettingsd XSETTINGS daemon" || return
+    assert_not_contains "$name" "xset display settings" || return
+    pass "$name"
+}
+test_xsettingsd_is_not_xset
+
+# A path or a local named xsettingsd is not a spawn of it.
+test_xsettingsd_name_is_not_a_spawn() {
+    local name="xsettingsd_name_is_not_a_spawn"
+    local cfg
+    cfg=$(write_config "xsdname.lua" 'local xsettingsd = dir .. "xsettingsd"
+local f = io.open(xsettingsd, "r")')
+    run_check "$cfg"
+    assert_not_contains "$name" "xsettingsd XSETTINGS daemon" || return
+    pass "$name"
+}
+test_xsettingsd_name_is_not_a_spawn
+
+# A real xset call still has to be caught.
+test_xset_still_warns() {
+    local name="xset_still_warns"
+    local cfg
+    cfg=$(write_config "xset.lua" 'awful.spawn("xset s on +dpms")')
+    run_check "$cfg"
+    assert_contains "$name" "xset display settings" || return
+    pass "$name"
+}
+test_xset_still_warns
+
+# A missing module used to be reported at line 0.
+test_missing_module_has_line_number() {
+    local name="missing_module_has_line_number"
+    local cfg
+    cfg=$(write_config "modline.lua" '-- padding
+-- padding
+local _m = require("totally_missing_module_xyz")')
+    run_check "$cfg"
+    assert_contains "$name" "modline.lua:3" || return
+    assert_not_contains "$name" "modline.lua:0" || return
+    pass "$name"
+}
+test_missing_module_has_line_number
+
 # === Summary ===
 
 echo ""


### PR DESCRIPTION
## Description
`somewm --check` listed the same problem more than once and got one name wrong. Four separate patterns look for `xclip`, so a line using it was reported four times. A `require()` built by joining strings
  made the checker read the same file twice. Anything starting with `xset` matched, including `xsettingsd`, which is a different program. Missing modules were reported at line 0 instead of the line they were
  on.