### PR TITLE
fix(check): an unbound xproperty call is fatal, not a warning

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -3067,6 +3067,9 @@ pattern_doc_anchor(const char *description)
 		{"awful.widget.clienticon - clients have no icon", "client-icons"},
 		{"c.icon - clients have no icon", "client-icons"},
 		{"xrdb Xresources loading", "xresources-and-xrdb"},
+		{"awesome.get_xproperty() - not defined", "x11-properties"},
+		{"awesome.set_xproperty() - not defined", "x11-properties"},
+		{"awesome.register_xproperty() - does nothing", "x11-properties"},
 		{NULL, NULL}
 	};
 	int i;
@@ -3081,14 +3084,17 @@ pattern_doc_anchor(const char *description)
 static const x11_pattern_t x11_patterns[] = {
 	/* === CRITICAL: Will fail or hang === */
 
-	/* X11 property APIs - safe no-op stubs that won't hang
-	 * Downgraded to WARNING since they just return nil, not block */
-	{"awesome.get_xproperty", "awesome.get_xproperty() [X11 only]",
-	 "Use persistent storage (gears.filesystem) or remove", SEVERITY_WARNING},
-	{"awesome.set_xproperty", "awesome.set_xproperty() [X11 only]",
-	 "Use persistent storage (gears.filesystem) or remove", SEVERITY_WARNING},
-	{"awesome.register_xproperty", "awesome.register_xproperty() [X11 only]",
-	 "Remove - X11 properties don't exist on Wayland", SEVERITY_WARNING},
+	/* Only register_xproperty is bound, as a no-op. get and set are not, so
+	 * calling either raises and the whole config fails to load. */
+	{"awesome.get_xproperty", "awesome.get_xproperty() - not defined",
+	 "Calling it aborts the config. For restart detection use awesome.startup",
+	 SEVERITY_CRITICAL},
+	{"awesome.set_xproperty", "awesome.set_xproperty() - not defined",
+	 "Calling it aborts the config. For restart detection use awesome.startup",
+	 SEVERITY_CRITICAL},
+	{"awesome.register_xproperty", "awesome.register_xproperty() - does nothing",
+	 "It is a no-op stub. Remove it, X11 properties don't exist on Wayland",
+	 SEVERITY_WARNING},
 
 	/* Blocking X11 tool calls that will hang */
 	{"io.popen(\"xrandr", "io.popen with xrandr (blocks)",

--- a/tests/restart/configs/startup/rc.lua
+++ b/tests/restart/configs/startup/rc.lua
@@ -1,0 +1,8 @@
+-- Records awesome.startup as the config sees it. The property is computed from
+-- the main loop rather than latched, so reading it later always gives false:
+-- only a read during the config load distinguishes a start from a reload.
+
+STARTUP_AT_LOAD = awesome.startup
+
+dofile(assert(os.getenv("SOMEWM_TEST_BASE_RC"),
+    "SOMEWM_TEST_BASE_RC must point at the base config to load"))

--- a/tests/restart/startup-flag-across-reload.sh
+++ b/tests/restart/startup-flag-across-reload.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# awesome.startup tells a config whether this is a fresh start or a reload.
+#
+# somewm --check points configs at it as the replacement for the X11 restart
+# probe built from awesome.get_xproperty, which is not bound here. That advice
+# only holds while the flag reads true during a fresh start's config load and
+# false during a reload's, so pin both.
+
+. "$(dirname "$0")/lib.sh"
+
+sw_start hr-startup --config "$RESTART_DIR/configs/startup/rc.lua" || finish
+
+check_eval hr-startup "a fresh start loads its config with startup true" \
+    'return tostring(STARTUP_AT_LOAD)' true
+check_eval hr-startup "and the flag is false once the loop is running" \
+    'return tostring(awesome.startup)' false
+
+sw_reload hr-startup || finish
+
+check_eval hr-startup "a reload loads its config with startup false" \
+    'return tostring(STARTUP_AT_LOAD)' false
+
+sw_check_log_clean hr-startup "post-reload log"
+
+finish

--- a/tests/test-check-mode.sh
+++ b/tests/test-check-mode.sh
@@ -678,6 +678,31 @@ local _m = require("totally_missing_module_xyz")')
 }
 test_missing_module_has_line_number
 
+# get_xproperty and set_xproperty are not bound at all, so calling either
+# raises and the config never loads. register_xproperty is a real no-op stub.
+test_xproperty_get_is_critical() {
+    local name="xproperty_get_is_critical"
+    local cfg
+    cfg=$(write_config "xprop_get.lua" 'local seen = awesome.get_xproperty("restarted")')
+    run_check "$cfg"
+    assert_exit "$name" 2 || return
+    assert_contains "$name" "awesome.get_xproperty() - not defined" || return
+    assert_contains "$name" "awesome.startup" || return
+    pass "$name"
+}
+test_xproperty_get_is_critical
+
+test_xproperty_register_stays_warning() {
+    local name="xproperty_register_stays_warning"
+    local cfg
+    cfg=$(write_config "xprop_reg.lua" 'awesome.register_xproperty("restarted", "boolean")')
+    run_check "$cfg"
+    assert_exit "$name" 1 || return
+    assert_contains "$name" "does nothing" || return
+    pass "$name"
+}
+test_xproperty_register_stays_warning
+
 # === Summary ===
 
 echo ""


### PR DESCRIPTION
## Description
`awesome.get_xproperty` and `awesome.set_xproperty` don't exist. Calling either one stops your config loading, so you get the fallback desktop instead of your own. `--check` called that a warning. It is critical now, and points at `awesome.startup`