### PR TITLE
fix(test): keep the log when a nested start fails

### DIFF
--- a/test_orchestrator.c
+++ b/test_orchestrator.c
@@ -761,6 +761,9 @@ test_start(int argc, char *argv[])
 		_exit(127);
 	}
 
+	/* Past this point a failure keeps the state directory. The log is the only
+	 * account of why the start failed, and the next start under this name
+	 * clears the directory anyway. */
 	if (write_pidfile_excl(state_dir, pid) < 0) {
 		fprintf(stderr, "Error: could not write pidfile\n");
 		kill(pid, SIGTERM);
@@ -772,8 +775,6 @@ test_start(int argc, char *argv[])
 		fprintf(stderr,
 		        "       Inspect %s for details.\n", log_path);
 		kill_and_wait(pid, sock_path);
-		if (!getenv("SOMEWM_TEST_KEEP_FAILED"))
-			rmtree(state_dir);
 		return 5;
 	}
 
@@ -782,8 +783,6 @@ test_start(int argc, char *argv[])
 		fprintf(stderr, "Error: nested compositor reported %s\n", fatal_line);
 		fprintf(stderr, "       Inspect %s for the full log.\n", log_path);
 		kill_and_wait(pid, sock_path);
-		if (!getenv("SOMEWM_TEST_KEEP_FAILED"))
-			rmtree(state_dir);
 		return 5;
 	}
 

--- a/tests/restart/lib.sh
+++ b/tests/restart/lib.sh
@@ -38,7 +38,6 @@ SOMEWM_EVAL_PACE=${SOMEWM_EVAL_PACE:-0.5}
 # The orchestrator must find the compositor, and a failed start must leave the
 # state dir (including the log) behind for us to copy.
 export SOMEWM_BINARY="$SOMEWM"
-export SOMEWM_TEST_KEEP_FAILED=1
 
 # Pin the closure guard to the one built beside the binary under test. The
 # compositor self-installs it by re-exec and looks in its compiled-in libdir


### PR DESCRIPTION
## Description

When `somewm-client test start` failed, it printed the path to the log and then deleted the directory holding it, so the only record of why the start failed was gone before you could read it. The directory now stays put.