### PR TITLE
Fix/check mode module resolution

### DIFF
--- a/luaa.c
+++ b/luaa.c
@@ -2926,31 +2926,17 @@ luaA_add_search_paths(const char **paths, int count)
 	}
 }
 
-/** Register everything a Lua state needs: the standard library, somewm's
- * search paths, and every somewm module and class.
+/** Point a Lua state at every directory somewm loads modules from: the
+ * development tree, the installed datadir, any -L/--search paths, and the
+ * user library directory.
  *
- * Boot (luaA_init) and the post-reload rebuild (luaA_create_fresh_state) both
- * run this, so there is one list instead of two that drift apart. Anything a
- * state needs belongs here; luaA_init keeps only the once-per-process work.
+ * Boot, the post-reload rebuild, and `--check` all call this, so what the
+ * checker believes require() can find is what require() can actually find.
  */
 static void
-luaA_register_state(lua_State *L)
+luaA_setup_package_paths(lua_State *L)
 {
 	const char *cur_path;
-
-	/* Panic handler for unprotected errors (AwesomeWM API parity) */
-	lua_atpanic(L, luaA_panic);
-
-	/* Set error handling function */
-	lualib_dofunction_on_error = luaA_dofunction_on_error;
-
-	luaL_openlibs(L);
-
-	/* Add AwesomeWM-compatible Lua extensions */
-	luaA_fixups(L);
-
-	/* Initialize the AwesomeWM object system (must precede any class setup) */
-	luaA_object_setup(L);
 
 	/* Add lua/ directory to package.path for require() support */
 	lua_getglobal(L, "package");
@@ -3027,6 +3013,33 @@ luaA_register_state(lua_State *L)
 			lua_pop(L, 1);  /* pop package table */
 		}
 	}
+}
+
+/** Register everything a Lua state needs: the standard library, somewm's
+ * search paths, and every somewm module and class.
+ *
+ * Boot (luaA_init) and the post-reload rebuild (luaA_create_fresh_state) both
+ * run this, so there is one list instead of two that drift apart. Anything a
+ * state needs belongs here; luaA_init keeps only the once-per-process work.
+ */
+static void
+luaA_register_state(lua_State *L)
+{
+	/* Panic handler for unprotected errors (AwesomeWM API parity) */
+	lua_atpanic(L, luaA_panic);
+
+	/* Set error handling function */
+	lualib_dofunction_on_error = luaA_dofunction_on_error;
+
+	luaL_openlibs(L);
+
+	/* Add AwesomeWM-compatible Lua extensions */
+	luaA_fixups(L);
+
+	/* Initialize the AwesomeWM object system (must precede any class setup) */
+	luaA_object_setup(L);
+
+	luaA_setup_package_paths(L);
 
 	/* Register somewm Lua modules */
 	luaA_signal_setup(L);
@@ -3596,41 +3609,6 @@ prescan_cleanup_visited(void)
 static void
 luaA_prescan_file(const char *config_path, const char *config_dir, int depth);
 
-/** Modules we never scan: the Lua stdlib, our own libraries, and common
- * third-party ones. Everything else is treated as config-local and resolved
- * against config_dir. Shared by the pre-scan and by --check so both walk the
- * same set of files.
- * \param name Module name as written in require()
- * \return true if the module is external and should be skipped
- */
-static bool
-prescan_module_is_external(const char *name)
-{
-	static const char *const exact[] = {
-		"string", "table", "math", "io", "os", "debug", "coroutine",
-		"package", "utf8", "bit", "bit32", "ffi", "jit",
-		"ruled", "lgi", "lain", "freedesktop", "vicious", "revelation",
-		"collision", "tyrannical", "cyclefocus", "radical", "cairo",
-		"posix", "cjson", "dkjson", "json", "socket", "http",
-		"penlight", "inspect", "luassert", "busted", NULL
-	};
-	static const char *const prefixes[] = {
-		"awful", "gears", "wibox", "naughty", "beautiful", "menubar",
-		"ruled.", "lgi.", "lain.", "freedesktop.", "vicious.",
-		"posix.", "cjson.", "socket.", "pl.", NULL
-	};
-	int i;
-
-	for (i = 0; exact[i]; i++)
-		if (strcmp(name, exact[i]) == 0)
-			return true;
-	for (i = 0; prefixes[i]; i++)
-		if (strncmp(name, prefixes[i], strlen(prefixes[i])) == 0)
-			return true;
-
-	return false;
-}
-
 /** Read the next require("mod") out of a file, skipping qualified calls such
  * as lgi.require() and requires that are commented out.
  * \param pos Cursor into content, advanced past the match
@@ -3711,18 +3689,13 @@ prescan_next_require(const char **pos, const char *content,
  * \param dir Directory to resolve against
  * \param path Receives the resolved path on success
  * \param pathlen Size of path
- * \param try1 Receives the "<dir>/mod.lua" candidate
- * \param t1len Size of try1
- * \param try2 Receives the "<dir>/mod/init.lua" candidate
- * \param t2len Size of try2
  * \return true if one of the candidates exists
  */
 static bool
 prescan_resolve_module(const char *name, const char *dir,
-                       char *path, size_t pathlen,
-                       char *try1, size_t t1len, char *try2, size_t t2len)
+                       char *path, size_t pathlen)
 {
-	char rel[256];
+	char rel[256], try[PATH_MAX];
 	char *p;
 
 	snprintf(rel, sizeof(rel), "%s", name);
@@ -3730,15 +3703,15 @@ prescan_resolve_module(const char *name, const char *dir,
 		if (*p == '.')
 			*p = '/';
 
-	snprintf(try1, t1len, "%s/%s.lua", dir, rel);
-	snprintf(try2, t2len, "%s/%s/init.lua", dir, rel);
-
-	if (access(try1, R_OK) == 0) {
-		snprintf(path, pathlen, "%s", try1);
+	snprintf(try, sizeof(try), "%s/%s.lua", dir, rel);
+	if (access(try, R_OK) == 0) {
+		snprintf(path, pathlen, "%s", try);
 		return true;
 	}
-	if (access(try2, R_OK) == 0) {
-		snprintf(path, pathlen, "%s", try2);
+
+	snprintf(try, sizeof(try), "%s/%s/init.lua", dir, rel);
+	if (access(try, R_OK) == 0) {
+		snprintf(path, pathlen, "%s", try);
 		return true;
 	}
 
@@ -3755,7 +3728,7 @@ luaA_prescan_requires(const char *content, const char *config_dir, int depth)
 {
 	const char *pos = content;
 	char module_name[256];
-	char path[PATH_MAX], try1[PATH_MAX], try2[PATH_MAX];
+	char path[PATH_MAX];
 	int require_line = 0;
 
 	if (depth >= PRESCAN_MAX_DEPTH || !config_dir)
@@ -3763,11 +3736,7 @@ luaA_prescan_requires(const char *content, const char *config_dir, int depth)
 
 	while (prescan_next_require(&pos, content, module_name, sizeof(module_name),
 	                            &require_line)) {
-		if (prescan_module_is_external(module_name))
-			continue;
-
-		if (prescan_resolve_module(module_name, config_dir, path, sizeof(path),
-		                           try1, sizeof(try1), try2, sizeof(try2)))
+		if (prescan_resolve_module(module_name, config_dir, path, sizeof(path)))
 			luaA_prescan_file(path, config_dir, depth + 1);
 	}
 }
@@ -4051,8 +4020,7 @@ check_mode_add_syntax_error(const char *file_path, const char *error_msg)
 /** Store a missing module error found during check mode */
 static void
 check_mode_add_missing_module(const char *source_file, int line_num,
-                              const char *module_name,
-                              const char *tried_path1, const char *tried_path2)
+                              const char *module_name)
 {
 	check_issue_t *issue;
 	char desc[512];
@@ -4060,14 +4028,15 @@ check_mode_add_missing_module(const char *source_file, int line_num,
 	if (check_issue_count >= CHECK_MAX_ISSUES)
 		return;
 
-	snprintf(desc, sizeof(desc), "require('%s') - module not found", module_name);
+	snprintf(desc, sizeof(desc), "require('%s') - not found on this system",
+	         module_name);
 
 	issue = &check_issues[check_issue_count++];
 	issue->file_path = strdup(source_file);
 	issue->line_number = line_num;
 	issue->line_content = strdup("");
 	issue->pattern_desc = strdup(desc);
-	issue->suggestion = "Check module path or install missing dependency";
+	issue->suggestion = "Install it, or check the name. Every path require() uses was searched";
 	issue->severity = SEVERITY_WARNING;
 	issue->is_syntax_error = true;  /* pattern_desc is dynamically allocated */
 
@@ -4351,6 +4320,141 @@ check_mode_print_report(const char *config_path, bool use_color)
 static void
 check_mode_scan_file(const char *config_path, const char *config_dir, int depth);
 
+/* A Lua state carrying somewm's real search paths, so --check asks Lua where a
+ * module lives instead of guessing. */
+static lua_State *check_resolver_L = NULL;
+static char check_config_root[PATH_MAX];
+
+#define CHECK_RESOLVER_KEY "somewm.check.resolve"
+
+/* Resolve a module the way require() does, but without loading it: --check
+ * must never run the config. package.searchpath arrived in 5.2, so 5.1 gets
+ * the same walk over the ';'-separated templates. */
+static const char check_resolver_lua[] =
+	"local searchpath = package.searchpath or function(name, path)\n"
+	"  local fname = (name:gsub('%.', '/'))\n"
+	"  for tmpl in path:gmatch('[^;]+') do\n"
+	"    local candidate = (tmpl:gsub('%?', fname))\n"
+	"    local f = io.open(candidate, 'r')\n"
+	"    if f then f:close() return candidate end\n"
+	"  end\n"
+	"end\n"
+	"return function(name)\n"
+	"  if package.loaded[name] ~= nil or package.preload[name] ~= nil then\n"
+	"    return ''\n"
+	"  end\n"
+	"  return searchpath(name, package.path) or searchpath(name, package.cpath)\n"
+	"end\n";
+
+/** Build the state --check resolves requires against.
+ * \param config_dir Directory holding the config, or NULL
+ */
+static void
+check_resolver_init(const char *config_dir)
+{
+	lua_State *L = luaL_newstate();
+
+	check_config_root[0] = '\0';
+
+	if (!L)
+		return;
+
+	luaL_openlibs(L);
+	luaA_setup_package_paths(L);
+
+	/* The config directory goes on front, exactly as it does at load time. */
+	if (config_dir) {
+		const char *old_path;
+
+		lua_getglobal(L, "package");
+		lua_getfield(L, -1, "path");
+		old_path = lua_tostring(L, -1);
+		lua_pop(L, 1);
+		lua_pushfstring(L, "%s/?.lua;%s/?/init.lua;%s",
+		                config_dir, config_dir, old_path);
+		lua_setfield(L, -2, "path");
+		lua_pop(L, 1);
+
+		snprintf(check_config_root, sizeof(check_config_root), "%s", config_dir);
+	}
+
+	if (luaL_loadstring(L, check_resolver_lua) || lua_pcall(L, 0, 1, 0)) {
+		lua_close(L);
+		return;
+	}
+	lua_setfield(L, LUA_REGISTRYINDEX, CHECK_RESOLVER_KEY);
+
+	check_resolver_L = L;
+}
+
+static void
+check_resolver_free(void)
+{
+	if (check_resolver_L) {
+		lua_close(check_resolver_L);
+		check_resolver_L = NULL;
+	}
+	check_config_root[0] = '\0';
+}
+
+/** Ask Lua whether require() would find a module.
+ * \param name Module name as written in require()
+ * \param path Receives the file it resolves to, empty for a built-in
+ * \param pathlen Size of path
+ * \return true if require() would find it
+ */
+static bool
+check_resolve_module(const char *name, char *path, size_t pathlen)
+{
+	lua_State *L = check_resolver_L;
+	const char *found;
+	bool ok = false;
+
+	path[0] = '\0';
+
+	/* With no resolver there is nothing to test, so stay quiet rather than
+	 * call every module missing. */
+	if (!L)
+		return true;
+
+	lua_getfield(L, LUA_REGISTRYINDEX, CHECK_RESOLVER_KEY);
+	lua_pushstring(L, name);
+	if (lua_pcall(L, 1, 1, 0)) {
+		lua_pop(L, 1);
+		return true;
+	}
+
+	found = lua_tostring(L, -1);
+	if (found) {
+		snprintf(path, pathlen, "%s", found);
+		ok = true;
+	}
+	lua_pop(L, 1);
+
+	return ok;
+}
+
+/** Is a resolved module the user's own Lua, and so worth scanning?
+ *
+ * A config-local module resolves through the template built from config_dir,
+ * so it comes back with that exact prefix and a plain compare is enough.
+ */
+static bool
+check_module_is_config_local(const char *resolved)
+{
+	size_t rootlen, len;
+
+	if (!resolved[0] || !check_config_root[0])
+		return false;
+
+	rootlen = strlen(check_config_root);
+	if (strncmp(resolved, check_config_root, rootlen) || resolved[rootlen] != '/')
+		return false;
+
+	len = strlen(resolved);
+	return len > 4 && !strcmp(resolved + len - 4, ".lua");
+}
+
 /** Scan requires in check mode */
 static void
 check_mode_scan_requires(const char *content, const char *config_dir,
@@ -4358,7 +4462,7 @@ check_mode_scan_requires(const char *content, const char *config_dir,
 {
 	const char *pos = content;
 	char module_name[256];
-	char path[PATH_MAX], try1[PATH_MAX], try2[PATH_MAX];
+	char resolved[PATH_MAX];
 	int require_line = 0;
 
 	if (depth >= PRESCAN_MAX_DEPTH || !config_dir)
@@ -4366,15 +4470,16 @@ check_mode_scan_requires(const char *content, const char *config_dir,
 
 	while (prescan_next_require(&pos, content, module_name, sizeof(module_name),
 	                            &require_line)) {
-		if (prescan_module_is_external(module_name))
-			continue;
-
-		if (prescan_resolve_module(module_name, config_dir, path, sizeof(path),
-		                           try1, sizeof(try1), try2, sizeof(try2)))
-			check_mode_scan_file(path, config_dir, depth + 1);
-		else
+		if (!check_resolve_module(module_name, resolved, sizeof(resolved))) {
 			check_mode_add_missing_module(source_file, require_line,
-			                              module_name, try1, try2);
+			                              module_name);
+			continue;
+		}
+
+		/* Only descend into the user's own files. Library and rock sources
+		 * are not theirs to fix, and a C module is not Lua at all. */
+		if (check_module_is_config_local(resolved))
+			check_mode_scan_file(resolved, config_dir, depth + 1);
 	}
 }
 
@@ -4506,7 +4611,9 @@ luaA_check_config(const char *config_path, bool use_color, int min_severity)
 	}
 
 	/* Scan the config and all its dependencies */
+	check_resolver_init(dir);
 	check_mode_scan_file(config_path, dir, 0);
+	check_resolver_free();
 
 	/* Run luacheck if available (gracefully skips if not installed) */
 	check_mode_run_luacheck(config_path);

--- a/luaa.c
+++ b/luaa.c
@@ -3015,6 +3015,30 @@ luaA_setup_package_paths(lua_State *L)
 	}
 }
 
+/** Put a directory at the front of package.path, so a module beside the config
+ * wins over one from the search paths.
+ *
+ * The config load does this for the config's own directory, and the scanners
+ * do it to the state they resolve against, so both agree on where a
+ * config-local require() comes from.
+ * \param L Lua state
+ * \param dir Directory to prepend
+ */
+static void
+luaA_prepend_module_dir(lua_State *L, const char *dir)
+{
+	const char *old_path;
+
+	lua_getglobal(L, "package");
+	lua_getfield(L, -1, "path");
+	old_path = lua_tostring(L, -1);
+	lua_pop(L, 1);
+
+	lua_pushfstring(L, "%s/?.lua;%s/?/init.lua;%s", dir, dir, old_path);
+	lua_setfield(L, -2, "path");
+	lua_pop(L, 1);
+}
+
 /** Register everything a Lua state needs: the standard library, somewm's
  * search paths, and every somewm module and class.
  *
@@ -3684,38 +3708,155 @@ prescan_next_require(const char **pos, const char *content,
 	return false;
 }
 
-/** Resolve a config-local module to a file under config_dir.
+/** Reduce a config path to the directory holding it, in place.
+ *
+ * A bare filename gives ".", so `somewm --check rc.lua` walks the requires
+ * instead of quietly scanning one file.
+ * \param path Config path, overwritten with its directory
+ * \return path, now the directory
+ */
+static const char *
+prescan_dirname(char *path)
+{
+	char *last_slash = strrchr(path, '/');
+
+	if (last_slash)
+		*last_slash = '\0';
+	else
+		strcpy(path, ".");
+
+	return path;
+}
+
+/* A Lua state carrying somewm's real search paths, so the scanners ask Lua
+ * where a module lives instead of guessing. The boot pre-scan and --check both
+ * resolve through it, so they walk the same set of files. */
+static lua_State *prescan_resolver_L = NULL;
+
+#define PRESCAN_RESOLVER_KEY "somewm.prescan.resolve"
+
+/* Resolve a module the way require() does, but without loading it: neither
+ * scanner may run the config. package.searchpath arrived in 5.2, so 5.1 gets
+ * the same walk over the ';'-separated templates. Answers are kept, because a
+ * config split across files requires the same handful of modules in each one
+ * and a miss costs an open() per template. */
+static const char prescan_resolver_lua[] =
+	"local searchpath = package.searchpath or function(name, path)\n"
+	"  local fname = (name:gsub('%.', '/'))\n"
+	"  for tmpl in path:gmatch('[^;]+') do\n"
+	"    local candidate = (tmpl:gsub('%?', fname))\n"
+	"    local f = io.open(candidate, 'r')\n"
+	"    if f then f:close() return candidate end\n"
+	"  end\n"
+	"end\n"
+	"local seen = {}\n"
+	"return function(name)\n"
+	"  local hit = seen[name]\n"
+	"  if hit ~= nil then return hit or nil end\n"
+	"  if package.loaded[name] ~= nil or package.preload[name] ~= nil then\n"
+	"    seen[name] = ''\n"
+	"    return ''\n"
+	"  end\n"
+	"  local found = searchpath(name, package.path)\n"
+	"           or searchpath(name, package.cpath)\n"
+	"  seen[name] = found or false\n"
+	"  return found\n"
+	"end\n";
+
+/** Build the state the scanners resolve requires against.
+ * \param config_dir Directory holding the config, or NULL
+ */
+static void
+prescan_resolver_init(const char *config_dir)
+{
+	lua_State *L = luaL_newstate();
+
+	if (!L)
+		return;
+
+	luaL_openlibs(L);
+	luaA_setup_package_paths(L);
+
+	/* The config directory goes on front, exactly as it does at load time. */
+	if (config_dir)
+		luaA_prepend_module_dir(L, config_dir);
+
+	if (luaL_loadstring(L, prescan_resolver_lua) || lua_pcall(L, 0, 1, 0)) {
+		lua_close(L);
+		return;
+	}
+	lua_setfield(L, LUA_REGISTRYINDEX, PRESCAN_RESOLVER_KEY);
+
+	prescan_resolver_L = L;
+}
+
+static void
+prescan_resolver_free(void)
+{
+	if (prescan_resolver_L) {
+		lua_close(prescan_resolver_L);
+		prescan_resolver_L = NULL;
+	}
+}
+
+/** Ask Lua whether require() would find a module.
  * \param name Module name as written in require()
- * \param dir Directory to resolve against
- * \param path Receives the resolved path on success
+ * \param path Receives the file it resolves to, empty for a built-in
  * \param pathlen Size of path
- * \return true if one of the candidates exists
+ * \return true if require() would find it
  */
 static bool
-prescan_resolve_module(const char *name, const char *dir,
-                       char *path, size_t pathlen)
+prescan_resolve_module(const char *name, char *path, size_t pathlen)
 {
-	char rel[256], try[PATH_MAX];
-	char *p;
+	lua_State *L = prescan_resolver_L;
+	const char *found;
+	bool ok = false;
 
-	snprintf(rel, sizeof(rel), "%s", name);
-	for (p = rel; *p; p++)
-		if (*p == '.')
-			*p = '/';
+	path[0] = '\0';
 
-	snprintf(try, sizeof(try), "%s/%s.lua", dir, rel);
-	if (access(try, R_OK) == 0) {
-		snprintf(path, pathlen, "%s", try);
+	/* With no resolver there is nothing to test, so stay quiet rather than
+	 * call every module missing. */
+	if (!L)
+		return true;
+
+	lua_getfield(L, LUA_REGISTRYINDEX, PRESCAN_RESOLVER_KEY);
+	lua_pushstring(L, name);
+	if (lua_pcall(L, 1, 1, 0)) {
+		lua_pop(L, 1);
 		return true;
 	}
 
-	snprintf(try, sizeof(try), "%s/%s/init.lua", dir, rel);
-	if (access(try, R_OK) == 0) {
-		snprintf(path, pathlen, "%s", try);
-		return true;
+	found = lua_tostring(L, -1);
+	if (found) {
+		snprintf(path, pathlen, "%s", found);
+		ok = true;
 	}
+	lua_pop(L, 1);
 
-	return false;
+	return ok;
+}
+
+/** Is a resolved module the user's own Lua, and so worth scanning?
+ *
+ * A config-local module resolves through the template built from config_dir,
+ * so it comes back with that exact prefix and a plain compare is enough.
+ * \param config_dir Directory holding the config
+ * \param resolved File the module resolved to
+ */
+static bool
+prescan_module_is_config_local(const char *config_dir, const char *resolved)
+{
+	size_t rootlen, len;
+
+	if (!resolved[0])
+		return false;
+
+	rootlen = strlen(config_dir);
+	if (strncmp(resolved, config_dir, rootlen) || resolved[rootlen] != '/')
+		return false;
+
+	len = strlen(resolved);
+	return len > 4 && !strcmp(resolved + len - 4, ".lua");
 }
 
 /** Scan every require()d file for X11 patterns.
@@ -3728,16 +3869,19 @@ luaA_prescan_requires(const char *content, const char *config_dir, int depth)
 {
 	const char *pos = content;
 	char module_name[256];
-	char path[PATH_MAX];
+	char resolved[PATH_MAX];
 	int require_line = 0;
 
-	if (depth >= PRESCAN_MAX_DEPTH || !config_dir)
+	if (depth >= PRESCAN_MAX_DEPTH)
 		return;
 
 	while (prescan_next_require(&pos, content, module_name, sizeof(module_name),
 	                            &require_line)) {
-		if (prescan_resolve_module(module_name, config_dir, path, sizeof(path)))
-			luaA_prescan_file(path, config_dir, depth + 1);
+		/* Only descend into the user's own files. Library and rock sources
+		 * are not theirs to fix, and a C module is not Lua at all. */
+		if (prescan_resolve_module(module_name, resolved, sizeof(resolved))
+		    && prescan_module_is_config_local(config_dir, resolved))
+			luaA_prescan_file(resolved, config_dir, depth + 1);
 	}
 }
 
@@ -3872,8 +4016,7 @@ luaA_prescan_file(const char *config_path, const char *config_dir, int depth)
 	}
 
 	/* Recursively scan required files */
-	if (config_dir)
-		luaA_prescan_requires(content, config_dir, depth);
+	luaA_prescan_requires(content, config_dir, depth);
 
 	free(content);
 }
@@ -3891,19 +4034,19 @@ luaA_prescan_config(const char *config_path, const char *config_dir)
 	/* Reset visited tracking */
 	prescan_cleanup_visited();
 
+	if (!config_path || access(config_path, R_OK) != 0)
+		return;
+
 	/* If no config_dir provided, derive from config_path */
-	if (!dir && config_path) {
-		char *last_slash;
+	if (!dir) {
 		strncpy(dir_buf, config_path, sizeof(dir_buf) - 1);
 		dir_buf[sizeof(dir_buf) - 1] = '\0';
-		last_slash = strrchr(dir_buf, '/');
-		if (last_slash) {
-			*last_slash = '\0';
-			dir = dir_buf;
-		}
+		dir = prescan_dirname(dir_buf);
 	}
 
+	prescan_resolver_init(dir);
 	luaA_prescan_file(config_path, dir, 0);
+	prescan_resolver_free();
 
 	prescan_cleanup_visited();
 }
@@ -4320,140 +4463,6 @@ check_mode_print_report(const char *config_path, bool use_color)
 static void
 check_mode_scan_file(const char *config_path, const char *config_dir, int depth);
 
-/* A Lua state carrying somewm's real search paths, so --check asks Lua where a
- * module lives instead of guessing. */
-static lua_State *check_resolver_L = NULL;
-static char check_config_root[PATH_MAX];
-
-#define CHECK_RESOLVER_KEY "somewm.check.resolve"
-
-/* Resolve a module the way require() does, but without loading it: --check
- * must never run the config. package.searchpath arrived in 5.2, so 5.1 gets
- * the same walk over the ';'-separated templates. */
-static const char check_resolver_lua[] =
-	"local searchpath = package.searchpath or function(name, path)\n"
-	"  local fname = (name:gsub('%.', '/'))\n"
-	"  for tmpl in path:gmatch('[^;]+') do\n"
-	"    local candidate = (tmpl:gsub('%?', fname))\n"
-	"    local f = io.open(candidate, 'r')\n"
-	"    if f then f:close() return candidate end\n"
-	"  end\n"
-	"end\n"
-	"return function(name)\n"
-	"  if package.loaded[name] ~= nil or package.preload[name] ~= nil then\n"
-	"    return ''\n"
-	"  end\n"
-	"  return searchpath(name, package.path) or searchpath(name, package.cpath)\n"
-	"end\n";
-
-/** Build the state --check resolves requires against.
- * \param config_dir Directory holding the config, or NULL
- */
-static void
-check_resolver_init(const char *config_dir)
-{
-	lua_State *L = luaL_newstate();
-
-	check_config_root[0] = '\0';
-
-	if (!L)
-		return;
-
-	luaL_openlibs(L);
-	luaA_setup_package_paths(L);
-
-	/* The config directory goes on front, exactly as it does at load time. */
-	if (config_dir) {
-		const char *old_path;
-
-		lua_getglobal(L, "package");
-		lua_getfield(L, -1, "path");
-		old_path = lua_tostring(L, -1);
-		lua_pop(L, 1);
-		lua_pushfstring(L, "%s/?.lua;%s/?/init.lua;%s",
-		                config_dir, config_dir, old_path);
-		lua_setfield(L, -2, "path");
-		lua_pop(L, 1);
-
-		snprintf(check_config_root, sizeof(check_config_root), "%s", config_dir);
-	}
-
-	if (luaL_loadstring(L, check_resolver_lua) || lua_pcall(L, 0, 1, 0)) {
-		lua_close(L);
-		return;
-	}
-	lua_setfield(L, LUA_REGISTRYINDEX, CHECK_RESOLVER_KEY);
-
-	check_resolver_L = L;
-}
-
-static void
-check_resolver_free(void)
-{
-	if (check_resolver_L) {
-		lua_close(check_resolver_L);
-		check_resolver_L = NULL;
-	}
-	check_config_root[0] = '\0';
-}
-
-/** Ask Lua whether require() would find a module.
- * \param name Module name as written in require()
- * \param path Receives the file it resolves to, empty for a built-in
- * \param pathlen Size of path
- * \return true if require() would find it
- */
-static bool
-check_resolve_module(const char *name, char *path, size_t pathlen)
-{
-	lua_State *L = check_resolver_L;
-	const char *found;
-	bool ok = false;
-
-	path[0] = '\0';
-
-	/* With no resolver there is nothing to test, so stay quiet rather than
-	 * call every module missing. */
-	if (!L)
-		return true;
-
-	lua_getfield(L, LUA_REGISTRYINDEX, CHECK_RESOLVER_KEY);
-	lua_pushstring(L, name);
-	if (lua_pcall(L, 1, 1, 0)) {
-		lua_pop(L, 1);
-		return true;
-	}
-
-	found = lua_tostring(L, -1);
-	if (found) {
-		snprintf(path, pathlen, "%s", found);
-		ok = true;
-	}
-	lua_pop(L, 1);
-
-	return ok;
-}
-
-/** Is a resolved module the user's own Lua, and so worth scanning?
- *
- * A config-local module resolves through the template built from config_dir,
- * so it comes back with that exact prefix and a plain compare is enough.
- */
-static bool
-check_module_is_config_local(const char *resolved)
-{
-	size_t rootlen, len;
-
-	if (!resolved[0] || !check_config_root[0])
-		return false;
-
-	rootlen = strlen(check_config_root);
-	if (strncmp(resolved, check_config_root, rootlen) || resolved[rootlen] != '/')
-		return false;
-
-	len = strlen(resolved);
-	return len > 4 && !strcmp(resolved + len - 4, ".lua");
-}
 
 /** Scan requires in check mode */
 static void
@@ -4465,12 +4474,12 @@ check_mode_scan_requires(const char *content, const char *config_dir,
 	char resolved[PATH_MAX];
 	int require_line = 0;
 
-	if (depth >= PRESCAN_MAX_DEPTH || !config_dir)
+	if (depth >= PRESCAN_MAX_DEPTH)
 		return;
 
 	while (prescan_next_require(&pos, content, module_name, sizeof(module_name),
 	                            &require_line)) {
-		if (!check_resolve_module(module_name, resolved, sizeof(resolved))) {
+		if (!prescan_resolve_module(module_name, resolved, sizeof(resolved))) {
 			check_mode_add_missing_module(source_file, require_line,
 			                              module_name);
 			continue;
@@ -4478,7 +4487,7 @@ check_mode_scan_requires(const char *content, const char *config_dir,
 
 		/* Only descend into the user's own files. Library and rock sources
 		 * are not theirs to fix, and a C module is not Lua at all. */
-		if (check_module_is_config_local(resolved))
+		if (prescan_module_is_config_local(config_dir, resolved))
 			check_mode_scan_file(resolved, config_dir, depth + 1);
 	}
 }
@@ -4577,8 +4586,7 @@ check_mode_scan_file(const char *config_path, const char *config_dir, int depth)
 	}
 
 	/* Recursively scan required files */
-	if (config_dir)
-		check_mode_scan_requires(content, config_dir, config_path, depth);
+	check_mode_scan_requires(content, config_dir, config_path, depth);
 
 	free(content);
 }
@@ -4593,8 +4601,7 @@ int
 luaA_check_config(const char *config_path, bool use_color, int min_severity)
 {
 	char dir_buf[PATH_MAX];
-	const char *dir = NULL;
-	char *last_slash;
+	const char *dir;
 	int result;
 
 	/* Reset state */
@@ -4604,16 +4611,12 @@ luaA_check_config(const char *config_path, bool use_color, int min_severity)
 	/* Derive config_dir from config_path */
 	strncpy(dir_buf, config_path, sizeof(dir_buf) - 1);
 	dir_buf[sizeof(dir_buf) - 1] = '\0';
-	last_slash = strrchr(dir_buf, '/');
-	if (last_slash) {
-		*last_slash = '\0';
-		dir = dir_buf;
-	}
+	dir = prescan_dirname(dir_buf);
 
 	/* Scan the config and all its dependencies */
-	check_resolver_init(dir);
+	prescan_resolver_init(dir);
 	check_mode_scan_file(config_path, dir, 0);
-	check_resolver_free();
+	prescan_resolver_free();
 
 	/* Run luacheck if available (gracefully skips if not installed) */
 	check_mode_run_luacheck(config_path);
@@ -5254,28 +5257,11 @@ luaA_loadrc(void)
 		/* Add config directory to package.path so require() can find local modules
 		 * (AwesomeWM compatibility - allows require("src.theme.user_variables")) */
 		{
-			char config_dir[512];
-			char *last_slash;
-			const char *old_path;
+			char config_dir[PATH_MAX];
 
 			strncpy(config_dir, config_paths[i], sizeof(config_dir) - 1);
 			config_dir[sizeof(config_dir) - 1] = '\0';
-
-			last_slash = strrchr(config_dir, '/');
-			if (last_slash) {
-				*last_slash = '\0';  /* Truncate at last slash to get directory */
-
-				/* Prepend config directory to package.path */
-				lua_getglobal(globalconf_L, "package");
-				lua_getfield(globalconf_L, -1, "path");
-				old_path = lua_tostring(globalconf_L, -1);
-				lua_pop(globalconf_L, 1);
-
-				lua_pushfstring(globalconf_L, "%s/?.lua;%s/?/init.lua;%s",
-					config_dir, config_dir, old_path);
-				lua_setfield(globalconf_L, -2, "path");
-				lua_pop(globalconf_L, 1);  /* pop package table */
-			}
+			luaA_prepend_module_dir(globalconf_L, prescan_dirname(config_dir));
 		}
 
 		/* Set conffile path BEFORE execution (AwesomeWM pattern) */

--- a/tests/restart/configs/prescan/rc.lua
+++ b/tests/restart/configs/prescan/rc.lua
@@ -18,4 +18,8 @@ dofile(assert(os.getenv("SOMEWM_TEST_BASE_RC"),
 
 require("deepmod")
 
+-- A library the scanner can now resolve, but must not read: findings in
+-- somewm's own Lua are not the user's to fix.
+require("awful")
+
 return x11_call, x11_lookalike

--- a/tests/restart/prescan-warns-without-blocking.sh
+++ b/tests/restart/prescan-warns-without-blocking.sh
@@ -24,6 +24,7 @@ check_log_count hr-prescan "but the lookalike name was not" "xsettingsd" 0
 check_log hr-prescan "the scanner reached the required module" "deepmod.lua"
 check_log hr-prescan "and reported the pattern it found there" \
     "GDK initialization deadlock"
+check_log_count hr-prescan "but not into somewm's own libraries" "awful/client.lua" 0
 check_log_count hr-prescan "no config was skipped" "Skipping this config" 0
 
 finish

--- a/tests/test-check-mode.sh
+++ b/tests/test-check-mode.sh
@@ -178,14 +178,14 @@ test_require_missing_reported() {
 return true')
     run_check "$cfg"
     assert_contains "$name" "totally_missing_module_xyz" || return
-    assert_contains "$name" "module not found" || return
+    assert_contains "$name" "not found on this system" || return
     pass "$name"
 }
 
 test_require_stdlib_skipped() {
     local name="require_stdlib_skipped"
     local cfg
-    # Verify none of these stdlib modules appear as "module not found"
+    # Verify none of these stdlib modules are reported missing
     cfg=$(write_config "req_stdlib.lua" 'require("string")
 require("table")
 require("math")
@@ -195,14 +195,14 @@ require("debug")
 require("coroutine")
 require("package")')
     run_check "$cfg"
-    assert_not_contains "$name" "module not found" || return
+    assert_not_contains "$name" "not found on this system" || return
     pass "$name"
 }
 
 test_require_awesomewm_skipped() {
     local name="require_awesomewm_skipped"
     local cfg
-    # Verify none of these AwesomeWM modules appear as "module not found"
+    # Verify none of these AwesomeWM modules are reported missing
     cfg=$(write_config "req_awesome.lua" 'require("awful")
 require("gears")
 require("wibox")
@@ -211,21 +211,30 @@ require("beautiful")
 require("menubar")
 require("ruled")')
     run_check "$cfg"
-    assert_not_contains "$name" "module not found" || return
+    assert_not_contains "$name" "not found on this system" || return
     pass "$name"
 }
 
-test_require_thirdparty_skipped() {
-    local name="require_thirdparty_skipped"
+test_require_somewm_module_found() {
+    local name="require_somewm_module_found"
     local cfg
-    # Verify none of these known third-party modules appear as "module not found"
-    cfg=$(write_config "req_thirdparty.lua" 'require("lgi")
-require("cairo")
-require("inspect")
-require("lain")
-require("dkjson")')
+    # somewm's own bundled modules resolve through package.path like any other
+    cfg=$(write_config "req_somewm.lua" 'require("somewm.layout_animation")')
     run_check "$cfg"
-    assert_not_contains "$name" "module not found" || return
+    assert_not_contains "$name" "not found on this system" || return
+    pass "$name"
+}
+
+test_require_library_not_scanned() {
+    local name="require_library_not_scanned"
+    local cfg
+    # A resolved library is not the user's code: report that it exists, but do
+    # not walk into it. awful/screen.lua and awful/client.lua both mention X11
+    # tools, so a leak shows up as findings in files the user cannot fix.
+    cfg=$(write_config "req_lib_scan.lua" 'require("awful")')
+    run_check "$cfg"
+    assert_not_contains "$name" "awful/screen.lua" || return
+    assert_not_contains "$name" "awful/client.lua" || return
     pass "$name"
 }
 
@@ -237,7 +246,7 @@ test_require_method_skipped() {
 local GLib = lgi.require("GLib")
 return GLib')
     run_check "$cfg"
-    assert_not_contains "$name" "module not found" || return
+    assert_not_contains "$name" "GLib" || return
     pass "$name"
 }
 
@@ -481,7 +490,8 @@ test_require_commented_ignored
 test_require_missing_reported
 test_require_stdlib_skipped
 test_require_awesomewm_skipped
-test_require_thirdparty_skipped
+test_require_somewm_module_found
+test_require_library_not_scanned
 test_require_method_skipped
 test_require_local_module
 test_require_init_module

--- a/tests/test-check-mode.sh
+++ b/tests/test-check-mode.sh
@@ -19,6 +19,8 @@ if [ ! -x "$SOMEWM" ]; then
     exit 1
 fi
 
+SOMEWM=$(cd "$(dirname "$SOMEWM")" && pwd)/$(basename "$SOMEWM")
+
 # Setup temp directory
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
@@ -235,6 +237,23 @@ test_require_library_not_scanned() {
     run_check "$cfg"
     assert_not_contains "$name" "awful/screen.lua" || return
     assert_not_contains "$name" "awful/client.lua" || return
+    pass "$name"
+}
+
+test_bare_filename_walks_requires() {
+    local name="bare_filename_walks_requires"
+    # The config directory came from the path alone, so a config named without
+    # one left it unset and the whole walk was skipped in silence.
+    write_config "bare/mod.lua" 'local lgi = require("lgi")
+local Gdk = lgi.require("Gdk")
+return Gdk' >/dev/null
+    write_config "bare/rc.lua" 'require("mod")' >/dev/null
+    set +e
+    CHECK_STDOUT=$(cd "$TMP_DIR/bare" && "$SOMEWM" --check rc.lua 2>/dev/null)
+    CHECK_EXIT=$?
+    set -e
+    assert_contains "$name" "mod.lua" || return
+    assert_contains "$name" "GDK initialization deadlock" || return
     pass "$name"
 }
 
@@ -492,6 +511,7 @@ test_require_stdlib_skipped
 test_require_awesomewm_skipped
 test_require_somewm_module_found
 test_require_library_not_scanned
+test_bare_filename_walks_requires
 test_require_method_skipped
 test_require_local_module
 test_require_init_module


### PR DESCRIPTION
## Description
- `--check` resolves requires through `package.searchpath` on a state carrying the runtime's search
  paths, not `config_dir` plus a hardcoded allowlist. somewm's own modules and installed rocks stop
  reporting as not found. Only files under `config_dir` are recursed into.
- `config_dir` was derived only when the path had a slash. A bare filename left it NULL, which skipped
  the require walk entirely. It now defaults to `.`.
- The boot pre-scan uses the same resolver as `--check`, so both read the same files.