### PR TITLE
fix: re-point every client scene node across a hot-reload

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -4899,9 +4899,8 @@ clients_detach(client_snapshot_t **out, int *out_count)
 				c->surface.xwayland->data = &snap->data;
 		}
 #endif
-		/* Also update scene tree data pointers */
-		if (c->scene)
-			c->scene->node.data = &snap->data;
+		/* Also update scene node back-pointers */
+		client_set_node_data(c, &snap->data);
 
 		/* NULL out owned resources in the OLD Lua userdata so that
 		 * client_wipe (called during lua_close GC) doesn't free them.
@@ -5000,11 +4999,7 @@ clients_restore(lua_State *L, client_snapshot_t *snaps, int num_clients)
 				c->surface.xwayland->data = c;
 		}
 #endif
-		if (c->scene) {
-			c->scene->node.data = c;
-			if (c->scene_surface)
-				c->scene_surface->node.data = c;
-		}
+		client_set_node_data(c, c);
 
 		/* Reference and push to arrays */
 		lua_pushvalue(L, -1);

--- a/meson.build
+++ b/meson.build
@@ -556,6 +556,15 @@ test_transient_client = executable(
   install: false,
 )
 
+# Test XDG client that opens a real xdg_popup, for hit-testing regressions
+test_popup_client = executable(
+  'test-popup-client',
+  ['tests/test-popup-client.c', xdg_shell_client_code],
+  xdg_shell_client_header,
+  dependencies: [wayland_client],
+  install: false,
+)
+
 # Test XDG fullscreen client for fullscreen protocol tests
 test_fullscreen_client = executable(
   'test-fullscreen-client',

--- a/somewm.c
+++ b/somewm.c
@@ -3895,6 +3895,31 @@ client_reregister_listeners(client_t *c)
 	}
 }
 
+/** Point every scene node that carries a back-pointer to this client at \a ptr.
+ *
+ * xytonode() reads these to answer "what is under the cursor", so each one
+ * must name a live client_t. A hot-reload frees the old userdata and builds
+ * new objects, so every node here has to be re-pointed: miss one and the
+ * next motion event reads through freed memory.
+ *
+ * Keep this the only place that list lives.
+ */
+void
+client_set_node_data(client_t *c, void *ptr)
+{
+	int i;
+
+	if (c->scene)
+		c->scene->node.data = ptr;
+	if (c->scene_surface)
+		c->scene_surface->node.data = ptr;
+	if (c->popups)
+		c->popups->node.data = ptr;
+	for (i = 0; i < 4; i++)
+		if (c->border[i])
+			c->border[i]->node.data = ptr;
+}
+
 void
 destroynotify(struct wl_listener *listener, void *data)
 {
@@ -4912,7 +4937,7 @@ mapnotify(struct wl_listener *listener, void *data)
 	 * client's content clip, which would crop any popup parented there. */
 	client_surface(c)->data = c->popups;
 
-	c->scene->node.data = c->scene_surface->node.data = c->popups->node.data = c;
+	client_set_node_data(c, c);
 
 	/* Register commit listener AFTER wlr_scene_xdg_surface_create() so our listener
 	 * fires AFTER wlroots' internal surface_reconfigure() which resets opacity to 1.0.
@@ -4957,11 +4982,10 @@ mapnotify(struct wl_listener *listener, void *data)
 		goto unset_fullscreen;
 	}
 
-	for (i = 0; i < 4; i++) {
+	for (i = 0; i < 4; i++)
 		c->border[i] = wlr_scene_rect_create(c->scene, 0, 0,
 				c->urgent ? get_urgentcolor() : get_bordercolor());
-		c->border[i]->node.data = c;
-	}
+	client_set_node_data(c, c);
 
 	/* Shadow is lazily created by apply_geometry_to_wlroots() on the first
 	 * refresh cycle after the map */
@@ -5386,6 +5410,26 @@ is_client_valid(Client* client)
 	return false;
 }
 
+/** Is \a ptr a layer surface this compositor currently tracks? */
+static bool
+is_layersurface_valid(void *ptr)
+{
+	Monitor *m;
+	LayerSurface *l;
+	int i;
+
+	if (ptr == NULL)
+		return false;
+
+	wl_list_for_each(m, &mons, link)
+		for (i = 0; i < 4; i++)
+			wl_list_for_each(l, &m->layers[i], link)
+				if (l == ptr)
+					return true;
+
+	return false;
+}
+
 void
 motionnotify(uint32_t time, struct wlr_input_device *device, double dx, double dy,
 		double dx_unaccel, double dy_unaccel)
@@ -5487,11 +5531,6 @@ motionnotify(uint32_t time, struct wlr_input_device *device, double dx, double d
 
 		/* Find what's under cursor */
 		xytonode(cursor->x, cursor->y, NULL, &current_client, NULL, &current_drawin, &titlebar_drawable, NULL, NULL);
-
-		/* Validate client pointer - xytonode can return stale pointers from scene graph
-		 * if a node's data field wasn't cleared when the client was destroyed */
-		if (current_client && !is_client_valid(current_client))
-				current_client = NULL;  /* Ignore stale/invalid client pointer */
 
 		if (current_client) {
 			/* Mouse is over a client */
@@ -8184,11 +8223,12 @@ xytonode(double x, double y, struct wlr_surface **psurface,
 				break;
 			pnode = &pnode->parent->node;
 		}
-		/* Check type at offset 0 - LayerSurface has 'type' as first field,
-		 * but Client has WINDOW_OBJECT_HEADER before client_type.
-		 * LayerSurface.type is at offset 0 and set to LayerShell. */
-		if (c && *((unsigned int *)c) == LayerShell) {
-			l = (LayerSurface *)c;
+		/* pnode->data is whatever that node's owner stored: a live
+		 * client, a live layer surface, or a pointer whose owner is
+		 * gone. Decide which by membership, never by reading a
+		 * discriminator through the pointer itself. */
+		if (c && !is_client_valid(c)) {
+			l = is_layersurface_valid(c) ? (LayerSurface *)c : NULL;
 			c = NULL;
 		}
 	}

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -288,6 +288,7 @@ static inline bool session_is_locked(void) {
  */
 void client_remove_all_listeners(client_t *c);
 void client_reregister_listeners(client_t *c);
+void client_set_node_data(client_t *c, void *ptr);
 void some_refresh(void);
 void somewm_pin_lgi_libs(void);
 

--- a/tests/restart/README.md
+++ b/tests/restart/README.md
@@ -195,6 +195,10 @@ release it on `"exit"` reddens whichever reload test runs next.
   reload.
 - `startup-flag-across-reload`: `awesome.startup` is true during a reload's
   config load too, and `awesome._restart` says which it was.
+- `client-popup-node-data-after-restart`: every scene node holding a
+  back-pointer to a client names the current `client_t`. The restore used to
+  re-point only `Client::scene` and `Client::scene_surface`, so a pointer
+  motion over an open popup read through the freed userdata.
 
 Config-timeout tests (a config that hangs longer than the limit is aborted and
 the fallback loads):

--- a/tests/restart/client-popup-node-data-after-restart.sh
+++ b/tests/restart/client-popup-node-data-after-restart.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Every scene node carrying a back-pointer to a client must name the client_t
+# the current Lua state owns.
+#
+# A hot-reload frees every client_t and builds new ones. clients_restore() used
+# to re-point only Client::scene and Client::scene_surface, leaving
+# Client::popups and the four border rects aimed at the freed userdata.
+# xytonode() walks a hit node's ancestors reading node.data, so the first
+# pointer motion over an open popup read through freed memory and took the
+# session down with it.
+#
+# The popup is the reachable half. It is the only stale node that is ever an
+# ancestor of a hit-testable buffer: the borders are siblings of the content
+# tree, and xytonode skips non-buffer hits, so they never enter the walk.
+#
+# What this asserts is the misresolution, not the crash. Whether the stale read
+# faults depends on whether the freed Lua arena has been returned to the OS,
+# which one reload in a sandbox will not do. The pointer is equally wrong
+# either way, so the popup failing to resolve to its client is the reliable
+# signal and the segfault is the same defect on a longer-lived session.
+
+. "$(dirname "$0")/lib.sh"
+
+sw_require_helper test-popup-client
+CLIENT=$SW_HELPER
+
+sw_start hr-popup --config "$ROOT_DIR/tests/rc.lua" || finish
+
+sw_spawn hr-popup "$CLIENT" || finish
+check_client_appeared hr-popup popup_test || finish
+
+# Float and place it, so the popup anchored off its bottom-right corner lands
+# somewhere the test can aim at.
+PLACE='local c; for _, x in ipairs(client.get()) do if x.class == "popup_test" then c = x end end; if not c then return "no client" end; c.floating = true; c:geometry({x = 100, y = 100, width = 300, height = 300}); local g = c:geometry(); return g.x .. "," .. g.y .. "," .. g.width .. "," .. g.height'
+
+check_eval hr-popup "the client can be placed before the reload" "$PLACE" 100,100,300,300
+
+sw_reload hr-popup || finish
+
+check_eval hr-popup "the client survives the reload" \
+    'return tostring(#client.get())' 1
+check_eval hr-popup "the client can be placed after the reload" "$PLACE" 100,100,300,300
+
+# The popup maps under Client::popups, the tree whose back-pointer the reload
+# used to miss.
+if kill -USR1 "$SPAWN_PID" 2>/dev/null; then
+    pass "signalled the client to open its popup"
+else
+    fail "signalled the client to open its popup" "kill -USR1 $SPAWN_PID failed"
+    finish
+fi
+
+deadline=$((SECONDS + 10))
+while [ "$SECONDS" -lt "$deadline" ]; do
+    log_has hr-popup "popup configured" && break
+    sleep 0.2
+done
+if log_has hr-popup "popup configured"; then
+    pass "the popup mapped"
+else
+    fail "the popup mapped" "no popup configure logged after 10s"
+    finish
+fi
+
+# mouse::move carries whatever xytonode() resolved the pointer to, which is the
+# read that crashed. mouse.current_client is no use here: it geometry-scans
+# globalconf.clients and never walks the scene graph at all.
+ARM='local c; for _, x in ipairs(client.get()) do if x.class == "popup_test" then c = x end end; if not c then return "no client" end; _G.HIT = "none"; c:connect_signal("mouse::move", function(cc) _G.HIT = cc.class end); return "armed"'
+
+# Sent twice: the first motion only establishes the cursor position.
+move_to() {
+    printf 'root.fake_input("motion_notify", false, %s, %s); root.fake_input("motion_notify", false, %s, %s); return "moved"' \
+        "$1" "$2" "$1" "$2"
+}
+
+check_eval hr-popup "a mouse::move probe can be armed" "$ARM" armed
+
+# Over the client's own content first. This resolves through Client::scene_surface,
+# which the reload always re-pointed correctly, so it proves the probe works
+# before the interesting case relies on it.
+check_eval hr-popup "pointer motion over the client content" \
+    "$(move_to 200 200)" moved
+check_eval hr-popup "the content resolves to its client" \
+    'return tostring(_G.HIT)' popup_test
+
+# Now the popup, which hangs off the parent's bottom-right corner and so covers
+# screen the content does not. This is the walk that reached Client::popups.
+check_eval hr-popup "the probe can be re-armed" \
+    '_G.HIT = "none"; return tostring(_G.HIT)' none
+check_eval hr-popup "pointer motion over the popup" \
+    "$(move_to 450 450)" moved
+check_eval hr-popup "the popup resolves to its own client" \
+    'return tostring(_G.HIT)' popup_test
+
+sw_check_log_clean hr-popup "post-motion log"
+
+finish

--- a/tests/test-popup-client.c
+++ b/tests/test-popup-client.c
@@ -1,0 +1,338 @@
+/**
+ * test-popup-client - XDG toplevel that opens a real xdg_popup on demand
+ *
+ * The popup is anchored off the parent's bottom-right corner, so it covers
+ * screen area the parent's own content does not. That is the only place a
+ * pointer can land on the popup's scene subtree: popups are parented under
+ * Client::popups, a sibling of the content tree, and hit-testing returns the
+ * topmost node.
+ *
+ * - Starts with one XDG toplevel (app_id: "popup_test")
+ * - On SIGUSR1: creates an xdg_popup on that toplevel
+ * - On SIGTERM: clean shutdown
+ *
+ * Usage: test-popup-client
+ */
+
+#include <errno.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <wayland-client.h>
+#include "xdg-shell-client-protocol.h"
+
+/* Popup geometry, in surface-local coordinates of the parent. */
+#define POPUP_SIZE 120
+
+static struct wl_display *g_display;
+static struct wl_registry *g_registry;
+static struct wl_compositor *g_compositor;
+static struct wl_shm *g_shm;
+static struct xdg_wm_base *g_xdg_wm_base;
+
+static bool g_running = true;
+static bool g_spawn_popup = false;
+
+static struct wl_surface *g_surface;
+static struct xdg_surface *g_xdg_surface;
+static struct xdg_toplevel *g_toplevel;
+
+static struct wl_surface *g_popup_surface;
+static struct xdg_surface *g_popup_xdg_surface;
+static struct xdg_popup *g_popup;
+
+static uint32_t g_width = 200, g_height = 200;
+
+static void handle_sigterm(int sig) {
+    (void)sig;
+    g_running = false;
+}
+
+static void handle_sigusr1(int sig) {
+    (void)sig;
+    g_spawn_popup = true;
+}
+
+static struct wl_buffer *create_buffer(uint32_t w, uint32_t h, uint32_t color) {
+    int stride = w * 4;
+    int size = stride * h;
+
+    char name[] = "/tmp/test-popup-XXXXXX";
+    int fd = mkstemp(name);
+    if (fd < 0) {
+        perror("mkstemp");
+        return NULL;
+    }
+    unlink(name);
+
+    if (ftruncate(fd, size) < 0) {
+        perror("ftruncate");
+        close(fd);
+        return NULL;
+    }
+
+    uint32_t *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (data == MAP_FAILED) {
+        perror("mmap");
+        close(fd);
+        return NULL;
+    }
+
+    for (int i = 0; i < (int)(w * h); i++)
+        data[i] = color;
+    munmap(data, size);
+
+    struct wl_shm_pool *pool = wl_shm_create_pool(g_shm, fd, size);
+    struct wl_buffer *buffer = wl_shm_pool_create_buffer(
+        pool, 0, w, h, stride, WL_SHM_FORMAT_ARGB8888);
+    wl_shm_pool_destroy(pool);
+    close(fd);
+
+    return buffer;
+}
+
+static void xdg_surface_configure(void *data,
+        struct xdg_surface *xdg_surface, uint32_t serial) {
+    (void)data;
+    xdg_surface_ack_configure(xdg_surface, serial);
+
+    struct wl_surface *surface = NULL;
+    uint32_t w = g_width, h = g_height;
+    uint32_t color = 0xFF404040; /* dark gray */
+
+    if (xdg_surface == g_xdg_surface) {
+        surface = g_surface;
+    } else if (xdg_surface == g_popup_xdg_surface) {
+        surface = g_popup_surface;
+        w = h = POPUP_SIZE;
+        color = 0xFF4080C0; /* blue, so a screenshot tells them apart */
+    }
+
+    if (surface) {
+        struct wl_buffer *buffer = create_buffer(w, h, color);
+        if (buffer) {
+            wl_surface_attach(surface, buffer, 0, 0);
+            wl_surface_commit(surface);
+        }
+    }
+}
+
+static const struct xdg_surface_listener xdg_surface_listener = {
+    .configure = xdg_surface_configure,
+};
+
+static void toplevel_configure(void *data, struct xdg_toplevel *toplevel,
+        int32_t w, int32_t h, struct wl_array *states) {
+    (void)data; (void)toplevel; (void)states;
+    if (w > 0) g_width = w;
+    if (h > 0) g_height = h;
+}
+
+static void toplevel_close(void *data, struct xdg_toplevel *toplevel) {
+    (void)data; (void)toplevel;
+    g_running = false;
+}
+
+static void toplevel_configure_bounds(void *data,
+        struct xdg_toplevel *toplevel, int32_t w, int32_t h) {
+    (void)data; (void)toplevel; (void)w; (void)h;
+}
+
+static void toplevel_wm_capabilities(void *data,
+        struct xdg_toplevel *toplevel, struct wl_array *caps) {
+    (void)data; (void)toplevel; (void)caps;
+}
+
+static const struct xdg_toplevel_listener toplevel_listener = {
+    .configure = toplevel_configure,
+    .close = toplevel_close,
+    .configure_bounds = toplevel_configure_bounds,
+    .wm_capabilities = toplevel_wm_capabilities,
+};
+
+static void popup_configure(void *data, struct xdg_popup *popup,
+        int32_t x, int32_t y, int32_t w, int32_t h) {
+    (void)data; (void)popup;
+    fprintf(stderr, "[test-popup-client] popup configured at %d,%d %dx%d\n",
+        x, y, w, h);
+}
+
+static void popup_done(void *data, struct xdg_popup *popup) {
+    (void)data; (void)popup;
+    fprintf(stderr, "[test-popup-client] popup dismissed\n");
+}
+
+static void popup_repositioned(void *data, struct xdg_popup *popup,
+        uint32_t token) {
+    (void)data; (void)popup; (void)token;
+}
+
+static const struct xdg_popup_listener popup_listener = {
+    .configure = popup_configure,
+    .popup_done = popup_done,
+    .repositioned = popup_repositioned,
+};
+
+static void xdg_wm_base_ping(void *data, struct xdg_wm_base *wm_base,
+        uint32_t serial) {
+    (void)data;
+    xdg_wm_base_pong(wm_base, serial);
+}
+
+static const struct xdg_wm_base_listener xdg_wm_base_listener = {
+    .ping = xdg_wm_base_ping,
+};
+
+static void registry_global(void *data, struct wl_registry *reg,
+        uint32_t name, const char *interface, uint32_t version) {
+    (void)data; (void)version;
+
+    if (strcmp(interface, wl_compositor_interface.name) == 0) {
+        g_compositor = wl_registry_bind(reg, name,
+            &wl_compositor_interface, 4);
+    } else if (strcmp(interface, wl_shm_interface.name) == 0) {
+        g_shm = wl_registry_bind(reg, name, &wl_shm_interface, 1);
+    } else if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
+        g_xdg_wm_base = wl_registry_bind(reg, name,
+            &xdg_wm_base_interface, 5);
+        xdg_wm_base_add_listener(g_xdg_wm_base, &xdg_wm_base_listener, NULL);
+    }
+}
+
+static void registry_global_remove(void *data, struct wl_registry *reg,
+        uint32_t name) {
+    (void)data; (void)reg; (void)name;
+}
+
+static const struct wl_registry_listener registry_listener = {
+    .global = registry_global,
+    .global_remove = registry_global_remove,
+};
+
+/* Open an xdg_popup hanging off the parent's bottom-right corner.
+ * No constraint adjustment: the compositor must leave it where we asked, so
+ * the test can aim a pointer at it. */
+static void create_popup(void) {
+    if (g_popup_surface) return; /* Already created */
+
+    fprintf(stderr, "[test-popup-client] creating popup\n");
+
+    struct xdg_positioner *positioner =
+        xdg_wm_base_create_positioner(g_xdg_wm_base);
+    xdg_positioner_set_size(positioner, POPUP_SIZE, POPUP_SIZE);
+    xdg_positioner_set_anchor_rect(positioner, 0, 0, g_width, g_height);
+    xdg_positioner_set_anchor(positioner, XDG_POSITIONER_ANCHOR_BOTTOM_RIGHT);
+    xdg_positioner_set_gravity(positioner, XDG_POSITIONER_GRAVITY_BOTTOM_RIGHT);
+    xdg_positioner_set_constraint_adjustment(positioner,
+        XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_NONE);
+
+    g_popup_surface = wl_compositor_create_surface(g_compositor);
+    g_popup_xdg_surface = xdg_wm_base_get_xdg_surface(
+        g_xdg_wm_base, g_popup_surface);
+    xdg_surface_add_listener(g_popup_xdg_surface, &xdg_surface_listener, NULL);
+
+    g_popup = xdg_surface_get_popup(g_popup_xdg_surface, g_xdg_surface,
+        positioner);
+    xdg_popup_add_listener(g_popup, &popup_listener, NULL);
+    xdg_positioner_destroy(positioner);
+
+    wl_surface_commit(g_popup_surface);
+    wl_display_flush(g_display);
+
+    fprintf(stderr, "[test-popup-client] popup created\n");
+}
+
+int main(int argc, char *argv[]) {
+    (void)argc; (void)argv;
+
+    /* sigaction without SA_RESTART, so dispatch returns EINTR and the loop
+     * gets a chance to see g_spawn_popup. */
+    struct sigaction sa_term = { .sa_handler = handle_sigterm };
+    struct sigaction sa_usr1 = { .sa_handler = handle_sigusr1 };
+    sigaction(SIGTERM, &sa_term, NULL);
+    sigaction(SIGINT, &sa_term, NULL);
+    sigaction(SIGUSR1, &sa_usr1, NULL);
+
+    g_display = wl_display_connect(NULL);
+    if (!g_display) {
+        fprintf(stderr, "Failed to connect to Wayland display\n");
+        return 1;
+    }
+
+    g_registry = wl_display_get_registry(g_display);
+    wl_registry_add_listener(g_registry, &registry_listener, NULL);
+    wl_display_roundtrip(g_display);
+
+    if (!g_compositor || !g_shm || !g_xdg_wm_base) {
+        fprintf(stderr, "Missing required Wayland globals\n");
+        return 1;
+    }
+
+    g_surface = wl_compositor_create_surface(g_compositor);
+    g_xdg_surface = xdg_wm_base_get_xdg_surface(g_xdg_wm_base, g_surface);
+    xdg_surface_add_listener(g_xdg_surface, &xdg_surface_listener, NULL);
+
+    g_toplevel = xdg_surface_get_toplevel(g_xdg_surface);
+    xdg_toplevel_add_listener(g_toplevel, &toplevel_listener, NULL);
+    xdg_toplevel_set_app_id(g_toplevel, "popup_test");
+    xdg_toplevel_set_title(g_toplevel, "Popup Parent");
+
+    wl_surface_commit(g_surface);
+    wl_display_roundtrip(g_display);
+
+    fprintf(stderr, "[test-popup-client] running (pid=%d)\n", getpid());
+
+    while (g_running) {
+        if (g_spawn_popup) {
+            g_spawn_popup = false;
+            create_popup();
+        }
+
+        if (wl_display_dispatch_pending(g_display) == -1)
+            break;
+
+        if (wl_display_flush(g_display) == -1 && errno != EAGAIN)
+            break;
+
+        while (wl_display_prepare_read(g_display) != 0) {
+            if (wl_display_dispatch_pending(g_display) == -1)
+                goto done;
+        }
+
+        struct pollfd pfd = {
+            .fd = wl_display_get_fd(g_display),
+            .events = POLLIN,
+        };
+        int ret = poll(&pfd, 1, 100);
+
+        if (ret > 0) {
+            wl_display_read_events(g_display);
+        } else {
+            wl_display_cancel_read(g_display);
+        }
+    }
+done:
+
+    fprintf(stderr, "[test-popup-client] shutting down\n");
+
+    if (g_popup) xdg_popup_destroy(g_popup);
+    if (g_popup_xdg_surface) xdg_surface_destroy(g_popup_xdg_surface);
+    if (g_popup_surface) wl_surface_destroy(g_popup_surface);
+
+    if (g_toplevel) xdg_toplevel_destroy(g_toplevel);
+    if (g_xdg_surface) xdg_surface_destroy(g_xdg_surface);
+    if (g_surface) wl_surface_destroy(g_surface);
+
+    if (g_xdg_wm_base) xdg_wm_base_destroy(g_xdg_wm_base);
+    if (g_shm) wl_shm_destroy(g_shm);
+    if (g_compositor) wl_compositor_destroy(g_compositor);
+    if (g_registry) wl_registry_destroy(g_registry);
+    wl_display_disconnect(g_display);
+
+    return 0;
+}


### PR DESCRIPTION
## Description
A hot-reload frees every `client_t`, but `clients_restore()` re-pointed only two of the seven scene nodes that point back at one, so the first pointer motion over an open popup read through the freed memory and took the session down.

One helper now updates all seven.