### PR TITLE
Fix/client content csd margins

### DIFF
--- a/root.c
+++ b/root.c
@@ -38,6 +38,7 @@
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/render/allocator.h>
 #include <wlr/types/wlr_xcursor_manager.h>
+#include <wlr/util/transform.h>
 #include <cairo.h>
 #include <drm_fourcc.h>
 #include <string.h>
@@ -1821,20 +1822,74 @@ composite_widgets_directly(cairo_t *cr, bool ontop_only)
 	}
 }
 
-/** Paint buf_surface at the node position, cropped to src and scaled to
- * dst_width x dst_height.
+/** Orient a source box of sw x sh under transform t, the way the scene
+ * renderer orients a buffer. */
+static void
+composite_transform_matrix(cairo_matrix_t *m, enum wl_output_transform t,
+                           double sw, double sh)
+{
+	switch (t) {
+	case WL_OUTPUT_TRANSFORM_90:
+		cairo_matrix_init(m, 0, -1, 1, 0, 0, sw); break;
+	case WL_OUTPUT_TRANSFORM_180:
+		cairo_matrix_init(m, -1, 0, 0, -1, sw, sh); break;
+	case WL_OUTPUT_TRANSFORM_270:
+		cairo_matrix_init(m, 0, 1, -1, 0, sh, 0); break;
+	case WL_OUTPUT_TRANSFORM_FLIPPED:
+		cairo_matrix_init(m, -1, 0, 0, 1, sw, 0); break;
+	case WL_OUTPUT_TRANSFORM_FLIPPED_90:
+		cairo_matrix_init(m, 0, 1, 1, 0, 0, 0); break;
+	case WL_OUTPUT_TRANSFORM_FLIPPED_180:
+		cairo_matrix_init(m, 1, 0, 0, -1, 0, sh); break;
+	case WL_OUTPUT_TRANSFORM_FLIPPED_270:
+		cairo_matrix_init(m, 0, -1, -1, 0, sh, sw); break;
+	default:
+		cairo_matrix_init_identity(m); break;
+	}
+}
+
+/** Paint buf_surface, the pixels of scene_buffer's buffer, at the node
+ * position the way the scene renderer would place them.
+ *
+ * Honours src_box (the crop wlroots sets when a surface is clipped to its xdg
+ * window geometry), dst_width/dst_height and transform. Deliberately ignores
+ * blend_mode and the wait timeline, which do not apply to a cairo target, and
+ * does not yet honour opacity or filter_mode.
  */
 static void
 composite_paint(struct screenshot_render_data *rdata, cairo_surface_t *buf_surface,
-                const struct wlr_fbox *src, int sx, int sy,
-                int dst_width, int dst_height)
+                struct wlr_scene_buffer *scene_buffer, int sx, int sy)
 {
+	enum wl_output_transform t = wlr_output_transform_invert(scene_buffer->transform);
+	bool swaps = t & WL_OUTPUT_TRANSFORM_90;
+	struct wlr_fbox src = scene_buffer->src_box;
+	int dst_width, dst_height;
+	double tw, th;
+	cairo_matrix_t m;
+
+	if (wlr_fbox_empty(&src))
+		src = (struct wlr_fbox){ 0, 0, scene_buffer->buffer->width,
+		                        scene_buffer->buffer->height };
+
+	tw = swaps ? src.height : src.width;
+	th = swaps ? src.width : src.height;
+
+	dst_width = scene_buffer->dst_width;
+	dst_height = scene_buffer->dst_height;
+	if (dst_width <= 0 || dst_height <= 0) {
+		dst_width = tw;
+		dst_height = th;
+	}
+
+	composite_transform_matrix(&m, t, src.width, src.height);
+
 	cairo_save(rdata->cr);
 	cairo_translate(rdata->cr, sx + rdata->offset_x, sy + rdata->offset_y);
 	cairo_rectangle(rdata->cr, 0, 0, dst_width, dst_height);
 	cairo_clip(rdata->cr);
-	cairo_scale(rdata->cr, dst_width / src->width, dst_height / src->height);
-	cairo_translate(rdata->cr, -src->x, -src->y);
+	cairo_scale(rdata->cr, dst_width / tw, dst_height / th);
+	cairo_transform(rdata->cr, &m);
+	cairo_translate(rdata->cr, -src.x, -src.y);
 	cairo_set_source_surface(rdata->cr, buf_surface, 0, 0);
 	cairo_paint(rdata->cr);
 	cairo_restore(rdata->cr);
@@ -1853,8 +1908,6 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 	struct screenshot_render_data *rdata = data;
 	struct wlr_buffer *buffer;
 	cairo_surface_t *buf_surface;
-	struct wlr_fbox src_box;
-	int dst_width, dst_height;
 	int buf_width, buf_height;
 	void *shm_data;
 	uint32_t shm_format;
@@ -1874,20 +1927,6 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 	if (buf_width <= 0 || buf_height <= 0)
 		return;
 
-	/* wlroots sets src_box when a surface is clipped to its xdg window
-	 * geometry, so cropping to it keeps client-side-decoration shadow
-	 * margins out of the capture. */
-	src_box = scene_buffer->src_box;
-	if (wlr_fbox_empty(&src_box))
-		src_box = (struct wlr_fbox){ 0, 0, buf_width, buf_height };
-
-	dst_width = scene_buffer->dst_width;
-	dst_height = scene_buffer->dst_height;
-	if (dst_width <= 0 || dst_height <= 0) {
-		dst_width = src_box.width;
-		dst_height = src_box.height;
-	}
-
 	/* First try direct buffer access (works for SHM buffers - widgets) */
 	if (wlr_buffer_begin_data_ptr_access(buffer, WLR_BUFFER_DATA_PTR_ACCESS_READ,
 	                                     &shm_data, &shm_format, &shm_stride)) {
@@ -1902,8 +1941,7 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 				shm_data, cairo_fmt, buf_width, buf_height, shm_stride);
 
 			if (cairo_surface_status(buf_surface) == CAIRO_STATUS_SUCCESS) {
-				composite_paint(rdata, buf_surface, &src_box,
-					sx, sy, dst_width, dst_height);
+				composite_paint(rdata, buf_surface, scene_buffer, sx, sy);
 				cairo_surface_destroy(buf_surface);
 			}
 		}
@@ -1952,7 +1990,7 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 		return;
 	}
 
-	composite_paint(rdata, buf_surface, &src_box, sx, sy, dst_width, dst_height);
+	composite_paint(rdata, buf_surface, scene_buffer, sx, sy);
 
 	cairo_surface_destroy(buf_surface);
 	if (need_free)

--- a/root.c
+++ b/root.c
@@ -1821,6 +1821,25 @@ composite_widgets_directly(cairo_t *cr, bool ontop_only)
 	}
 }
 
+/** Paint buf_surface at the node position, cropped to src and scaled to
+ * dst_width x dst_height.
+ */
+static void
+composite_paint(struct screenshot_render_data *rdata, cairo_surface_t *buf_surface,
+                const struct wlr_fbox *src, int sx, int sy,
+                int dst_width, int dst_height)
+{
+	cairo_save(rdata->cr);
+	cairo_translate(rdata->cr, sx + rdata->offset_x, sy + rdata->offset_y);
+	cairo_rectangle(rdata->cr, 0, 0, dst_width, dst_height);
+	cairo_clip(rdata->cr);
+	cairo_scale(rdata->cr, dst_width / src->width, dst_height / src->height);
+	cairo_translate(rdata->cr, -src->x, -src->y);
+	cairo_set_source_surface(rdata->cr, buf_surface, 0, 0);
+	cairo_paint(rdata->cr);
+	cairo_restore(rdata->cr);
+}
+
 /** Callback for wlr_scene_output_for_each_buffer
  * Reads pixels from each scene buffer and composites onto Cairo surface.
  * Handles both SHM buffers (widgets) and GPU buffers (clients).
@@ -1834,8 +1853,9 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 	struct screenshot_render_data *rdata = data;
 	struct wlr_buffer *buffer;
 	cairo_surface_t *buf_surface;
+	struct wlr_fbox src_box;
 	int dst_width, dst_height;
-	int src_width, src_height;
+	int buf_width, buf_height;
 	void *shm_data;
 	uint32_t shm_format;
 	size_t shm_stride;
@@ -1848,19 +1868,25 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 		return;
 
 	buffer = scene_buffer->buffer;
-	src_width = buffer->width;
-	src_height = buffer->height;
+	buf_width = buffer->width;
+	buf_height = buffer->height;
+
+	if (buf_width <= 0 || buf_height <= 0)
+		return;
+
+	/* wlroots sets src_box when a surface is clipped to its xdg window
+	 * geometry, so cropping to it keeps client-side-decoration shadow
+	 * margins out of the capture. */
+	src_box = scene_buffer->src_box;
+	if (wlr_fbox_empty(&src_box))
+		src_box = (struct wlr_fbox){ 0, 0, buf_width, buf_height };
+
 	dst_width = scene_buffer->dst_width;
 	dst_height = scene_buffer->dst_height;
-
-	/* Fall back to buffer dimensions if dst not set */
 	if (dst_width <= 0 || dst_height <= 0) {
-		dst_width = src_width;
-		dst_height = src_height;
+		dst_width = src_box.width;
+		dst_height = src_box.height;
 	}
-
-	if (src_width <= 0 || src_height <= 0)
-		return;
 
 	/* First try direct buffer access (works for SHM buffers - widgets) */
 	if (wlr_buffer_begin_data_ptr_access(buffer, WLR_BUFFER_DATA_PTR_ACCESS_READ,
@@ -1873,24 +1899,11 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 			            CAIRO_FORMAT_ARGB32 : CAIRO_FORMAT_RGB24;
 			/* Use actual buffer dimensions, not dst dimensions */
 			buf_surface = cairo_image_surface_create_for_data(
-				shm_data, cairo_fmt, src_width, src_height, shm_stride);
+				shm_data, cairo_fmt, buf_width, buf_height, shm_stride);
 
 			if (cairo_surface_status(buf_surface) == CAIRO_STATUS_SUCCESS) {
-				cairo_save(rdata->cr);
-				/* Scale if buffer pixels differ from logical size */
-				if (src_width != dst_width || src_height != dst_height) {
-					cairo_translate(rdata->cr,
-						sx + rdata->offset_x, sy + rdata->offset_y);
-					cairo_scale(rdata->cr,
-						(double)dst_width / src_width,
-						(double)dst_height / src_height);
-					cairo_set_source_surface(rdata->cr, buf_surface, 0, 0);
-				} else {
-					cairo_set_source_surface(rdata->cr, buf_surface,
-						sx + rdata->offset_x, sy + rdata->offset_y);
-				}
-				cairo_paint(rdata->cr);
-				cairo_restore(rdata->cr);
+				composite_paint(rdata, buf_surface, &src_box,
+					sx, sy, dst_width, dst_height);
 				cairo_surface_destroy(buf_surface);
 			}
 		}
@@ -1907,8 +1920,8 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 			return;
 
 		/* Read at full buffer resolution, not dst (logical) dimensions */
-		stride = src_width * 4;
-		pixels = malloc(stride * src_height);
+		stride = buf_width * 4;
+		pixels = malloc(stride * buf_height);
 		if (!pixels) {
 			wlr_texture_destroy(texture);
 			return;
@@ -1919,7 +1932,7 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 			.data = pixels,
 			.format = DRM_FORMAT_ARGB8888,
 			.stride = stride,
-			.src_box = { .x = 0, .y = 0, .width = src_width, .height = src_height },
+			.src_box = { .x = 0, .y = 0, .width = buf_width, .height = buf_height },
 		})) {
 			free(pixels);
 			wlr_texture_destroy(texture);
@@ -1931,7 +1944,7 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 
 	/* Create Cairo surface at full buffer resolution */
 	buf_surface = cairo_image_surface_create_for_data(
-		pixels, CAIRO_FORMAT_ARGB32, src_width, src_height, stride);
+		pixels, CAIRO_FORMAT_ARGB32, buf_width, buf_height, stride);
 
 	if (cairo_surface_status(buf_surface) != CAIRO_STATUS_SUCCESS) {
 		if (need_free)
@@ -1939,21 +1952,7 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 		return;
 	}
 
-	/* Composite onto target, scaling from buffer resolution to logical size */
-	cairo_save(rdata->cr);
-	if (src_width != dst_width || src_height != dst_height) {
-		cairo_translate(rdata->cr,
-			sx + rdata->offset_x, sy + rdata->offset_y);
-		cairo_scale(rdata->cr,
-			(double)dst_width / src_width,
-			(double)dst_height / src_height);
-		cairo_set_source_surface(rdata->cr, buf_surface, 0, 0);
-	} else {
-		cairo_set_source_surface(rdata->cr, buf_surface,
-			sx + rdata->offset_x, sy + rdata->offset_y);
-	}
-	cairo_paint(rdata->cr);
-	cairo_restore(rdata->cr);
+	composite_paint(rdata, buf_surface, &src_box, sx, sy, dst_width, dst_height);
 
 	cairo_surface_destroy(buf_surface);
 	if (need_free)

--- a/tests/test-client-content-pattern.lua
+++ b/tests/test-client-content-pattern.lua
@@ -10,7 +10,9 @@
 --- The Lua driver samples one pixel near the center of each logical
 --- quadrant via FFI to cairo and asserts the dominant color.
 ---
---- Runs at scale=1 (guards the src==dst fast path) and scale=2 (HiDPI).
+--- Runs at scale=1, at scale=2 (HiDPI), and once more at scale=1 with the
+--- client attaching a transparent shadow margin around a smaller xdg window
+--- geometry, the way a client-side-decorated app does.
 --- Exercises the SHM fast path of luaA_client_get_content; the GPU texture
 --- path uses identical composite logic but exercising it requires a
 --- DMA-BUF client.
@@ -98,12 +100,16 @@ local function dominant_color(r, g, b)
     return string.format("rgb(%d,%d,%d)", r, g, b)
 end
 
-local function run_at_scale(target_scale, pids)
+local function run_at_scale(target_scale, pids, margin)
     local s = screen[1]
     s.scale = target_scale
     async.sleep(0.05)   -- let the scale change propagate to outputs
 
-    local pid = awful.spawn({BINARY})
+    local cmd = {BINARY}
+    if margin then
+        cmd[2], cmd[3] = "--margin", tostring(margin)
+    end
+    local pid = awful.spawn(cmd)
     assert(type(pid) == "number" and pid > 0,
         "Failed to spawn binary: " .. tostring(pid))
     table.insert(pids, pid)
@@ -146,13 +152,22 @@ local function run_at_scale(target_scale, pids)
     local br = dominant_color(pixel_rgb(raw, qx2, qy2))
 
     io.stderr:write(string.format(
-        "[content-pattern] scale=%s surface=%dx%d TL=%s TR=%s BL=%s BR=%s\n",
-        tostring(target_scale), w, h, tl, tr, bl, br))
+        "[content-pattern] scale=%s margin=%s surface=%dx%d TL=%s TR=%s BL=%s BR=%s\n",
+        tostring(target_scale), tostring(margin), w, h, tl, tr, bl, br))
 
     assert(tl == "red"   , "TL quadrant should be red, got "    .. tl)
     assert(tr == "green" , "TR quadrant should be green, got "  .. tr)
     assert(bl == "blue"  , "BL quadrant should be blue, got "   .. bl)
     assert(br == "yellow", "BR quadrant should be yellow, got " .. br)
+
+    if margin then
+        -- The shadow margin must be cropped out, not squeezed into the
+        -- content rect, so the very corner is pattern rather than the
+        -- transparent ring.
+        local corner = dominant_color(pixel_rgb(raw, 1, 1))
+        assert(corner == "red",
+            "margin run: pixel (1,1) should be red, got " .. corner)
+    end
 
     c:kill()
     async.wait_for_no_clients(3)
@@ -166,6 +181,7 @@ runner.run_async(function()
     local ok, err = pcall(function()
         run_at_scale(1.0, pids)
         run_at_scale(2.0, pids)
+        run_at_scale(1.0, pids, 40)
     end)
 
     -- Always-run cleanup

--- a/tests/test-client-content-pattern.lua
+++ b/tests/test-client-content-pattern.lua
@@ -12,7 +12,9 @@
 ---
 --- Runs at scale=1, at scale=2 (HiDPI), and once more at scale=1 with the
 --- client attaching a transparent shadow margin around a smaller xdg window
---- geometry, the way a client-side-decorated app does.
+--- geometry, the way a client-side-decorated app does. Eight more runs
+--- commit the buffer with each wl_surface.set_buffer_transform, which
+--- permutes the on-screen quadrants; c.content must permute with them.
 --- Exercises the SHM fast path of luaA_client_get_content; the GPU texture
 --- path uses identical composite logic but exercising it requires a
 --- DMA-BUF client.
@@ -89,7 +91,32 @@ local function pixel_rgb(raw_surface, x, y)
     local data   = ffi.C.cairo_image_surface_get_data(raw_surface)
     local stride = ffi.C.cairo_image_surface_get_stride(raw_surface)
     local off = y * stride + x * 4
-    return data[off + 2], data[off + 1], data[off + 0]   -- R, G, B
+    return data[off + 2], data[off + 1], data[off + 0], data[off + 3]
+end
+
+-- Re-fetch c.content until every quadrant sample is opaque. A commit that has
+-- landed in the marker file has not necessarily reached the scene graph, and
+-- the geometry change above can retrigger one, so a capture taken too early
+-- comes back part transparent. Gates on paintedness only, never on colour, so
+-- a genuinely wrong orientation still fails rather than spinning.
+local function content_when_painted(c, timeout_secs)
+    local raw
+    async.wait_for_condition(function()
+        raw = c.content
+        if not raw then return false end
+        -- Dimensions via FFI, not gears.surface: an lgi wrapper owns the
+        -- surface and would destroy it here, leaving the caller a dangling
+        -- pointer.
+        local w = ffi.C.cairo_image_surface_get_width(raw)
+        local h = ffi.C.cairo_image_surface_get_height(raw)
+        if w <= 4 or h <= 4 then return false end
+        for _, p in ipairs({{0.25, 0.25}, {0.75, 0.25}, {0.25, 0.75}, {0.75, 0.75}}) do
+            local _, _, _, a = pixel_rgb(raw, math.floor(w * p[1]), math.floor(h * p[2]))
+            if a < 200 then return false end
+        end
+        return true
+    end, timeout_secs or 5, 0.02)
+    return raw
 end
 
 local function dominant_color(r, g, b)
@@ -100,14 +127,40 @@ local function dominant_color(r, g, b)
     return string.format("rgb(%d,%d,%d)", r, g, b)
 end
 
-local function run_at_scale(target_scale, pids, margin)
+-- On-screen quadrant order per wl_surface.set_buffer_transform. Each row was
+-- read off a grim capture of the compositor's own output, so the expectations
+-- are independent of how root.c builds its matrices.
+local TRANSFORM_QUADRANTS = {
+    [0] = {"red",    "green",  "blue",   "yellow"},
+    [1] = {"blue",   "red",    "yellow", "green"},
+    [2] = {"yellow", "blue",   "green",  "red"},
+    [3] = {"green",  "yellow", "red",    "blue"},
+    [4] = {"green",  "red",    "yellow", "blue"},
+    [5] = {"red",    "blue",   "green",  "yellow"},
+    [6] = {"blue",   "yellow", "red",    "green"},
+    [7] = {"yellow", "green",  "blue",   "red"},
+}
+local CORNERS = {"TL", "TR", "BL", "BR"}
+
+-- Spawned client pids, drained by the cleanup block at the end.
+local pids = {}
+
+local function run_case(args)
     local s = screen[1]
-    s.scale = target_scale
-    async.sleep(0.05)   -- let the scale change propagate to outputs
+    local margin, transform = args.margin, args.transform
+    if s.scale ~= args.scale then
+        s.scale = args.scale
+        async.sleep(0.05)   -- let the scale change propagate to outputs
+    end
 
     local cmd = {BINARY}
     if margin then
-        cmd[2], cmd[3] = "--margin", tostring(margin)
+        table.insert(cmd, "--margin")
+        table.insert(cmd, tostring(margin))
+    end
+    if transform then
+        table.insert(cmd, "--transform")
+        table.insert(cmd, tostring(transform))
     end
     local pid = awful.spawn(cmd)
     assert(type(pid) == "number" and pid > 0,
@@ -115,7 +168,7 @@ local function run_at_scale(target_scale, pids, margin)
     table.insert(pids, pid)
 
     local c = async.wait_for_client(APP_ID, 5)
-    assert(c, "Client never appeared at scale=" .. tostring(target_scale))
+    assert(c, "Client never appeared at scale=" .. tostring(args.scale))
 
     -- Move the client off the scene origin so c.content's scene-tree walk
     -- exercises non-zero buffer positions. A regression here (commit
@@ -129,19 +182,19 @@ local function run_at_scale(target_scale, pids, margin)
     -- Wait for the buffer at the target scale to actually be committed.
     -- At scale=1 this is the first commit; at scale=2 the C client first
     -- commits at scale=1 (default) then re-renders after preferred_buffer_scale.
-    local ok = wait_for_scale_commit(pid, target_scale, 5)
+    local ok = wait_for_scale_commit(pid, args.scale, 5)
     assert(ok, string.format(
-        "C client never committed scale=%d (marker file never matched)", target_scale))
+        "C client never committed scale=%d (marker file never matched)", args.scale))
 
     -- Surface dims should now match logical content dimensions.
-    local raw = c.content
-    assert(raw, "c.content returned nil at scale=" .. tostring(target_scale))
+    local raw = content_when_painted(c, 5)
+    assert(raw, "c.content returned nil at scale=" .. tostring(args.scale))
 
     local img = gears.surface(raw)
     local w = img:get_width()
     local h = img:get_height()
     assert(w > 4 and h > 4, string.format(
-        "c.content surface too small (%dx%d) at scale=%d", w, h, target_scale))
+        "c.content surface too small (%dx%d) at scale=%d", w, h, args.scale))
 
     -- Sample one pixel near the center of each logical quadrant.
     local qx1, qx2 = math.floor(w * 0.25), math.floor(w * 0.75)
@@ -151,22 +204,27 @@ local function run_at_scale(target_scale, pids, margin)
     local bl = dominant_color(pixel_rgb(raw, qx1, qy2))
     local br = dominant_color(pixel_rgb(raw, qx2, qy2))
 
-    io.stderr:write(string.format(
-        "[content-pattern] scale=%s margin=%s surface=%dx%d TL=%s TR=%s BL=%s BR=%s\n",
-        tostring(target_scale), tostring(margin), w, h, tl, tr, bl, br))
+    local want = TRANSFORM_QUADRANTS[transform or 0]
+    assert(want, "no expected quadrants for transform " .. tostring(transform))
 
-    assert(tl == "red"   , "TL quadrant should be red, got "    .. tl)
-    assert(tr == "green" , "TR quadrant should be green, got "  .. tr)
-    assert(bl == "blue"  , "BL quadrant should be blue, got "   .. bl)
-    assert(br == "yellow", "BR quadrant should be yellow, got " .. br)
+    io.stderr:write(string.format(
+        "[content-pattern] scale=%s margin=%s transform=%s surface=%dx%d TL=%s TR=%s BL=%s BR=%s\n",
+        tostring(args.scale), tostring(margin), tostring(transform),
+        w, h, tl, tr, bl, br))
+
+    for i, got in ipairs({tl, tr, bl, br}) do
+        assert(got == want[i], string.format(
+            "%s quadrant should be %s, got %s (transform=%s)",
+            CORNERS[i], want[i], got, tostring(transform)))
+    end
 
     if margin then
         -- The shadow margin must be cropped out, not squeezed into the
         -- content rect, so the very corner is pattern rather than the
         -- transparent ring.
         local corner = dominant_color(pixel_rgb(raw, 1, 1))
-        assert(corner == "red",
-            "margin run: pixel (1,1) should be red, got " .. corner)
+        assert(corner == want[1],
+            "margin run: pixel (1,1) should be " .. want[1] .. ", got " .. corner)
     end
 
     c:kill()
@@ -176,12 +234,14 @@ end
 runner.run_async(function()
     local s = screen[1]
     local original_scale = s.scale
-    local pids = {}
 
     local ok, err = pcall(function()
-        run_at_scale(1.0, pids)
-        run_at_scale(2.0, pids)
-        run_at_scale(1.0, pids, 40)
+        run_case { scale = 1.0 }
+        run_case { scale = 2.0 }
+        run_case { scale = 1.0, margin = 40 }
+        for t = 1, 7 do
+            run_case { scale = 1.0, transform = t }
+        end
     end)
 
     -- Always-run cleanup

--- a/tests/test-content-pattern-client.c
+++ b/tests/test-content-pattern-client.c
@@ -19,6 +19,9 @@
  * pattern and the xdg window geometry points at the pattern, mimicking a
  * client-side-decoration shadow margin.
  *
+ * With --transform N the buffer is committed with wl_surface.set_buffer_transform
+ * N, so the compositor re-orients it and the on-screen quadrants permute.
+ *
  * Lifecycle: SIGTERM/SIGINT for clean exit. App ID: "content_pattern_test".
  */
 
@@ -50,6 +53,7 @@ static struct wl_buffer *g_current_buffer;
 
 static int g_logical_w = 200, g_logical_h = 200;
 static int g_margin = 0;
+static int g_transform = 0;
 static int g_pending_scale = 1;
 static int g_current_scale = 0;     /* 0 = nothing committed yet */
 static char g_marker_path[256];
@@ -135,6 +139,7 @@ static void render_pattern(void) {
     }
 
     wl_surface_set_buffer_scale(g_surface, scale);
+    wl_surface_set_buffer_transform(g_surface, g_transform);
     if (g_margin > 0)
         xdg_surface_set_window_geometry(g_xdg_surface, g_margin, g_margin,
                                         g_logical_w, g_logical_h);
@@ -276,10 +281,22 @@ static const struct wl_registry_listener registry_listener = {
 };
 
 int main(int argc, char *argv[]) {
-    if (argc == 3 && strcmp(argv[1], "--margin") == 0)
-        g_margin = atoi(argv[2]);
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--margin") == 0 && i + 1 < argc)
+            g_margin = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--transform") == 0 && i + 1 < argc)
+            g_transform = atoi(argv[++i]);
+        else {
+            fprintf(stderr, "Usage: %s [--margin N] [--transform N]\n", argv[0]);
+            return 1;
+        }
+    }
     if (g_margin < 0)
         g_margin = 0;
+    if (g_transform < 0 || g_transform > 7) {
+        fprintf(stderr, "--transform must be 0..7\n");
+        return 1;
+    }
 
     snprintf(g_marker_path, sizeof(g_marker_path),
              "/tmp/test-content-pattern-%d.scale", (int)getpid());

--- a/tests/test-content-pattern-client.c
+++ b/tests/test-content-pattern-client.c
@@ -15,6 +15,10 @@
  *   TL = red    (0xFFFF0000)   TR = green  (0xFF00FF00)
  *   BL = blue   (0xFF0000FF)   BR = yellow (0xFFFFFF00)
  *
+ * With --margin N a transparent ring N logical pixels wide surrounds the
+ * pattern and the xdg window geometry points at the pattern, mimicking a
+ * client-side-decoration shadow margin.
+ *
  * Lifecycle: SIGTERM/SIGINT for clean exit. App ID: "content_pattern_test".
  */
 
@@ -45,6 +49,7 @@ static struct xdg_toplevel *g_toplevel;
 static struct wl_buffer *g_current_buffer;
 
 static int g_logical_w = 200, g_logical_h = 200;
+static int g_margin = 0;
 static int g_pending_scale = 1;
 static int g_current_scale = 0;     /* 0 = nothing committed yet */
 static char g_marker_path[256];
@@ -56,14 +61,17 @@ static void handle_term(int sig) {
     g_running = 0;
 }
 
-/* Create an SHM-backed wl_buffer at the given physical dims, filled with the
- * 4-quadrant ARGB8888 pattern. Caller owns the returned buffer. */
-static struct wl_buffer *create_pattern_buffer(int w, int h) {
+/* Create an SHM-backed wl_buffer holding the 4-quadrant ARGB8888 pattern at
+ * the given physical dims, inset by a transparent ring of m physical pixels.
+ * Caller owns the returned buffer. */
+static struct wl_buffer *create_pattern_buffer(int w, int h, int m) {
     if (w <= 0 || h <= 0)
         return NULL;
 
-    int stride = w * 4;
-    size_t size = (size_t)stride * (size_t)h;
+    int buf_w = w + 2 * m;
+    int buf_h = h + 2 * m;
+    int stride = buf_w * 4;
+    size_t size = (size_t)stride * (size_t)buf_h;
 
     char tmpl[] = "/tmp/test-content-pattern-buf-XXXXXX";
     int fd = mkstemp(tmpl);
@@ -86,6 +94,8 @@ static struct wl_buffer *create_pattern_buffer(int w, int h) {
         return NULL;
     }
 
+    memset(data, 0, size);
+
     int half_w = w / 2;
     int half_h = h / 2;
     for (int y = 0; y < h; y++) {
@@ -95,14 +105,14 @@ static struct wl_buffer *create_pattern_buffer(int w, int h) {
             else if (x >= half_w && y <  half_h) color = 0xFF00FF00; /* TR green  */
             else if (x <  half_w && y >= half_h) color = 0xFF0000FF; /* BL blue   */
             else                                 color = 0xFFFFFF00; /* BR yellow */
-            data[y * w + x] = color;
+            data[(y + m) * buf_w + (x + m)] = color;
         }
     }
     munmap(data, size);
 
     struct wl_shm_pool *pool = wl_shm_create_pool(g_shm, fd, size);
     struct wl_buffer *buf = wl_shm_pool_create_buffer(
-        pool, 0, w, h, stride, WL_SHM_FORMAT_ARGB8888);
+        pool, 0, buf_w, buf_h, stride, WL_SHM_FORMAT_ARGB8888);
     wl_shm_pool_destroy(pool);
     close(fd);
 
@@ -115,8 +125,9 @@ static void render_pattern(void) {
     int scale = g_pending_scale > 0 ? g_pending_scale : 1;
     int phys_w = g_logical_w * scale;
     int phys_h = g_logical_h * scale;
+    int phys_m = g_margin * scale;
 
-    struct wl_buffer *buf = create_pattern_buffer(phys_w, phys_h);
+    struct wl_buffer *buf = create_pattern_buffer(phys_w, phys_h, phys_m);
     if (!buf) {
         fprintf(stderr, "[content-pattern-client] buffer alloc failed (%dx%d)\n",
                 phys_w, phys_h);
@@ -124,8 +135,11 @@ static void render_pattern(void) {
     }
 
     wl_surface_set_buffer_scale(g_surface, scale);
+    if (g_margin > 0)
+        xdg_surface_set_window_geometry(g_xdg_surface, g_margin, g_margin,
+                                        g_logical_w, g_logical_h);
     wl_surface_attach(g_surface, buf, 0, 0);
-    wl_surface_damage_buffer(g_surface, 0, 0, phys_w, phys_h);
+    wl_surface_damage_buffer(g_surface, 0, 0, INT32_MAX, INT32_MAX);
     wl_surface_commit(g_surface);
     wl_display_flush(g_display);
 
@@ -262,7 +276,10 @@ static const struct wl_registry_listener registry_listener = {
 };
 
 int main(int argc, char *argv[]) {
-    (void)argc; (void)argv;
+    if (argc == 3 && strcmp(argv[1], "--margin") == 0)
+        g_margin = atoi(argv[2]);
+    if (g_margin < 0)
+        g_margin = 0;
 
     snprintf(g_marker_path, sizeof(g_marker_path),
              "/tmp/test-content-pattern-%d.scale", (int)getpid());


### PR DESCRIPTION
## Description
Screenshots of clients that draw their own decorations came out with transparent borders around the content. Reported against Discord, but it hits any client that attaches a shadow margin, so most GTK and Electron apps. It applies to `c.content`, `root.content` and `screen.content` alike.

Those clients attach a buffer bigger than their window and use the extra ring for shadows. somewm crops that ring off when it draws them. The screenshot code ignored the crop and squeezed the whole buffer into the content rectangle instead.

Now the screenshot code reads the same crop the renderer does. It was ignoring buffer rotation in the same place, so that is fixed too. That one affected our own shadow edges.

Fixes #689.


## Test Plan
Heavy testing live and comparing screenshots


## AI Usage
Used Claude Code to help me reproduce the issue to mixed results.  Was nice to use it in driving somewm-client screenshot and grim for testing.


## Checklist
- [ ] Lua libraries (`lua/awful/`, `lua/gears/`, `lua/wibox/`, `lua/naughty/`) are **not modified** — if a bug surfaces in Lua, the fix belongs in C
- [ ] Tests pass (`make test-unit && make test-integration`)
