### PR TITLE
fix: awesome.startup reads true during a hot-reload

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -2333,7 +2333,11 @@ luaA_awesome_index(lua_State *L)
 	}
 
 	if (A_STREQ(key, "startup")) {
-		lua_pushboolean(L, globalconf.loop == NULL);
+		/* Upstream restarts by execvp, so its rc.lua and client scan
+		 * always run before the loop exists. Ours run inside the loop
+		 * during a hot-reload, which must read as startup too. */
+		lua_pushboolean(L, globalconf.loop == NULL ||
+			globalconf.hot_reload_in_progress);
 		return 1;
 	}
 
@@ -3316,10 +3320,10 @@ static const x11_pattern_t x11_patterns[] = {
 	/* Only register_xproperty is bound, as a no-op. get and set are not, so
 	 * calling either raises and the whole config fails to load. */
 	{"awesome.get_xproperty", "awesome.get_xproperty() - not defined",
-	 "Calling it aborts the config. For restart detection use awesome.startup",
+	 "Calling it aborts the config. For restart detection use awesome._restart",
 	 SEVERITY_CRITICAL},
 	{"awesome.set_xproperty", "awesome.set_xproperty() - not defined",
-	 "Calling it aborts the config. For restart detection use awesome.startup",
+	 "Calling it aborts the config. For restart detection use awesome._restart",
 	 SEVERITY_CRITICAL},
 	{"awesome.register_xproperty", "awesome.register_xproperty() - does nothing",
 	 "It is a no-op stub. Remove it, X11 properties don't exist on Wayland",

--- a/tests/restart/README.md
+++ b/tests/restart/README.md
@@ -190,8 +190,11 @@ release it on `"exit"` reddens whichever reload test runs next.
   config under a running instance, since no startup can reach that state: at
   startup there are no clients yet.
 - `tags-after-restart`, `client-survives-restart`, `client-order-after-restart`,
-  `transient-screen-restart`: clients, tags, stacking order and transient
-  relationships survive a reload.
+  `transient-screen-restart`, `client-screen-after-restart`: clients, tags,
+  stacking order, transient relationships and the client's screen survive a
+  reload.
+- `startup-flag-across-reload`: `awesome.startup` is true during a reload's
+  config load too, and `awesome._restart` says which it was.
 
 Config-timeout tests (a config that hangs longer than the limit is aborted and
 the fallback loads):

--- a/tests/restart/client-screen-after-restart.sh
+++ b/tests/restart/client-screen-after-restart.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# A client on a screen the mouse is not on stays there across a hot-reload.
+# The default config's screen rule is awful.screen.preferred, which keeps
+# c.screen only while awesome.startup reads true.
+
+. "$(dirname "$0")/lib.sh"
+
+sw_require_helper test-fullscreen-client
+CLIENT=$SW_HELPER
+
+sw_start hr-screen --config "$RESTART_DIR/configs/preferred-screen/rc.lua" || finish
+
+sw_eval hr-screen 'awesome._test_add_output(800, 600)'
+check_wait_true hr-screen "a second screen exists" 'return tostring(screen.count() == 2)' || finish
+
+sw_spawn hr-screen "$CLIENT" || finish
+check_client_appeared hr-screen fullscreen_test || finish
+
+# Assign the screen directly: move_to_screen drags the mouse along with the
+# client, and the whole point is that the mouse is on the other screen.
+check_eval hr-screen "the client is on screen 2 and the mouse on screen 1" \
+    'client.get()[1].screen = screen[2]; local g = screen[1].geometry; mouse.coords({ x = g.x + g.width / 2, y = g.y + g.height / 2 }); return tostring(client.get()[1].screen.index) .. "/" .. tostring(mouse.screen.index)' \
+    "2/1"
+
+sw_reload hr-screen || finish
+
+check_eval hr-screen "the client is still on screen 2 after the reload" \
+    'return tostring(client.get()[1].screen.index)' 2
+
+sw_check_log_clean hr-screen "post-reload log"
+
+finish

--- a/tests/restart/configs/preferred-screen/rc.lua
+++ b/tests/restart/configs/preferred-screen/rc.lua
@@ -1,0 +1,9 @@
+-- The default config's screen rule.
+
+dofile(assert(os.getenv("SOMEWM_TEST_BASE_RC"),
+    "SOMEWM_TEST_BASE_RC must point at the base config to load"))
+
+require("ruled.client").append_rule {
+    rule = {},
+    properties = { screen = require("awful").screen.preferred },
+}

--- a/tests/restart/configs/startup/rc.lua
+++ b/tests/restart/configs/startup/rc.lua
@@ -1,8 +1,10 @@
--- Records awesome.startup as the config sees it. The property is computed from
--- the main loop rather than latched, so reading it later always gives false:
--- only a read during the config load distinguishes a start from a reload.
+-- Records the two flags as the config sees them. awesome.startup is computed
+-- rather than latched, so reading it later always gives false: only a read
+-- during the config load sees it true. awesome._restart is nil on a fresh start
+-- and true once a reload has begun.
 
 STARTUP_AT_LOAD = awesome.startup
+RESTART_AT_LOAD = awesome._restart
 
 dofile(assert(os.getenv("SOMEWM_TEST_BASE_RC"),
     "SOMEWM_TEST_BASE_RC must point at the base config to load"))

--- a/tests/restart/startup-flag-across-reload.sh
+++ b/tests/restart/startup-flag-across-reload.sh
@@ -1,25 +1,23 @@
 #!/usr/bin/env bash
 #
-# awesome.startup tells a config whether this is a fresh start or a reload.
-#
-# somewm --check points configs at it as the replacement for the X11 restart
-# probe built from awesome.get_xproperty, which is not bound here. That advice
-# only holds while the flag reads true during a fresh start's config load and
-# false during a reload's, so pin both.
+# awesome.startup is true while a config loads, on a fresh start and on a
+# reload alike, and false once the loop is running. awesome._restart is what
+# says which of the two it was; somewm --check points configs at it as the
+# replacement for the X11 restart probe built from awesome.get_xproperty.
 
 . "$(dirname "$0")/lib.sh"
 
+FLAGS='return tostring(STARTUP_AT_LOAD) .. "/" .. tostring(RESTART_AT_LOAD) .. "/" .. tostring(awesome.startup)'
+
 sw_start hr-startup --config "$RESTART_DIR/configs/startup/rc.lua" || finish
 
-check_eval hr-startup "a fresh start loads its config with startup true" \
-    'return tostring(STARTUP_AT_LOAD)' true
-check_eval hr-startup "and the flag is false once the loop is running" \
-    'return tostring(awesome.startup)' false
+check_eval hr-startup "fresh start: startup true at load, _restart unset, startup false in the loop" \
+    "$FLAGS" "true/nil/false"
 
 sw_reload hr-startup || finish
 
-check_eval hr-startup "a reload loads its config with startup false" \
-    'return tostring(STARTUP_AT_LOAD)' false
+check_eval hr-startup "reload: startup true at load, _restart true, startup false in the loop" \
+    "$FLAGS" "true/true/false"
 
 sw_check_log_clean hr-startup "post-reload log"
 

--- a/tests/test-check-mode.sh
+++ b/tests/test-check-mode.sh
@@ -687,7 +687,7 @@ test_xproperty_get_is_critical() {
     run_check "$cfg"
     assert_exit "$name" 2 || return
     assert_contains "$name" "awesome.get_xproperty() - not defined" || return
-    assert_contains "$name" "awesome.startup" || return
+    assert_contains "$name" "awesome._restart" || return
     pass "$name"
 }
 test_xproperty_get_is_critical


### PR DESCRIPTION
## Description
Upstream restarts by execvp, so its rc.lua and client scan always run before the main loop exists and `awesome.startup` reads true. Ours run inside the loop during a hot-reload, so every startup-gated reader in `awful` and `ruled` took the wrong branch. `awesome.startup` is now true while a config loads on a reload too; `awesome._restart` says which of the two it was, and `--check` points configs at it instead.


## Test Plan
Extended `tests/restart/startup-flag-across-reload.sh` to pin both flags at load and in the loop, and added `tests/restart/client-screen-after-restart.sh`, which fails without the fix: `awful.screen.preferred` moved a client to the mouse's screen on reload.


## AI Usage
non


## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
