### PR TITLE
Backport keyrelease and libinput switch support

### DIFF
--- a/objects/keybinding.c
+++ b/objects/keybinding.c
@@ -255,7 +255,7 @@ luaA_keybind(lua_State *L)
  * \return 1 if handled, 0 if not
  */
 int
-luaA_key_check_and_emit(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym)
+luaA_key_check_and_emit(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym, bool is_keypress)
 {
 	xkb_keysym_t lower_base = xkb_keysym_to_lower(base_sym);
 	int i;
@@ -285,7 +285,7 @@ luaA_key_check_and_emit(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_k
 		if (key->modifiers == mods && (keycode_match || keysym_match)) {
 			/* Push key object onto stack and emit signal using AwesomeWM's proper function */
 			luaA_object_push(global_L, key);
-			luaA_awm_object_emit_signal(global_L, -1, "press", 0);
+			luaA_awm_object_emit_signal(global_L, -1, is_keypress ? "press" : "release", 0);
 			lua_pop(global_L, 1);
 
 			/* Return after emitting - no need for further processing */
@@ -307,7 +307,7 @@ luaA_key_check_and_emit(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_k
  * \return 1 if handled, 0 if not
  */
 int
-luaA_client_key_check_and_emit(client_t *c, uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym)
+luaA_client_key_check_and_emit(client_t *c, uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym, bool is_keypress)
 {
 	xkb_keysym_t lower_base = xkb_keysym_to_lower(base_sym);
 	int i;
@@ -344,7 +344,7 @@ luaA_client_key_check_and_emit(client_t *c, uint32_t mods, uint32_t keycode, xkb
 			luaA_object_push_item(global_L, -1, key);
 			/* Emit signal with client as argument (1 arg) - client is at -2, key at -1 */
 			lua_pushvalue(global_L, -2);  /* Copy client to top for signal arg */
-			luaA_awm_object_emit_signal(global_L, -2, "press", 1);
+			luaA_awm_object_emit_signal(global_L, -2, is_keypress ? "press" : "release", 1);
 			/* Pop key object and client */
 			lua_pop(global_L, 2);
 

--- a/objects/keybinding.h
+++ b/objects/keybinding.h
@@ -3,6 +3,7 @@
 
 #include <lua.h>
 #include <xkbcommon/xkbcommon.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 /* Forward declare client_t */
@@ -11,10 +12,10 @@ typedef struct client_t client_t;
 void luaA_keybinding_setup(lua_State *L);
 
 /* NEW AwesomeWM-compatible system: key objects with signals */
-int luaA_key_check_and_emit(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym);
+int luaA_key_check_and_emit(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym, bool is_keypress);
 
 /* Client-specific keybindings - checks client's keys array and passes client as arg */
-int luaA_client_key_check_and_emit(client_t *c, uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym);
+int luaA_client_key_check_and_emit(client_t *c, uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym, bool is_keypress);
 
 /* OLD DEPRECATED system: direct callback storage */
 int luaA_keybind_check(uint32_t mods, xkb_keysym_t sym, xkb_keysym_t base_sym);

--- a/somewm.c
+++ b/somewm.c
@@ -300,7 +300,7 @@ static void touchnotifymotion(struct wl_listener *listener, void *data);
 static void touchnotifyup(struct wl_listener *listener, void *data);
 static void touchnotifycancel(struct wl_listener *listener, void *data);
 static void touchnotifyframe(struct wl_listener *listener, void *data);
-static int keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym);
+static int keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym, bool is_keypress);
 static void keypress(struct wl_listener *listener, void *data);
 static void keypressmod(struct wl_listener *listener, void *data);
 static int keyrepeat(void *data);
@@ -4597,11 +4597,11 @@ get_urgentcolor(void)
 /* ========== KEYBINDING SYSTEM ========== */
 
 /* Forward declarations for AwesomeWM-compatible Lua keybinding system */
-extern int luaA_key_check_and_emit(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym);
-extern int luaA_client_key_check_and_emit(client_t *c, uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym);
+extern int luaA_key_check_and_emit(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym, bool is_keypress);
+extern int luaA_client_key_check_and_emit(client_t *c, uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym, bool is_keypress);
 
 int
-keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym)
+keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_sym, bool is_keypress)
 {
 	client_t *focused;
 	struct wlr_surface *surface;
@@ -4625,12 +4625,12 @@ keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t base_
 	focused = surface ? some_client_from_surface(surface) : NULL;
 
 	/* Check client-specific Lua key objects first (AwesomeWM pattern)
-	 * Client keybindings pass the client as argument to the "press" signal */
-	if (focused && luaA_client_key_check_and_emit(focused, CLEANMASK(mods), keycode, sym, base_sym))
+	 * Client keybindings pass the client as argument to the "press" or "release" signal */
+	if (focused && luaA_client_key_check_and_emit(focused, CLEANMASK(mods), keycode, sym, base_sym, is_keypress))
 		return 1;
 
 	/* Check global Lua key objects (AwesomeWM pattern) */
-	if (luaA_key_check_and_emit(CLEANMASK(mods), keycode, sym, base_sym))
+	if (luaA_key_check_and_emit(CLEANMASK(mods), keycode, sym, base_sym, is_keypress))
 		return 1;
 
 	/* Hardcoded VT switching (compositor-level, non-configurable)
@@ -4725,9 +4725,13 @@ keypress(struct wl_listener *listener, void *data)
 	/* On _press_ if there is no active screen locker,
 	 * attempt to process a compositor keybinding.
 	 * Block for both ext-session-lock-v1 (locked) and Lua lock (some_is_lua_locked). */
-	if (!session_is_locked() && event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
-		for (i = 0; i < nsyms; i++)
-			handled = keybinding(mods, keycode, syms[i], base_sym) || handled;
+	if (!session_is_locked()) {
+		bool is_keypress = event->state == WL_KEYBOARD_KEY_STATE_PRESSED;
+		for (i = 0; i < nsyms; i++) {
+			bool binding_handled = keybinding(mods, keycode, syms[i], base_sym, is_keypress);
+			if (is_keypress)
+				handled = binding_handled || handled;
+		}
 	}
 
 	if (handled && group->wlr_group->keyboard.repeat_info.delay > 0) {
@@ -4811,7 +4815,9 @@ keyrepeat(void *data)
 			1000 / group->wlr_group->keyboard.repeat_info.rate);
 
 	for (i = 0; i < group->nsyms; i++)
-		keybinding(group->mods, group->keycode, group->keysyms[i], group->base_sym);
+		/* Hardcode is_keypress = true for the keybinding() call since
+		 * keyrepeat really only matters for key down condition */
+		keybinding(group->mods, group->keycode, group->keysyms[i], group->base_sym, true);
 
 	return 0;
 }

--- a/somewm.c
+++ b/somewm.c
@@ -65,6 +65,7 @@
 #include <wlr/types/wlr_session_lock_v1.h>
 #include <wlr/types/wlr_single_pixel_buffer_v1.h>
 #include <wlr/types/wlr_subcompositor.h>
+#include <wlr/types/wlr_switch.h>
 #include <wlr/types/wlr_tablet_pad.h>
 #include <wlr/types/wlr_tablet_tool.h>
 #include <wlr/types/wlr_tablet_v2.h>
@@ -207,6 +208,12 @@ typedef struct {
 	struct wl_list link;
 } TrackedTouch;
 
+typedef struct {
+	struct wlr_switch *switch_dev;
+	struct wl_listener toggle;
+	struct wl_listener destroy;
+} TrackedSwitch;
+
 /* function declarations */
 static void applybounds(Client *c, struct wlr_box *bbox);
 void arrange(Monitor *m);
@@ -239,6 +246,7 @@ static void createlocksurface(struct wl_listener *listener, void *data);
 static void createmon(struct wl_listener *listener, void *data);
 static void createnotify(struct wl_listener *listener, void *data);
 static void createpointer(struct wlr_pointer *pointer);
+static void createswitch(struct wlr_switch *sw);
 static void createtablet(struct wlr_tablet *tablet);
 static void createtabletpad(struct wlr_tablet_pad *pad);
 static void createtouch(struct wlr_touch *touch);
@@ -258,6 +266,7 @@ static void destroynotify(struct wl_listener *listener, void *data);
 static void destroypointerconstraint(struct wl_listener *listener, void *data);
 static void destroysessionlock(struct wl_listener *listener, void *data);
 static void destroykeyboardgroup(struct wl_listener *listener, void *data);
+static void destroyswitchtracker(struct wl_listener *listener, void *data);
 static void destroytrackedpointer(struct wl_listener *listener, void *data);
 static void destroytrackedtablet(struct wl_listener *listener, void *data);
 static void destroytrackedtabletpad(struct wl_listener *listener, void *data);
@@ -286,6 +295,7 @@ static void gestureholdend(struct wl_listener *listener, void *data);
 static void gpureset(struct wl_listener *listener, void *data);
 static void handlesig(int signo);
 static void inputdevice(struct wl_listener *listener, void *data);
+static void switchevent(struct wl_listener *listener, void *data);
 static void tabletnotifyaxis(struct wl_listener *listener, void *data);
 static void tabletnotifyproximity(struct wl_listener *listener, void *data);
 static void tabletnotifytip(struct wl_listener *listener, void *data);
@@ -3201,6 +3211,16 @@ tabletpadnotifyattach(struct wl_listener *listener, void *data)
 }
 
 static void
+createswitch(struct wlr_switch *sw)
+{
+	TrackedSwitch *ts = ecalloc(1, sizeof(*ts));
+
+	ts->switch_dev = sw;
+	LISTEN(&sw->events.toggle, &ts->toggle, switchevent);
+	LISTEN(&sw->base.events.destroy, &ts->destroy, destroyswitchtracker);
+}
+
+static void
 createtablet(struct wlr_tablet *tablet)
 {
 	TrackedTablet *tt = ecalloc(1, sizeof(*tt));
@@ -3990,6 +4010,44 @@ destroypointerconstraint(struct wl_listener *listener, void *data)
 }
 
 static void
+destroyswitchtracker(struct wl_listener *listener, void *data)
+{
+	TrackedSwitch *ts = wl_container_of(listener, ts, destroy);
+	wl_list_remove(&ts->toggle.link);
+	wl_list_remove(&ts->destroy.link);
+	free(ts);
+}
+
+static void
+switchevent(struct wl_listener *listener, void *data)
+{
+	TrackedSwitch *ts = wl_container_of(listener, ts, toggle);
+	struct wlr_switch_toggle_event *event = data;
+
+	char* type;
+	switch (event->switch_type) {
+	case WLR_SWITCH_TYPE_LID:
+		type = "lid";
+		break;
+	case WLR_SWITCH_TYPE_TABLET_MODE:
+		type = "tablet_mode";
+		break;
+	case WLR_SWITCH_TYPE_KEYPAD_SLIDE:
+		type = "keypad_slide";
+		break;
+	default:
+		type = "unknown";
+		break;
+	}
+
+	luaA_emit_signal_global_with_table("switch::toggle", 6,
+		"device_name", ts->switch_dev && ts->switch_dev->base.name
+			? ts->switch_dev->base.name : "",
+		"type", type,
+		"state", event->switch_state == WLR_SWITCH_STATE_ON ? "on" : "off");
+}
+
+static void
 destroytrackedpointer(struct wl_listener *listener, void *data)
 {
 	TrackedPointer *tp = wl_container_of(listener, tp, destroy);
@@ -4513,6 +4571,9 @@ inputdevice(struct wl_listener *listener, void *data)
 		break;
 	case WLR_INPUT_DEVICE_POINTER:
 		createpointer(wlr_pointer_from_input_device(device));
+		break;
+	case WLR_INPUT_DEVICE_SWITCH:
+		createswitch(wlr_switch_from_input_device(device));
 		break;
 	case WLR_INPUT_DEVICE_TABLET:
 		createtablet(wlr_tablet_from_input_device(device));


### PR DESCRIPTION
## Description
Backport https://github.com/trip-zip/somewm/commit/e09b1f54eb49d897f4f2c26f32c53503ece8e6d6 and https://github.com/trip-zip/somewm/commit/4ae74d73f36f959477076fdc160f7e9e56c21a7f to the 1.4 branch.

## Test Plan
Built and tested on my device


## AI Usage
None


## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
