### PR TITLE
fix(input): allow pointer emulation even outside clients

### DIFF
--- a/somewm.c
+++ b/somewm.c
@@ -2767,14 +2767,11 @@ touchnotifydown(struct wl_listener *listener, void *data)
 	input_map_coords(&s, event->x, event->y, &lx, &ly);
 	xytonode(lx, ly, &surface, &c, NULL, NULL, NULL, &sx, &sy);
 
-	if (!surface)
-		return;
-
 	/* wlroots itself refuses to create a touch point (logged as an ERROR)
 	 * for a client with no bound wl_touch resource, so only forward the
 	 * raw event to clients that can actually use it. Everyone else gets
 	 * an emulated click instead, if enabled. */
-	if (!touch_client_needs_pointer_emulation(surface)) {
+	if (surface && !touch_client_needs_pointer_emulation(surface)) {
 		/* Touch-aware clients get real, raw touch - no synthetic
 		 * wl_pointer click (see touch_emulate_click()'s comment for
 		 * why). They still deserve focus/raise on a deliberate tap


### PR DESCRIPTION
## Description
Allow elements such as wibar and title bar to also receive emulated pointer events


## Test Plan
Tested on my device mentioned in https://github.com/trip-zip/somewm/issues/524


## AI Usage
None

## Checklist
- [x] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [x] Tests pass (`make test-unit && make test-integration`)
