### PR TITLE
fix: restore client tags and selected tags across a hot-reload

### DIFF
--- a/DEVIATIONS.md
+++ b/DEVIATIONS.md
@@ -187,7 +187,7 @@ These modifications to AwesomeWM's Lua libraries were necessary for Wayland comp
 | `awful/widget/tasklist.lua` | Icon slot falls back to `awful.client.get_icon_path(c)`; templates can receive a file path string where upstream always passes a surface | Same missing Wayland icon protocol |
 | `awful/widget/keyboardlayout.lua` | `next_layout`/`set_layout` wrap-around off-by-one fixed | Upstream cycles to an out-of-range group index |
 | `awful/widget/layoutlist.lua` | `source.for_screen` returns `{}` for a nil screen instead of asserting | Screens can be absent mid hot-reload |
-| `awful/permissions/init.lua` | Layer surface keyboard focus handlers; `request::tag` guards a nil `transient_for.screen`; hosts the focus restore and tag persistence handlers (see SomeWM-Only Features) | Wayland layer-shell, output hotplug and hot-reload have no X11 equivalent |
+| `awful/permissions/init.lua` | Layer surface keyboard focus handlers; `request::tag` guards a nil `transient_for.screen` and applies `hints.tags` when the signal carries a list; hosts the focus restore and tag persistence handlers (see SomeWM-Only Features) | Wayland layer-shell, output hotplug and hot-reload have no X11 equivalent |
 | `awful/mouse/snap.lua` | ARGB32 shapes, surface lifetime; edge snap dwell gating (see SomeWM-Only Features) | Same Wayland surface patterns as `wibox/init.lua` |
 | `awful/root.lua` | `_remove_*` calls the C-side removal hook immediately when present | somewm's C layer exposes `_remove_` hooks; also flushes removals upstream leaves queued |
 | `awful/screenshot.lua` | Snipping overlay wibox sets `surface_scale = 1.0` | HiDPI overlay repaint was ~1 FPS at physical resolution |
@@ -369,6 +369,20 @@ by the window are simply not visible. Configs that set it still parse.
 When a lock screen, layer surface, or output change releases focus, the compositor emits the somewm-only `request::focus_restore` screen signal. `awful.permissions.focus_restore` handles it by activating the best client from focus history.
 
 When a screen is removed, `awful.permissions.tag_screen` saves its tag state (name, selection, layout, master settings, clients) into `awful.permissions.saved_tags`, keyed by output name. `somewmrc.lua` restores the saved state when the output reconnects.
+
+A hot-reload (`awesome.restart()`) re-runs `rc.lua` in the same process, so every tag is built from scratch. Before the old Lua state closes, the compositor records each tag's screen and name, whether it was selected, and which clients were on it. After `rc.lua` has run, each recorded tag is matched to the first new tag on the same screen with the same name, or to nothing. There is no fallback by position: a tag renamed in `rc.lua` loses its clients to the rules, and a tag created at runtime (a `new_tag` rule, a volatile tag) never lands on a config tag.
+
+For each client with at least one match, the compositor emits `request::tag` on the client before the rules run, with the first matched tag as the tag argument and hints of:
+
+```lua
+{ reason = "restart", tags = { <every matched tag> } }
+```
+
+`awful.permissions.tag` applies `hints.tags` when present, so a client on several tags comes back on all of them. AwesomeWM does the same thing on its own restart through `_NET_WM_DESKTOP`, but restores only the first tag and does not restore the selection. The rules then run as on AwesomeWM's restart: a rule with no `tag` property emits `request::tag` with reason `"rules"` and the handler returns early because the client already has tags, a `tag =` rule replaces the restored tags, a `tags =` rule merges only when given tag objects on the client's screen and replaces when given names, and a `screen =` rule pointing at another screen discards the restore. A client whose tags all fail to match gets no signal and is placed by the rules as if it were new.
+
+The selection is restored next, still before the rules run, so a client the rules place on the selected tags lands on the restored selection. Per screen with at least one recorded selected tag that matched, every tag on the screen is set selected or not to match the record, then `tag::history::update` is emitted once, so `awful.tag`'s history holds the restored set and nothing in between. No `request::select` is emitted. A screen whose selected tags matched nothing keeps the selection `rc.lua` made.
+
+Floating state and per-tag layout are not restored.
 
 ### Cursor Theming
 

--- a/DEVIATIONS.md
+++ b/DEVIATIONS.md
@@ -370,9 +370,9 @@ When a lock screen, layer surface, or output change releases focus, the composit
 
 When a screen is removed, `awful.permissions.tag_screen` saves its tag state (name, selection, layout, master settings, clients) into `awful.permissions.saved_tags`, keyed by output name. `somewmrc.lua` restores the saved state when the output reconnects.
 
-A hot-reload (`awesome.restart()`) re-runs `rc.lua` in the same process, so every tag is built from scratch. Before the old Lua state closes, the compositor records each tag's screen and name, active layout name, whether it was selected, and which clients were on it. After `rc.lua` has run, each recorded tag is matched to the first new tag on the same screen with the same name, or to nothing. There is no fallback by position: a tag renamed in `rc.lua` loses its clients to the rules, and a tag created at runtime (a `new_tag` rule, a volatile tag) never lands on a config tag.
+A hot-reload (`awesome.restart()`) re-runs `rc.lua` in the same process, so every tag is built from scratch. Before the old Lua state closes, the compositor records each tag's screen and name, whether it was selected, which clients were on it, and the state `awful` keeps for it in Lua: the layout name, `master_width_factor`, `master_count`, `column_count` and `gap`. After `rc.lua` has run, each recorded tag is matched to the first new tag on the same screen with the same name, or to nothing. There is no fallback by position: a tag renamed in `rc.lua` loses its clients to the rules, and a tag created at runtime (a `new_tag` rule, a volatile tag) never lands on a config tag.
 
-For each matched tag, the compositor selects the first same-named layout from the rebuilt tag's allowed `layouts` list before it restores clients or selection. Layout objects belong to their Lua state and cannot be reused directly. If the old layout has no named match in the new list, the tag keeps the layout selected by `rc.lua`.
+For each matched tag, the compositor selects the first same-named layout from the rebuilt tag's allowed `layouts` list, and puts the four numbers back, before it restores clients or selection. Layout objects belong to their Lua state and cannot be reused directly. If the old layout has no named match in the new list, the tag keeps the layout selected by `rc.lua`. Only what the old session actually set is recorded, so a property it left alone comes back from the new config and theme instead of from the old session.
 
 For each client with at least one match, the compositor emits `request::tag` on the client before the rules run, with the first matched tag as the tag argument and hints of:
 
@@ -384,7 +384,9 @@ For each client with at least one match, the compositor emits `request::tag` on 
 
 The selection is restored next, still before the rules run, so a client the rules place on the selected tags lands on the restored selection. Per screen with at least one recorded selected tag that matched, every tag on the screen is set selected or not to match the record, then `tag::history::update` is emitted once, so `awful.tag`'s history holds the restored set and nothing in between. No `request::select` is emitted. A screen whose selected tags matched nothing keeps the selection `rc.lua` made.
 
-Explicit per-client floating state is not restored. Titlebars are rebuilt by the rules; their old extents are removed before their Lua drawables are discarded so recreating the same titlebars does not grow client geometry across reloads.
+A client's floating state is restored before the rules run, so a rule with a `floating` property still wins. Only a floating state something set explicitly is restored: a client that floats because of its type floats again for the same reason.
+
+Titlebars are rebuilt by the rules; their old extents are removed before their Lua drawables are discarded so recreating the same titlebars does not grow client geometry across reloads.
 
 ### Cursor Theming
 

--- a/DEVIATIONS.md
+++ b/DEVIATIONS.md
@@ -370,7 +370,9 @@ When a lock screen, layer surface, or output change releases focus, the composit
 
 When a screen is removed, `awful.permissions.tag_screen` saves its tag state (name, selection, layout, master settings, clients) into `awful.permissions.saved_tags`, keyed by output name. `somewmrc.lua` restores the saved state when the output reconnects.
 
-A hot-reload (`awesome.restart()`) re-runs `rc.lua` in the same process, so every tag is built from scratch. Before the old Lua state closes, the compositor records each tag's screen and name, whether it was selected, and which clients were on it. After `rc.lua` has run, each recorded tag is matched to the first new tag on the same screen with the same name, or to nothing. There is no fallback by position: a tag renamed in `rc.lua` loses its clients to the rules, and a tag created at runtime (a `new_tag` rule, a volatile tag) never lands on a config tag.
+A hot-reload (`awesome.restart()`) re-runs `rc.lua` in the same process, so every tag is built from scratch. Before the old Lua state closes, the compositor records each tag's screen and name, active layout name, whether it was selected, and which clients were on it. After `rc.lua` has run, each recorded tag is matched to the first new tag on the same screen with the same name, or to nothing. There is no fallback by position: a tag renamed in `rc.lua` loses its clients to the rules, and a tag created at runtime (a `new_tag` rule, a volatile tag) never lands on a config tag.
+
+For each matched tag, the compositor selects the first same-named layout from the rebuilt tag's allowed `layouts` list before it restores clients or selection. Layout objects belong to their Lua state and cannot be reused directly. If the old layout has no named match in the new list, the tag keeps the layout selected by `rc.lua`.
 
 For each client with at least one match, the compositor emits `request::tag` on the client before the rules run, with the first matched tag as the tag argument and hints of:
 
@@ -382,7 +384,7 @@ For each client with at least one match, the compositor emits `request::tag` on 
 
 The selection is restored next, still before the rules run, so a client the rules place on the selected tags lands on the restored selection. Per screen with at least one recorded selected tag that matched, every tag on the screen is set selected or not to match the record, then `tag::history::update` is emitted once, so `awful.tag`'s history holds the restored set and nothing in between. No `request::select` is emitted. A screen whose selected tags matched nothing keeps the selection `rc.lua` made.
 
-Floating state and per-tag layout are not restored.
+Explicit per-client floating state is not restored. Titlebars are rebuilt by the rules; their old extents are removed before their Lua drawables are discarded so recreating the same titlebars does not grow client geometry across reloads.
 
 ### Cursor Theming
 

--- a/lua/awful/permissions/init.lua
+++ b/lua/awful/permissions/init.lua
@@ -308,6 +308,8 @@ end
 -- @tparam[opt] tag|boolean t A tag to use. If `true`, then the client is made `sticky`.
 -- @tparam[opt={}] table hints Extra information.
 -- @tparam[opt=nil] nil|string hints.reason Why the tag is being changed.
+-- @tparam[opt=nil] nil|table hints.tags Every tag to apply, used in place of
+--  `t` alone. somewm sets this when restoring tags across a hot-reload.
 -- @sourcesignal client request::tag
 function permissions.tag(c, t, hints) --luacheck: no unused
     -- There is nothing to do
@@ -340,7 +342,9 @@ function permissions.tag(c, t, hints) --luacheck: no unused
         c.sticky = true
     else
         c.screen = t.screen
-        c:tags({ t })
+        -- A hot-reload restore names every tag the client had, not just the
+        -- first. Any other caller passes no list and keeps upstream behavior.
+        c:tags(hints and hints.tags or { t })
     end
 end
 

--- a/luaa.c
+++ b/luaa.c
@@ -5574,6 +5574,9 @@ typedef struct {
 	 * theme, not from here. */
 	double numbers[TAG_NUMBER_COUNT];
 	bool has_number[TAG_NUMBER_COUNT];
+	/* Lua 5.3 tells an integer from a float, and a count restored as a
+	 * float reads as "2.0" wherever a config prints it. */
+	bool integer_number[TAG_NUMBER_COUNT];
 } tag_snapshot_t;
 
 typedef struct {
@@ -5696,7 +5699,10 @@ tag_restore_snapshot_state(lua_State *L)
 
 	for (i = 0; i < TAG_NUMBER_COUNT; i++)
 		if (ts->has_number[i]) {
-			lua_pushnumber(L, ts->numbers[i]);
+			if (ts->integer_number[i])
+				lua_pushinteger(L, (lua_Integer) ts->numbers[i]);
+			else
+				lua_pushnumber(L, ts->numbers[i]);
 			lua_setfield(L, 1, tag_numbers[i].property);
 		}
 	return 0;
@@ -5952,6 +5958,9 @@ luaA_hot_reload(void)
 						       tag_numbers[j].stored)) {
 				ts->has_number[j] = lua_isnumber(L, -1);
 				ts->numbers[j] = lua_tonumber(L, -1);
+#if LUA_VERSION_NUM >= 503
+				ts->integer_number[j] = lua_isinteger(L, -1);
+#endif
 				lua_pop(L, 1);
 			}
 

--- a/luaa.c
+++ b/luaa.c
@@ -5086,6 +5086,23 @@ clients_restore(lua_State *L, client_snapshot_t *snaps, int num_clients)
 		c->toplevel_handle = NULL;
 		c->screen = NULL;
 		c->transient_for = NULL;
+		/* Geometry includes the old titlebars, but their Lua drawables cannot
+		 * cross into the new state. Strip the old extents before resetting the
+		 * sizes so request::titlebars can add the rebuilt bars exactly once.
+		 * Keep this as the inverse of titlebar_resize(), including X11 gravity. */
+		{
+			int left = c->titlebar[CLIENT_TITLEBAR_LEFT].size;
+			int right = c->titlebar[CLIENT_TITLEBAR_RIGHT].size;
+			int top = c->titlebar[CLIENT_TITLEBAR_TOP].size;
+			int bottom = c->titlebar[CLIENT_TITLEBAR_BOTTOM].size;
+
+			c->geometry.width = MAX(1, c->geometry.width - left - right);
+			c->geometry.height = MAX(1, c->geometry.height - top - bottom);
+			if (c->size_hints.flags & XCB_ICCCM_SIZE_HINT_P_WIN_GRAVITY)
+				xwindow_translate_for_gravity(c->size_hints.win_gravity,
+					-left, -top, -right, -bottom,
+					&c->geometry.x, &c->geometry.y);
+		}
 		for (j = 0; j < CLIENT_TITLEBAR_COUNT; j++) {
 			c->titlebar[j].drawable = NULL;
 			c->titlebar[j].size = 0;
@@ -5546,6 +5563,8 @@ typedef struct {
 	/* Owns the name string (transferred from old tag_t to prevent
 	 * double-free during GC). Freed in cleanup. */
 	char *name;
+	/* Name of the active Lua layout, copied before class teardown. */
+	char *layout_name;
 	/* Screen index (0-based, -1 if the tag had no screen). */
 	int screen_index;
 	bool selected;
@@ -5578,6 +5597,50 @@ tag_resolve_snapshot(const tag_snapshot_t *ts)
 		if ((*tag)->screen == screen && (*tag)->name && !strcmp(ts->name, (*tag)->name))
 			return *tag;
 	return NULL;
+}
+
+/** Restore a snapshotted layout from the matched tag's rebuilt allowed list.
+ * Layout objects belong to a Lua state, so only their stable public name can
+ * cross a hot-reload. A missing or nameless layout leaves rc.lua's choice
+ * untouched.
+ */
+static void
+tag_restore_snapshot_layout(lua_State *L, tag_t *tag, const tag_snapshot_t *ts)
+{
+	int tag_idx, layouts_idx;
+
+	if (!tag || !ts->layout_name)
+		return;
+
+	luaA_object_push(L, tag);
+	tag_idx = lua_gettop(L);
+	lua_getfield(L, tag_idx, "layouts");
+	if (!lua_istable(L, -1)) {
+		lua_pop(L, 2);
+		return;
+	}
+	layouts_idx = lua_gettop(L);
+
+	for (int i = 1; i <= (int)luaA_rawlen(L, layouts_idx); i++) {
+		lua_rawgeti(L, layouts_idx, i);
+		if (!lua_istable(L, -1)) {
+			lua_pop(L, 1);
+			continue;
+		}
+		lua_getfield(L, -1, "name");
+		bool matches = lua_isstring(L, -1)
+			&& !strcmp(ts->layout_name, lua_tostring(L, -1));
+		lua_pop(L, 1);
+		if (matches) {
+			lua_pushvalue(L, -1);
+			lua_setfield(L, tag_idx, "layout");
+			lua_pop(L, 1);
+			break;
+		}
+		lua_pop(L, 1);
+	}
+
+	lua_pop(L, 2);
 }
 
 /** Perform in-process hot-reload of the Lua state.
@@ -5679,6 +5742,35 @@ luaA_hot_reload(void)
 			g_main_context_iteration(NULL, FALSE);
 	}
 
+	/* Layouts live entirely in Lua. Copy their names before class teardown
+	 * clears the property handlers needed to reach tag.layout. The remaining
+	 * tag state is filled in after screens are available for index lookups. */
+	num_tags = globalconf.tags.len;
+	if (num_tags > 0) {
+		tag_snaps = calloc(num_tags, sizeof(tag_snapshot_t));
+		if (!tag_snaps) {
+			fprintf(stderr, "somewm: hot-reload: failed to allocate tag snapshots\n");
+			goto fail;
+		}
+	}
+	for (i = 0; i < num_tags; i++) {
+		luaA_object_push(L, globalconf.tags.tab[i]);
+		lua_getfield(L, -1, "layout");
+		if (lua_istable(L, -1)) {
+			lua_getfield(L, -1, "name");
+			if (lua_isstring(L, -1)) {
+				tag_snaps[i].layout_name = strdup(lua_tostring(L, -1));
+				if (!tag_snaps[i].layout_name) {
+					lua_pop(L, 3);
+					fprintf(stderr, "somewm: hot-reload: failed to copy tag layout name\n");
+					goto fail;
+				}
+			}
+			lua_pop(L, 1);
+		}
+		lua_pop(L, 2);
+	}
+
 	luaA_state_teardown_lua(L, true);
 
 	/* ================================================================
@@ -5728,14 +5820,7 @@ luaA_hot_reload(void)
 	 * clients_detach() builds.
 	 */
 
-	num_tags = globalconf.tags.len;
 	if (num_tags > 0) {
-		tag_snaps = calloc(num_tags, sizeof(tag_snapshot_t));
-		if (!tag_snaps) {
-			fprintf(stderr, "somewm: hot-reload: failed to allocate tag snapshots\n");
-			num_tags = 0;
-			goto fail;
-		}
 		if (globalconf.clients.len > 0) {
 			tag_members = calloc((size_t)num_tags * globalconf.clients.len, sizeof(bool));
 			if (!tag_members) {
@@ -6046,6 +6131,11 @@ luaA_hot_reload(void)
 			tag_map[i] = tag_resolve_snapshot(&tag_snaps[i]);
 	}
 
+	/* Re-select the old layout from each matched tag's rebuilt layout list
+	 * before tagging or selection can arrange clients. */
+	for (i = 0; i < num_tags; i++)
+		tag_restore_snapshot_layout(L, tag_map[i], &tag_snaps[i]);
+
 	for (i = 0; i < num_clients; i++) {
 		client_t *c = globalconf.clients.tab[i];
 		tag_t *first = NULL;
@@ -6203,8 +6293,10 @@ fail:
 cleanup:
 	/* Free snapshot arrays */
 	if (tag_snaps)
-		for (i = 0; i < num_tags; i++)
+		for (i = 0; i < num_tags; i++) {
 			free(tag_snaps[i].name);
+			free(tag_snaps[i].layout_name);
+		}
 	if (screen_snaps)
 		for (i = 0; i < num_screens; i++)
 			free(screen_snaps[i].name);

--- a/luaa.c
+++ b/luaa.c
@@ -5087,25 +5087,11 @@ clients_restore(lua_State *L, client_snapshot_t *snaps, int num_clients)
 		c->screen = NULL;
 		c->transient_for = NULL;
 		/* Geometry includes the old titlebars, but their Lua drawables cannot
-		 * cross into the new state. Strip the old extents before resetting the
-		 * sizes so request::titlebars can add the rebuilt bars exactly once.
-		 * Keep this as the inverse of titlebar_resize(), including X11 gravity. */
-		{
-			int left = c->titlebar[CLIENT_TITLEBAR_LEFT].size;
-			int right = c->titlebar[CLIENT_TITLEBAR_RIGHT].size;
-			int top = c->titlebar[CLIENT_TITLEBAR_TOP].size;
-			int bottom = c->titlebar[CLIENT_TITLEBAR_BOTTOM].size;
-
-			c->geometry.width = MAX(1, c->geometry.width - left - right);
-			c->geometry.height = MAX(1, c->geometry.height - top - bottom);
-			if (c->size_hints.flags & XCB_ICCCM_SIZE_HINT_P_WIN_GRAVITY)
-				xwindow_translate_for_gravity(c->size_hints.win_gravity,
-					-left, -top, -right, -bottom,
-					&c->geometry.x, &c->geometry.y);
-		}
+		 * cross into the new state. Strip the extents and the sizes together
+		 * so request::titlebars can add the rebuilt bars exactly once. */
+		client_strip_titlebar_geometry(c);
 		for (j = 0; j < CLIENT_TITLEBAR_COUNT; j++) {
 			c->titlebar[j].drawable = NULL;
-			c->titlebar[j].size = 0;
 			if (c->titlebar[j].scene_buffer) {
 				wlr_scene_node_destroy(&c->titlebar[j].scene_buffer->node);
 				c->titlebar[j].scene_buffer = NULL;
@@ -5559,9 +5545,10 @@ typedef struct {
 	screen_lifecycle_t lifecycle;
 } screen_snapshot_t;
 
-/* The per-tag numbers a session is worth keeping, the same set
- * awful.permissions.tag_screen saves when a screen goes away. awful does not
- * always store a property under its own name: gap is stored as useless_gap. */
+/* The per-tag numbers a session is worth keeping. awful.permissions.tag_screen
+ * answers the same question for a screen that goes away and saves all of these
+ * but column_count. awful does not always store a property under its own name:
+ * gap is stored as useless_gap. */
 static const struct {
 	const char *stored;
 	const char *property;
@@ -5655,12 +5642,46 @@ none:
 	return false;
 }
 
-/** Restore a snapshotted tag's Lua-side state onto the tag rc.lua rebuilt.
+/** Select the layout named `name` from the layouts a tag allows.
  *
  * Layout objects belong to a Lua state, so only their stable public name can
- * cross a hot-reload: the name is matched against the rebuilt tag's allowed
- * list, and a layout that has no named match there leaves rc.lua's choice
- * untouched.
+ * cross a hot-reload. A name the rebuilt list does not offer leaves rc.lua's
+ * choice untouched.
+ *
+ * \param tag_idx Stack index of the tag.
+ */
+static void
+tag_select_layout_by_name(lua_State *L, int tag_idx, const char *name)
+{
+	int layouts_idx, len, i;
+
+	lua_getfield(L, tag_idx, "layouts");
+	if (!lua_istable(L, -1)) {
+		lua_pop(L, 1);
+		return;
+	}
+	layouts_idx = lua_gettop(L);
+	len = (int) luaA_rawlen(L, layouts_idx);
+
+	for (i = 1; i <= len; i++) {
+		lua_rawgeti(L, layouts_idx, i);
+		if (!lua_istable(L, -1)) {
+			lua_pop(L, 1);
+			continue;
+		}
+		lua_getfield(L, -1, "name");
+		if (lua_isstring(L, -1) && !strcmp(name, lua_tostring(L, -1))) {
+			lua_pop(L, 1);
+			lua_setfield(L, tag_idx, "layout");
+			break;
+		}
+		lua_pop(L, 2);
+	}
+
+	lua_pop(L, 1);
+}
+
+/** Restore a snapshotted tag's Lua-side state onto the tag rc.lua rebuilt.
  *
  * Called through hot_reload_call: the tag is at 1, the snapshot at 2.
  */
@@ -5670,32 +5691,8 @@ tag_restore_snapshot_state(lua_State *L)
 	const tag_snapshot_t *ts = lua_touserdata(L, 2);
 	int i;
 
-	if (ts->layout_name) {
-		lua_getfield(L, 1, "layouts");
-		if (lua_istable(L, -1)) {
-			int layouts_idx = lua_gettop(L);
-
-			for (i = 1; i <= (int) luaA_rawlen(L, layouts_idx); i++) {
-				bool matches;
-
-				lua_rawgeti(L, layouts_idx, i);
-				if (!lua_istable(L, -1)) {
-					lua_pop(L, 1);
-					continue;
-				}
-				lua_getfield(L, -1, "name");
-				matches = lua_isstring(L, -1)
-					&& !strcmp(ts->layout_name, lua_tostring(L, -1));
-				lua_pop(L, 1);
-				if (matches) {
-					lua_setfield(L, 1, "layout");
-					break;
-				}
-				lua_pop(L, 1);
-			}
-		}
-		lua_pop(L, 1);
-	}
+	if (ts->layout_name)
+		tag_select_layout_by_name(L, 1, ts->layout_name);
 
 	for (i = 0; i < TAG_NUMBER_COUNT; i++)
 		if (ts->has_number[i]) {
@@ -5724,7 +5721,9 @@ client_restore_floating(lua_State *L)
  *
  * Protected, because a property setter runs config code: past the point the
  * old state closed, a reload has nothing to unwind to and an error would take
- * the compositor with it.
+ * the compositor with it. A plain pcall rather than luaA_dofunction: its error
+ * handler emits debug::error, which would re-enter the config from inside a
+ * half-restored reload.
  */
 static void
 hot_reload_call(lua_State *L, lua_CFunction fn, void *object, const void *arg)
@@ -6260,7 +6259,7 @@ luaA_hot_reload(void)
 		if (!client_snaps[i].was_mapped)
 			continue;
 
-		if (client_floating && client_floating[i] >= 0)
+		if (client_floating[i] >= 0)
 			hot_reload_call(L, client_restore_floating, c,
 					&client_floating[i]);
 

--- a/luaa.c
+++ b/luaa.c
@@ -5559,15 +5559,34 @@ typedef struct {
 	screen_lifecycle_t lifecycle;
 } screen_snapshot_t;
 
+/* The per-tag numbers a session is worth keeping, the same set
+ * awful.permissions.tag_screen saves when a screen goes away. awful does not
+ * always store a property under its own name: gap is stored as useless_gap. */
+static const struct {
+	const char *stored;
+	const char *property;
+} tag_numbers[] = {
+	{ "master_width_factor", "master_width_factor" },
+	{ "master_count",        "master_count"        },
+	{ "column_count",        "column_count"        },
+	{ "useless_gap",         "gap"                 },
+};
+#define TAG_NUMBER_COUNT ((int) (sizeof(tag_numbers) / sizeof(tag_numbers[0])))
+
 typedef struct {
 	/* Owns the name string (transferred from old tag_t to prevent
 	 * double-free during GC). Freed in cleanup. */
 	char *name;
-	/* Name of the active Lua layout, copied before class teardown. */
+	/* Name of the active Lua layout. Owned, freed in cleanup. */
 	char *layout_name;
 	/* Screen index (0-based, -1 if the tag had no screen). */
 	int screen_index;
 	bool selected;
+	/* The rest of awful's Lua-side tag state. Only what the old state had
+	 * set: what it left alone has to come back from the new config and
+	 * theme, not from here. */
+	double numbers[TAG_NUMBER_COUNT];
+	bool has_number[TAG_NUMBER_COUNT];
 } tag_snapshot_t;
 
 typedef struct {
@@ -5599,48 +5618,125 @@ tag_resolve_snapshot(const tag_snapshot_t *ts)
 	return NULL;
 }
 
-/** Restore a snapshotted layout from the matched tag's rebuilt allowed list.
+/** Push the value awful stores for one of an object's properties.
+ *
+ * awful keeps a tag's layout and a client's floating state in a Lua table on
+ * the object (awful.tag.setproperty, awful.client.property.set), so both go
+ * with the state. Reading that table rather than the property matters: the
+ * property getters fall back to the theme, or to an implicit value, and what
+ * the old config never set has to come back from the new one. It is also what
+ * lets the read happen after the class teardown, which leaves the property
+ * handlers behind but not the object's private table.
+ *
+ * \param bag The table awful stores the property in.
+ * \return true when a value was pushed, false when the object has none.
+ */
+static bool
+object_push_awful_property(lua_State *L, void *object, const char *bag, const char *key)
+{
+	luaA_object_push(L, object);
+	lua_getfield(L, -1, "_private");
+	lua_remove(L, -2);
+	if (!lua_istable(L, -1))
+		goto none;
+
+	lua_getfield(L, -1, bag);
+	lua_remove(L, -2);
+	if (!lua_istable(L, -1))
+		goto none;
+
+	lua_getfield(L, -1, key);
+	lua_remove(L, -2);
+	if (lua_isnil(L, -1))
+		goto none;
+	return true;
+none:
+	lua_pop(L, 1);
+	return false;
+}
+
+/** Restore a snapshotted tag's Lua-side state onto the tag rc.lua rebuilt.
+ *
  * Layout objects belong to a Lua state, so only their stable public name can
- * cross a hot-reload. A missing or nameless layout leaves rc.lua's choice
+ * cross a hot-reload: the name is matched against the rebuilt tag's allowed
+ * list, and a layout that has no named match there leaves rc.lua's choice
  * untouched.
+ *
+ * Called through hot_reload_call: the tag is at 1, the snapshot at 2.
+ */
+static int
+tag_restore_snapshot_state(lua_State *L)
+{
+	const tag_snapshot_t *ts = lua_touserdata(L, 2);
+	int i;
+
+	if (ts->layout_name) {
+		lua_getfield(L, 1, "layouts");
+		if (lua_istable(L, -1)) {
+			int layouts_idx = lua_gettop(L);
+
+			for (i = 1; i <= (int) luaA_rawlen(L, layouts_idx); i++) {
+				bool matches;
+
+				lua_rawgeti(L, layouts_idx, i);
+				if (!lua_istable(L, -1)) {
+					lua_pop(L, 1);
+					continue;
+				}
+				lua_getfield(L, -1, "name");
+				matches = lua_isstring(L, -1)
+					&& !strcmp(ts->layout_name, lua_tostring(L, -1));
+				lua_pop(L, 1);
+				if (matches) {
+					lua_setfield(L, 1, "layout");
+					break;
+				}
+				lua_pop(L, 1);
+			}
+		}
+		lua_pop(L, 1);
+	}
+
+	for (i = 0; i < TAG_NUMBER_COUNT; i++)
+		if (ts->has_number[i]) {
+			lua_pushnumber(L, ts->numbers[i]);
+			lua_setfield(L, 1, tag_numbers[i].property);
+		}
+	return 0;
+}
+
+/** Put a client's floating state back, before the rules run so a rule with an
+ * explicit floating property still wins.
+ *
+ * Called through hot_reload_call: the client is at 1, the flag at 2.
+ */
+static int
+client_restore_floating(lua_State *L)
+{
+	const int *floating = lua_touserdata(L, 2);
+
+	lua_pushboolean(L, *floating);
+	lua_setfield(L, 1, "floating");
+	return 0;
+}
+
+/** Call one of the restore functions above with the object and its snapshot.
+ *
+ * Protected, because a property setter runs config code: past the point the
+ * old state closed, a reload has nothing to unwind to and an error would take
+ * the compositor with it.
  */
 static void
-tag_restore_snapshot_layout(lua_State *L, tag_t *tag, const tag_snapshot_t *ts)
+hot_reload_call(lua_State *L, lua_CFunction fn, void *object, const void *arg)
 {
-	int tag_idx, layouts_idx;
-
-	if (!tag || !ts->layout_name)
-		return;
-
-	luaA_object_push(L, tag);
-	tag_idx = lua_gettop(L);
-	lua_getfield(L, tag_idx, "layouts");
-	if (!lua_istable(L, -1)) {
-		lua_pop(L, 2);
-		return;
-	}
-	layouts_idx = lua_gettop(L);
-
-	for (int i = 1; i <= (int)luaA_rawlen(L, layouts_idx); i++) {
-		lua_rawgeti(L, layouts_idx, i);
-		if (!lua_istable(L, -1)) {
-			lua_pop(L, 1);
-			continue;
-		}
-		lua_getfield(L, -1, "name");
-		bool matches = lua_isstring(L, -1)
-			&& !strcmp(ts->layout_name, lua_tostring(L, -1));
-		lua_pop(L, 1);
-		if (matches) {
-			lua_pushvalue(L, -1);
-			lua_setfield(L, tag_idx, "layout");
-			lua_pop(L, 1);
-			break;
-		}
+	lua_pushcfunction(L, fn);
+	luaA_object_push(L, object);
+	lua_pushlightuserdata(L, (void *) arg);
+	if (lua_pcall(L, 2, 0, 0)) {
+		fprintf(stderr, "somewm: hot-reload: restoring state: %s\n",
+			lua_tostring(L, -1));
 		lua_pop(L, 1);
 	}
-
-	lua_pop(L, 2);
 }
 
 /** Perform in-process hot-reload of the Lua state.
@@ -5661,6 +5757,8 @@ luaA_hot_reload(void)
 	int num_tags = 0;
 	/* num_tags by num_clients: was client i on tag t before the reload? */
 	bool *tag_members = NULL;
+	/* Per client: the floating state something set, or -1 for none. */
+	int *client_floating = NULL;
 	/* Each snapshot tag's counterpart in the rebuilt tag list, or NULL. */
 	tag_t **tag_map = NULL;
 	int num_retagged = 0;
@@ -5742,35 +5840,6 @@ luaA_hot_reload(void)
 			g_main_context_iteration(NULL, FALSE);
 	}
 
-	/* Layouts live entirely in Lua. Copy their names before class teardown
-	 * clears the property handlers needed to reach tag.layout. The remaining
-	 * tag state is filled in after screens are available for index lookups. */
-	num_tags = globalconf.tags.len;
-	if (num_tags > 0) {
-		tag_snaps = calloc(num_tags, sizeof(tag_snapshot_t));
-		if (!tag_snaps) {
-			fprintf(stderr, "somewm: hot-reload: failed to allocate tag snapshots\n");
-			goto fail;
-		}
-	}
-	for (i = 0; i < num_tags; i++) {
-		luaA_object_push(L, globalconf.tags.tab[i]);
-		lua_getfield(L, -1, "layout");
-		if (lua_istable(L, -1)) {
-			lua_getfield(L, -1, "name");
-			if (lua_isstring(L, -1)) {
-				tag_snaps[i].layout_name = strdup(lua_tostring(L, -1));
-				if (!tag_snaps[i].layout_name) {
-					lua_pop(L, 3);
-					fprintf(stderr, "somewm: hot-reload: failed to copy tag layout name\n");
-					goto fail;
-				}
-			}
-			lua_pop(L, 1);
-		}
-		lua_pop(L, 2);
-	}
-
 	luaA_state_teardown_lua(L, true);
 
 	/* ================================================================
@@ -5812,20 +5881,49 @@ luaA_hot_reload(void)
 	}
 
 	/* ================================================================
-	 * Phase B2: Snapshot tag membership
+	 * Phase B2: Snapshot what only the old Lua state knows
 	 * ================================================================
 	 * Before the clients detach: a tag's client array holds pointers that
 	 * are only resolvable while globalconf.clients is populated, and a
 	 * client's position there is also its position in the snapshot array
-	 * clients_detach() builds.
+	 * clients_detach() builds. The state is still readable here, which is
+	 * the one chance to take the tag and client state that lives in Lua.
 	 */
 
+	num_tags = globalconf.tags.len;
 	if (num_tags > 0) {
+		tag_snaps = calloc(num_tags, sizeof(tag_snapshot_t));
+		if (!tag_snaps) {
+			fprintf(stderr, "somewm: hot-reload: failed to allocate tag snapshots\n");
+			num_tags = 0;
+			goto fail;
+		}
 		if (globalconf.clients.len > 0) {
 			tag_members = calloc((size_t)num_tags * globalconf.clients.len, sizeof(bool));
 			if (!tag_members) {
 				fprintf(stderr, "somewm: hot-reload: failed to allocate tag membership\n");
 				goto fail;
+			}
+		}
+	}
+
+	/* Whether a client floats is a Lua-side property, and only an explicit
+	 * one is worth recording: a client that floats because of its type
+	 * floats again for the same reason once the rules have run. */
+	if (globalconf.clients.len > 0) {
+		client_floating = calloc(globalconf.clients.len, sizeof(int));
+		if (!client_floating) {
+			fprintf(stderr, "somewm: hot-reload: failed to allocate floating states\n");
+			goto fail;
+		}
+		for (i = 0; i < globalconf.clients.len; i++) {
+			client_t *c = globalconf.clients.tab[i];
+
+			client_floating[i] = -1;
+			if (object_push_awful_property(L, c, "awful_client_properties",
+						       "floating")) {
+				client_floating[i] = lua_toboolean(L, -1);
+				lua_pop(L, 1);
 			}
 		}
 	}
@@ -5842,6 +5940,21 @@ luaA_hot_reload(void)
 				break;
 			}
 		ts->selected = t->selected;
+
+		if (object_push_awful_property(L, t, "awful_tag_properties", "layout")) {
+			lua_getfield(L, -1, "name");
+			if (lua_isstring(L, -1))
+				ts->layout_name = strdup(lua_tostring(L, -1));
+			lua_pop(L, 2);
+		}
+
+		for (j = 0; j < TAG_NUMBER_COUNT; j++)
+			if (object_push_awful_property(L, t, "awful_tag_properties",
+						       tag_numbers[j].stored)) {
+				ts->has_number[j] = lua_isnumber(L, -1);
+				ts->numbers[j] = lua_tonumber(L, -1);
+				lua_pop(L, 1);
+			}
 
 		for (k = 0; k < t->clients.len; k++)
 			for (j = 0; j < globalconf.clients.len; j++)
@@ -6131,10 +6244,13 @@ luaA_hot_reload(void)
 			tag_map[i] = tag_resolve_snapshot(&tag_snaps[i]);
 	}
 
-	/* Re-select the old layout from each matched tag's rebuilt layout list
-	 * before tagging or selection can arrange clients. */
+	/* Re-select the old layout from each matched tag's rebuilt layout list,
+	 * and put its master and gap numbers back, before tagging or selection
+	 * can arrange clients. */
 	for (i = 0; i < num_tags; i++)
-		tag_restore_snapshot_layout(L, tag_map[i], &tag_snaps[i]);
+		if (tag_map[i])
+			hot_reload_call(L, tag_restore_snapshot_state,
+					tag_map[i], &tag_snaps[i]);
 
 	for (i = 0; i < num_clients; i++) {
 		client_t *c = globalconf.clients.tab[i];
@@ -6143,6 +6259,10 @@ luaA_hot_reload(void)
 
 		if (!client_snaps[i].was_mapped)
 			continue;
+
+		if (client_floating && client_floating[i] >= 0)
+			hot_reload_call(L, client_restore_floating, c,
+					&client_floating[i]);
 
 		luaA_object_push(L, c);
 		lua_createtable(L, 0, 2);
@@ -6310,6 +6430,7 @@ cleanup:
 	free(tag_snaps);
 	free(tag_members);
 	free(tag_map);
+	free(client_floating);
 	free(systray_snaps);
 }
 

--- a/luaa.c
+++ b/luaa.c
@@ -5546,12 +5546,39 @@ typedef struct {
 	/* Owns the name string (transferred from old tag_t to prevent
 	 * double-free during GC). Freed in cleanup. */
 	char *name;
+	/* Screen index (0-based, -1 if the tag had no screen). */
+	int screen_index;
+	bool selected;
 } tag_snapshot_t;
 
 typedef struct {
 	char *bus_name;
 	char *object_path;
 } systray_snapshot_t;
+
+/** Find the tag a snapshot maps onto in the tag list rc.lua just rebuilt: the
+ * first tag on the same screen with the same name. There is no fallback by
+ * position; globalconf.tags holds creation order, not the order the user sees,
+ * and a tag created at runtime would land on whatever config tag now sits in
+ * its slot.
+ *
+ * \param ts The snapshot to resolve.
+ * \return The matching tag, or NULL if the new config has nothing to match.
+ */
+static tag_t *
+tag_resolve_snapshot(const tag_snapshot_t *ts)
+{
+	screen_t *screen;
+
+	if (!ts->name || ts->screen_index < 0 || ts->screen_index >= globalconf.screens.len)
+		return NULL;
+	screen = globalconf.screens.tab[ts->screen_index];
+
+	foreach(tag, globalconf.tags)
+		if ((*tag)->screen == screen && (*tag)->name && !strcmp(ts->name, (*tag)->name))
+			return *tag;
+	return NULL;
+}
 
 /** Perform in-process hot-reload of the Lua state.
  * Must be called from an idle callback, NOT from within a Lua pcall.
@@ -5569,6 +5596,11 @@ luaA_hot_reload(void)
 	int num_screens = 0;
 	tag_snapshot_t *tag_snaps = NULL;
 	int num_tags = 0;
+	/* num_tags by num_clients: was client i on tag t before the reload? */
+	bool *tag_members = NULL;
+	/* Each snapshot tag's counterpart in the rebuilt tag list, or NULL. */
+	tag_t **tag_map = NULL;
+	int num_retagged = 0;
 	systray_snapshot_t *systray_snaps = NULL;
 	int num_systray = 0;
 
@@ -5688,17 +5720,13 @@ luaA_hot_reload(void)
 	}
 
 	/* ================================================================
-	 * Phase B2: Snapshot and detach clients
-	 * ================================================================ */
-
-	if (!clients_detach(&client_snaps, &num_clients)) {
-		fprintf(stderr, "somewm: hot-reload: failed to allocate client snapshots\n");
-		goto fail;
-	}
-
-	/* ================================================================
-	 * Phase B3: Snapshot tags
-	 * ================================================================ */
+	 * Phase B2: Snapshot tag membership
+	 * ================================================================
+	 * Before the clients detach: a tag's client array holds pointers that
+	 * are only resolvable while globalconf.clients is populated, and a
+	 * client's position there is also its position in the snapshot array
+	 * clients_detach() builds.
+	 */
 
 	num_tags = globalconf.tags.len;
 	if (num_tags > 0) {
@@ -5708,13 +5736,55 @@ luaA_hot_reload(void)
 			num_tags = 0;
 			goto fail;
 		}
+		if (globalconf.clients.len > 0) {
+			tag_members = calloc((size_t)num_tags * globalconf.clients.len, sizeof(bool));
+			if (!tag_members) {
+				fprintf(stderr, "somewm: hot-reload: failed to allocate tag membership\n");
+				goto fail;
+			}
+		}
 	}
+
+	for (i = 0; i < num_tags; i++) {
+		tag_t *t = globalconf.tags.tab[i];
+		tag_snapshot_t *ts = &tag_snaps[i];
+		int j, k;
+
+		ts->screen_index = -1;
+		for (j = 0; j < globalconf.screens.len; j++)
+			if (globalconf.screens.tab[j] == t->screen) {
+				ts->screen_index = j;
+				break;
+			}
+		ts->selected = t->selected;
+
+		for (k = 0; k < t->clients.len; k++)
+			for (j = 0; j < globalconf.clients.len; j++)
+				if (globalconf.clients.tab[j] == t->clients.tab[k]) {
+					tag_members[i * globalconf.clients.len + j] = true;
+					break;
+				}
+	}
+
+	/* ================================================================
+	 * Phase B3: Snapshot and detach clients
+	 * ================================================================ */
+
+	if (!clients_detach(&client_snaps, &num_clients)) {
+		fprintf(stderr, "somewm: hot-reload: failed to allocate client snapshots\n");
+		goto fail;
+	}
+
+	/* ================================================================
+	 * Phase B4: Take the tag names and drop the stale client arrays
+	 * ================================================================ */
 
 	for (i = 0; i < num_tags; i++) {
 		tag_t *t = globalconf.tags.tab[i];
 
 		/* Transfer name ownership to snapshot so tag_wipe doesn't free it.
-		 * Tags are recreated from rc.lua defaults, not restored from snapshots. */
+		 * Tags themselves are recreated by rc.lua; only their membership
+		 * and selection are restored onto the result. */
 		tag_snaps[i].name = t->name;
 		t->name = NULL;
 
@@ -5961,6 +6031,93 @@ luaA_hot_reload(void)
 		}
 	}
 
+	/* Restore tag membership before the rules run. AwesomeWM's own restart
+	 * does the same through _NET_WM_DESKTOP and request::tag; the hints
+	 * carry every tag rather than only the first. A rule with an explicit
+	 * tag still overrides this, and a client whose tags resolve to nothing
+	 * falls through to the rules untouched. */
+	if (num_tags > 0) {
+		tag_map = calloc(num_tags, sizeof(tag_t *));
+		if (!tag_map) {
+			fprintf(stderr, "somewm: hot-reload: failed to allocate tag map\n");
+			goto fail;
+		}
+		for (i = 0; i < num_tags; i++)
+			tag_map[i] = tag_resolve_snapshot(&tag_snaps[i]);
+	}
+
+	for (i = 0; i < num_clients; i++) {
+		client_t *c = globalconf.clients.tab[i];
+		tag_t *first = NULL;
+		int t, slot = 0;
+
+		if (!client_snaps[i].was_mapped)
+			continue;
+
+		luaA_object_push(L, c);
+		lua_createtable(L, 0, 2);
+		lua_pushliteral(L, "restart");
+		lua_setfield(L, -2, "reason");
+		lua_newtable(L);
+
+		for (t = 0; t < num_tags; t++) {
+			if (!tag_map[t] || !tag_members[t * num_clients + i])
+				continue;
+			if (!first)
+				first = tag_map[t];
+			luaA_object_push(L, tag_map[t]);
+			lua_rawseti(L, -2, ++slot);
+		}
+		lua_setfield(L, -2, "tags");
+
+		if (!first) {
+			lua_pop(L, 2);
+			continue;
+		}
+
+		luaA_object_push(L, first);
+		lua_insert(L, -2);
+		luaA_object_emit_signal(L, -3, "request::tag", 2);
+		lua_pop(L, 1);
+		num_retagged++;
+	}
+
+	/* Restore the selected tags, still before the rules run: a client that
+	 * resolved nothing is then placed on the selection the screen comes back
+	 * to, and no rule has had the chance to delete a tag that tag_map points at.
+	 * Every tag on the screen is set in C and awful.tag's history is updated
+	 * once, so it never records a half-restored set. A screen whose selected
+	 * tags all resolved to nothing keeps the selection rc.lua made. */
+	for (i = 0; i < num_screens && i < globalconf.screens.len; i++) {
+		screen_t *screen = globalconf.screens.tab[i];
+		bool restored = false;
+		int j, t;
+
+		for (t = 0; t < num_tags; t++)
+			if (tag_snaps[t].selected && tag_snaps[t].screen_index == i && tag_map[t])
+				restored = true;
+		if (!restored)
+			continue;
+
+		for (j = 0; j < globalconf.tags.len; j++) {
+			tag_t *tag = globalconf.tags.tab[j];
+			bool view = false;
+
+			if (tag->screen != screen)
+				continue;
+			for (t = 0; t < num_tags; t++)
+				if (tag_snaps[t].selected && tag_map[t] == tag)
+					view = true;
+			luaA_object_push(L, tag);
+			tag_view(L, -1, view);
+			lua_pop(L, 1);
+		}
+
+		luaA_object_push(L, screen);
+		luaA_object_emit_signal(L, -1, "tag::history::update", 0);
+		lua_pop(L, 1);
+	}
+
 	for (i = 0; i < num_clients; i++) {
 		client_t *c = globalconf.clients.tab[i];
 
@@ -6021,8 +6178,8 @@ luaA_hot_reload(void)
 
 	globalconf.hot_reload_in_progress = false;
 
-	fprintf(stderr, "somewm: hot-reload: complete (%d clients, %d screens, %d tags reset)\n",
-		num_clients, num_screens, num_tags);
+	fprintf(stderr, "somewm: hot-reload: complete (%d clients, %d screens, %d tags, "
+		"%d clients retagged)\n", num_clients, num_screens, num_tags, num_retagged);
 
 	/* Mark new Lgi closures as ready - allows guard to dispatch them.
 	 * Must be called AFTER rc.lua is fully loaded and Lgi is stable. */
@@ -6059,6 +6216,8 @@ cleanup:
 	free(client_snaps);
 	free(screen_snaps);
 	free(tag_snaps);
+	free(tag_members);
+	free(tag_map);
 	free(systray_snaps);
 }
 

--- a/objects/client.c
+++ b/objects/client.c
@@ -2502,6 +2502,35 @@ client_add_titlebar_geometry(client_t *c, area_t *geometry)
     geometry->height += c->titlebar[CLIENT_TITLEBAR_BOTTOM].size;
 }
 
+/** Take the titlebars out of a client's geometry and forget their sizes, the
+ * inverse of growing every bar from zero with titlebar_resize().
+ *
+ * The hot-reload calls this: titlebar drawables belong to the Lua state and
+ * cannot cross a reload, so the sizes reset to zero while the geometry still
+ * counts them. Without this the config re-creating the same titlebars grows
+ * the client by their extents on every reload.
+ *
+ * \param c The client to strip.
+ */
+void
+client_strip_titlebar_geometry(client_t *c)
+{
+    int left = c->titlebar[CLIENT_TITLEBAR_LEFT].size;
+    int right = c->titlebar[CLIENT_TITLEBAR_RIGHT].size;
+    int top = c->titlebar[CLIENT_TITLEBAR_TOP].size;
+    int bottom = c->titlebar[CLIENT_TITLEBAR_BOTTOM].size;
+
+    c->geometry.width = MAX(1, c->geometry.width - left - right);
+    c->geometry.height = MAX(1, c->geometry.height - top - bottom);
+    if (c->size_hints.flags & XCB_ICCCM_SIZE_HINT_P_WIN_GRAVITY)
+        xwindow_translate_for_gravity(c->size_hints.win_gravity,
+                                      -left, -top, -right, -bottom,
+                                      &c->geometry.x, &c->geometry.y);
+
+    for (client_titlebar_t bar = CLIENT_TITLEBAR_TOP; bar < CLIENT_TITLEBAR_COUNT; bar++)
+        c->titlebar[bar].size = 0;
+}
+
 area_t
 client_get_undecorated_geometry(client_t *c)
 {

--- a/objects/client.h
+++ b/objects/client.h
@@ -420,6 +420,7 @@ void client_emit_scanning(void);
 drawable_t *client_get_drawable(client_t *, int, int);
 drawable_t *client_get_drawable_offset(client_t *, int *, int *);
 area_t client_get_undecorated_geometry(client_t *);
+void client_strip_titlebar_geometry(client_t *);
 void client_apply_opacity_to_scene(client_t *, float);
 void client_update_titlebar_positions(client_t *);
 

--- a/objects/tag.c
+++ b/objects/tag.c
@@ -225,7 +225,7 @@ luaA_tag_set_name(lua_State *L, tag_t *tag)
  * \param udx The index of the tag on the stack.
  * \param view Set selected or not.
  */
-static void
+void
 tag_view(lua_State *L, int udx, bool view)
 {
 	tag_t *tag = luaA_checkudata(L, udx, &tag_class);

--- a/objects/tag.h
+++ b/objects/tag.h
@@ -81,6 +81,7 @@ ARRAY_TYPE(tag_t *, tag)
 int tags_get_current_or_first_selected_index(void);
 void tag_client(lua_State *, client_t *);
 void untag_client(client_t *, tag_t *);
+void tag_view(lua_State *, int, bool);
 bool is_client_tagged(client_t *, tag_t *);
 void tag_unref_simplified(tag_t **);
 

--- a/tests/restart/README.md
+++ b/tests/restart/README.md
@@ -190,12 +190,14 @@ release it on `"exit"` reddens whichever reload test runs next.
   config under a running instance, since no startup can reach that state: at
   startup there are no clients yet.
 - `tags-after-restart`: each client comes back on the tags it was on, each
-  screen keeps its viewed tags and layouts, and floating geometry remains
-  stable across three reloads: the same config with two tags viewed, one that
-  drops a tag and the saved layout (a client left with nothing is placed by the
-  rules on the restored selection, and the matched tag keeps the new default),
-  and one that renames the tags (everything falls through to the rules and keeps
-  the new config's default layouts).
+  screen keeps its viewed tags, layouts and master and gap numbers, and
+  floating geometry remains stable across three reloads: the same config with
+  two tags viewed, one that drops a tag and the saved layout (a client left
+  with nothing is placed by the rules on the restored selection, and the
+  matched tag keeps the new default), and one that renames the tags
+  (everything falls through to the rules and keeps the new config's defaults).
+- `floating-after-restart`: a client made floating on a tiled tag is still
+  floating after a reload.
 - `client-survives-restart`, `client-order-after-restart`,
   `transient-screen-restart`, `client-screen-after-restart`: clients, stacking
   order, transient relationships and the client's screen survive a reload.

--- a/tests/restart/README.md
+++ b/tests/restart/README.md
@@ -189,11 +189,13 @@ release it on `"exit"` reddens whichever reload test runs next.
   clients already restored into the state it closes. The test swaps the
   config under a running instance, since no startup can reach that state: at
   startup there are no clients yet.
-- `tags-after-restart`: each client comes back on the tags it was on and each
-  screen comes back on the tags it had viewed, across three reloads: the same
-  config with two tags viewed, one that drops a tag (a client left with nothing
-  is placed by the rules on the restored selection), and one that renames the
-  tags (everything falls through to the rules).
+- `tags-after-restart`: each client comes back on the tags it was on, each
+  screen keeps its viewed tags and layouts, and floating geometry remains
+  stable across three reloads: the same config with two tags viewed, one that
+  drops a tag and the saved layout (a client left with nothing is placed by the
+  rules on the restored selection, and the matched tag keeps the new default),
+  and one that renames the tags (everything falls through to the rules and keeps
+  the new config's default layouts).
 - `client-survives-restart`, `client-order-after-restart`,
   `transient-screen-restart`, `client-screen-after-restart`: clients, stacking
   order, transient relationships and the client's screen survive a reload.

--- a/tests/restart/README.md
+++ b/tests/restart/README.md
@@ -189,10 +189,14 @@ release it on `"exit"` reddens whichever reload test runs next.
   clients already restored into the state it closes. The test swaps the
   config under a running instance, since no startup can reach that state: at
   startup there are no clients yet.
-- `tags-after-restart`, `client-survives-restart`, `client-order-after-restart`,
-  `transient-screen-restart`, `client-screen-after-restart`: clients, tags,
-  stacking order, transient relationships and the client's screen survive a
-  reload.
+- `tags-after-restart`: each client comes back on the tags it was on and each
+  screen comes back on the tags it had viewed, across three reloads: the same
+  config with two tags viewed, one that drops a tag (a client left with nothing
+  is placed by the rules on the restored selection), and one that renames the
+  tags (everything falls through to the rules).
+- `client-survives-restart`, `client-order-after-restart`,
+  `transient-screen-restart`, `client-screen-after-restart`: clients, stacking
+  order, transient relationships and the client's screen survive a reload.
 - `startup-flag-across-reload`: `awesome.startup` is true during a reload's
   config load too, and `awesome._restart` says which it was.
 - `client-popup-node-data-after-restart`: every scene node holding a

--- a/tests/restart/configs/tags/rc.lua
+++ b/tests/restart/configs/tags/rc.lua
@@ -1,0 +1,27 @@
+-- Three tags on every screen, for the hot-reload tag restore test.
+--
+-- A copy of tests/rc.lua rather than a dofile(SOMEWM_TEST_BASE_RC) layer like
+-- the other configs here: the base already creates a tag per screen, so a
+-- layer would have to delete it, and the test rewrites the tag list in this
+-- file between reloads. tests/rc.lua keeps its single tag either way, which is
+-- what every other test in the suite expects.
+
+pcall(require, "luarocks.loader")
+
+local awful = require("awful")
+require("awful.autofocus")
+
+awful.layout.layouts = {
+    awful.layout.suit.floating,
+    awful.layout.suit.tile,
+}
+
+awful.screen.connect_for_each_screen(function(s)
+    awful.tag({ "1", "2", "3" }, s, awful.layout.layouts[1])
+end)
+
+awesome.connect_signal("debug::error", function(err)
+    io.stderr:write("ERROR: " .. tostring(err) .. "\n")
+end)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/restart/configs/tags/rc.lua
+++ b/tests/restart/configs/tags/rc.lua
@@ -9,6 +9,7 @@
 pcall(require, "luarocks.loader")
 
 local awful = require("awful")
+local ruled = require("ruled")
 require("awful.autofocus")
 
 awful.layout.layouts = {
@@ -18,6 +19,19 @@ awful.layout.layouts = {
 
 awful.screen.connect_for_each_screen(function(s)
     awful.tag({ "1", "2", "3" }, s, awful.layout.layouts[1])
+end)
+
+-- Rebuild a known titlebar on floating clients so repeated reloads also prove
+-- that discarding stale Lua drawables does not grow the preserved geometry.
+ruled.client.connect_signal("request::rules", function()
+    ruled.client.append_rule {
+        rule = {},
+        properties = { floating = true, titlebars_enabled = true },
+    }
+end)
+
+client.connect_signal("request::titlebars", function(c)
+    awful.titlebar(c, { size = 23, position = "top" })
 end)
 
 awesome.connect_signal("debug::error", function(err)

--- a/tests/restart/floating-after-restart.sh
+++ b/tests/restart/floating-after-restart.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# A client made floating stays floating across a hot-reload. The flag lives in
+# Lua (awful.client.property), so the state close takes it, and on a tiled tag
+# the client comes back tiled unless the reload puts it back.
+
+. "$(dirname "$0")/lib.sh"
+
+sw_require_helper test-fullscreen-client
+CLIENT=$SW_HELPER
+
+sw_start hr-floating --config "$ROOT_DIR/tests/rc.lua" || finish
+
+check_eval hr-floating "the tag is tiled" \
+    'local t = screen.primary.tags[1]; t.layout = require("awful").layout.suit.tile; return t.layout.name' \
+    tile
+
+sw_spawn hr-floating "$CLIENT" || finish
+check_client_appeared hr-floating fullscreen_test || finish
+
+check_eval hr-floating "the client is floating" \
+    'client.get()[1].floating = true; return tostring(client.get()[1].floating)' true
+
+sw_reload hr-floating || finish
+
+check_eval hr-floating "the client is still floating after the reload" \
+    'return tostring(client.get()[1].floating)' true
+
+sw_check_log_clean hr-floating "post-reload log"
+
+finish

--- a/tests/restart/tags-after-restart.sh
+++ b/tests/restart/tags-after-restart.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Client tag membership and the selected tags must survive a hot-reload.
+# Client tag membership, selected tags, layouts and floating geometry must
+# survive a hot-reload.
 #
 # rc.lua builds every tag from scratch when it re-runs, so before the reload
 # the compositor snapshots which tags each client was on and which were
@@ -9,7 +10,7 @@
 # tests/rc.lua, whose single tag made every wrong answer look right.
 #
 # Three reloads, one instance: the same config with two tags viewed, a shorter
-# tag list, and a renamed one.
+# tag and layout list, and renamed tags.
 
 . "$(dirname "$0")/lib.sh"
 
@@ -29,12 +30,25 @@ set_tags() {
     fi
 }
 
-# Tag names, selection and order on the primary screen.
-TAGS='local t = {}; for _, tg in ipairs(screen.primary.tags) do t[#t+1] = tg.name .. ":" .. tostring(tg.selected) end; return table.concat(t, ",")'
+set_floating_only() {
+    sed -i '/awful\.layout\.suit\.tile,/d' "$CONFIG"
+    if grep -qF "awful.layout.suit.tile," "$CONFIG"; then
+        fail "config limited to floating layout" "tile entry remains"
+        return 1
+    fi
+}
+
+# Tag names, selection, order and layout on the primary screen.
+TAGS='local t = {}; for _, tg in ipairs(screen.primary.tags) do t[#t+1] = tg.name .. ":" .. tostring(tg.selected) .. ":" .. tg.layout.name end; return table.concat(t, ",")'
 
 # The sorted tag names of the client with this pid.
 client_tags() {
     echo "local pid = $1; for _, c in ipairs(client.get()) do if c.pid == pid then local n = {}; for _, t in ipairs(c:tags()) do n[#n+1] = t.name end; table.sort(n); return table.concat(n, \",\") end end; return \"no client\""
+}
+
+# Exact outer geometry, floating state and rebuilt titlebar size for a client.
+client_geometry() {
+    echo "local pid = $1; for _, c in ipairs(client.get()) do if c.pid == pid then local g = c:geometry(); local _, top = c:titlebar_top(); return g.x .. \",\" .. g.y .. \",\" .. g.width .. \",\" .. g.height .. \":\" .. tostring(c.floating) .. \":\" .. top end end; return \"no client\""
 }
 
 # Move the client with this pid onto the tags at these 1-based positions.
@@ -51,7 +65,8 @@ view() {
 set_tags '"1", "2", "3"' || finish
 sw_start hr-tags --config "$CONFIG" || finish
 
-check_eval hr-tags "the config gave the screen three tags" "$TAGS" "1:true,2:false,3:false"
+check_eval hr-tags "the config gave the screen three floating tags" "$TAGS" \
+    "1:true:floating,2:false:floating,3:false:floating"
 
 sw_spawn hr-tags "$CLIENT" || finish
 check_client_appeared hr-tags fullscreen_test || finish
@@ -64,29 +79,50 @@ PID_B=$SPAWN_PID
 
 check_eval hr-tags "client A moved to tag 3" "$(retag "$PID_A" 3)" ok
 check_eval hr-tags "client B moved to tags 2 and 3" "$(retag "$PID_B" "2, 3")" ok
+check_eval hr-tags "tag 2 changed to tile" \
+    'screen.primary.tags[2].layout = require("awful").layout.suit.tile; return screen.primary.tags[2].layout.name' tile
 check_eval hr-tags "tags 2 and 3 viewed together" "$(view "2, 3")" ok
+
+sw_eval hr-tags "$(client_geometry "$PID_A")"
+before_geometry_a=$EVAL_VALUE
+sw_eval hr-tags "$(client_geometry "$PID_B")"
+before_geometry_b=$EVAL_VALUE
+check_match "client A starts floating with a 23px titlebar" \
+    "$before_geometry_a" '^-?[0-9]+,-?[0-9]+,[1-9][0-9]*,[1-9][0-9]*:true:23$'
+check_match "client B starts floating with a 23px titlebar" \
+    "$before_geometry_b" '^-?[0-9]+,-?[0-9]+,[1-9][0-9]*,[1-9][0-9]*:true:23$'
 
 # --- reload 1: the same config ----------------------------------------------
 
 sw_reload hr-tags || finish
 
 check_eval hr-tags "tag names, order and both viewed tags survive the reload" \
-    "$TAGS" "1:false,2:true,3:true"
+    "$TAGS" "1:false:floating,2:true:tile,3:true:floating"
 check_eval hr-tags "client A is still on tag 3 alone" "$(client_tags "$PID_A")" "3"
 check_eval hr-tags "client B is still on tags 2 and 3" "$(client_tags "$PID_B")" "2,3"
+check_eval hr-tags "client A geometry does not grow on the first reload" \
+    "$(client_geometry "$PID_A")" "$before_geometry_a"
+check_eval hr-tags "client B geometry does not grow on the first reload" \
+    "$(client_geometry "$PID_B")" "$before_geometry_b"
 
 sw_check_log_clean hr-tags "log after the first reload" || finish
 
-# --- reload 2: the third tag is gone -----------------------------------------
+# --- reload 2: the third tag and tile layout are gone ------------------------
 
 check_eval hr-tags "only tag 2 viewed" "$(view 2)" ok
 set_tags '"1", "2"' || finish
+set_floating_only || finish
 sw_reload hr-tags || finish
 
-check_eval hr-tags "the shorter tag list loads with tag 2 still viewed" "$TAGS" "1:false,2:true"
+check_eval hr-tags "an unavailable old layout falls back to rc.lua's default" \
+    "$TAGS" "1:false:floating,2:true:floating"
 check_eval hr-tags "client A resolves nothing and the rules place it on the restored selection" \
     "$(client_tags "$PID_A")" "2"
 check_eval hr-tags "client B keeps the tag that still exists" "$(client_tags "$PID_B")" "2"
+check_eval hr-tags "client A geometry does not grow on the second reload" \
+    "$(client_geometry "$PID_A")" "$before_geometry_a"
+check_eval hr-tags "client B geometry does not grow on the second reload" \
+    "$(client_geometry "$PID_B")" "$before_geometry_b"
 
 sw_check_log_clean hr-tags "log after the second reload" || finish
 
@@ -95,9 +131,14 @@ sw_check_log_clean hr-tags "log after the second reload" || finish
 set_tags '"a", "b"' || finish
 sw_reload hr-tags || finish
 
-check_eval hr-tags "the renamed tags load with rc.lua's own selection" "$TAGS" "a:true,b:false"
+check_eval hr-tags "renamed tags keep rc.lua's selection and default layouts" \
+    "$TAGS" "a:true:floating,b:false:floating"
 check_eval hr-tags "client A falls through to the rules" "$(client_tags "$PID_A")" "a"
 check_eval hr-tags "client B falls through to the rules" "$(client_tags "$PID_B")" "a"
+check_eval hr-tags "client A geometry does not grow on the third reload" \
+    "$(client_geometry "$PID_A")" "$before_geometry_a"
+check_eval hr-tags "client B geometry does not grow on the third reload" \
+    "$(client_geometry "$PID_B")" "$before_geometry_b"
 
 sw_check_log_clean hr-tags "log after the third reload"
 

--- a/tests/restart/tags-after-restart.sh
+++ b/tests/restart/tags-after-restart.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# Client tag membership, selected tags, layouts and floating geometry must
-# survive a hot-reload.
+# Client tag membership, selected tags, a tag's own state and floating geometry
+# must survive a hot-reload.
 #
 # rc.lua builds every tag from scratch when it re-runs, so before the reload
 # the compositor snapshots which tags each client was on and which were
@@ -51,6 +51,10 @@ client_geometry() {
     echo "local pid = $1; for _, c in ipairs(client.get()) do if c.pid == pid then local g = c:geometry(); local _, top = c:titlebar_top(); return g.x .. \",\" .. g.y .. \",\" .. g.width .. \",\" .. g.height .. \":\" .. tostring(c.floating) .. \":\" .. top end end; return \"no client\""
 }
 
+# The master and gap numbers awful keeps beside the layout, which live in Lua
+# and so go with the state the reload closes.
+NUMBERS='local t = screen.primary.tags[2]; return t.master_width_factor .. ":" .. t.master_count .. ":" .. t.column_count .. ":" .. t.gap'
+
 # Move the client with this pid onto the tags at these 1-based positions.
 retag() {
     local pid="$1" idx="$2"
@@ -81,6 +85,13 @@ check_eval hr-tags "client A moved to tag 3" "$(retag "$PID_A" 3)" ok
 check_eval hr-tags "client B moved to tags 2 and 3" "$(retag "$PID_B" "2, 3")" ok
 check_eval hr-tags "tag 2 changed to tile" \
     'screen.primary.tags[2].layout = require("awful").layout.suit.tile; return screen.primary.tags[2].layout.name' tile
+
+sw_eval hr-tags "$NUMBERS"
+default_numbers=$EVAL_VALUE
+info "tag 2 numbers as the config left them: $default_numbers"
+check_eval hr-tags "tag 2 given its own master and gap numbers" \
+    'local t = screen.primary.tags[2]; t.master_width_factor = 0.7; t.master_count = 2; t.column_count = 3; t.gap = 5; return "ok"' \
+    ok
 check_eval hr-tags "tags 2 and 3 viewed together" "$(view "2, 3")" ok
 
 sw_eval hr-tags "$(client_geometry "$PID_A")"
@@ -104,6 +115,7 @@ check_eval hr-tags "client A geometry does not grow on the first reload" \
     "$(client_geometry "$PID_A")" "$before_geometry_a"
 check_eval hr-tags "client B geometry does not grow on the first reload" \
     "$(client_geometry "$PID_B")" "$before_geometry_b"
+check_eval hr-tags "tag 2 keeps its master and gap numbers" "$NUMBERS" "0.7:2:3:5"
 
 sw_check_log_clean hr-tags "log after the first reload" || finish
 
@@ -139,6 +151,8 @@ check_eval hr-tags "client A geometry does not grow on the third reload" \
     "$(client_geometry "$PID_A")" "$before_geometry_a"
 check_eval hr-tags "client B geometry does not grow on the third reload" \
     "$(client_geometry "$PID_B")" "$before_geometry_b"
+check_eval hr-tags "the renamed tag matches nothing and keeps the config's numbers" \
+    "$NUMBERS" "$default_numbers"
 
 sw_check_log_clean hr-tags "log after the third reload"
 

--- a/tests/restart/tags-after-restart.sh
+++ b/tests/restart/tags-after-restart.sh
@@ -1,42 +1,104 @@
 #!/usr/bin/env bash
 #
-# Tags, and the clients attached to them, must survive a hot-reload.
+# Client tag membership and the selected tags must survive a hot-reload.
 #
-# Replaces tests/test-hot-reload-tags.lua, which printed the tag list, called
-# awesome.restart() and passed if nothing crashed. The client-to-tag association
-# half is new: the reload snapshots tags by value and re-attaches clients to
-# them, and nothing has ever checked that the association comes back.
+# rc.lua builds every tag from scratch when it re-runs, so before the reload
+# the compositor snapshots which tags each client was on and which were
+# viewed, then re-applies both onto the tags the new config created, matched
+# by name per screen. The earlier version of this test ran against
+# tests/rc.lua, whose single tag made every wrong answer look right.
+#
+# Three reloads, one instance: the same config with two tags viewed, a shorter
+# tag list, and a renamed one.
 
 . "$(dirname "$0")/lib.sh"
 
 sw_require_helper test-fullscreen-client
 CLIENT=$SW_HELPER
 
-sw_start hr-tags --config "$ROOT_DIR/tests/rc.lua" || finish
+# Our own copy, because the reload re-reads the same -c path and the test
+# rewrites the tag list between reloads.
+CONFIG="$SOMEWM_RESTART_RUNTIME/tags-rc.lua"
 
-TAGS='local t = {}; for _, tg in ipairs(screen.primary.tags) do t[#t+1] = tg.name .. ":" .. tostring(tg.selected) .. ":" .. tostring(tg.index) end; return table.concat(t, ",")'
+set_tags() {
+    sed -E "s/^( *awful\.tag\()\{[^}]*\}/\1{ $1 }/" \
+        "$RESTART_DIR/configs/tags/rc.lua" > "$CONFIG"
+    if ! grep -qF "awful.tag({ $1 }" "$CONFIG"; then
+        fail "config rewritten to tags $1" "substitution did not apply"
+        return 1
+    fi
+}
 
-sw_eval hr-tags "$TAGS"
-before=$EVAL_VALUE
-info "phase-1 tags: $before"
-check_match "phase-1 has at least one tag" "$before" '^[^,]+:(true|false):[0-9]+'
+# Tag names, selection and order on the primary screen.
+TAGS='local t = {}; for _, tg in ipairs(screen.primary.tags) do t[#t+1] = tg.name .. ":" .. tostring(tg.selected) end; return table.concat(t, ",")'
+
+# The sorted tag names of the client with this pid.
+client_tags() {
+    echo "local pid = $1; for _, c in ipairs(client.get()) do if c.pid == pid then local n = {}; for _, t in ipairs(c:tags()) do n[#n+1] = t.name end; table.sort(n); return table.concat(n, \",\") end end; return \"no client\""
+}
+
+# Move the client with this pid onto the tags at these 1-based positions.
+retag() {
+    local pid="$1" idx="$2"
+    echo "local pid = $pid; for _, c in ipairs(client.get()) do if c.pid == pid then local ts = screen.primary.tags; local sel = {}; for _, i in ipairs({$idx}) do sel[#sel+1] = ts[i] end; c:tags(sel); return \"ok\" end end; return \"no client\""
+}
+
+# View the tags at these 1-based positions, and only those.
+view() {
+    echo "local ts = screen.primary.tags; local sel = {}; for _, i in ipairs({$1}) do sel[#sel+1] = ts[i] end; require(\"awful\").tag.viewmore(sel, screen.primary); return \"ok\""
+}
+
+set_tags '"1", "2", "3"' || finish
+sw_start hr-tags --config "$CONFIG" || finish
+
+check_eval hr-tags "the config gave the screen three tags" "$TAGS" "1:true,2:false,3:false"
 
 sw_spawn hr-tags "$CLIENT" || finish
 check_client_appeared hr-tags fullscreen_test || finish
+PID_A=$SPAWN_PID
 
-CTAG='local c = client.get()[1]; if not c then return "no client" end; local ts = c:tags(); return tostring(#ts) .. ":" .. tostring(ts[1] and ts[1].name)'
-sw_eval hr-tags "$CTAG"
-before_ctag=$EVAL_VALUE
-info "phase-1 client tags: $before_ctag"
-check_match "phase-1 client is on a tag" "$before_ctag" '^[1-9][0-9]*:'
+sw_spawn hr-tags "$CLIENT" || finish
+check_wait_true hr-tags "the second client appeared" \
+    'return tostring(#client.get() == 2)' || finish
+PID_B=$SPAWN_PID
+
+check_eval hr-tags "client A moved to tag 3" "$(retag "$PID_A" 3)" ok
+check_eval hr-tags "client B moved to tags 2 and 3" "$(retag "$PID_B" "2, 3")" ok
+check_eval hr-tags "tags 2 and 3 viewed together" "$(view "2, 3")" ok
+
+# --- reload 1: the same config ----------------------------------------------
 
 sw_reload hr-tags || finish
 
-check_eval hr-tags "tag names, selection and order survive the reload" "$TAGS" "$before"
-check_eval hr-tags "the screen still has a selected tag" \
-    'return tostring(screen.primary.selected_tag ~= nil)' true
-check_eval hr-tags "the client is still attached to the same tag" "$CTAG" "$before_ctag"
+check_eval hr-tags "tag names, order and both viewed tags survive the reload" \
+    "$TAGS" "1:false,2:true,3:true"
+check_eval hr-tags "client A is still on tag 3 alone" "$(client_tags "$PID_A")" "3"
+check_eval hr-tags "client B is still on tags 2 and 3" "$(client_tags "$PID_B")" "2,3"
 
-sw_check_log_clean hr-tags "post-reload log"
+sw_check_log_clean hr-tags "log after the first reload" || finish
+
+# --- reload 2: the third tag is gone -----------------------------------------
+
+check_eval hr-tags "only tag 2 viewed" "$(view 2)" ok
+set_tags '"1", "2"' || finish
+sw_reload hr-tags || finish
+
+check_eval hr-tags "the shorter tag list loads with tag 2 still viewed" "$TAGS" "1:false,2:true"
+check_eval hr-tags "client A resolves nothing and the rules place it on the restored selection" \
+    "$(client_tags "$PID_A")" "2"
+check_eval hr-tags "client B keeps the tag that still exists" "$(client_tags "$PID_B")" "2"
+
+sw_check_log_clean hr-tags "log after the second reload" || finish
+
+# --- reload 3: the tags are renamed -----------------------------------------
+
+set_tags '"a", "b"' || finish
+sw_reload hr-tags || finish
+
+check_eval hr-tags "the renamed tags load with rc.lua's own selection" "$TAGS" "a:true,b:false"
+check_eval hr-tags "client A falls through to the rules" "$(client_tags "$PID_A")" "a"
+check_eval hr-tags "client B falls through to the rules" "$(client_tags "$PID_B")" "a"
+
+sw_check_log_clean hr-tags "log after the third reload"
 
 finish

--- a/tests/restart/tags-after-restart.sh
+++ b/tests/restart/tags-after-restart.sh
@@ -41,14 +41,19 @@ set_floating_only() {
 # Tag names, selection, order and layout on the primary screen.
 TAGS='local t = {}; for _, tg in ipairs(screen.primary.tags) do t[#t+1] = tg.name .. ":" .. tostring(tg.selected) .. ":" .. tg.layout.name end; return table.concat(t, ",")'
 
+# Run a body against the client with this pid, as `c`.
+for_client() {
+    echo "local pid = $1; for _, c in ipairs(client.get()) do if c.pid == pid then $2 end end; return \"no client\""
+}
+
 # The sorted tag names of the client with this pid.
 client_tags() {
-    echo "local pid = $1; for _, c in ipairs(client.get()) do if c.pid == pid then local n = {}; for _, t in ipairs(c:tags()) do n[#n+1] = t.name end; table.sort(n); return table.concat(n, \",\") end end; return \"no client\""
+    for_client "$1" 'local n = {}; for _, t in ipairs(c:tags()) do n[#n+1] = t.name end; table.sort(n); return table.concat(n, ",")'
 }
 
 # Exact outer geometry, floating state and rebuilt titlebar size for a client.
 client_geometry() {
-    echo "local pid = $1; for _, c in ipairs(client.get()) do if c.pid == pid then local g = c:geometry(); local _, top = c:titlebar_top(); return g.x .. \",\" .. g.y .. \",\" .. g.width .. \",\" .. g.height .. \":\" .. tostring(c.floating) .. \":\" .. top end end; return \"no client\""
+    for_client "$1" 'local g = c:geometry(); local _, top = c:titlebar_top(); return g.x .. "," .. g.y .. "," .. g.width .. "," .. g.height .. ":" .. tostring(c.floating) .. ":" .. top'
 }
 
 # The master and gap numbers awful keeps beside the layout, which live in Lua
@@ -57,8 +62,15 @@ NUMBERS='local t = screen.primary.tags[2]; return t.master_width_factor .. ":" .
 
 # Move the client with this pid onto the tags at these 1-based positions.
 retag() {
-    local pid="$1" idx="$2"
-    echo "local pid = $pid; for _, c in ipairs(client.get()) do if c.pid == pid then local ts = screen.primary.tags; local sel = {}; for _, i in ipairs({$idx}) do sel[#sel+1] = ts[i] end; c:tags(sel); return \"ok\" end end; return \"no client\""
+    for_client "$1" "local ts = screen.primary.tags; local sel = {}; for _, i in ipairs({$2}) do sel[#sel+1] = ts[i] end; c:tags(sel); return \"ok\""
+}
+
+# Both clients still have the geometry they started with.
+check_geometry_stable() {
+    check_eval hr-tags "client A geometry does not grow on the $1 reload" \
+        "$(client_geometry "$PID_A")" "$before_geometry_a"
+    check_eval hr-tags "client B geometry does not grow on the $1 reload" \
+        "$(client_geometry "$PID_B")" "$before_geometry_b"
 }
 
 # View the tags at these 1-based positions, and only those.
@@ -111,10 +123,7 @@ check_eval hr-tags "tag names, order and both viewed tags survive the reload" \
     "$TAGS" "1:false:floating,2:true:tile,3:true:floating"
 check_eval hr-tags "client A is still on tag 3 alone" "$(client_tags "$PID_A")" "3"
 check_eval hr-tags "client B is still on tags 2 and 3" "$(client_tags "$PID_B")" "2,3"
-check_eval hr-tags "client A geometry does not grow on the first reload" \
-    "$(client_geometry "$PID_A")" "$before_geometry_a"
-check_eval hr-tags "client B geometry does not grow on the first reload" \
-    "$(client_geometry "$PID_B")" "$before_geometry_b"
+check_geometry_stable first
 check_eval hr-tags "tag 2 keeps its master and gap numbers" "$NUMBERS" "0.7:2:3:5"
 
 sw_check_log_clean hr-tags "log after the first reload" || finish
@@ -131,10 +140,7 @@ check_eval hr-tags "an unavailable old layout falls back to rc.lua's default" \
 check_eval hr-tags "client A resolves nothing and the rules place it on the restored selection" \
     "$(client_tags "$PID_A")" "2"
 check_eval hr-tags "client B keeps the tag that still exists" "$(client_tags "$PID_B")" "2"
-check_eval hr-tags "client A geometry does not grow on the second reload" \
-    "$(client_geometry "$PID_A")" "$before_geometry_a"
-check_eval hr-tags "client B geometry does not grow on the second reload" \
-    "$(client_geometry "$PID_B")" "$before_geometry_b"
+check_geometry_stable second
 
 sw_check_log_clean hr-tags "log after the second reload" || finish
 
@@ -147,10 +153,7 @@ check_eval hr-tags "renamed tags keep rc.lua's selection and default layouts" \
     "$TAGS" "a:true:floating,b:false:floating"
 check_eval hr-tags "client A falls through to the rules" "$(client_tags "$PID_A")" "a"
 check_eval hr-tags "client B falls through to the rules" "$(client_tags "$PID_B")" "a"
-check_eval hr-tags "client A geometry does not grow on the third reload" \
-    "$(client_geometry "$PID_A")" "$before_geometry_a"
-check_eval hr-tags "client B geometry does not grow on the third reload" \
-    "$(client_geometry "$PID_B")" "$before_geometry_b"
+check_geometry_stable third
 check_eval hr-tags "the renamed tag matches nothing and keeps the config's numbers" \
     "$NUMBERS" "$default_numbers"
 


### PR DESCRIPTION
## Description
Closes #731. 

A hot-reload rebuilt every tag from rc.lua and dropped which tags each client was on and which tags were viewed. 

The compositor now records both before the old state closes, matches each tag by name per screen after rc.lua runs, emits request::tag with every matched tag before the rules, and restores the selection before the rules so a client left with no match lands on it. Renamed and runtime-created tags fall through to the rules. Modifies lua/awful/permissions/init.lua to apply hints.tags; documented in DEVIATIONS.md.