### PR TITLE
Backport/1.4 input and fixes

### DIFF
--- a/UPSTREAM_PORTS.md
+++ b/UPSTREAM_PORTS.md
@@ -8,6 +8,7 @@ Since SomeWM is not a direct git fork, we manually port relevant changes from up
 
 | AwesomeWM PR | Description | SomeWM PR | Date |
 |--------------|-------------|-----------|------|
+| [#4122](https://github.com/awesomeWM/awesome/pull/4122) | Round placement margins and offsets to whole pixels | N/A | 2026-08-27 |
 | [#4079](https://github.com/awesomeWM/awesome/pull/4079) | Add group support for append_client_keybindings | N/A | 2026-04-01 |
 | [#4066](https://github.com/awesomeWM/awesome/pull/4066) | Use lua_pushliteral instead of lua_pushstring | N/A | 2026-04-01 |
 | [#4060](https://github.com/awesomeWM/awesome/pull/4060) | Use luaA_class_add_properties batch API | N/A | 2026-04-01 |

--- a/globalconf.h
+++ b/globalconf.h
@@ -118,6 +118,9 @@ typedef struct InputSettings {
      * surface, so cropping-then-stretching a sub-region would scale touch
      * motion itself. */
     char *tool_mode;                /* "absolute", "relative" */
+    int emulate_pointer;            /* touch-specific: synthesize wl_pointer
+                                      * clicks for clients that never bound
+                                      * wl_touch; 0=off, 1=on */
     char **map_to_output_list;      /* ordered candidates: "*", output name, or
                                       * make/model/serial identifier; first
                                       * connected candidate wins */

--- a/globalconf.h
+++ b/globalconf.h
@@ -109,11 +109,32 @@ typedef struct InputSettings {
     char *tap_button_map;           /* "lrm", "lmr" */
     char *clickfinger_button_map;   /* "lrm", "lmr" */
     bool accel_speed_set;           /* true if accel_speed was explicitly set */
+
+    /* Tablet tool-specific rule properties (used by awful.input.rules) */
+    char *tool_mode;                /* "absolute", "relative" */
+    char **map_to_output_list;      /* ordered candidates: "*", output name, or
+                                      * make/model/serial identifier; first
+                                      * connected candidate wins */
+    int map_to_output_count;
+    bool map_from_region_set;       /* true if region is explicitly set */
+    double map_from_region_x1;
+    double map_from_region_y1;
+    double map_from_region_x2;
+    double map_from_region_y2;
+
+    /* Absolute output-layout-pixel target rectangle; takes precedence over
+     * map_to_output_list when set (mirrors sway: an input is mapped to
+     * either an output or a region, not both). */
+    bool map_to_region_set;
+    double map_to_region_x1;
+    double map_to_region_y1;
+    double map_to_region_x2;
+    double map_to_region_y2;
 } InputSettings;
 
 /** Per-device input rule (evaluated in order, last match wins per property) */
 typedef struct InputRule {
-    char *type;                     /* "touchpad" or "pointer", NULL=match any */
+    char *type;                     /* e.g. "touchpad", "pointer", "tablet", "tablet-tool-pen", "tablet-tool"; NULL=match any */
     char *name;                     /* device name substring, NULL=match any */
     InputSettings properties;
 } InputRule;

--- a/globalconf.h
+++ b/globalconf.h
@@ -110,7 +110,13 @@ typedef struct InputSettings {
     char *clickfinger_button_map;   /* "lrm", "lmr" */
     bool accel_speed_set;           /* true if accel_speed was explicitly set */
 
-    /* Tablet tool-specific rule properties (used by awful.input.rules) */
+    /* Tablet/touch rule properties (used by awful.input.rules). tool_mode
+     * is tablet tool-specific; map_to_output/map_to_region are shared by
+     * both "tablet" and "touch" rule types, but map_from_region only takes
+     * effect for tablet tools (see tablet_map_coords() in somewm.c) - a
+     * touchscreen's raw coordinates are already 1:1 with its physical
+     * surface, so cropping-then-stretching a sub-region would scale touch
+     * motion itself. */
     char *tool_mode;                /* "absolute", "relative" */
     char **map_to_output_list;      /* ordered candidates: "*", output name, or
                                       * make/model/serial identifier; first
@@ -134,7 +140,7 @@ typedef struct InputSettings {
 
 /** Per-device input rule (evaluated in order, last match wins per property) */
 typedef struct InputRule {
-    char *type;                     /* e.g. "touchpad", "pointer", "tablet", "tablet-tool-pen", "tablet-tool"; NULL=match any */
+    char *type;                     /* e.g. "touchpad", "pointer", "tablet", "tablet-tool-pen", "tablet-tool", "touch"; NULL=match any */
     char *name;                     /* device name substring, NULL=match any */
     InputSettings properties;
 } InputRule;

--- a/input.c
+++ b/input.c
@@ -1262,7 +1262,10 @@ inputdevice(struct wl_listener *listener, void *data)
 		createswitch(wlr_switch_from_input_device(device));
 		break;
 	default:
-		/* TODO handle other input device types */
+		wlr_log(WLR_INFO,
+			"[input] ignoring unsupported device type=%d name=%s",
+			device->type,
+			device->name ? device->name : "(unknown)");
 		break;
 	}
 

--- a/input.c
+++ b/input.c
@@ -29,6 +29,9 @@
 #include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_switch.h>
+#include <wlr/types/wlr_tablet_pad.h>
+#include <wlr/types/wlr_tablet_tool.h>
+#include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/util/log.h>
 #include <wlr/util/region.h>
@@ -81,6 +84,15 @@ void cursorframe(struct wl_listener *listener, void *data);
 void motionrelative(struct wl_listener *listener, void *data);
 void motionabsolute(struct wl_listener *listener, void *data);
 void inputdevice(struct wl_listener *listener, void *data);
+static void tabletnotifyaxis(struct wl_listener *listener, void *data);
+static void tabletnotifyproximity(struct wl_listener *listener, void *data);
+static void tabletnotifytip(struct wl_listener *listener, void *data);
+static void tabletnotifybutton(struct wl_listener *listener, void *data);
+static void tabletpadnotifybutton(struct wl_listener *listener, void *data);
+static void tabletpadnotifyring(struct wl_listener *listener, void *data);
+static void tabletpadnotifystrip(struct wl_listener *listener, void *data);
+static void tabletpadnotifyattach(struct wl_listener *listener, void *data);
+static void tabletpadnotifysurfacedestroy(struct wl_listener *listener, void *data);
 void virtualkeyboard(struct wl_listener *listener, void *data);
 void virtualpointer(struct wl_listener *listener, void *data);
 void createpointerconstraint(struct wl_listener *listener, void *data);
@@ -95,6 +107,9 @@ void gestureholdbegin(struct wl_listener *listener, void *data);
 void gestureholdend(struct wl_listener *listener, void *data);
 void destroypointerconstraint(struct wl_listener *listener, void *data);
 static void destroytrackedpointer(struct wl_listener *listener, void *data);
+static void destroytrackedtablet(struct wl_listener *listener, void *data);
+static void destroytrackedtabletpad(struct wl_listener *listener, void *data);
+static void destroytrackedtablettool(struct wl_listener *listener, void *data);
 static void destroyswitchtracker(struct wl_listener *listener, void *data);
 static void switchevent(struct wl_listener *listener, void *data);
 void motionnotify(uint32_t time, struct wlr_input_device *device, double dx, double dy,
@@ -105,6 +120,8 @@ int keybinding(uint32_t mods, uint32_t keycode, xkb_keysym_t sym, xkb_keysym_t b
 void createkeyboard(struct wlr_keyboard *keyboard);
 KeyboardGroup *createkeyboardgroup(void);
 void createpointer(struct wlr_pointer *pointer);
+static void createtablet(struct wlr_tablet *tablet);
+static void createtabletpad(struct wlr_tablet_pad *pad);
 void cursorconstrain(struct wlr_pointer_constraint_v1 *constraint);
 void cursorwarptohint(void);
 void apply_input_settings_to_device(struct libinput_device *device);
@@ -133,6 +150,50 @@ typedef struct {
 	struct wl_listener destroy;
 	struct wl_list link;
 } TrackedPointer;
+
+/* Tracked tablet device for tool-event listeners and debug logging */
+typedef struct {
+	struct wlr_tablet *tablet;
+	struct wlr_tablet_v2_tablet *tablet_v2;
+	struct wl_listener axis;
+	struct wl_listener proximity;
+	struct wl_listener tip;
+	struct wl_listener button;
+	struct wl_listener destroy;
+	struct wl_list link;
+} TrackedTablet;
+
+/* Tracked tablet pad for debug logging in MVP phase */
+typedef struct {
+	struct wlr_tablet_pad *pad;
+	struct wlr_tablet_v2_tablet_pad *pad_v2;
+	struct wlr_tablet *attached_tablet;
+	struct wlr_surface *current_surface;
+	struct wl_listener button;
+	struct wl_listener ring;
+	struct wl_listener strip;
+	struct wl_listener attach_tablet;
+	struct wl_listener surface_destroy;
+	struct wl_listener destroy;
+	struct wl_list link;
+} TrackedTabletPad;
+
+typedef struct {
+	struct wlr_tablet_tool *tool;
+	struct wlr_tablet_v2_tablet_tool *tool_v2;
+	struct wlr_tablet *tablet;
+	/* Last known normalized (0..1) position and tilt, tracked per-tool so
+	 * a single-axis wlr_tablet_tool_axis_event (see tabletnotifyaxis())
+	 * can still resolve a full x/y or tilt_x/tilt_y pair. */
+	double last_x, last_y;
+	bool has_x, has_y;
+	double last_tilt_x, last_tilt_y;
+	bool has_tilt_x, has_tilt_y;
+	struct wl_listener destroy;
+	struct wl_list link;
+} TrackedTabletTool;
+
+static TrackedTablet *find_tracked_tablet_by_device(struct wlr_input_device *device);
 
 typedef struct {
 	struct wlr_switch *switch_dev;
@@ -909,6 +970,24 @@ motionnotify(uint32_t time, struct wlr_input_device *device, double dx, double d
 			wlr_cursor_set_xcursor(cursor, cursor_mgr, selected_root_cursor ? selected_root_cursor : "default");
 	}
 
+	/* Tablet-capable clients should receive stylus motion via tablet-v2 only.
+	 * Suppress wl_pointer motion emulation to avoid duplicate events in apps
+	 * like Krita's tablet tester. */
+	if (time && !seat->drag && device && device->type == WLR_INPUT_DEVICE_TABLET) {
+		TrackedTablet *tt = find_tracked_tablet_by_device(device);
+		struct wlr_surface *tablet_surface = NULL;
+		double tablet_sx = 0.0, tablet_sy = 0.0;
+
+		xytonode(cursor->x, cursor->y, &tablet_surface, NULL, NULL, NULL, NULL,
+				&tablet_sx, &tablet_sy);
+
+		if (tt && tt->tablet_v2 && tablet_surface
+				&& wlr_surface_accepts_tablet_v2(tablet_surface, tt->tablet_v2)) {
+			wlr_seat_pointer_notify_clear_focus(seat);
+			return;
+		}
+	}
+
 	pointerfocus(c, surface, sx, sy, time);
 }
 
@@ -1258,6 +1337,12 @@ inputdevice(struct wl_listener *listener, void *data)
 	case WLR_INPUT_DEVICE_POINTER:
 		createpointer(wlr_pointer_from_input_device(device));
 		break;
+	case WLR_INPUT_DEVICE_TABLET:
+		createtablet(wlr_tablet_from_input_device(device));
+		break;
+	case WLR_INPUT_DEVICE_TABLET_PAD:
+		createtabletpad(wlr_tablet_pad_from_input_device(device));
+		break;
 	case WLR_INPUT_DEVICE_SWITCH:
 		createswitch(wlr_switch_from_input_device(device));
 		break;
@@ -1349,24 +1434,75 @@ get_input_device_type(struct libinput_device *device)
 		? "touchpad" : "pointer";
 }
 
-/* Resolve effective input settings for a device by overlaying matching rules
- * on top of the global defaults. String fields in the result are borrowed
- * pointers (not owned), so the caller must not free them. */
+static const char *
+tablet_tool_type_to_rule_type(enum wlr_tablet_tool_type type)
+{
+	switch (type) {
+	case WLR_TABLET_TOOL_TYPE_PEN:
+		return "tablet-tool-pen";
+	case WLR_TABLET_TOOL_TYPE_ERASER:
+		return "tablet-tool-eraser";
+	case WLR_TABLET_TOOL_TYPE_BRUSH:
+		return "tablet-tool-brush";
+	case WLR_TABLET_TOOL_TYPE_PENCIL:
+		return "tablet-tool-pencil";
+	case WLR_TABLET_TOOL_TYPE_AIRBRUSH:
+		return "tablet-tool-airbrush";
+	case WLR_TABLET_TOOL_TYPE_MOUSE:
+		return "tablet-tool-mouse";
+	case WLR_TABLET_TOOL_TYPE_LENS:
+		return "tablet-tool-lens";
+	case WLR_TABLET_TOOL_TYPE_TOTEM:
+		return "tablet-tool-totem";
+	default:
+		return NULL;
+	}
+}
+
+/* A rule's `type` can match on either of two independent axes: the device
+ * class (`primary`, e.g. "tablet") or, for tablets, which tool triggered
+ * the current event (`secondary`, e.g. "tablet-tool-pen"). Plain pointer/
+ * touchpad devices only have a `primary` axis (see resolve_input_settings());
+ * tablets pass both, since `primary` is always the constant "tablet" while
+ * `secondary` varies per event (see resolve_tablet_settings()) - so
+ * `{type="tablet"}` matches any tool on any tablet, `{type="tablet-tool-pen"}`
+ * matches a pen on any tablet, and both can be combined with `name` (always
+ * the tablet's own name, never the tool's) to narrow to one device. */
+static bool
+input_rule_type_matches(const char *rule_type, const char *primary, const char *secondary)
+{
+	if (!rule_type)
+		return true;
+
+	if (primary && strcmp(rule_type, primary) == 0)
+		return true;
+
+	if (secondary && strcmp(rule_type, secondary) == 0)
+		return true;
+
+	/* tablet-tool is a wildcard for any concrete tablet-tool-* type. */
+	if (secondary && strcmp(rule_type, "tablet-tool") == 0
+			&& strncmp(secondary, "tablet-tool-", strlen("tablet-tool-")) == 0)
+		return true;
+
+	return false;
+}
+
+/* Resolve effective input settings by overlaying matching rules on top of
+ * global defaults. String fields in the result are borrowed pointers
+ * (not owned), so the caller must not free them. */
 static void
-resolve_input_settings(struct libinput_device *device, struct InputSettings *out)
+resolve_input_settings_for_types(const char *type_primary,
+		const char *type_secondary, const char *dev_name,
+		struct InputSettings *out)
 {
 	/* Start with global defaults */
 	*out = globalconf.input;
-	/* String fields are borrowed from globalconf, not duplicated */
-
-	const char *dev_type = get_input_device_type(device);
-	const char *dev_name = libinput_device_get_name(device);
 
 	for (int i = 0; i < globalconf.input_rules_count; i++) {
 		struct InputRule *rule = &globalconf.input_rules[i];
 
-		/* Check type match */
-		if (rule->type && strcmp(rule->type, dev_type) != 0)
+		if (!input_rule_type_matches(rule->type, type_primary, type_secondary))
 			continue;
 		/* Check name match (substring) */
 		if (rule->name && (!dev_name || !strstr(dev_name, rule->name)))
@@ -1395,7 +1531,115 @@ resolve_input_settings(struct libinput_device *device, struct InputSettings *out
 			out->accel_speed = p->accel_speed;
 			out->accel_speed_set = true;
 		}
+		if (p->tool_mode) out->tool_mode = p->tool_mode;
+		if (p->map_to_output_count) {
+			out->map_to_output_list = p->map_to_output_list;
+			out->map_to_output_count = p->map_to_output_count;
+		}
+		if (p->map_from_region_set) {
+			out->map_from_region_set = true;
+			out->map_from_region_x1 = p->map_from_region_x1;
+			out->map_from_region_y1 = p->map_from_region_y1;
+			out->map_from_region_x2 = p->map_from_region_x2;
+			out->map_from_region_y2 = p->map_from_region_y2;
+		}
+		if (p->map_to_region_set) {
+			out->map_to_region_set = true;
+			out->map_to_region_x1 = p->map_to_region_x1;
+			out->map_to_region_y1 = p->map_to_region_y1;
+			out->map_to_region_x2 = p->map_to_region_x2;
+			out->map_to_region_y2 = p->map_to_region_y2;
+		}
 	}
+}
+/* Normalize tablet coordinates and map them into layout coordinates.
+ * Returns true if an explicit output mapping was successfully applied. */
+static bool
+tablet_map_coords(const struct InputSettings *s, double in_x, double in_y,
+		double *out_lx, double *out_ly)
+{
+	struct wlr_box box = {0};
+	Monitor *target = NULL;
+	double tx = in_x;
+	double ty = in_y;
+
+	/* First restrict input region to map_from_region setting and
+	 * remap-and-bound it to the unit square.*/
+	if (s->map_from_region_set) {
+		double w = s->map_from_region_x2 - s->map_from_region_x1;
+		double h = s->map_from_region_y2 - s->map_from_region_y1;
+
+		if (fabs(w) < 1e-9 || fabs(h) < 1e-9) {
+			wlr_log(WLR_ERROR,
+				"[tablet-map] invalid map_from_region: (%f,%f)-(%f,%f), falling back to raw coords",
+				s->map_from_region_x1, s->map_from_region_y1,
+				s->map_from_region_x2, s->map_from_region_y2);
+		} else {
+			tx = (in_x - s->map_from_region_x1) / w;
+			ty = (in_y - s->map_from_region_y1) / h;
+			tx = fmax(0.0, fmin(1.0, tx));
+			ty = fmax(0.0, fmin(1.0, ty));
+		}
+	}
+
+	/* An explicit target region takes precedence over map_to_output
+	 * (mirrors sway's mutually-exclusive output/region mapping). */
+	if (s->map_to_region_set) {
+		double w = s->map_to_region_x2 - s->map_to_region_x1;
+		double h = s->map_to_region_y2 - s->map_to_region_y1;
+
+		if (fabs(w) < 1e-9 || fabs(h) < 1e-9) {
+			wlr_log(WLR_ERROR,
+				"[tablet-map] invalid map_to_region: (%f,%f)-(%f,%f), falling back to map_to_output",
+				s->map_to_region_x1, s->map_to_region_y1,
+				s->map_to_region_x2, s->map_to_region_y2);
+		} else {
+			*out_lx = s->map_to_region_x1 + tx * w;
+			*out_ly = s->map_to_region_y1 + ty * h;
+			return true;
+		}
+	}
+
+	/* Map to a provided output monitor by identifying matching candidates
+	 * provided in map_to_output setting. */
+	for (int i = 0; i < s->map_to_output_count; i++) {
+		const char *candidate = s->map_to_output_list[i];
+
+		/* Map to entire layout, so stop mapping matching here. */
+		if (strcmp(candidate, "*") == 0)
+			break;
+
+		target = some_monitor_by_name(candidate);
+		if (target)
+			break;
+
+		wlr_log(WLR_INFO,
+			"[tablet-map] output '%s' not found, trying next candidate",
+			candidate);
+	}
+
+	/* Target output found. Map coordinates to it. */
+	if (target) {
+		*out_lx = target->m.x + tx * target->m.width;
+		*out_ly = target->m.y + ty * target->m.height;
+		return true;
+	}
+
+	wlr_output_layout_get_box(output_layout, NULL, &box);
+	*out_lx = box.x + tx * box.width;
+	*out_ly = box.y + ty * box.height;
+	return false;
+}
+
+/* Resolve effective input settings for a device by overlaying matching rules
+ * on top of the global defaults. String fields in the result are borrowed
+ * pointers (not owned), so the caller must not free them. */
+static void
+resolve_input_settings(struct libinput_device *device, struct InputSettings *out)
+{
+	const char *dev_type = get_input_device_type(device);
+	const char *dev_name = libinput_device_get_name(device);
+	resolve_input_settings_for_types(dev_type, NULL, dev_name, out);
 }
 
 /* Apply resolved input settings to a single libinput device */
@@ -1532,6 +1776,650 @@ apply_input_settings_to_all_devices(void)
 	}
 }
 
+/* primary is the constant "tablet" (see input_rule_type_matches()); only
+ * secondary (the active tool's type) varies per call. */
+static void
+resolve_tablet_settings(struct wlr_tablet *tablet, struct wlr_tablet_tool *tool,
+		struct InputSettings *out)
+{
+	const char *tool_type = tool ? tablet_tool_type_to_rule_type(tool->type) : NULL;
+	const char *dev_name = tablet && tablet->base.name ? tablet->base.name : NULL;
+
+	resolve_input_settings_for_types("tablet", tool_type, dev_name, out);
+
+	/* Puck-style tools have no fixed position on the tablet surface, so
+	 * absolute placement makes no sense for them; sway hardcodes this too
+	 * (sway-input(5): "Mouse and lens tools ignore this setting and are
+	 * always treated as relative") and doesn't let tool_mode rules override
+	 * it, so match that here. */
+	if (tool && (tool->type == WLR_TABLET_TOOL_TYPE_MOUSE
+			|| tool->type == WLR_TABLET_TOOL_TYPE_LENS))
+		out->tool_mode = "relative";
+}
+
+static TrackedTablet *
+find_tracked_tablet(struct wlr_tablet *tablet)
+{
+	TrackedTablet *tt;
+
+	wl_list_for_each(tt, &tracked_tablets, link) {
+		if (tt->tablet == tablet)
+			return tt;
+	}
+
+	return NULL;
+}
+
+static TrackedTablet *
+find_tracked_tablet_by_device(struct wlr_input_device *device)
+{
+	TrackedTablet *tt;
+
+	if (!device || device->type != WLR_INPUT_DEVICE_TABLET)
+		return NULL;
+
+	wl_list_for_each(tt, &tracked_tablets, link) {
+		if (&tt->tablet->base == device)
+			return tt;
+	}
+
+	return NULL;
+}
+
+/* Tracks a tool regardless of tablet-v2 support: axis position caching
+ * (tabletnotifyaxis()) needs this even when tablet_v2_mgr is unavailable. */
+static TrackedTabletTool *
+find_or_create_tracked_tablet_tool(struct wlr_tablet *tablet, struct wlr_tablet_tool *tool)
+{
+	TrackedTabletTool *ttt;
+
+	if (!tool)
+		return NULL;
+
+	wl_list_for_each(ttt, &tracked_tablet_tools, link) {
+		if (ttt->tool == tool) {
+			if (tablet)
+				ttt->tablet = tablet;
+			return ttt;
+		}
+	}
+
+	ttt = ecalloc(1, sizeof(*ttt));
+	ttt->tool = tool;
+	ttt->tablet = tablet;
+	wl_list_insert(&tracked_tablet_tools, &ttt->link);
+	LISTEN(&tool->events.destroy, &ttt->destroy, destroytrackedtablettool);
+
+	return ttt;
+}
+
+static struct wlr_tablet_v2_tablet_tool *
+get_or_create_tablet_v2_tool(struct wlr_tablet *tablet, struct wlr_tablet_tool *tool)
+{
+	TrackedTabletTool *ttt;
+
+	if (!tablet_v2_mgr)
+		return NULL;
+
+	ttt = find_or_create_tracked_tablet_tool(tablet, tool);
+	if (!ttt)
+		return NULL;
+
+	if (!ttt->tool_v2)
+		ttt->tool_v2 = wlr_tablet_tool_create(tablet_v2_mgr, seat, tool);
+
+	return ttt->tool_v2;
+}
+
+static TrackedTablet *
+find_tracked_tablet_by_tool(struct wlr_tablet_tool *tool)
+{
+	TrackedTabletTool *ttt;
+
+	if (!tool)
+		return NULL;
+
+	wl_list_for_each(ttt, &tracked_tablet_tools, link) {
+		if (ttt->tool == tool)
+			return find_tracked_tablet(ttt->tablet);
+	}
+
+	return NULL;
+}
+
+static TrackedTablet *
+find_tracked_tablet_by_attach_payload(void *payload)
+{
+	TrackedTablet *tt;
+	TrackedTablet *by_tool;
+
+	if (!payload)
+		return NULL;
+
+	/* libinput backends usually provide a wlr_tablet_tool payload. */
+	by_tool = find_tracked_tablet_by_tool((struct wlr_tablet_tool *)payload);
+	if (by_tool)
+		return by_tool;
+
+	/* Wayland backend can provide a wlr_input_device payload for the tablet. */
+	wl_list_for_each(tt, &tracked_tablets, link) {
+		if (&tt->tablet->base == payload)
+			return tt;
+	}
+
+	return NULL;
+}
+
+/* True if pad and tablet are libinput devices from the same physical
+ * hardware (e.g. the pad and pen halves of a single Wacom tablet), per
+ * libinput's device-group grouping. This is the authoritative way to pair
+ * a pad with its tablet; unlike the attach_tablet event, it doesn't depend
+ * on a backend actually emitting that signal. */
+static bool
+tablet_pad_shares_libinput_group(struct wlr_tablet_pad *pad, struct wlr_tablet *tablet)
+{
+	struct libinput_device *pad_dev, *tablet_dev;
+
+	if (!pad || !tablet
+			|| !wlr_input_device_is_libinput(&pad->base)
+			|| !wlr_input_device_is_libinput(&tablet->base))
+		return false;
+
+	pad_dev = wlr_libinput_get_device_handle(&pad->base);
+	tablet_dev = wlr_libinput_get_device_handle(&tablet->base);
+	if (!pad_dev || !tablet_dev)
+		return false;
+
+	return libinput_device_get_device_group(pad_dev)
+		== libinput_device_get_device_group(tablet_dev);
+}
+
+static void
+tabletpad_clear_focus(TrackedTabletPad *tp)
+{
+	if (!tp->current_surface)
+		return;
+
+	wlr_tablet_v2_tablet_pad_notify_leave(tp->pad_v2, tp->current_surface);
+	wl_list_remove(&tp->surface_destroy.link);
+	wl_list_init(&tp->surface_destroy.link);
+	tp->current_surface = NULL;
+}
+
+static void
+tabletpad_attach_tablet(TrackedTabletPad *tp, struct wlr_tablet *tablet)
+{
+	if (tp->attached_tablet == tablet)
+		return;
+
+	tabletpad_clear_focus(tp);
+	tp->attached_tablet = tablet;
+
+	wlr_log(WLR_INFO,
+		"[tablet-pad] attach device=%s mapped_tablet=%s",
+		tp->pad && tp->pad->base.name ? tp->pad->base.name : "(unknown)",
+		tablet && tablet->base.name ? tablet->base.name : "(unmapped)");
+}
+
+static void
+tabletpad_set_focus_for_cursor(TrackedTabletPad *tp)
+{
+	TrackedTablet *tt;
+	struct wlr_surface *surface = NULL;
+	double sx = 0.0, sy = 0.0;
+
+	if (!tp->pad_v2 || !tp->attached_tablet)
+		return;
+
+	tt = find_tracked_tablet(tp->attached_tablet);
+	if (!tt || !tt->tablet_v2)
+		return;
+
+	xytonode(cursor->x, cursor->y, &surface, NULL, NULL, NULL, NULL, &sx, &sy);
+	if (surface == tp->current_surface)
+		return;
+
+	tabletpad_clear_focus(tp);
+
+	if (!surface || !wlr_surface_accepts_tablet_v2(surface, tt->tablet_v2))
+		return;
+
+	wlr_tablet_v2_tablet_pad_notify_enter(tp->pad_v2, tt->tablet_v2, surface);
+	tp->current_surface = surface;
+	tp->surface_destroy.notify = tabletpadnotifysurfacedestroy;
+	wl_signal_add(&surface->events.destroy, &tp->surface_destroy);
+}
+
+static void
+tabletpadnotifysurfacedestroy(struct wl_listener *listener, void *data)
+{
+	TrackedTabletPad *tp = wl_container_of(listener, tp, surface_destroy);
+
+	(void)data;
+	tabletpad_clear_focus(tp);
+}
+
+static void
+tablet_notify_proximity_in_for_cursor(struct wlr_tablet *tablet,
+		struct wlr_tablet_tool *tool)
+{
+	TrackedTablet *tt;
+	struct wlr_tablet_v2_tablet_tool *tool_v2;
+	struct wlr_surface *surface = NULL;
+	double sx = 0.0, sy = 0.0;
+
+	if (!tablet_v2_mgr)
+		return;
+
+	tt = find_tracked_tablet(tablet);
+	if (!tt || !tt->tablet_v2)
+		return;
+
+	tool_v2 = get_or_create_tablet_v2_tool(tablet, tool);
+	if (!tool_v2)
+		return;
+
+	xytonode(cursor->x, cursor->y, &surface, NULL, NULL, NULL, NULL, &sx, &sy);
+	if (!surface)
+		return;
+
+	if (!wlr_surface_accepts_tablet_v2(surface, tt->tablet_v2))
+		return;
+
+	wlr_tablet_v2_tablet_tool_notify_proximity_in(tool_v2, tt->tablet_v2, surface);
+}
+
+static void
+tablet_apply_absolute_motion(struct wlr_tablet *tablet,
+		struct wlr_tablet_tool *tool, uint32_t time_msec,
+		double x, double y)
+{
+	struct InputSettings s;
+	double lx, ly, dx, dy;
+
+	resolve_tablet_settings(tablet, tool, &s);
+	tablet_map_coords(&s, x, y, &lx, &ly);
+	dx = lx - cursor->x;
+	dy = ly - cursor->y;
+
+	motionnotify(time_msec, &tablet->base, dx, dy, dx, dy);
+}
+
+static void
+tablet_apply_relative_motion(struct wlr_tablet *tablet,
+		struct wlr_tablet_tool *tool, uint32_t time_msec,
+		double dx, double dy)
+{
+	motionnotify(time_msec, &tablet->base, dx, dy, dx, dy);
+}
+
+static void
+tablet_apply_motion(struct wlr_tablet *tablet, struct wlr_tablet_tool *tool,
+		uint32_t time_msec, double x, double y, double dx, double dy)
+{
+	struct InputSettings s;
+	resolve_tablet_settings(tablet, tool, &s);
+	const char *tool_mode = s.tool_mode ? s.tool_mode : "absolute";
+
+	if (strcmp(tool_mode, "relative") == 0) {
+		tablet_apply_relative_motion(tablet, tool, time_msec, dx, dy);
+	} else {
+		if (strcmp(tool_mode, "absolute") != 0) {
+			wlr_log(WLR_INFO,
+					"[tablet] unknown tool_mode '%s', falling back to absolute",
+					tool_mode);
+		}
+
+		tablet_apply_absolute_motion(tablet, tool, time_msec, x, y);
+	}
+}
+
+static void
+tablet_apply_motion_absoluteonly(struct wlr_tablet *tablet,
+		struct wlr_tablet_tool *tool, uint32_t time_msec, double x, double y)
+{
+	struct InputSettings s;
+	resolve_tablet_settings(tablet, tool, &s);
+	const char *tool_mode = s.tool_mode ? s.tool_mode : "absolute";
+
+	if (strcmp(tool_mode, "relative") == 0) {
+		/* Nothing to do. */
+		return;
+	}
+
+	if (strcmp(tool_mode, "absolute") != 0) {
+		wlr_log(WLR_INFO,
+				"[tablet] unknown tool_mode '%s', falling back to absolute",
+				tool_mode);
+	}
+
+	tablet_apply_absolute_motion(tablet, tool, time_msec, x, y);
+}
+
+static void
+tabletnotifyaxis(struct wl_listener *listener, void *data)
+{
+	TrackedTablet *tt = wl_container_of(listener, tt, axis);
+	struct wlr_tablet_tool_axis_event *event = data;
+	struct wlr_tablet_v2_tablet_tool *tool_v2 = NULL;
+	TrackedTabletTool *ttt;
+	struct wlr_surface *surface = NULL;
+	double sx = 0.0, sy = 0.0;
+	double x, y, tilt_x, tilt_y;
+	bool updated_x, updated_y, has_xy;
+	bool updated_tilt_x, updated_tilt_y, has_tilt;
+
+	updated_x = event->updated_axes & WLR_TABLET_TOOL_AXIS_X;
+	updated_y = event->updated_axes & WLR_TABLET_TOOL_AXIS_Y;
+	updated_tilt_x = event->updated_axes & WLR_TABLET_TOOL_AXIS_TILT_X;
+	updated_tilt_y = event->updated_axes & WLR_TABLET_TOOL_AXIS_TILT_Y;
+
+	/* wlroots backends (e.g. libinput) only fill in x/y for the axes that
+	 * actually changed - a tool dragged along a single axis near the
+	 * tablet's edge is a normal, frequent event, not a malformed one, and
+	 * the other field is left at 0 rather than the tool's real position.
+	 * Track each tool's last known position so a single-axis update still
+	 * moves the cursor instead of being dropped, or worse, snapping to
+	 * (0, y)/(x, 0) if we trusted the unset field. */
+	ttt = find_or_create_tracked_tablet_tool(tt->tablet, event->tool);
+
+	x = (updated_x || !ttt) ? event->x : ttt->last_x;
+	y = (updated_y || !ttt) ? event->y : ttt->last_y;
+	has_xy = (updated_x || (ttt && ttt->has_x)) && (updated_y || (ttt && ttt->has_y));
+
+	/* Same reasoning applies to tilt: WLR_TABLET_TOOL_AXIS_TILT_X and
+	 * _TILT_Y are independent bits, so a report that only changed one of
+	 * them must not be treated as "no tilt update" nor have the other
+	 * axis read back as 0. */
+	tilt_x = (updated_tilt_x || !ttt) ? event->tilt_x : ttt->last_tilt_x;
+	tilt_y = (updated_tilt_y || !ttt) ? event->tilt_y : ttt->last_tilt_y;
+	has_tilt = (updated_tilt_x || (ttt && ttt->has_tilt_x))
+		&& (updated_tilt_y || (ttt && ttt->has_tilt_y));
+
+	if (ttt) {
+		if (updated_x) {
+			ttt->last_x = event->x;
+			ttt->has_x = true;
+		}
+		if (updated_y) {
+			ttt->last_y = event->y;
+			ttt->has_y = true;
+		}
+		if (updated_tilt_x) {
+			ttt->last_tilt_x = event->tilt_x;
+			ttt->has_tilt_x = true;
+		}
+		if (updated_tilt_y) {
+			ttt->last_tilt_y = event->tilt_y;
+			ttt->has_tilt_y = true;
+		}
+	}
+
+	if (has_xy) {
+		tablet_apply_motion(tt->tablet, event->tool, event->time_msec, x, y, event->dx, event->dy);
+	}
+
+	tool_v2 = get_or_create_tablet_v2_tool(tt->tablet, event->tool);
+	if (tool_v2) {
+		if (has_xy) {
+			tablet_notify_proximity_in_for_cursor(tt->tablet, event->tool);
+			xytonode(cursor->x, cursor->y, &surface, NULL, NULL, NULL, NULL, &sx, &sy);
+			if (surface && tt->tablet_v2
+					&& wlr_surface_accepts_tablet_v2(surface, tt->tablet_v2))
+				wlr_tablet_v2_tablet_tool_notify_motion(tool_v2, sx, sy);
+		}
+
+		if (event->updated_axes & WLR_TABLET_TOOL_AXIS_PRESSURE)
+			wlr_tablet_v2_tablet_tool_notify_pressure(tool_v2, event->pressure);
+		if (event->updated_axes & WLR_TABLET_TOOL_AXIS_DISTANCE)
+			wlr_tablet_v2_tablet_tool_notify_distance(tool_v2, event->distance);
+		if (has_tilt)
+			wlr_tablet_v2_tablet_tool_notify_tilt(tool_v2, tilt_x, tilt_y);
+		if (event->updated_axes & WLR_TABLET_TOOL_AXIS_ROTATION)
+			wlr_tablet_v2_tablet_tool_notify_rotation(tool_v2, event->rotation);
+		if (event->updated_axes & WLR_TABLET_TOOL_AXIS_SLIDER)
+			wlr_tablet_v2_tablet_tool_notify_slider(tool_v2, event->slider);
+		if (event->updated_axes & WLR_TABLET_TOOL_AXIS_WHEEL)
+			wlr_tablet_v2_tablet_tool_notify_wheel(tool_v2, event->wheel_delta, 0);
+	}
+	wlr_seat_pointer_notify_frame(seat);
+}
+
+static void
+tabletnotifyproximity(struct wl_listener *listener, void *data)
+{
+	TrackedTablet *tt = wl_container_of(listener, tt, proximity);
+	struct wlr_tablet_tool_proximity_event *event = data;
+	struct wlr_tablet_v2_tablet_tool *tool_v2;
+
+	tool_v2 = get_or_create_tablet_v2_tool(tt->tablet, event->tool);
+	if (!tool_v2)
+		return;
+
+	if (event->state == WLR_TABLET_TOOL_PROXIMITY_IN) {
+		tablet_apply_motion_absoluteonly(tt->tablet, event->tool, event->time_msec, event->x, event->y);
+		tablet_notify_proximity_in_for_cursor(tt->tablet, event->tool);
+	} else {
+		wlr_tablet_v2_tablet_tool_notify_proximity_out(tool_v2);
+		/* Refresh wl_pointer focus/cursor immediately after stylus leave. */
+		motionnotify(0, NULL, 0, 0, 0, 0);
+	}
+}
+
+static void
+tabletnotifytip(struct wl_listener *listener, void *data)
+{
+	TrackedTablet *tt = wl_container_of(listener, tt, tip);
+	struct wlr_tablet_tool_tip_event *event = data;
+	struct wlr_pointer_button_event button_event = {0};
+	struct wlr_tablet_v2_tablet_tool *tool_v2;
+
+	tablet_apply_motion_absoluteonly(tt->tablet, event->tool, event->time_msec, event->x, event->y);
+
+	button_event.time_msec = event->time_msec;
+	button_event.button = BTN_LEFT;
+	button_event.state = event->state == WLR_TABLET_TOOL_TIP_DOWN
+		? WL_POINTER_BUTTON_STATE_PRESSED
+		: WL_POINTER_BUTTON_STATE_RELEASED;
+
+	tool_v2 = get_or_create_tablet_v2_tool(tt->tablet, event->tool);
+	if (tool_v2) {
+		tablet_notify_proximity_in_for_cursor(tt->tablet, event->tool);
+		if (button_event.state == WL_POINTER_BUTTON_STATE_PRESSED)
+			wlr_tablet_v2_tablet_tool_notify_down(tool_v2);
+		else
+			wlr_tablet_v2_tablet_tool_notify_up(tool_v2);
+	}
+
+	/* Routed through buttonpress() rather than calling
+	 * wlr_seat_pointer_notify_button() directly: buttonpress() is where
+	 * Lua button-binding dispatch (click-to-focus/raise) happens. A tip
+	 * on an unfocused window must focus/raise it the same way a mouse
+	 * click would - a raw notify_button() call sends the client the click
+	 * but skips that dispatch entirely. The tablet tool already drives a
+	 * real, hovering cursor (tablet_apply_motion() always calls
+	 * motionnotify()), so tip down/up map directly onto press/release. */
+	buttonpress(NULL, &button_event);
+	wlr_seat_pointer_notify_frame(seat);
+	wlr_idle_notifier_v1_notify_activity(idle_notifier, seat);
+	some_notify_activity();
+}
+
+static void
+tabletnotifybutton(struct wl_listener *listener, void *data)
+{
+	TrackedTablet *tt = wl_container_of(listener, tt, button);
+	struct wlr_tablet_tool_button_event *event = data;
+	struct wlr_tablet_v2_tablet_tool *tool_v2;
+	enum zwp_tablet_pad_v2_button_state state;
+
+	tool_v2 = get_or_create_tablet_v2_tool(tt->tablet, event->tool);
+	if (!tool_v2)
+		return;
+
+	tablet_notify_proximity_in_for_cursor(tt->tablet, event->tool);
+	state = event->state == WLR_BUTTON_PRESSED
+		? ZWP_TABLET_PAD_V2_BUTTON_STATE_PRESSED
+		: ZWP_TABLET_PAD_V2_BUTTON_STATE_RELEASED;
+	wlr_tablet_v2_tablet_tool_notify_button(tool_v2, event->button, state);
+}
+
+static void
+tabletpadnotifybutton(struct wl_listener *listener, void *data)
+{
+	TrackedTabletPad *tp = wl_container_of(listener, tp, button);
+	struct wlr_tablet_pad_button_event *event = data;
+	enum zwp_tablet_pad_v2_button_state state;
+
+	if (!tp->pad_v2)
+		return;
+
+	tabletpad_set_focus_for_cursor(tp);
+	if (!tp->current_surface)
+		return;
+
+	state = event->state == WLR_BUTTON_PRESSED
+		? ZWP_TABLET_PAD_V2_BUTTON_STATE_PRESSED
+		: ZWP_TABLET_PAD_V2_BUTTON_STATE_RELEASED;
+	wlr_tablet_v2_tablet_pad_notify_mode(tp->pad_v2, event->group,
+		event->mode, event->time_msec);
+	wlr_tablet_v2_tablet_pad_notify_button(tp->pad_v2, event->button,
+		event->time_msec, state);
+}
+
+static void
+tabletpadnotifyring(struct wl_listener *listener, void *data)
+{
+	TrackedTabletPad *tp = wl_container_of(listener, tp, ring);
+	struct wlr_tablet_pad_ring_event *event = data;
+	bool finger;
+
+	if (!tp->pad_v2)
+		return;
+
+	tabletpad_set_focus_for_cursor(tp);
+	if (!tp->current_surface)
+		return;
+
+	finger = event->source == WLR_TABLET_PAD_RING_SOURCE_FINGER;
+	wlr_tablet_v2_tablet_pad_notify_ring(tp->pad_v2, event->ring,
+		event->position, finger, event->time_msec);
+}
+
+static void
+tabletpadnotifystrip(struct wl_listener *listener, void *data)
+{
+	TrackedTabletPad *tp = wl_container_of(listener, tp, strip);
+	struct wlr_tablet_pad_strip_event *event = data;
+	bool finger;
+
+	if (!tp->pad_v2)
+		return;
+
+	tabletpad_set_focus_for_cursor(tp);
+	if (!tp->current_surface)
+		return;
+
+	finger = event->source == WLR_TABLET_PAD_STRIP_SOURCE_FINGER;
+	wlr_tablet_v2_tablet_pad_notify_strip(tp->pad_v2, event->strip,
+		event->position, finger, event->time_msec);
+}
+
+static void
+tabletpadnotifyattach(struct wl_listener *listener, void *data)
+{
+	TrackedTabletPad *tp = wl_container_of(listener, tp, attach_tablet);
+	TrackedTablet *tt;
+
+	tt = find_tracked_tablet_by_attach_payload(data);
+	if (tt)
+		tabletpad_attach_tablet(tp, tt->tablet);
+	else
+		tabletpad_attach_tablet(tp, NULL);
+}
+
+static void
+createtablet(struct wlr_tablet *tablet)
+{
+	TrackedTablet *tt = ecalloc(1, sizeof(*tt));
+
+	tt->tablet = tablet;
+	tt->tablet_v2 = tablet_v2_mgr
+		? wlr_tablet_create(tablet_v2_mgr, seat, &tablet->base)
+		: NULL;
+	wl_list_insert(&tracked_tablets, &tt->link);
+
+	LISTEN(&tablet->events.axis, &tt->axis, tabletnotifyaxis);
+	LISTEN(&tablet->events.proximity, &tt->proximity, tabletnotifyproximity);
+	LISTEN(&tablet->events.tip, &tt->tip, tabletnotifytip);
+	LISTEN(&tablet->events.button, &tt->button, tabletnotifybutton);
+	LISTEN(&tablet->base.events.destroy, &tt->destroy, destroytrackedtablet);
+
+	wlr_cursor_attach_input_device(cursor, &tablet->base);
+
+	wlr_log(WLR_INFO,
+		"[tablet] new device name=%s size_mm=%.1fx%.1f vid=0x%04x pid=0x%04x",
+		tablet->base.name ? tablet->base.name : "(unknown)",
+		tablet->width_mm,
+		tablet->height_mm,
+		tablet->usb_vendor_id,
+		tablet->usb_product_id);
+
+	if (!tt->tablet_v2)
+		wlr_log(WLR_INFO, "[tablet] tablet-v2 registration unavailable for device=%s",
+			tablet->base.name ? tablet->base.name : "(unknown)");
+
+	/* Pair with any already-known pad from the same physical hardware. */
+	{
+		TrackedTabletPad *tp;
+		wl_list_for_each(tp, &tracked_tablet_pads, link) {
+			if (tablet_pad_shares_libinput_group(tp->pad, tablet))
+				tabletpad_attach_tablet(tp, tablet);
+		}
+	}
+}
+
+static void
+createtabletpad(struct wlr_tablet_pad *pad)
+{
+	TrackedTabletPad *tp = ecalloc(1, sizeof(*tp));
+
+	tp->pad = pad;
+	tp->pad_v2 = tablet_v2_mgr
+		? wlr_tablet_pad_create(tablet_v2_mgr, seat, &pad->base)
+		: NULL;
+	wl_list_insert(&tracked_tablet_pads, &tp->link);
+	wl_list_init(&tp->surface_destroy.link);
+
+	LISTEN(&pad->events.button, &tp->button, tabletpadnotifybutton);
+	LISTEN(&pad->events.ring, &tp->ring, tabletpadnotifyring);
+	LISTEN(&pad->events.strip, &tp->strip, tabletpadnotifystrip);
+	LISTEN(&pad->events.attach_tablet, &tp->attach_tablet, tabletpadnotifyattach);
+	LISTEN(&pad->base.events.destroy, &tp->destroy, destroytrackedtabletpad);
+
+	wlr_log(WLR_INFO,
+		"[tablet-pad] new device name=%s buttons=%zu rings=%zu strips=%zu",
+		pad->base.name ? pad->base.name : "(unknown)",
+		pad->button_count,
+		pad->ring_count,
+		pad->strip_count);
+
+	if (!tp->pad_v2)
+		wlr_log(WLR_INFO, "[tablet-pad] tablet-v2 registration unavailable for device=%s",
+			pad->base.name ? pad->base.name : "(unknown)");
+
+	/* Pair with any already-known tablet from the same physical hardware. */
+	{
+		TrackedTablet *tt;
+		wl_list_for_each(tt, &tracked_tablets, link) {
+			if (tablet_pad_shares_libinput_group(pad, tt->tablet)) {
+				tabletpad_attach_tablet(tp, tt->tablet);
+				break;
+			}
+		}
+	}
+}
+
 void
 createpointer(struct wlr_pointer *pointer)
 {
@@ -1571,6 +2459,63 @@ destroytrackedpointer(struct wl_listener *listener, void *data)
 	wl_list_remove(&tp->destroy.link);
 	wl_list_remove(&tp->link);
 	free(tp);
+}
+
+static void
+destroytrackedtablet(struct wl_listener *listener, void *data)
+{
+	TrackedTablet *tt = wl_container_of(listener, tt, destroy);
+	TrackedTabletPad *tp;
+	TrackedTabletTool *ttt;
+
+	/* Other trackers keep raw struct wlr_tablet* back-references
+	 * (attached_tablet / tool->tablet) that wlroots has no signal for;
+	 * clear them here so they don't dangle once tt->tablet is freed. */
+	wl_list_for_each(tp, &tracked_tablet_pads, link) {
+		if (tp->attached_tablet == tt->tablet) {
+			tabletpad_clear_focus(tp);
+			tp->attached_tablet = NULL;
+		}
+	}
+
+	wl_list_for_each(ttt, &tracked_tablet_tools, link) {
+		if (ttt->tablet == tt->tablet)
+			ttt->tablet = NULL;
+	}
+
+	wl_list_remove(&tt->axis.link);
+	wl_list_remove(&tt->proximity.link);
+	wl_list_remove(&tt->tip.link);
+	wl_list_remove(&tt->button.link);
+	wl_list_remove(&tt->destroy.link);
+	wl_list_remove(&tt->link);
+	free(tt);
+}
+
+static void
+destroytrackedtabletpad(struct wl_listener *listener, void *data)
+{
+	TrackedTabletPad *tp = wl_container_of(listener, tp, destroy);
+
+	wl_list_remove(&tp->button.link);
+	wl_list_remove(&tp->ring.link);
+	wl_list_remove(&tp->strip.link);
+	wl_list_remove(&tp->attach_tablet.link);
+	wl_list_remove(&tp->surface_destroy.link);
+	wl_list_remove(&tp->destroy.link);
+	wl_list_remove(&tp->link);
+	free(tp);
+}
+
+static void
+destroytrackedtablettool(struct wl_listener *listener, void *data)
+{
+	TrackedTabletTool *ttt = wl_container_of(listener, ttt, destroy);
+
+	(void)data;
+	wl_list_remove(&ttt->destroy.link);
+	wl_list_remove(&ttt->link);
+	free(ttt);
 }
 
 static void

--- a/input.c
+++ b/input.c
@@ -2158,14 +2158,11 @@ touchnotifydown(struct wl_listener *listener, void *data)
 	input_map_coords(&s, event->x, event->y, &lx, &ly);
 	xytonode(lx, ly, &surface, &c, NULL, NULL, NULL, &sx, &sy);
 
-	if (!surface)
-		return;
-
 	/* wlroots itself refuses to create a touch point (logged as an ERROR)
 	 * for a client with no bound wl_touch resource, so only forward the
 	 * raw event to clients that can actually use it. Everyone else gets
 	 * an emulated click instead, if enabled. */
-	if (!touch_client_needs_pointer_emulation(surface)) {
+	if (surface && !touch_client_needs_pointer_emulation(surface)) {
 		/* Touch-aware clients get real, raw touch - no synthetic
 		 * wl_pointer click (see touch_emulate_click()'s comment for
 		 * why). They still deserve focus/raise on a deliberate tap

--- a/input.c
+++ b/input.c
@@ -1546,6 +1546,7 @@ resolve_input_settings_for_types(const char *type_primary,
 		if (p->middle_button_emulation != -2) out->middle_button_emulation = p->middle_button_emulation;
 		if (p->scroll_button != -2) out->scroll_button = p->scroll_button;
 		if (p->scroll_button_lock != -2) out->scroll_button_lock = p->scroll_button_lock;
+		if (p->emulate_pointer != -2) out->emulate_pointer = p->emulate_pointer;
 		if (p->scroll_method) out->scroll_method = p->scroll_method;
 		if (p->click_method) out->click_method = p->click_method;
 		if (p->clickfinger_button_map) out->clickfinger_button_map = p->clickfinger_button_map;
@@ -2077,6 +2078,69 @@ tabletpadnotifysurfacedestroy(struct wl_listener *listener, void *data)
 	tabletpad_clear_focus(tp);
 }
 
+/* A client that never bound wl_touch (e.g. it only understands wl_pointer,
+ * or - for XWayland - Xwayland itself handles touch internally and may or
+ * may not forward a click) needs a synthesized click to be usable by touch
+ * at all. Touch-aware clients (they bound wl_touch) are untouched: this
+ * check is what keeps emulation from ever firing double input for them. */
+static bool
+touch_client_needs_pointer_emulation(struct wlr_surface *surface)
+{
+	struct wlr_seat_client *sc = wlr_seat_client_for_wl_client(seat,
+		wl_resource_get_client(surface->resource));
+	return !sc || wl_list_empty(&sc->touches);
+}
+
+/* Synthesizes an atomic left-click (press+release, no separate touch_id
+ * tracking needed) via buttonpress() so Lua button-binding dispatch and
+ * click-to-focus/raise run normally. Only for clients with no wl_touch
+ * binding - touch-aware clients get real touch instead, see touchnotifydown(). */
+static void
+touch_emulate_click(struct wlr_touch *touch, double lx, double ly, uint32_t time_msec)
+{
+	struct wlr_pointer_button_event press = {0};
+	struct wlr_pointer_button_event release = {0};
+
+	motionnotify(time_msec, &touch->base, lx - cursor->x, ly - cursor->y,
+		lx - cursor->x, ly - cursor->y);
+
+	press.time_msec = time_msec;
+	press.button = BTN_LEFT;
+	press.state = WL_POINTER_BUTTON_STATE_PRESSED;
+	buttonpress(NULL, &press);
+	wlr_seat_pointer_notify_frame(seat);
+
+	release.time_msec = time_msec;
+	release.button = BTN_LEFT;
+	release.state = WL_POINTER_BUTTON_STATE_RELEASED;
+	buttonpress(NULL, &release);
+	wlr_seat_pointer_notify_frame(seat);
+
+	/* Real touch has no hover state; clear synthetic pointer focus so the
+	 * tapped surface doesn't get stuck showing a hover highlight with no
+	 * real mouse-leave ever following. */
+	wlr_seat_pointer_notify_clear_focus(seat);
+}
+
+/* Whether some other surface already has an active touch point right now.
+ * Gates focus-stealing in touchnotifydown(): touching a second, different
+ * window while a touch is still down elsewhere (e.g. drawing on an
+ * unfocused canvas on one screen while touch-scrolling a document on
+ * another) must not disturb whichever window currently has focus.
+ * Concurrent touches on the *same* surface (a two-finger gesture) don't
+ * count as "elsewhere" and don't block focus. */
+static bool
+touch_point_active_elsewhere(struct wlr_surface *surface)
+{
+	struct wlr_touch_point *point;
+
+	wl_list_for_each(point, &seat->touch_state.touch_points, link) {
+		if (point->surface && point->surface != surface)
+			return true;
+	}
+	return false;
+}
+
 /* Touch is inherently absolute and multi-point (keyed by touch_id), unlike
  * tablet tools it doesn't move a shared cursor position via motionnotify();
  * each point maps straight to layout coords and then surface-local coords. */
@@ -2086,16 +2150,42 @@ touchnotifydown(struct wl_listener *listener, void *data)
 	struct wlr_touch_down_event *event = data;
 	struct InputSettings s;
 	struct wlr_surface *surface = NULL;
+	Client *c = NULL;
 	double lx, ly, sx, sy;
 
 	(void)listener;
 	resolve_touch_settings(event->touch, &s);
 	input_map_coords(&s, event->x, event->y, &lx, &ly);
-	xytonode(lx, ly, &surface, NULL, NULL, NULL, NULL, &sx, &sy);
+	xytonode(lx, ly, &surface, &c, NULL, NULL, NULL, &sx, &sy);
 
-	if (surface)
+	if (!surface)
+		return;
+
+	/* wlroots itself refuses to create a touch point (logged as an ERROR)
+	 * for a client with no bound wl_touch resource, so only forward the
+	 * raw event to clients that can actually use it. Everyone else gets
+	 * an emulated click instead, if enabled. */
+	if (!touch_client_needs_pointer_emulation(surface)) {
+		/* Touch-aware clients get real, raw touch - no synthetic
+		 * wl_pointer click (see touch_emulate_click()'s comment for
+		 * why). They still deserve focus/raise on a deliberate tap
+		 * though, the same way a mouse click gets it: go through the
+		 * same rc.lua button-binding dispatch buttonpress() uses,
+		 * just without the final wl_pointer delivery to the client. */
+		if (c && (!client_is_unmanaged(c) || client_wants_focus(c))
+				&& !touch_point_active_elsewhere(surface)) {
+			struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(seat);
+			uint32_t mods = keyboard ? wlr_keyboard_get_modifiers(keyboard) : 0;
+			int rel_x = (int)lx - c->geometry.x;
+			int rel_y = (int)ly - c->geometry.y;
+
+			luaA_client_button_check(c, rel_x, rel_y, BTN_LEFT,
+			                        CLEANMASK(mods), true);
+		}
 		wlr_seat_touch_notify_down(seat, surface, event->time_msec,
 			event->touch_id, sx, sy);
+	} else if (s.emulate_pointer)
+		touch_emulate_click(event->touch, lx, ly, event->time_msec);
 }
 
 static void
@@ -2111,6 +2201,10 @@ touchnotifymotion(struct wl_listener *listener, void *data)
 
 	(void)listener;
 
+	/* No point was ever created for this touch_id if the down event was
+	 * emulated instead of forwarded (see touchnotifydown()) - skip, same
+	 * guard touchnotifycancel() already uses, avoids another wlroots
+	 * "unknown touch point" ERROR log. */
 	point = wlr_seat_touch_get_point(seat, event->touch_id);
 	if (!point)
 		return;
@@ -2144,7 +2238,8 @@ touchnotifyup(struct wl_listener *listener, void *data)
 	struct wlr_touch_up_event *event = data;
 
 	(void)listener;
-	wlr_seat_touch_notify_up(seat, event->time_msec, event->touch_id);
+	if (wlr_seat_touch_get_point(seat, event->touch_id))
+		wlr_seat_touch_notify_up(seat, event->time_msec, event->touch_id);
 }
 
 static void

--- a/input.c
+++ b/input.c
@@ -32,6 +32,7 @@
 #include <wlr/types/wlr_tablet_pad.h>
 #include <wlr/types/wlr_tablet_tool.h>
 #include <wlr/types/wlr_tablet_v2.h>
+#include <wlr/types/wlr_touch.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/util/log.h>
 #include <wlr/util/region.h>
@@ -93,6 +94,11 @@ static void tabletpadnotifyring(struct wl_listener *listener, void *data);
 static void tabletpadnotifystrip(struct wl_listener *listener, void *data);
 static void tabletpadnotifyattach(struct wl_listener *listener, void *data);
 static void tabletpadnotifysurfacedestroy(struct wl_listener *listener, void *data);
+static void touchnotifydown(struct wl_listener *listener, void *data);
+static void touchnotifymotion(struct wl_listener *listener, void *data);
+static void touchnotifyup(struct wl_listener *listener, void *data);
+static void touchnotifycancel(struct wl_listener *listener, void *data);
+static void touchnotifyframe(struct wl_listener *listener, void *data);
 void virtualkeyboard(struct wl_listener *listener, void *data);
 void virtualpointer(struct wl_listener *listener, void *data);
 void createpointerconstraint(struct wl_listener *listener, void *data);
@@ -110,6 +116,7 @@ static void destroytrackedpointer(struct wl_listener *listener, void *data);
 static void destroytrackedtablet(struct wl_listener *listener, void *data);
 static void destroytrackedtabletpad(struct wl_listener *listener, void *data);
 static void destroytrackedtablettool(struct wl_listener *listener, void *data);
+static void destroytrackedtouch(struct wl_listener *listener, void *data);
 static void destroyswitchtracker(struct wl_listener *listener, void *data);
 static void switchevent(struct wl_listener *listener, void *data);
 void motionnotify(uint32_t time, struct wlr_input_device *device, double dx, double dy,
@@ -122,6 +129,7 @@ KeyboardGroup *createkeyboardgroup(void);
 void createpointer(struct wlr_pointer *pointer);
 static void createtablet(struct wlr_tablet *tablet);
 static void createtabletpad(struct wlr_tablet_pad *pad);
+static void createtouch(struct wlr_touch *touch);
 void cursorconstrain(struct wlr_pointer_constraint_v1 *constraint);
 void cursorwarptohint(void);
 void apply_input_settings_to_device(struct libinput_device *device);
@@ -192,6 +200,20 @@ typedef struct {
 	struct wl_listener destroy;
 	struct wl_list link;
 } TrackedTabletTool;
+
+/* Tracked touch device. wl_touch is core-protocol (gated by
+ * wl_seat.capabilities, not a separate extension manager like tablet-v2),
+ * so no "_v2" handle is needed here. */
+typedef struct {
+	struct wlr_touch *touch;
+	struct wl_listener down;
+	struct wl_listener up;
+	struct wl_listener motion;
+	struct wl_listener cancel;
+	struct wl_listener frame;
+	struct wl_listener destroy;
+	struct wl_list link;
+} TrackedTouch;
 
 static TrackedTablet *find_tracked_tablet_by_device(struct wlr_input_device *device);
 
@@ -1343,6 +1365,9 @@ inputdevice(struct wl_listener *listener, void *data)
 	case WLR_INPUT_DEVICE_TABLET_PAD:
 		createtabletpad(wlr_tablet_pad_from_input_device(device));
 		break;
+	case WLR_INPUT_DEVICE_TOUCH:
+		createtouch(wlr_touch_from_input_device(device));
+		break;
 	case WLR_INPUT_DEVICE_SWITCH:
 		createswitch(wlr_switch_from_input_device(device));
 		break;
@@ -1552,35 +1577,40 @@ resolve_input_settings_for_types(const char *type_primary,
 		}
 	}
 }
-/* Normalize tablet coordinates and map them into layout coordinates.
+/* Find the single enabled output, if there is exactly one. Used as a
+ * zero-config default so an unconfigured tablet/touch device maps onto
+ * the one screen that exists instead of spanning the whole layout. Once
+ * a second output is enabled this no longer applies and callers fall
+ * back to whole-layout mapping unless an explicit map_to_output rule is
+ * set. */
+static Monitor *
+single_enabled_monitor(void)
+{
+	Monitor *m, *found = NULL;
+
+	wl_list_for_each(m, &mons, link) {
+		if (!m->wlr_output || !m->wlr_output->enabled)
+			continue;
+		if (found)
+			return NULL; /* more than one enabled output */
+		found = m;
+	}
+
+	return found;
+}
+
+/* Map already-normalized [0,1] device-space coordinates (tx,ty) into layout
+ * coordinates, honoring map_to_region / map_to_output / the single-enabled-
+ * output default. Shared by tablet and touch - tablet additionally crops
+ * via map_from_region before calling this (see tablet_map_coords() below);
+ * touch calls this directly since map_from_region doesn't apply to it.
  * Returns true if an explicit output mapping was successfully applied. */
 static bool
-tablet_map_coords(const struct InputSettings *s, double in_x, double in_y,
+input_map_coords(const struct InputSettings *s, double tx, double ty,
 		double *out_lx, double *out_ly)
 {
 	struct wlr_box box = {0};
 	Monitor *target = NULL;
-	double tx = in_x;
-	double ty = in_y;
-
-	/* First restrict input region to map_from_region setting and
-	 * remap-and-bound it to the unit square.*/
-	if (s->map_from_region_set) {
-		double w = s->map_from_region_x2 - s->map_from_region_x1;
-		double h = s->map_from_region_y2 - s->map_from_region_y1;
-
-		if (fabs(w) < 1e-9 || fabs(h) < 1e-9) {
-			wlr_log(WLR_ERROR,
-				"[tablet-map] invalid map_from_region: (%f,%f)-(%f,%f), falling back to raw coords",
-				s->map_from_region_x1, s->map_from_region_y1,
-				s->map_from_region_x2, s->map_from_region_y2);
-		} else {
-			tx = (in_x - s->map_from_region_x1) / w;
-			ty = (in_y - s->map_from_region_y1) / h;
-			tx = fmax(0.0, fmin(1.0, tx));
-			ty = fmax(0.0, fmin(1.0, ty));
-		}
-	}
 
 	/* An explicit target region takes precedence over map_to_output
 	 * (mirrors sway's mutually-exclusive output/region mapping). */
@@ -1590,7 +1620,7 @@ tablet_map_coords(const struct InputSettings *s, double in_x, double in_y,
 
 		if (fabs(w) < 1e-9 || fabs(h) < 1e-9) {
 			wlr_log(WLR_ERROR,
-				"[tablet-map] invalid map_to_region: (%f,%f)-(%f,%f), falling back to map_to_output",
+				"[input-map] invalid map_to_region: (%f,%f)-(%f,%f), falling back to map_to_output",
 				s->map_to_region_x1, s->map_to_region_y1,
 				s->map_to_region_x2, s->map_to_region_y2);
 		} else {
@@ -1614,9 +1644,14 @@ tablet_map_coords(const struct InputSettings *s, double in_x, double in_y,
 			break;
 
 		wlr_log(WLR_INFO,
-			"[tablet-map] output '%s' not found, trying next candidate",
+			"[input-map] output '%s' not found, trying next candidate",
 			candidate);
 	}
+
+	/* Zero-config default: if nothing matched above and there's exactly
+	 * one enabled output, use it instead of spanning the whole layout. */
+	if (!target)
+		target = single_enabled_monitor();
 
 	/* Target output found. Map coordinates to it. */
 	if (target) {
@@ -1629,6 +1664,39 @@ tablet_map_coords(const struct InputSettings *s, double in_x, double in_y,
 	*out_lx = box.x + tx * box.width;
 	*out_ly = box.y + ty * box.height;
 	return false;
+}
+
+/* Normalize tablet tool coordinates and map them into layout coordinates.
+ * map_from_region crops-then-stretches a sub-area of the tablet's native
+ * surface across the whole target (see input_map_coords() above for why
+ * this doesn't apply to touch), matching real sway: apply_mapping_from_region()
+ * in sway/input/cursor.c is only ever called from handle_tablet_tool_position().
+ * Returns true if an explicit output mapping was successfully applied. */
+static bool
+tablet_map_coords(const struct InputSettings *s, double in_x, double in_y,
+		double *out_lx, double *out_ly)
+{
+	double tx = in_x;
+	double ty = in_y;
+
+	if (s->map_from_region_set) {
+		double w = s->map_from_region_x2 - s->map_from_region_x1;
+		double h = s->map_from_region_y2 - s->map_from_region_y1;
+
+		if (fabs(w) < 1e-9 || fabs(h) < 1e-9) {
+			wlr_log(WLR_ERROR,
+				"[tablet-map] invalid map_from_region: (%f,%f)-(%f,%f), falling back to raw coords",
+				s->map_from_region_x1, s->map_from_region_y1,
+				s->map_from_region_x2, s->map_from_region_y2);
+		} else {
+			tx = (in_x - s->map_from_region_x1) / w;
+			ty = (in_y - s->map_from_region_y1) / h;
+			tx = fmax(0.0, fmin(1.0, tx));
+			ty = fmax(0.0, fmin(1.0, ty));
+		}
+	}
+
+	return input_map_coords(s, tx, ty, out_lx, out_ly);
 }
 
 /* Resolve effective input settings for a device by overlaying matching rules
@@ -1795,6 +1863,16 @@ resolve_tablet_settings(struct wlr_tablet *tablet, struct wlr_tablet_tool *tool,
 	if (tool && (tool->type == WLR_TABLET_TOOL_TYPE_MOUSE
 			|| tool->type == WLR_TABLET_TOOL_TYPE_LENS))
 		out->tool_mode = "relative";
+}
+
+/* primary is the constant "touch"; touch devices have no secondary/tool
+ * axis analogous to tablet tools. */
+static void
+resolve_touch_settings(struct wlr_touch *touch, struct InputSettings *out)
+{
+	const char *dev_name = touch && touch->base.name ? touch->base.name : NULL;
+
+	resolve_input_settings_for_types("touch", NULL, dev_name, out);
 }
 
 static TrackedTablet *
@@ -1997,6 +2075,96 @@ tabletpadnotifysurfacedestroy(struct wl_listener *listener, void *data)
 
 	(void)data;
 	tabletpad_clear_focus(tp);
+}
+
+/* Touch is inherently absolute and multi-point (keyed by touch_id), unlike
+ * tablet tools it doesn't move a shared cursor position via motionnotify();
+ * each point maps straight to layout coords and then surface-local coords. */
+static void
+touchnotifydown(struct wl_listener *listener, void *data)
+{
+	struct wlr_touch_down_event *event = data;
+	struct InputSettings s;
+	struct wlr_surface *surface = NULL;
+	double lx, ly, sx, sy;
+
+	(void)listener;
+	resolve_touch_settings(event->touch, &s);
+	input_map_coords(&s, event->x, event->y, &lx, &ly);
+	xytonode(lx, ly, &surface, NULL, NULL, NULL, NULL, &sx, &sy);
+
+	if (surface)
+		wlr_seat_touch_notify_down(seat, surface, event->time_msec,
+			event->touch_id, sx, sy);
+}
+
+static void
+touchnotifymotion(struct wl_listener *listener, void *data)
+{
+	struct wlr_touch_motion_event *event = data;
+	struct InputSettings s;
+	struct wlr_touch_point *point;
+	struct wlr_surface *surface;
+	Client *c = NULL;
+	LayerSurface *l = NULL;
+	double lx, ly, sx, sy;
+
+	(void)listener;
+
+	point = wlr_seat_touch_get_point(seat, event->touch_id);
+	if (!point)
+		return;
+
+	resolve_touch_settings(event->touch, &s);
+	input_map_coords(&s, event->x, event->y, &lx, &ly);
+
+	/* wlr_seat_touch_notify_motion() takes no surface argument - it always
+	 * delivers to the client of the touch point's original down surface.
+	 * Re-resolving the topmost surface under the finger here, the way the
+	 * down handler does, would compute sx/sy relative to a different
+	 * surface once the finger drags across a window boundary (wrong local
+	 * coords delivered to the down surface's client), and would drop the
+	 * event outright once the finger drags off any surface at all. Stay
+	 * pinned to point->surface instead and project lx/ly onto its origin -
+	 * mirrors how motionnotify() keeps a held mouse button pinned to its
+	 * focused surface while the cursor roams elsewhere. */
+	surface = point->surface;
+	if (!surface || toplevel_from_wlr_surface(surface, &c, &l) < 0)
+		return;
+
+	sx = lx - (l ? l->scene->node.x : c->geometry.x);
+	sy = ly - (l ? l->scene->node.y : c->geometry.y);
+
+	wlr_seat_touch_notify_motion(seat, event->time_msec, event->touch_id, sx, sy);
+}
+
+static void
+touchnotifyup(struct wl_listener *listener, void *data)
+{
+	struct wlr_touch_up_event *event = data;
+
+	(void)listener;
+	wlr_seat_touch_notify_up(seat, event->time_msec, event->touch_id);
+}
+
+static void
+touchnotifycancel(struct wl_listener *listener, void *data)
+{
+	struct wlr_touch_cancel_event *event = data;
+	struct wlr_touch_point *point;
+
+	(void)listener;
+	point = wlr_seat_touch_get_point(seat, event->touch_id);
+	if (point)
+		wlr_seat_touch_notify_cancel(seat, point->client);
+}
+
+static void
+touchnotifyframe(struct wl_listener *listener, void *data)
+{
+	(void)listener;
+	(void)data;
+	wlr_seat_touch_notify_frame(seat);
 }
 
 static void
@@ -2420,6 +2588,27 @@ createtabletpad(struct wlr_tablet_pad *pad)
 	}
 }
 
+static void
+createtouch(struct wlr_touch *touch)
+{
+	TrackedTouch *tc = ecalloc(1, sizeof(*tc));
+
+	tc->touch = touch;
+	wl_list_insert(&tracked_touches, &tc->link);
+
+	LISTEN(&touch->events.down, &tc->down, touchnotifydown);
+	LISTEN(&touch->events.up, &tc->up, touchnotifyup);
+	LISTEN(&touch->events.motion, &tc->motion, touchnotifymotion);
+	LISTEN(&touch->events.cancel, &tc->cancel, touchnotifycancel);
+	LISTEN(&touch->events.frame, &tc->frame, touchnotifyframe);
+	LISTEN(&touch->base.events.destroy, &tc->destroy, destroytrackedtouch);
+
+	wlr_cursor_attach_input_device(cursor, &touch->base);
+
+	wlr_log(WLR_INFO, "[touch] new device name=%s",
+		touch->base.name ? touch->base.name : "(unknown)");
+}
+
 void
 createpointer(struct wlr_pointer *pointer)
 {
@@ -2516,6 +2705,22 @@ destroytrackedtablettool(struct wl_listener *listener, void *data)
 	wl_list_remove(&ttt->destroy.link);
 	wl_list_remove(&ttt->link);
 	free(ttt);
+}
+
+static void
+destroytrackedtouch(struct wl_listener *listener, void *data)
+{
+	TrackedTouch *tc = wl_container_of(listener, tc, destroy);
+
+	(void)data;
+	wl_list_remove(&tc->down.link);
+	wl_list_remove(&tc->up.link);
+	wl_list_remove(&tc->motion.link);
+	wl_list_remove(&tc->cancel.link);
+	wl_list_remove(&tc->frame.link);
+	wl_list_remove(&tc->destroy.link);
+	wl_list_remove(&tc->link);
+	free(tc);
 }
 
 static void

--- a/lua/awful/placement.lua
+++ b/lua/awful/placement.lua
@@ -39,7 +39,8 @@
 --
 -- **margins** (*number* or *table*):
 --
---  A table with left, right, top, bottom keys or a number
+--  A table with left, right, top, bottom keys or a number. Fractional values
+--  are rounded to a whole number of pixels.
 --
 -- **parent** (client, wibox, mouse or screen):
 --
@@ -58,7 +59,8 @@
 --
 -- **offset** (*table or number*):
 --
--- The offset(s) to apply to the new geometry.
+-- The offset(s) to apply to the new geometry. Fractional values are rounded
+-- to a whole number of pixels.
 --
 -- **store_geometry** (*boolean*):
 --
@@ -348,7 +350,22 @@ local function get_decoration(args)
         top  = args.margins or 0 , bottom = args.margins or 0
     }
 
-    return m, offset
+    -- The margins and offsets are added to the geometry when it is read and
+    -- removed again when it is written back, but the C code rounds the drawin
+    -- geometry to whole pixels. Fractional values, such as half of an odd
+    -- theme size, would make that round trip grow the drawable by one pixel on
+    -- every pass of an attached placement, until the C stack overflows (#4121).
+    return {
+        left   = gmath.round(m.left   or 0),
+        right  = gmath.round(m.right  or 0),
+        top    = gmath.round(m.top    or 0),
+        bottom = gmath.round(m.bottom or 0),
+    }, {
+        x      = gmath.round(offset.x      or 0),
+        y      = gmath.round(offset.y      or 0),
+        width  = gmath.round(offset.width  or 0),
+        height = gmath.round(offset.height or 0),
+    }
 end
 
 --- Apply some modifications before applying the new geometry.

--- a/luaa.c
+++ b/luaa.c
@@ -3026,31 +3026,17 @@ luaA_add_search_paths(const char **paths, int count)
 	}
 }
 
-/** Register everything a Lua state needs: the standard library, somewm's
- * search paths, and every somewm module and class.
+/** Point a Lua state at every directory somewm loads modules from: the
+ * development tree, the installed datadir, any -L/--search paths, and the
+ * user library directory.
  *
- * Boot (luaA_init) and the post-reload rebuild (luaA_create_fresh_state) both
- * run this, so there is one list instead of two that drift apart. Anything a
- * state needs belongs here; luaA_init keeps only the once-per-process work.
+ * Boot, the post-reload rebuild, and `--check` all call this, so what the
+ * checker believes require() can find is what require() can actually find.
  */
 static void
-luaA_register_state(lua_State *L)
+luaA_setup_package_paths(lua_State *L)
 {
 	const char *cur_path;
-
-	/* Panic handler for unprotected errors (AwesomeWM API parity) */
-	lua_atpanic(L, luaA_panic);
-
-	/* Set error handling function */
-	lualib_dofunction_on_error = luaA_dofunction_on_error;
-
-	luaL_openlibs(L);
-
-	/* Add AwesomeWM-compatible Lua extensions */
-	luaA_fixups(L);
-
-	/* Initialize the AwesomeWM object system (must precede any class setup) */
-	luaA_object_setup(L);
 
 	/* Add lua/ directory to package.path for require() support */
 	lua_getglobal(L, "package");
@@ -3127,6 +3113,33 @@ luaA_register_state(lua_State *L)
 			lua_pop(L, 1);  /* pop package table */
 		}
 	}
+}
+
+/** Register everything a Lua state needs: the standard library, somewm's
+ * search paths, and every somewm module and class.
+ *
+ * Boot (luaA_init) and the post-reload rebuild (luaA_create_fresh_state) both
+ * run this, so there is one list instead of two that drift apart. Anything a
+ * state needs belongs here; luaA_init keeps only the once-per-process work.
+ */
+static void
+luaA_register_state(lua_State *L)
+{
+	/* Panic handler for unprotected errors (AwesomeWM API parity) */
+	lua_atpanic(L, luaA_panic);
+
+	/* Set error handling function */
+	lualib_dofunction_on_error = luaA_dofunction_on_error;
+
+	luaL_openlibs(L);
+
+	/* Add AwesomeWM-compatible Lua extensions */
+	luaA_fixups(L);
+
+	/* Initialize the AwesomeWM object system (must precede any class setup) */
+	luaA_object_setup(L);
+
+	luaA_setup_package_paths(L);
 
 	/* Register somewm Lua modules */
 	luaA_signal_setup(L);
@@ -3625,41 +3638,6 @@ prescan_cleanup_visited(void)
 static void
 luaA_prescan_file(const char *config_path, const char *config_dir, int depth);
 
-/** Modules we never scan: the Lua stdlib, our own libraries, and common
- * third-party ones. Everything else is treated as config-local and resolved
- * against config_dir. Shared by the pre-scan and by --check so both walk the
- * same set of files.
- * \param name Module name as written in require()
- * \return true if the module is external and should be skipped
- */
-static bool
-prescan_module_is_external(const char *name)
-{
-	static const char *const exact[] = {
-		"string", "table", "math", "io", "os", "debug", "coroutine",
-		"package", "utf8", "bit", "bit32", "ffi", "jit",
-		"ruled", "lgi", "lain", "freedesktop", "vicious", "revelation",
-		"collision", "tyrannical", "cyclefocus", "radical", "cairo",
-		"posix", "cjson", "dkjson", "json", "socket", "http",
-		"penlight", "inspect", "luassert", "busted", NULL
-	};
-	static const char *const prefixes[] = {
-		"awful", "gears", "wibox", "naughty", "beautiful", "menubar",
-		"ruled.", "lgi.", "lain.", "freedesktop.", "vicious.",
-		"posix.", "cjson.", "socket.", "pl.", NULL
-	};
-	int i;
-
-	for (i = 0; exact[i]; i++)
-		if (strcmp(name, exact[i]) == 0)
-			return true;
-	for (i = 0; prefixes[i]; i++)
-		if (strncmp(name, prefixes[i], strlen(prefixes[i])) == 0)
-			return true;
-
-	return false;
-}
-
 /** Read the next require("mod") out of a file, skipping qualified calls such
  * as lgi.require() and requires that are commented out.
  * \param pos Cursor into content, advanced past the match
@@ -3740,18 +3718,13 @@ prescan_next_require(const char **pos, const char *content,
  * \param dir Directory to resolve against
  * \param path Receives the resolved path on success
  * \param pathlen Size of path
- * \param try1 Receives the "<dir>/mod.lua" candidate
- * \param t1len Size of try1
- * \param try2 Receives the "<dir>/mod/init.lua" candidate
- * \param t2len Size of try2
  * \return true if one of the candidates exists
  */
 static bool
 prescan_resolve_module(const char *name, const char *dir,
-                       char *path, size_t pathlen,
-                       char *try1, size_t t1len, char *try2, size_t t2len)
+                       char *path, size_t pathlen)
 {
-	char rel[256];
+	char rel[256], try[PATH_MAX];
 	char *p;
 
 	snprintf(rel, sizeof(rel), "%s", name);
@@ -3759,15 +3732,15 @@ prescan_resolve_module(const char *name, const char *dir,
 		if (*p == '.')
 			*p = '/';
 
-	snprintf(try1, t1len, "%s/%s.lua", dir, rel);
-	snprintf(try2, t2len, "%s/%s/init.lua", dir, rel);
-
-	if (access(try1, R_OK) == 0) {
-		snprintf(path, pathlen, "%s", try1);
+	snprintf(try, sizeof(try), "%s/%s.lua", dir, rel);
+	if (access(try, R_OK) == 0) {
+		snprintf(path, pathlen, "%s", try);
 		return true;
 	}
-	if (access(try2, R_OK) == 0) {
-		snprintf(path, pathlen, "%s", try2);
+
+	snprintf(try, sizeof(try), "%s/%s/init.lua", dir, rel);
+	if (access(try, R_OK) == 0) {
+		snprintf(path, pathlen, "%s", try);
 		return true;
 	}
 
@@ -3784,7 +3757,7 @@ luaA_prescan_requires(const char *content, const char *config_dir, int depth)
 {
 	const char *pos = content;
 	char module_name[256];
-	char path[PATH_MAX], try1[PATH_MAX], try2[PATH_MAX];
+	char path[PATH_MAX];
 	int require_line = 0;
 
 	if (depth >= PRESCAN_MAX_DEPTH || !config_dir)
@@ -3792,11 +3765,7 @@ luaA_prescan_requires(const char *content, const char *config_dir, int depth)
 
 	while (prescan_next_require(&pos, content, module_name, sizeof(module_name),
 	                            &require_line)) {
-		if (prescan_module_is_external(module_name))
-			continue;
-
-		if (prescan_resolve_module(module_name, config_dir, path, sizeof(path),
-		                           try1, sizeof(try1), try2, sizeof(try2)))
+		if (prescan_resolve_module(module_name, config_dir, path, sizeof(path)))
 			luaA_prescan_file(path, config_dir, depth + 1);
 	}
 }
@@ -4080,8 +4049,7 @@ check_mode_add_syntax_error(const char *file_path, const char *error_msg)
 /** Store a missing module error found during check mode */
 static void
 check_mode_add_missing_module(const char *source_file, int line_num,
-                              const char *module_name,
-                              const char *tried_path1, const char *tried_path2)
+                              const char *module_name)
 {
 	check_issue_t *issue;
 	char desc[512];
@@ -4089,14 +4057,15 @@ check_mode_add_missing_module(const char *source_file, int line_num,
 	if (check_issue_count >= CHECK_MAX_ISSUES)
 		return;
 
-	snprintf(desc, sizeof(desc), "require('%s') - module not found", module_name);
+	snprintf(desc, sizeof(desc), "require('%s') - not found on this system",
+	         module_name);
 
 	issue = &check_issues[check_issue_count++];
 	issue->file_path = strdup(source_file);
 	issue->line_number = line_num;
 	issue->line_content = strdup("");
 	issue->pattern_desc = strdup(desc);
-	issue->suggestion = "Check module path or install missing dependency";
+	issue->suggestion = "Install it, or check the name. Every path require() uses was searched";
 	issue->severity = SEVERITY_WARNING;
 	issue->is_syntax_error = true;  /* pattern_desc is dynamically allocated */
 
@@ -4380,6 +4349,141 @@ check_mode_print_report(const char *config_path, bool use_color)
 static void
 check_mode_scan_file(const char *config_path, const char *config_dir, int depth);
 
+/* A Lua state carrying somewm's real search paths, so --check asks Lua where a
+ * module lives instead of guessing. */
+static lua_State *check_resolver_L = NULL;
+static char check_config_root[PATH_MAX];
+
+#define CHECK_RESOLVER_KEY "somewm.check.resolve"
+
+/* Resolve a module the way require() does, but without loading it: --check
+ * must never run the config. package.searchpath arrived in 5.2, so 5.1 gets
+ * the same walk over the ';'-separated templates. */
+static const char check_resolver_lua[] =
+	"local searchpath = package.searchpath or function(name, path)\n"
+	"  local fname = (name:gsub('%.', '/'))\n"
+	"  for tmpl in path:gmatch('[^;]+') do\n"
+	"    local candidate = (tmpl:gsub('%?', fname))\n"
+	"    local f = io.open(candidate, 'r')\n"
+	"    if f then f:close() return candidate end\n"
+	"  end\n"
+	"end\n"
+	"return function(name)\n"
+	"  if package.loaded[name] ~= nil or package.preload[name] ~= nil then\n"
+	"    return ''\n"
+	"  end\n"
+	"  return searchpath(name, package.path) or searchpath(name, package.cpath)\n"
+	"end\n";
+
+/** Build the state --check resolves requires against.
+ * \param config_dir Directory holding the config, or NULL
+ */
+static void
+check_resolver_init(const char *config_dir)
+{
+	lua_State *L = luaL_newstate();
+
+	check_config_root[0] = '\0';
+
+	if (!L)
+		return;
+
+	luaL_openlibs(L);
+	luaA_setup_package_paths(L);
+
+	/* The config directory goes on front, exactly as it does at load time. */
+	if (config_dir) {
+		const char *old_path;
+
+		lua_getglobal(L, "package");
+		lua_getfield(L, -1, "path");
+		old_path = lua_tostring(L, -1);
+		lua_pop(L, 1);
+		lua_pushfstring(L, "%s/?.lua;%s/?/init.lua;%s",
+		                config_dir, config_dir, old_path);
+		lua_setfield(L, -2, "path");
+		lua_pop(L, 1);
+
+		snprintf(check_config_root, sizeof(check_config_root), "%s", config_dir);
+	}
+
+	if (luaL_loadstring(L, check_resolver_lua) || lua_pcall(L, 0, 1, 0)) {
+		lua_close(L);
+		return;
+	}
+	lua_setfield(L, LUA_REGISTRYINDEX, CHECK_RESOLVER_KEY);
+
+	check_resolver_L = L;
+}
+
+static void
+check_resolver_free(void)
+{
+	if (check_resolver_L) {
+		lua_close(check_resolver_L);
+		check_resolver_L = NULL;
+	}
+	check_config_root[0] = '\0';
+}
+
+/** Ask Lua whether require() would find a module.
+ * \param name Module name as written in require()
+ * \param path Receives the file it resolves to, empty for a built-in
+ * \param pathlen Size of path
+ * \return true if require() would find it
+ */
+static bool
+check_resolve_module(const char *name, char *path, size_t pathlen)
+{
+	lua_State *L = check_resolver_L;
+	const char *found;
+	bool ok = false;
+
+	path[0] = '\0';
+
+	/* With no resolver there is nothing to test, so stay quiet rather than
+	 * call every module missing. */
+	if (!L)
+		return true;
+
+	lua_getfield(L, LUA_REGISTRYINDEX, CHECK_RESOLVER_KEY);
+	lua_pushstring(L, name);
+	if (lua_pcall(L, 1, 1, 0)) {
+		lua_pop(L, 1);
+		return true;
+	}
+
+	found = lua_tostring(L, -1);
+	if (found) {
+		snprintf(path, pathlen, "%s", found);
+		ok = true;
+	}
+	lua_pop(L, 1);
+
+	return ok;
+}
+
+/** Is a resolved module the user's own Lua, and so worth scanning?
+ *
+ * A config-local module resolves through the template built from config_dir,
+ * so it comes back with that exact prefix and a plain compare is enough.
+ */
+static bool
+check_module_is_config_local(const char *resolved)
+{
+	size_t rootlen, len;
+
+	if (!resolved[0] || !check_config_root[0])
+		return false;
+
+	rootlen = strlen(check_config_root);
+	if (strncmp(resolved, check_config_root, rootlen) || resolved[rootlen] != '/')
+		return false;
+
+	len = strlen(resolved);
+	return len > 4 && !strcmp(resolved + len - 4, ".lua");
+}
+
 /** Scan requires in check mode */
 static void
 check_mode_scan_requires(const char *content, const char *config_dir,
@@ -4387,7 +4491,7 @@ check_mode_scan_requires(const char *content, const char *config_dir,
 {
 	const char *pos = content;
 	char module_name[256];
-	char path[PATH_MAX], try1[PATH_MAX], try2[PATH_MAX];
+	char resolved[PATH_MAX];
 	int require_line = 0;
 
 	if (depth >= PRESCAN_MAX_DEPTH || !config_dir)
@@ -4395,15 +4499,16 @@ check_mode_scan_requires(const char *content, const char *config_dir,
 
 	while (prescan_next_require(&pos, content, module_name, sizeof(module_name),
 	                            &require_line)) {
-		if (prescan_module_is_external(module_name))
-			continue;
-
-		if (prescan_resolve_module(module_name, config_dir, path, sizeof(path),
-		                           try1, sizeof(try1), try2, sizeof(try2)))
-			check_mode_scan_file(path, config_dir, depth + 1);
-		else
+		if (!check_resolve_module(module_name, resolved, sizeof(resolved))) {
 			check_mode_add_missing_module(source_file, require_line,
-			                              module_name, try1, try2);
+			                              module_name);
+			continue;
+		}
+
+		/* Only descend into the user's own files. Library and rock sources
+		 * are not theirs to fix, and a C module is not Lua at all. */
+		if (check_module_is_config_local(resolved))
+			check_mode_scan_file(resolved, config_dir, depth + 1);
 	}
 }
 
@@ -4535,7 +4640,9 @@ luaA_check_config(const char *config_path, bool use_color, int min_severity)
 	}
 
 	/* Scan the config and all its dependencies */
+	check_resolver_init(dir);
 	check_mode_scan_file(config_path, dir, 0);
+	check_resolver_free();
 
 	/* Run luacheck if available (gracefully skips if not installed) */
 	check_mode_run_luacheck(config_path);

--- a/luaa.c
+++ b/luaa.c
@@ -3115,6 +3115,30 @@ luaA_setup_package_paths(lua_State *L)
 	}
 }
 
+/** Put a directory at the front of package.path, so a module beside the config
+ * wins over one from the search paths.
+ *
+ * The config load does this for the config's own directory, and the scanners
+ * do it to the state they resolve against, so both agree on where a
+ * config-local require() comes from.
+ * \param L Lua state
+ * \param dir Directory to prepend
+ */
+static void
+luaA_prepend_module_dir(lua_State *L, const char *dir)
+{
+	const char *old_path;
+
+	lua_getglobal(L, "package");
+	lua_getfield(L, -1, "path");
+	old_path = lua_tostring(L, -1);
+	lua_pop(L, 1);
+
+	lua_pushfstring(L, "%s/?.lua;%s/?/init.lua;%s", dir, dir, old_path);
+	lua_setfield(L, -2, "path");
+	lua_pop(L, 1);
+}
+
 /** Register everything a Lua state needs: the standard library, somewm's
  * search paths, and every somewm module and class.
  *
@@ -3713,38 +3737,155 @@ prescan_next_require(const char **pos, const char *content,
 	return false;
 }
 
-/** Resolve a config-local module to a file under config_dir.
+/** Reduce a config path to the directory holding it, in place.
+ *
+ * A bare filename gives ".", so `somewm --check rc.lua` walks the requires
+ * instead of quietly scanning one file.
+ * \param path Config path, overwritten with its directory
+ * \return path, now the directory
+ */
+static const char *
+prescan_dirname(char *path)
+{
+	char *last_slash = strrchr(path, '/');
+
+	if (last_slash)
+		*last_slash = '\0';
+	else
+		strcpy(path, ".");
+
+	return path;
+}
+
+/* A Lua state carrying somewm's real search paths, so the scanners ask Lua
+ * where a module lives instead of guessing. The boot pre-scan and --check both
+ * resolve through it, so they walk the same set of files. */
+static lua_State *prescan_resolver_L = NULL;
+
+#define PRESCAN_RESOLVER_KEY "somewm.prescan.resolve"
+
+/* Resolve a module the way require() does, but without loading it: neither
+ * scanner may run the config. package.searchpath arrived in 5.2, so 5.1 gets
+ * the same walk over the ';'-separated templates. Answers are kept, because a
+ * config split across files requires the same handful of modules in each one
+ * and a miss costs an open() per template. */
+static const char prescan_resolver_lua[] =
+	"local searchpath = package.searchpath or function(name, path)\n"
+	"  local fname = (name:gsub('%.', '/'))\n"
+	"  for tmpl in path:gmatch('[^;]+') do\n"
+	"    local candidate = (tmpl:gsub('%?', fname))\n"
+	"    local f = io.open(candidate, 'r')\n"
+	"    if f then f:close() return candidate end\n"
+	"  end\n"
+	"end\n"
+	"local seen = {}\n"
+	"return function(name)\n"
+	"  local hit = seen[name]\n"
+	"  if hit ~= nil then return hit or nil end\n"
+	"  if package.loaded[name] ~= nil or package.preload[name] ~= nil then\n"
+	"    seen[name] = ''\n"
+	"    return ''\n"
+	"  end\n"
+	"  local found = searchpath(name, package.path)\n"
+	"           or searchpath(name, package.cpath)\n"
+	"  seen[name] = found or false\n"
+	"  return found\n"
+	"end\n";
+
+/** Build the state the scanners resolve requires against.
+ * \param config_dir Directory holding the config, or NULL
+ */
+static void
+prescan_resolver_init(const char *config_dir)
+{
+	lua_State *L = luaL_newstate();
+
+	if (!L)
+		return;
+
+	luaL_openlibs(L);
+	luaA_setup_package_paths(L);
+
+	/* The config directory goes on front, exactly as it does at load time. */
+	if (config_dir)
+		luaA_prepend_module_dir(L, config_dir);
+
+	if (luaL_loadstring(L, prescan_resolver_lua) || lua_pcall(L, 0, 1, 0)) {
+		lua_close(L);
+		return;
+	}
+	lua_setfield(L, LUA_REGISTRYINDEX, PRESCAN_RESOLVER_KEY);
+
+	prescan_resolver_L = L;
+}
+
+static void
+prescan_resolver_free(void)
+{
+	if (prescan_resolver_L) {
+		lua_close(prescan_resolver_L);
+		prescan_resolver_L = NULL;
+	}
+}
+
+/** Ask Lua whether require() would find a module.
  * \param name Module name as written in require()
- * \param dir Directory to resolve against
- * \param path Receives the resolved path on success
+ * \param path Receives the file it resolves to, empty for a built-in
  * \param pathlen Size of path
- * \return true if one of the candidates exists
+ * \return true if require() would find it
  */
 static bool
-prescan_resolve_module(const char *name, const char *dir,
-                       char *path, size_t pathlen)
+prescan_resolve_module(const char *name, char *path, size_t pathlen)
 {
-	char rel[256], try[PATH_MAX];
-	char *p;
+	lua_State *L = prescan_resolver_L;
+	const char *found;
+	bool ok = false;
 
-	snprintf(rel, sizeof(rel), "%s", name);
-	for (p = rel; *p; p++)
-		if (*p == '.')
-			*p = '/';
+	path[0] = '\0';
 
-	snprintf(try, sizeof(try), "%s/%s.lua", dir, rel);
-	if (access(try, R_OK) == 0) {
-		snprintf(path, pathlen, "%s", try);
+	/* With no resolver there is nothing to test, so stay quiet rather than
+	 * call every module missing. */
+	if (!L)
+		return true;
+
+	lua_getfield(L, LUA_REGISTRYINDEX, PRESCAN_RESOLVER_KEY);
+	lua_pushstring(L, name);
+	if (lua_pcall(L, 1, 1, 0)) {
+		lua_pop(L, 1);
 		return true;
 	}
 
-	snprintf(try, sizeof(try), "%s/%s/init.lua", dir, rel);
-	if (access(try, R_OK) == 0) {
-		snprintf(path, pathlen, "%s", try);
-		return true;
+	found = lua_tostring(L, -1);
+	if (found) {
+		snprintf(path, pathlen, "%s", found);
+		ok = true;
 	}
+	lua_pop(L, 1);
 
-	return false;
+	return ok;
+}
+
+/** Is a resolved module the user's own Lua, and so worth scanning?
+ *
+ * A config-local module resolves through the template built from config_dir,
+ * so it comes back with that exact prefix and a plain compare is enough.
+ * \param config_dir Directory holding the config
+ * \param resolved File the module resolved to
+ */
+static bool
+prescan_module_is_config_local(const char *config_dir, const char *resolved)
+{
+	size_t rootlen, len;
+
+	if (!resolved[0])
+		return false;
+
+	rootlen = strlen(config_dir);
+	if (strncmp(resolved, config_dir, rootlen) || resolved[rootlen] != '/')
+		return false;
+
+	len = strlen(resolved);
+	return len > 4 && !strcmp(resolved + len - 4, ".lua");
 }
 
 /** Scan every require()d file for X11 patterns.
@@ -3757,16 +3898,19 @@ luaA_prescan_requires(const char *content, const char *config_dir, int depth)
 {
 	const char *pos = content;
 	char module_name[256];
-	char path[PATH_MAX];
+	char resolved[PATH_MAX];
 	int require_line = 0;
 
-	if (depth >= PRESCAN_MAX_DEPTH || !config_dir)
+	if (depth >= PRESCAN_MAX_DEPTH)
 		return;
 
 	while (prescan_next_require(&pos, content, module_name, sizeof(module_name),
 	                            &require_line)) {
-		if (prescan_resolve_module(module_name, config_dir, path, sizeof(path)))
-			luaA_prescan_file(path, config_dir, depth + 1);
+		/* Only descend into the user's own files. Library and rock sources
+		 * are not theirs to fix, and a C module is not Lua at all. */
+		if (prescan_resolve_module(module_name, resolved, sizeof(resolved))
+		    && prescan_module_is_config_local(config_dir, resolved))
+			luaA_prescan_file(resolved, config_dir, depth + 1);
 	}
 }
 
@@ -3901,8 +4045,7 @@ luaA_prescan_file(const char *config_path, const char *config_dir, int depth)
 	}
 
 	/* Recursively scan required files */
-	if (config_dir)
-		luaA_prescan_requires(content, config_dir, depth);
+	luaA_prescan_requires(content, config_dir, depth);
 
 	free(content);
 }
@@ -3920,19 +4063,19 @@ luaA_prescan_config(const char *config_path, const char *config_dir)
 	/* Reset visited tracking */
 	prescan_cleanup_visited();
 
+	if (!config_path || access(config_path, R_OK) != 0)
+		return;
+
 	/* If no config_dir provided, derive from config_path */
-	if (!dir && config_path) {
-		char *last_slash;
+	if (!dir) {
 		strncpy(dir_buf, config_path, sizeof(dir_buf) - 1);
 		dir_buf[sizeof(dir_buf) - 1] = '\0';
-		last_slash = strrchr(dir_buf, '/');
-		if (last_slash) {
-			*last_slash = '\0';
-			dir = dir_buf;
-		}
+		dir = prescan_dirname(dir_buf);
 	}
 
+	prescan_resolver_init(dir);
 	luaA_prescan_file(config_path, dir, 0);
+	prescan_resolver_free();
 
 	prescan_cleanup_visited();
 }
@@ -4349,140 +4492,6 @@ check_mode_print_report(const char *config_path, bool use_color)
 static void
 check_mode_scan_file(const char *config_path, const char *config_dir, int depth);
 
-/* A Lua state carrying somewm's real search paths, so --check asks Lua where a
- * module lives instead of guessing. */
-static lua_State *check_resolver_L = NULL;
-static char check_config_root[PATH_MAX];
-
-#define CHECK_RESOLVER_KEY "somewm.check.resolve"
-
-/* Resolve a module the way require() does, but without loading it: --check
- * must never run the config. package.searchpath arrived in 5.2, so 5.1 gets
- * the same walk over the ';'-separated templates. */
-static const char check_resolver_lua[] =
-	"local searchpath = package.searchpath or function(name, path)\n"
-	"  local fname = (name:gsub('%.', '/'))\n"
-	"  for tmpl in path:gmatch('[^;]+') do\n"
-	"    local candidate = (tmpl:gsub('%?', fname))\n"
-	"    local f = io.open(candidate, 'r')\n"
-	"    if f then f:close() return candidate end\n"
-	"  end\n"
-	"end\n"
-	"return function(name)\n"
-	"  if package.loaded[name] ~= nil or package.preload[name] ~= nil then\n"
-	"    return ''\n"
-	"  end\n"
-	"  return searchpath(name, package.path) or searchpath(name, package.cpath)\n"
-	"end\n";
-
-/** Build the state --check resolves requires against.
- * \param config_dir Directory holding the config, or NULL
- */
-static void
-check_resolver_init(const char *config_dir)
-{
-	lua_State *L = luaL_newstate();
-
-	check_config_root[0] = '\0';
-
-	if (!L)
-		return;
-
-	luaL_openlibs(L);
-	luaA_setup_package_paths(L);
-
-	/* The config directory goes on front, exactly as it does at load time. */
-	if (config_dir) {
-		const char *old_path;
-
-		lua_getglobal(L, "package");
-		lua_getfield(L, -1, "path");
-		old_path = lua_tostring(L, -1);
-		lua_pop(L, 1);
-		lua_pushfstring(L, "%s/?.lua;%s/?/init.lua;%s",
-		                config_dir, config_dir, old_path);
-		lua_setfield(L, -2, "path");
-		lua_pop(L, 1);
-
-		snprintf(check_config_root, sizeof(check_config_root), "%s", config_dir);
-	}
-
-	if (luaL_loadstring(L, check_resolver_lua) || lua_pcall(L, 0, 1, 0)) {
-		lua_close(L);
-		return;
-	}
-	lua_setfield(L, LUA_REGISTRYINDEX, CHECK_RESOLVER_KEY);
-
-	check_resolver_L = L;
-}
-
-static void
-check_resolver_free(void)
-{
-	if (check_resolver_L) {
-		lua_close(check_resolver_L);
-		check_resolver_L = NULL;
-	}
-	check_config_root[0] = '\0';
-}
-
-/** Ask Lua whether require() would find a module.
- * \param name Module name as written in require()
- * \param path Receives the file it resolves to, empty for a built-in
- * \param pathlen Size of path
- * \return true if require() would find it
- */
-static bool
-check_resolve_module(const char *name, char *path, size_t pathlen)
-{
-	lua_State *L = check_resolver_L;
-	const char *found;
-	bool ok = false;
-
-	path[0] = '\0';
-
-	/* With no resolver there is nothing to test, so stay quiet rather than
-	 * call every module missing. */
-	if (!L)
-		return true;
-
-	lua_getfield(L, LUA_REGISTRYINDEX, CHECK_RESOLVER_KEY);
-	lua_pushstring(L, name);
-	if (lua_pcall(L, 1, 1, 0)) {
-		lua_pop(L, 1);
-		return true;
-	}
-
-	found = lua_tostring(L, -1);
-	if (found) {
-		snprintf(path, pathlen, "%s", found);
-		ok = true;
-	}
-	lua_pop(L, 1);
-
-	return ok;
-}
-
-/** Is a resolved module the user's own Lua, and so worth scanning?
- *
- * A config-local module resolves through the template built from config_dir,
- * so it comes back with that exact prefix and a plain compare is enough.
- */
-static bool
-check_module_is_config_local(const char *resolved)
-{
-	size_t rootlen, len;
-
-	if (!resolved[0] || !check_config_root[0])
-		return false;
-
-	rootlen = strlen(check_config_root);
-	if (strncmp(resolved, check_config_root, rootlen) || resolved[rootlen] != '/')
-		return false;
-
-	len = strlen(resolved);
-	return len > 4 && !strcmp(resolved + len - 4, ".lua");
-}
 
 /** Scan requires in check mode */
 static void
@@ -4494,12 +4503,12 @@ check_mode_scan_requires(const char *content, const char *config_dir,
 	char resolved[PATH_MAX];
 	int require_line = 0;
 
-	if (depth >= PRESCAN_MAX_DEPTH || !config_dir)
+	if (depth >= PRESCAN_MAX_DEPTH)
 		return;
 
 	while (prescan_next_require(&pos, content, module_name, sizeof(module_name),
 	                            &require_line)) {
-		if (!check_resolve_module(module_name, resolved, sizeof(resolved))) {
+		if (!prescan_resolve_module(module_name, resolved, sizeof(resolved))) {
 			check_mode_add_missing_module(source_file, require_line,
 			                              module_name);
 			continue;
@@ -4507,7 +4516,7 @@ check_mode_scan_requires(const char *content, const char *config_dir,
 
 		/* Only descend into the user's own files. Library and rock sources
 		 * are not theirs to fix, and a C module is not Lua at all. */
-		if (check_module_is_config_local(resolved))
+		if (prescan_module_is_config_local(config_dir, resolved))
 			check_mode_scan_file(resolved, config_dir, depth + 1);
 	}
 }
@@ -4606,8 +4615,7 @@ check_mode_scan_file(const char *config_path, const char *config_dir, int depth)
 	}
 
 	/* Recursively scan required files */
-	if (config_dir)
-		check_mode_scan_requires(content, config_dir, config_path, depth);
+	check_mode_scan_requires(content, config_dir, config_path, depth);
 
 	free(content);
 }
@@ -4622,8 +4630,7 @@ int
 luaA_check_config(const char *config_path, bool use_color, int min_severity)
 {
 	char dir_buf[PATH_MAX];
-	const char *dir = NULL;
-	char *last_slash;
+	const char *dir;
 	int result;
 
 	/* Reset state */
@@ -4633,16 +4640,12 @@ luaA_check_config(const char *config_path, bool use_color, int min_severity)
 	/* Derive config_dir from config_path */
 	strncpy(dir_buf, config_path, sizeof(dir_buf) - 1);
 	dir_buf[sizeof(dir_buf) - 1] = '\0';
-	last_slash = strrchr(dir_buf, '/');
-	if (last_slash) {
-		*last_slash = '\0';
-		dir = dir_buf;
-	}
+	dir = prescan_dirname(dir_buf);
 
 	/* Scan the config and all its dependencies */
-	check_resolver_init(dir);
+	prescan_resolver_init(dir);
 	check_mode_scan_file(config_path, dir, 0);
-	check_resolver_free();
+	prescan_resolver_free();
 
 	/* Run luacheck if available (gracefully skips if not installed) */
 	check_mode_run_luacheck(config_path);
@@ -5334,28 +5337,11 @@ luaA_loadrc(void)
 		/* Add config directory to package.path so require() can find local modules
 		 * (AwesomeWM compatibility - allows require("src.theme.user_variables")) */
 		{
-			char config_dir[512];
-			char *last_slash;
-			const char *old_path;
+			char config_dir[PATH_MAX];
 
 			strncpy(config_dir, config_paths[i], sizeof(config_dir) - 1);
 			config_dir[sizeof(config_dir) - 1] = '\0';
-
-			last_slash = strrchr(config_dir, '/');
-			if (last_slash) {
-				*last_slash = '\0';  /* Truncate at last slash to get directory */
-
-				/* Prepend config directory to package.path */
-				lua_getglobal(globalconf_L, "package");
-				lua_getfield(globalconf_L, -1, "path");
-				old_path = lua_tostring(globalconf_L, -1);
-				lua_pop(globalconf_L, 1);
-
-				lua_pushfstring(globalconf_L, "%s/?.lua;%s/?/init.lua;%s",
-					config_dir, config_dir, old_path);
-				lua_setfield(globalconf_L, -2, "path");
-				lua_pop(globalconf_L, 1);  /* pop package table */
-			}
+			luaA_prepend_module_dir(globalconf_L, prescan_dirname(config_dir));
 		}
 
 		/* Set conffile path BEFORE execution (AwesomeWM pattern) */

--- a/luaa.c
+++ b/luaa.c
@@ -1068,6 +1068,7 @@ input_settings_init_unset(InputSettings *s)
 	s->tap_button_map = NULL;
 	s->accel_speed_set = false;
 	s->tool_mode = NULL;
+	s->emulate_pointer = -2;
 	s->map_to_output_list = NULL;
 	s->map_to_output_count = 0;
 	s->map_from_region_set = false;
@@ -1360,6 +1361,7 @@ luaA_awesome_set_input_rules(lua_State *L)
 			p->middle_button_emulation = input_rule_get_int(L, pidx, "middle_button_emulation", -2);
 			p->scroll_button = input_rule_get_int(L, pidx, "scroll_button", -2);
 			p->scroll_button_lock = input_rule_get_int(L, pidx, "scroll_button_lock", -2);
+			p->emulate_pointer = input_rule_get_int(L, pidx, "emulate_pointer", -2);
 
 			p->scroll_method = input_rule_get_string(L, pidx, "scroll_method");
 			p->click_method = input_rule_get_string(L, pidx, "click_method");

--- a/luaa.c
+++ b/luaa.c
@@ -1034,6 +1034,10 @@ input_rules_free(void)
 		free(r->properties.send_events_mode);
 		free(r->properties.accel_profile);
 		free(r->properties.tap_button_map);
+		free(r->properties.tool_mode);
+		for (int j = 0; j < r->properties.map_to_output_count; j++)
+			free(r->properties.map_to_output_list[j]);
+		free(r->properties.map_to_output_list);
 	}
 	free(globalconf.input_rules);
 	globalconf.input_rules = NULL;
@@ -1063,6 +1067,19 @@ input_settings_init_unset(InputSettings *s)
 	s->accel_speed = 0.0;
 	s->tap_button_map = NULL;
 	s->accel_speed_set = false;
+	s->tool_mode = NULL;
+	s->map_to_output_list = NULL;
+	s->map_to_output_count = 0;
+	s->map_from_region_set = false;
+	s->map_from_region_x1 = 0.0;
+	s->map_from_region_y1 = 0.0;
+	s->map_from_region_x2 = 0.0;
+	s->map_from_region_y2 = 0.0;
+	s->map_to_region_set = false;
+	s->map_to_region_x1 = 0.0;
+	s->map_to_region_y1 = 0.0;
+	s->map_to_region_x2 = 0.0;
+	s->map_to_region_y2 = 0.0;
 }
 
 /** Read an optional int field from a Lua table on the stack.
@@ -1088,6 +1105,201 @@ input_rule_get_string(lua_State *L, int idx, const char *field)
 		result = strdup(lua_tostring(L, -1));
 	lua_pop(L, 1);
 	return result;
+}
+
+/** Read and validate optional tool mode from a Lua table.
+ * Returns strdup'd value or NULL if field is absent. */
+static char *
+input_rule_get_tool_mode(lua_State *L, int idx, const char *field)
+{
+	char *result = NULL;
+	const char *val;
+
+	lua_getfield(L, idx, field);
+	if (!lua_isnil(L, -1)) {
+		val = luaL_checkstring(L, -1);
+		if (strcmp(val, "absolute") != 0 && strcmp(val, "relative") != 0) {
+			lua_pop(L, 1);
+			luaL_error(L,
+				"awful.input.rules: invalid properties.%s '%s' (expected 'absolute' or 'relative')",
+				field, val);
+			return NULL;
+		}
+		result = strdup(val);
+	}
+	lua_pop(L, 1);
+	return result;
+}
+
+/* Parses "NxM" into out_x/out_y. Special-cases a "0x" prefix the same way
+ * sway's own map_from_region parser does (sway/commands/input/map_from_region.c):
+ * strtod()/scanf's %f also accept C99 hex-float syntax, and glibc treats a
+ * bare "0x..." (no required 'p' exponent) as a complete hex-float literal -
+ * so a plain %lf silently swallows the "0x" of e.g. "0x0" as a hex-float
+ * lead-in instead of stopping at the intended 'x' separator, corrupting any
+ * region string whose first coordinate is 0 (the natural top-left corner,
+ * so the single most common value anyone would type). */
+static bool
+parse_coord_pair(const char *str, double *out_x, double *out_y)
+{
+	char *end;
+	const char *y_start;
+
+	if (str[0] == '0' && str[1] == 'x') {
+		*out_x = 0;
+		end = (char *)str + 1;
+	} else {
+		*out_x = strtod(str, &end);
+		if (end == str)
+			return false;
+	}
+	if (*end != 'x')
+		return false;
+
+	y_start = end + 1;
+	*out_y = strtod(y_start, &end);
+	return end != y_start && *end == '\0';
+}
+
+/** Read and parse an optional two-corner region field from a Lua table.
+ * Used for both map_from_region (tablet-space, normalized/mm) and
+ * map_to_region (output-layout pixels) - the field itself carries no
+ * semantics here, just two corner points. Accepts either:
+ * - string: "X1xY1 X2xY2"
+ * - table: { x1 = <number>, y1 = <number>, x2 = <number>, y2 = <number> }
+ */
+static void
+input_rule_get_region(lua_State *L, int idx, const char *field,
+		bool *set, double *x1, double *y1, double *x2, double *y2)
+{
+	*set = false;
+
+	lua_getfield(L, idx, field);
+	if (lua_isnil(L, -1)) {
+		lua_pop(L, 1);
+		return;
+	}
+
+	if (lua_isstring(L, -1)) {
+		const char *raw = lua_tostring(L, -1);
+		char first[64], second[64];
+		double sx1, sy1, sx2, sy2;
+		bool ok = sscanf(raw, "%63s %63s", first, second) == 2
+			&& parse_coord_pair(first, &sx1, &sy1)
+			&& parse_coord_pair(second, &sx2, &sy2);
+		if (!ok) {
+			lua_pop(L, 1);
+			luaL_error(L,
+				"awful.input.rules: invalid properties.%s '%s' (expected 'X1xY1 X2xY2')",
+				field, raw);
+			return;
+		}
+		*x1 = sx1;
+		*y1 = sy1;
+		*x2 = sx2;
+		*y2 = sy2;
+		*set = true;
+		lua_pop(L, 1);
+		return;
+	}
+
+	if (lua_istable(L, -1)) {
+		double sx1, sy1, sx2, sy2;
+
+		lua_getfield(L, -1, "x1");
+		sx1 = luaL_checknumber(L, -1);
+		lua_pop(L, 1);
+
+		lua_getfield(L, -1, "y1");
+		sy1 = luaL_checknumber(L, -1);
+		lua_pop(L, 1);
+
+		lua_getfield(L, -1, "x2");
+		sx2 = luaL_checknumber(L, -1);
+		lua_pop(L, 1);
+
+		lua_getfield(L, -1, "y2");
+		sy2 = luaL_checknumber(L, -1);
+		lua_pop(L, 1);
+
+		*x1 = sx1;
+		*y1 = sy1;
+		*x2 = sx2;
+		*y2 = sy2;
+		*set = true;
+		lua_pop(L, 1);
+		return;
+	}
+
+	lua_pop(L, 1);
+	luaL_error(L,
+		"awful.input.rules: invalid properties.%s type (expected string or table)",
+		field);
+}
+
+/** Read the optional map_to_output field from a Lua table.
+ * Accepts either a single string or an ordered array of strings, tried in
+ * order with the first connected candidate winning. Returns a newly
+ * allocated array of strdup'd strings via *out_list (NULL if the field is
+ * absent), with element count via *out_count. */
+static void
+input_rule_get_map_to_output(lua_State *L, int idx, const char *field,
+		char ***out_list, int *out_count)
+{
+	*out_list = NULL;
+	*out_count = 0;
+
+	lua_getfield(L, idx, field);
+	if (lua_isnil(L, -1)) {
+		lua_pop(L, 1);
+		return;
+	}
+
+	if (lua_isstring(L, -1)) {
+		char **list = calloc(1, sizeof(char *));
+		list[0] = strdup(lua_tostring(L, -1));
+		*out_list = list;
+		*out_count = 1;
+		lua_pop(L, 1);
+		return;
+	}
+
+	if (lua_istable(L, -1)) {
+		int n = luaA_rawlen(L, -1);
+		char **list;
+
+		if (n == 0) {
+			lua_pop(L, 1);
+			return;
+		}
+
+		list = calloc(n, sizeof(char *));
+		for (int i = 0; i < n; i++) {
+			lua_rawgeti(L, -1, i + 1);
+			if (!lua_isstring(L, -1)) {
+				lua_pop(L, 2);
+				for (int j = 0; j < i; j++)
+					free(list[j]);
+				free(list);
+				luaL_error(L,
+					"awful.input.rules: invalid properties.%s[%d] (expected string)",
+					field, i + 1);
+				return;
+			}
+			list[i] = strdup(lua_tostring(L, -1));
+			lua_pop(L, 1);
+		}
+
+		*out_list = list;
+		*out_count = n;
+		lua_pop(L, 1);
+		return;
+	}
+
+	lua_pop(L, 1);
+	luaL_error(L,
+		"awful.input.rules: invalid properties.%s type (expected string or array of strings)",
+		field);
 }
 
 /** Set input rules from Lua.
@@ -1155,6 +1367,21 @@ luaA_awesome_set_input_rules(lua_State *L)
 			p->send_events_mode = input_rule_get_string(L, pidx, "send_events_mode");
 			p->accel_profile = input_rule_get_string(L, pidx, "accel_profile");
 			p->tap_button_map = input_rule_get_string(L, pidx, "tap_button_map");
+			p->tool_mode = input_rule_get_tool_mode(L, pidx, "tool_mode");
+			input_rule_get_map_to_output(L, pidx, "map_to_output",
+				&p->map_to_output_list, &p->map_to_output_count);
+			input_rule_get_region(L, pidx, "map_from_region",
+				&p->map_from_region_set,
+				&p->map_from_region_x1,
+				&p->map_from_region_y1,
+				&p->map_from_region_x2,
+				&p->map_from_region_y2);
+			input_rule_get_region(L, pidx, "map_to_region",
+				&p->map_to_region_set,
+				&p->map_to_region_x1,
+				&p->map_to_region_y1,
+				&p->map_to_region_x2,
+				&p->map_to_region_y2);
 
 			lua_getfield(L, pidx, "accel_speed");
 			if (!lua_isnil(L, -1)) {

--- a/meson.build
+++ b/meson.build
@@ -201,8 +201,26 @@ message('Using wlroots version: ' + wlroots_version)
 
 # PAM authentication (optional, for lock screen)
 pam_option = get_option('pam')
-pam_dep = dependency('pam', required: pam_option)
-have_pam = pam_dep.found()
+# There are three cases: If pam_option is disabled, we do not look for and do
+# not build against PAM. If pam_option is enabled, we require PAM to the found.
+# If pam_option is auto, we opportunistically enable it if found.
+have_pam = false
+if not pam_option.disabled()
+  pam_dep = dependency('pam', required: false)
+  if not pam_dep.found()
+    # Some distributions (e.g., Debian) do not ship PAM with pkg-config/cmake
+    # files. Do a fallback scan.
+    pam_cc = meson.get_compiler('c')
+    pam_lib = pam_cc.find_library('pam', required: false)
+    if pam_lib.found() and pam_cc.has_header('security/pam_appl.h')
+      pam_dep = pam_lib
+    endif
+  endif
+  have_pam = pam_dep.found()
+endif
+if pam_option.enabled() and not pam_dep.found()
+  error('PAM was requested (-Dpam=enabled) but libpam could not be found (checked pkgconfig, cmake, and a plain library search)')
+endif
 if have_pam
   message('PAM authentication enabled')
 else

--- a/meson.build
+++ b/meson.build
@@ -240,6 +240,7 @@ protocols = [
   [wayland_protocols_dir / 'staging/cursor-shape/cursor-shape-v1.xml', 'enum-header'],
   [wayland_protocols_dir / 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml', 'enum-header'],
   [wayland_protocols_dir / 'stable/xdg-shell/xdg-shell.xml', 'server-header'],
+  [wayland_protocols_dir / 'stable/tablet/tablet-v2.xml', 'server-header'],
   # Local protocols
   ['protocols/wlr-layer-shell-unstable-v1.xml', 'enum-header'],
   ['protocols/wlr-output-power-management-unstable-v1.xml', 'server-header'],

--- a/root.c
+++ b/root.c
@@ -37,6 +37,7 @@
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/render/allocator.h>
 #include <wlr/types/wlr_xcursor_manager.h>
+#include <wlr/util/transform.h>
 #include <cairo.h>
 #include <drm_fourcc.h>
 #include <string.h>
@@ -985,20 +986,74 @@ composite_widgets_directly(cairo_t *cr, bool ontop_only)
 	}
 }
 
-/** Paint buf_surface at the node position, cropped to src and scaled to
- * dst_width x dst_height.
+/** Orient a source box of sw x sh under transform t, the way the scene
+ * renderer orients a buffer. */
+static void
+composite_transform_matrix(cairo_matrix_t *m, enum wl_output_transform t,
+                           double sw, double sh)
+{
+	switch (t) {
+	case WL_OUTPUT_TRANSFORM_90:
+		cairo_matrix_init(m, 0, -1, 1, 0, 0, sw); break;
+	case WL_OUTPUT_TRANSFORM_180:
+		cairo_matrix_init(m, -1, 0, 0, -1, sw, sh); break;
+	case WL_OUTPUT_TRANSFORM_270:
+		cairo_matrix_init(m, 0, 1, -1, 0, sh, 0); break;
+	case WL_OUTPUT_TRANSFORM_FLIPPED:
+		cairo_matrix_init(m, -1, 0, 0, 1, sw, 0); break;
+	case WL_OUTPUT_TRANSFORM_FLIPPED_90:
+		cairo_matrix_init(m, 0, 1, 1, 0, 0, 0); break;
+	case WL_OUTPUT_TRANSFORM_FLIPPED_180:
+		cairo_matrix_init(m, 1, 0, 0, -1, 0, sh); break;
+	case WL_OUTPUT_TRANSFORM_FLIPPED_270:
+		cairo_matrix_init(m, 0, -1, -1, 0, sh, sw); break;
+	default:
+		cairo_matrix_init_identity(m); break;
+	}
+}
+
+/** Paint buf_surface, the pixels of scene_buffer's buffer, at the node
+ * position the way the scene renderer would place them.
+ *
+ * Honours src_box (the crop wlroots sets when a surface is clipped to its xdg
+ * window geometry), dst_width/dst_height and transform. Deliberately ignores
+ * blend_mode and the wait timeline, which do not apply to a cairo target, and
+ * does not yet honour opacity or filter_mode.
  */
 static void
 composite_paint(struct screenshot_render_data *rdata, cairo_surface_t *buf_surface,
-                const struct wlr_fbox *src, int sx, int sy,
-                int dst_width, int dst_height)
+                struct wlr_scene_buffer *scene_buffer, int sx, int sy)
 {
+	enum wl_output_transform t = wlr_output_transform_invert(scene_buffer->transform);
+	bool swaps = t & WL_OUTPUT_TRANSFORM_90;
+	struct wlr_fbox src = scene_buffer->src_box;
+	int dst_width, dst_height;
+	double tw, th;
+	cairo_matrix_t m;
+
+	if (wlr_fbox_empty(&src))
+		src = (struct wlr_fbox){ 0, 0, scene_buffer->buffer->width,
+		                        scene_buffer->buffer->height };
+
+	tw = swaps ? src.height : src.width;
+	th = swaps ? src.width : src.height;
+
+	dst_width = scene_buffer->dst_width;
+	dst_height = scene_buffer->dst_height;
+	if (dst_width <= 0 || dst_height <= 0) {
+		dst_width = tw;
+		dst_height = th;
+	}
+
+	composite_transform_matrix(&m, t, src.width, src.height);
+
 	cairo_save(rdata->cr);
 	cairo_translate(rdata->cr, sx + rdata->offset_x, sy + rdata->offset_y);
 	cairo_rectangle(rdata->cr, 0, 0, dst_width, dst_height);
 	cairo_clip(rdata->cr);
-	cairo_scale(rdata->cr, dst_width / src->width, dst_height / src->height);
-	cairo_translate(rdata->cr, -src->x, -src->y);
+	cairo_scale(rdata->cr, dst_width / tw, dst_height / th);
+	cairo_transform(rdata->cr, &m);
+	cairo_translate(rdata->cr, -src.x, -src.y);
 	cairo_set_source_surface(rdata->cr, buf_surface, 0, 0);
 	cairo_paint(rdata->cr);
 	cairo_restore(rdata->cr);
@@ -1017,8 +1072,6 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 	struct screenshot_render_data *rdata = data;
 	struct wlr_buffer *buffer;
 	cairo_surface_t *buf_surface;
-	struct wlr_fbox src_box;
-	int dst_width, dst_height;
 	int buf_width, buf_height;
 	void *shm_data;
 	uint32_t shm_format;
@@ -1038,20 +1091,6 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 	if (buf_width <= 0 || buf_height <= 0)
 		return;
 
-	/* wlroots sets src_box when a surface is clipped to its xdg window
-	 * geometry, so cropping to it keeps client-side-decoration shadow
-	 * margins out of the capture. */
-	src_box = scene_buffer->src_box;
-	if (wlr_fbox_empty(&src_box))
-		src_box = (struct wlr_fbox){ 0, 0, buf_width, buf_height };
-
-	dst_width = scene_buffer->dst_width;
-	dst_height = scene_buffer->dst_height;
-	if (dst_width <= 0 || dst_height <= 0) {
-		dst_width = src_box.width;
-		dst_height = src_box.height;
-	}
-
 	/* First try direct buffer access (works for SHM buffers - widgets) */
 	if (wlr_buffer_begin_data_ptr_access(buffer, WLR_BUFFER_DATA_PTR_ACCESS_READ,
 	                                     &shm_data, &shm_format, &shm_stride)) {
@@ -1066,8 +1105,7 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 				shm_data, cairo_fmt, buf_width, buf_height, shm_stride);
 
 			if (cairo_surface_status(buf_surface) == CAIRO_STATUS_SUCCESS) {
-				composite_paint(rdata, buf_surface, &src_box,
-					sx, sy, dst_width, dst_height);
+				composite_paint(rdata, buf_surface, scene_buffer, sx, sy);
 				cairo_surface_destroy(buf_surface);
 			}
 		}
@@ -1116,7 +1154,7 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 		return;
 	}
 
-	composite_paint(rdata, buf_surface, &src_box, sx, sy, dst_width, dst_height);
+	composite_paint(rdata, buf_surface, scene_buffer, sx, sy);
 
 	cairo_surface_destroy(buf_surface);
 	if (need_free)

--- a/root.c
+++ b/root.c
@@ -985,6 +985,25 @@ composite_widgets_directly(cairo_t *cr, bool ontop_only)
 	}
 }
 
+/** Paint buf_surface at the node position, cropped to src and scaled to
+ * dst_width x dst_height.
+ */
+static void
+composite_paint(struct screenshot_render_data *rdata, cairo_surface_t *buf_surface,
+                const struct wlr_fbox *src, int sx, int sy,
+                int dst_width, int dst_height)
+{
+	cairo_save(rdata->cr);
+	cairo_translate(rdata->cr, sx + rdata->offset_x, sy + rdata->offset_y);
+	cairo_rectangle(rdata->cr, 0, 0, dst_width, dst_height);
+	cairo_clip(rdata->cr);
+	cairo_scale(rdata->cr, dst_width / src->width, dst_height / src->height);
+	cairo_translate(rdata->cr, -src->x, -src->y);
+	cairo_set_source_surface(rdata->cr, buf_surface, 0, 0);
+	cairo_paint(rdata->cr);
+	cairo_restore(rdata->cr);
+}
+
 /** Callback for wlr_scene_output_for_each_buffer
  * Reads pixels from each scene buffer and composites onto Cairo surface.
  * Handles both SHM buffers (widgets) and GPU buffers (clients).
@@ -998,8 +1017,9 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 	struct screenshot_render_data *rdata = data;
 	struct wlr_buffer *buffer;
 	cairo_surface_t *buf_surface;
+	struct wlr_fbox src_box;
 	int dst_width, dst_height;
-	int src_width, src_height;
+	int buf_width, buf_height;
 	void *shm_data;
 	uint32_t shm_format;
 	size_t shm_stride;
@@ -1012,19 +1032,25 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 		return;
 
 	buffer = scene_buffer->buffer;
-	src_width = buffer->width;
-	src_height = buffer->height;
+	buf_width = buffer->width;
+	buf_height = buffer->height;
+
+	if (buf_width <= 0 || buf_height <= 0)
+		return;
+
+	/* wlroots sets src_box when a surface is clipped to its xdg window
+	 * geometry, so cropping to it keeps client-side-decoration shadow
+	 * margins out of the capture. */
+	src_box = scene_buffer->src_box;
+	if (wlr_fbox_empty(&src_box))
+		src_box = (struct wlr_fbox){ 0, 0, buf_width, buf_height };
+
 	dst_width = scene_buffer->dst_width;
 	dst_height = scene_buffer->dst_height;
-
-	/* Fall back to buffer dimensions if dst not set */
 	if (dst_width <= 0 || dst_height <= 0) {
-		dst_width = src_width;
-		dst_height = src_height;
+		dst_width = src_box.width;
+		dst_height = src_box.height;
 	}
-
-	if (src_width <= 0 || src_height <= 0)
-		return;
 
 	/* First try direct buffer access (works for SHM buffers - widgets) */
 	if (wlr_buffer_begin_data_ptr_access(buffer, WLR_BUFFER_DATA_PTR_ACCESS_READ,
@@ -1037,24 +1063,11 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 			            CAIRO_FORMAT_ARGB32 : CAIRO_FORMAT_RGB24;
 			/* Use actual buffer dimensions, not dst dimensions */
 			buf_surface = cairo_image_surface_create_for_data(
-				shm_data, cairo_fmt, src_width, src_height, shm_stride);
+				shm_data, cairo_fmt, buf_width, buf_height, shm_stride);
 
 			if (cairo_surface_status(buf_surface) == CAIRO_STATUS_SUCCESS) {
-				cairo_save(rdata->cr);
-				/* Scale if buffer pixels differ from logical size */
-				if (src_width != dst_width || src_height != dst_height) {
-					cairo_translate(rdata->cr,
-						sx + rdata->offset_x, sy + rdata->offset_y);
-					cairo_scale(rdata->cr,
-						(double)dst_width / src_width,
-						(double)dst_height / src_height);
-					cairo_set_source_surface(rdata->cr, buf_surface, 0, 0);
-				} else {
-					cairo_set_source_surface(rdata->cr, buf_surface,
-						sx + rdata->offset_x, sy + rdata->offset_y);
-				}
-				cairo_paint(rdata->cr);
-				cairo_restore(rdata->cr);
+				composite_paint(rdata, buf_surface, &src_box,
+					sx, sy, dst_width, dst_height);
 				cairo_surface_destroy(buf_surface);
 			}
 		}
@@ -1071,8 +1084,8 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 			return;
 
 		/* Read at full buffer resolution, not dst (logical) dimensions */
-		stride = src_width * 4;
-		pixels = malloc(stride * src_height);
+		stride = buf_width * 4;
+		pixels = malloc(stride * buf_height);
 		if (!pixels) {
 			wlr_texture_destroy(texture);
 			return;
@@ -1083,7 +1096,7 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 			.data = pixels,
 			.format = DRM_FORMAT_ARGB8888,
 			.stride = stride,
-			.src_box = { .x = 0, .y = 0, .width = src_width, .height = src_height },
+			.src_box = { .x = 0, .y = 0, .width = buf_width, .height = buf_height },
 		})) {
 			free(pixels);
 			wlr_texture_destroy(texture);
@@ -1095,7 +1108,7 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 
 	/* Create Cairo surface at full buffer resolution */
 	buf_surface = cairo_image_surface_create_for_data(
-		pixels, CAIRO_FORMAT_ARGB32, src_width, src_height, stride);
+		pixels, CAIRO_FORMAT_ARGB32, buf_width, buf_height, stride);
 
 	if (cairo_surface_status(buf_surface) != CAIRO_STATUS_SUCCESS) {
 		if (need_free)
@@ -1103,21 +1116,7 @@ composite_scene_buffer_to_cairo(struct wlr_scene_buffer *scene_buffer,
 		return;
 	}
 
-	/* Composite onto target, scaling from buffer resolution to logical size */
-	cairo_save(rdata->cr);
-	if (src_width != dst_width || src_height != dst_height) {
-		cairo_translate(rdata->cr,
-			sx + rdata->offset_x, sy + rdata->offset_y);
-		cairo_scale(rdata->cr,
-			(double)dst_width / src_width,
-			(double)dst_height / src_height);
-		cairo_set_source_surface(rdata->cr, buf_surface, 0, 0);
-	} else {
-		cairo_set_source_surface(rdata->cr, buf_surface,
-			sx + rdata->offset_x, sy + rdata->offset_y);
-	}
-	cairo_paint(rdata->cr);
-	cairo_restore(rdata->cr);
+	composite_paint(rdata, buf_surface, &src_box, sx, sy, dst_width, dst_height);
 
 	cairo_surface_destroy(buf_surface);
 	if (need_free)

--- a/somewm.c
+++ b/somewm.c
@@ -61,6 +61,7 @@
 #include <wlr/types/wlr_server_decoration.h>
 #include <wlr/types/wlr_single_pixel_buffer_v1.h>
 #include <wlr/types/wlr_subcompositor.h>
+#include <wlr/types/wlr_tablet_v2.h>
 #include <wlr/types/wlr_viewporter.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/types/wlr_xdg_activation_v1.h>
@@ -173,6 +174,10 @@ struct wlr_output_layout *output_layout;
 struct wlr_box sgeom;
 struct wl_list mons;
 struct wl_list tracked_pointers; /* For runtime libinput config */
+struct wl_list tracked_tablets;
+struct wl_list tracked_tablet_pads;
+struct wl_list tracked_tablet_tools;
+struct wlr_tablet_manager_v2 *tablet_v2_mgr;
 Monitor *selmon;
 /* in_updatemons, updatemons_pending: owned by monitor.c */
 
@@ -1233,6 +1238,9 @@ setup(void)
 	 * backend. */
 	wl_list_init(&mons);
 	wl_list_init(&tracked_pointers);
+	wl_list_init(&tracked_tablets);
+	wl_list_init(&tracked_tablet_pads);
+	wl_list_init(&tracked_tablet_tools);
 	wl_signal_add(&backend->events.new_output, &new_output);
 
 	/* Set up our client lists, the xdg-shell and the layer-shell. The xdg-shell is a
@@ -1346,6 +1354,7 @@ setup(void)
 	wl_signal_add(&seat->events.request_set_primary_selection, &request_set_psel);
 	wl_signal_add(&seat->events.request_start_drag, &request_start_drag);
 	wl_signal_add(&seat->events.start_drag, &start_drag);
+	tablet_v2_mgr = wlr_tablet_v2_create(dpy);
 
 	/* Initialize runtime configuration with C defaults (before Lua loads).
 	 * These defaults provide sane fallbacks if rc.lua doesn't set values.
@@ -1414,6 +1423,20 @@ setup(void)
 	globalconf.input.accel_speed = 0.0;
 	globalconf.input.tap_button_map = NULL;  /* String property - set via Lua */
 	globalconf.input.clickfinger_button_map = NULL;  /* String property - set via Lua */
+
+	globalconf.input.tool_mode = NULL;  /* Rule-only tablet tool property */
+	globalconf.input.map_to_output_list = NULL;  /* Rule-only tablet property */
+	globalconf.input.map_to_output_count = 0;
+	globalconf.input.map_from_region_set = false;
+	globalconf.input.map_from_region_x1 = 0.0;
+	globalconf.input.map_from_region_y1 = 0.0;
+	globalconf.input.map_from_region_x2 = 0.0;
+	globalconf.input.map_from_region_y2 = 0.0;
+	globalconf.input.map_to_region_set = false;
+	globalconf.input.map_to_region_x1 = 0.0;
+	globalconf.input.map_to_region_y1 = 0.0;
+	globalconf.input.map_to_region_x2 = 0.0;
+	globalconf.input.map_to_region_y2 = 0.0;
 
 	/* Logging defaults (only set if not already set by -d flag) */
 	if (globalconf.log_level == 0)

--- a/somewm.c
+++ b/somewm.c
@@ -1427,6 +1427,8 @@ setup(void)
 	globalconf.input.clickfinger_button_map = NULL;  /* String property - set via Lua */
 
 	globalconf.input.tool_mode = NULL;  /* Rule-only tablet tool property */
+	globalconf.input.emulate_pointer = 1;  /* touch: synthesize pointer clicks for
+	                                         * clients that never bound wl_touch */
 	globalconf.input.map_to_output_list = NULL;  /* Rule-only tablet property */
 	globalconf.input.map_to_output_count = 0;
 	globalconf.input.map_from_region_set = false;

--- a/somewm.c
+++ b/somewm.c
@@ -177,6 +177,7 @@ struct wl_list tracked_pointers; /* For runtime libinput config */
 struct wl_list tracked_tablets;
 struct wl_list tracked_tablet_pads;
 struct wl_list tracked_tablet_tools;
+struct wl_list tracked_touches;
 struct wlr_tablet_manager_v2 *tablet_v2_mgr;
 Monitor *selmon;
 /* in_updatemons, updatemons_pending: owned by monitor.c */
@@ -1241,6 +1242,7 @@ setup(void)
 	wl_list_init(&tracked_tablets);
 	wl_list_init(&tracked_tablet_pads);
 	wl_list_init(&tracked_tablet_tools);
+	wl_list_init(&tracked_touches);
 	wl_signal_add(&backend->events.new_output, &new_output);
 
 	/* Set up our client lists, the xdg-shell and the layer-shell. The xdg-shell is a
@@ -1448,9 +1450,12 @@ setup(void)
 	/* The cursor and the group keyboard exist regardless of physical devices,
 	 * so advertise both capabilities once here. Waiting for a device event
 	 * leaves them at zero on headless backends and clients can bind neither
-	 * wl_pointer nor wl_keyboard. */
+	 * wl_pointer nor wl_keyboard. Touch is advertised unconditionally too,
+	 * for the same reason (a bound wl_touch that never fires costs nothing,
+	 * but toggling capabilities at runtime is fragile). */
 	wlr_seat_set_capabilities(seat,
-		WL_SEAT_CAPABILITY_POINTER | WL_SEAT_CAPABILITY_KEYBOARD);
+		WL_SEAT_CAPABILITY_POINTER | WL_SEAT_CAPABILITY_KEYBOARD
+		| WL_SEAT_CAPABILITY_TOUCH);
 
 	output_mgr = wlr_output_manager_v1_create(dpy);
 	wl_signal_add(&output_mgr->events.apply, &output_mgr_apply);

--- a/somewm.h
+++ b/somewm.h
@@ -110,6 +110,7 @@ extern struct wl_list tracked_pointers;
 extern struct wl_list tracked_tablets;
 extern struct wl_list tracked_tablet_pads;
 extern struct wl_list tracked_tablet_tools;
+extern struct wl_list tracked_touches;
 extern struct wlr_tablet_manager_v2 *tablet_v2_mgr;
 
 /* Scene elements */

--- a/somewm.h
+++ b/somewm.h
@@ -107,6 +107,10 @@ extern struct wl_list mons;
 extern Monitor *selmon;
 extern struct wlr_box sgeom;
 extern struct wl_list tracked_pointers;
+extern struct wl_list tracked_tablets;
+extern struct wl_list tracked_tablet_pads;
+extern struct wl_list tracked_tablet_tools;
+extern struct wlr_tablet_manager_v2 *tablet_v2_mgr;
 
 /* Scene elements */
 extern struct wlr_scene_tree *drag_icon;

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -1373,7 +1373,22 @@ some_monitor_at_cursor(void)
 }
 
 /*
- * Find monitor by output name (e.g., "HDMI-A-1", "eDP-1")
+ * Build the "make model serial" output identifier (same convention as sway
+ * and wlr-randr). Unlike the connector name (e.g. "DP-8"), this stays
+ * stable across DRM connector renumbering on replug/redock.
+ */
+static void
+monitor_output_identifier(struct wlr_output *output, char *buf, size_t len)
+{
+	snprintf(buf, len, "%s %s %s",
+		output->make ? output->make : "Unknown",
+		output->model ? output->model : "Unknown",
+		output->serial ? output->serial : "Unknown");
+}
+
+/*
+ * Find monitor by output name (e.g., "HDMI-A-1", "eDP-1") or, failing that,
+ * by its make/model/serial identifier (e.g. "Dell Inc. DELL U2415 ABC123").
  */
 Monitor *
 some_monitor_by_name(const char *name)
@@ -1385,6 +1400,17 @@ some_monitor_by_name(const char *name)
 
 	wl_list_for_each(m, &mons, link) {
 		if (m->wlr_output && m->wlr_output->name && strcmp(m->wlr_output->name, name) == 0)
+			return m;
+	}
+
+	wl_list_for_each(m, &mons, link) {
+		char id[256];
+
+		if (!m->wlr_output)
+			continue;
+
+		monitor_output_identifier(m->wlr_output, id, sizeof(id));
+		if (strcmp(id, name) == 0)
 			return m;
 	}
 

--- a/somewm_api.c
+++ b/somewm_api.c
@@ -1373,6 +1373,25 @@ some_monitor_at_cursor(void)
 }
 
 /*
+ * Find monitor by output name (e.g., "HDMI-A-1", "eDP-1")
+ */
+Monitor *
+some_monitor_by_name(const char *name)
+{
+	Monitor *m;
+
+	if (!name)
+		return NULL;
+
+	wl_list_for_each(m, &mons, link) {
+		if (m->wlr_output && m->wlr_output->name && strcmp(m->wlr_output->name, name) == 0)
+			return m;
+	}
+
+	return NULL;
+}
+
+/*
  * Get current cursor position
  */
 void

--- a/somewm_api.h
+++ b/somewm_api.h
@@ -125,6 +125,7 @@ Monitor *some_get_focused_monitor(void);
 struct wl_list *some_get_monitors(void);
 Monitor *some_monitor_at(double lx, double ly);
 Monitor *some_monitor_from_direction(Monitor *from, enum wlr_direction dir);
+Monitor *some_monitor_by_name(const char *name);
 void some_focus_monitor(Monitor *m);
 void some_focus_monitor_direction(enum wlr_direction dir);
 void some_move_client_to_monitor_direction(enum wlr_direction dir);

--- a/spec/awful/input_spec.lua
+++ b/spec/awful/input_spec.lua
@@ -371,6 +371,27 @@ describe("awful.input", function()
             assert.is.equal(3, #input.rules)
             assert.is.same(rules, input.rules)
         end)
+
+        it("rules accept tablet properties", function()
+            local rules = {
+                { rule = { type = "tablet" },
+                  properties = {
+                      map_to_output = "*",
+                                            tool_mode = "absolute",
+                      map_from_region = "0x0 100x100",
+                  } },
+                                { rule = { type = "tablet-tool-pen", name = "Wacom Intuos S Pen" },
+                  properties = {
+                                            tool_mode = "relative",
+                      map_to_output = "DP-1",
+                      map_from_region = { x1 = 1, y1 = 2, x2 = 3, y2 = 4 },
+                  } },
+            }
+
+            input.rules = rules
+            assert.is.same(rules, input.rules)
+            assert.is.equal(1, #input_rules_calls)
+        end)
     end)
 
     describe("realistic usage scenarios", function()

--- a/spec/awful/input_spec.lua
+++ b/spec/awful/input_spec.lua
@@ -400,6 +400,7 @@ describe("awful.input", function()
                 { rule = { type = "touch", name = "Wacom HID 1234 Finger" },
                   properties = {
                       map_to_output = { "eDP-1", "AOC U27E3U ZX3QBHA000360" },
+                      emulate_pointer = false,
                   } },
             }
 

--- a/spec/awful/input_spec.lua
+++ b/spec/awful/input_spec.lua
@@ -392,6 +392,21 @@ describe("awful.input", function()
             assert.is.same(rules, input.rules)
             assert.is.equal(1, #input_rules_calls)
         end)
+
+        it("rules accept touch properties", function()
+            local rules = {
+                { rule = { type = "touch" },
+                  properties = { map_to_output = "*" } },
+                { rule = { type = "touch", name = "Wacom HID 1234 Finger" },
+                  properties = {
+                      map_to_output = { "eDP-1", "AOC U27E3U ZX3QBHA000360" },
+                  } },
+            }
+
+            input.rules = rules
+            assert.is.same(rules, input.rules)
+            assert.is.equal(1, #input_rules_calls)
+        end)
     end)
 
     describe("realistic usage scenarios", function()

--- a/tests/restart/configs/prescan/rc.lua
+++ b/tests/restart/configs/prescan/rc.lua
@@ -18,4 +18,8 @@ dofile(assert(os.getenv("SOMEWM_TEST_BASE_RC"),
 
 require("deepmod")
 
+-- A library the scanner can now resolve, but must not read: findings in
+-- somewm's own Lua are not the user's to fix.
+require("awful")
+
 return x11_call, x11_lookalike

--- a/tests/restart/prescan-warns-without-blocking.sh
+++ b/tests/restart/prescan-warns-without-blocking.sh
@@ -24,6 +24,7 @@ check_log_count hr-prescan "but the lookalike name was not" "xsettingsd" 0
 check_log hr-prescan "the scanner reached the required module" "deepmod.lua"
 check_log hr-prescan "and reported the pattern it found there" \
     "GDK initialization deadlock"
+check_log_count hr-prescan "but not into somewm's own libraries" "awful/client.lua" 0
 check_log_count hr-prescan "no config was skipped" "Skipping this config" 0
 
 finish

--- a/tests/test-check-mode.sh
+++ b/tests/test-check-mode.sh
@@ -178,14 +178,14 @@ test_require_missing_reported() {
 return true')
     run_check "$cfg"
     assert_contains "$name" "totally_missing_module_xyz" || return
-    assert_contains "$name" "module not found" || return
+    assert_contains "$name" "not found on this system" || return
     pass "$name"
 }
 
 test_require_stdlib_skipped() {
     local name="require_stdlib_skipped"
     local cfg
-    # Verify none of these stdlib modules appear as "module not found"
+    # Verify none of these stdlib modules are reported missing
     cfg=$(write_config "req_stdlib.lua" 'require("string")
 require("table")
 require("math")
@@ -195,14 +195,14 @@ require("debug")
 require("coroutine")
 require("package")')
     run_check "$cfg"
-    assert_not_contains "$name" "module not found" || return
+    assert_not_contains "$name" "not found on this system" || return
     pass "$name"
 }
 
 test_require_awesomewm_skipped() {
     local name="require_awesomewm_skipped"
     local cfg
-    # Verify none of these AwesomeWM modules appear as "module not found"
+    # Verify none of these AwesomeWM modules are reported missing
     cfg=$(write_config "req_awesome.lua" 'require("awful")
 require("gears")
 require("wibox")
@@ -211,21 +211,30 @@ require("beautiful")
 require("menubar")
 require("ruled")')
     run_check "$cfg"
-    assert_not_contains "$name" "module not found" || return
+    assert_not_contains "$name" "not found on this system" || return
     pass "$name"
 }
 
-test_require_thirdparty_skipped() {
-    local name="require_thirdparty_skipped"
+test_require_somewm_module_found() {
+    local name="require_somewm_module_found"
     local cfg
-    # Verify none of these known third-party modules appear as "module not found"
-    cfg=$(write_config "req_thirdparty.lua" 'require("lgi")
-require("cairo")
-require("inspect")
-require("lain")
-require("dkjson")')
+    # somewm's own bundled modules resolve through package.path like any other
+    cfg=$(write_config "req_somewm.lua" 'require("somewm.layout_animation")')
     run_check "$cfg"
-    assert_not_contains "$name" "module not found" || return
+    assert_not_contains "$name" "not found on this system" || return
+    pass "$name"
+}
+
+test_require_library_not_scanned() {
+    local name="require_library_not_scanned"
+    local cfg
+    # A resolved library is not the user's code: report that it exists, but do
+    # not walk into it. awful/screen.lua and awful/client.lua both mention X11
+    # tools, so a leak shows up as findings in files the user cannot fix.
+    cfg=$(write_config "req_lib_scan.lua" 'require("awful")')
+    run_check "$cfg"
+    assert_not_contains "$name" "awful/screen.lua" || return
+    assert_not_contains "$name" "awful/client.lua" || return
     pass "$name"
 }
 
@@ -237,7 +246,7 @@ test_require_method_skipped() {
 local GLib = lgi.require("GLib")
 return GLib')
     run_check "$cfg"
-    assert_not_contains "$name" "module not found" || return
+    assert_not_contains "$name" "GLib" || return
     pass "$name"
 }
 
@@ -481,7 +490,8 @@ test_require_commented_ignored
 test_require_missing_reported
 test_require_stdlib_skipped
 test_require_awesomewm_skipped
-test_require_thirdparty_skipped
+test_require_somewm_module_found
+test_require_library_not_scanned
 test_require_method_skipped
 test_require_local_module
 test_require_init_module

--- a/tests/test-check-mode.sh
+++ b/tests/test-check-mode.sh
@@ -19,6 +19,8 @@ if [ ! -x "$SOMEWM" ]; then
     exit 1
 fi
 
+SOMEWM=$(cd "$(dirname "$SOMEWM")" && pwd)/$(basename "$SOMEWM")
+
 # Setup temp directory
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
@@ -235,6 +237,23 @@ test_require_library_not_scanned() {
     run_check "$cfg"
     assert_not_contains "$name" "awful/screen.lua" || return
     assert_not_contains "$name" "awful/client.lua" || return
+    pass "$name"
+}
+
+test_bare_filename_walks_requires() {
+    local name="bare_filename_walks_requires"
+    # The config directory came from the path alone, so a config named without
+    # one left it unset and the whole walk was skipped in silence.
+    write_config "bare/mod.lua" 'local lgi = require("lgi")
+local Gdk = lgi.require("Gdk")
+return Gdk' >/dev/null
+    write_config "bare/rc.lua" 'require("mod")' >/dev/null
+    set +e
+    CHECK_STDOUT=$(cd "$TMP_DIR/bare" && "$SOMEWM" --check rc.lua 2>/dev/null)
+    CHECK_EXIT=$?
+    set -e
+    assert_contains "$name" "mod.lua" || return
+    assert_contains "$name" "GDK initialization deadlock" || return
     pass "$name"
 }
 
@@ -492,6 +511,7 @@ test_require_stdlib_skipped
 test_require_awesomewm_skipped
 test_require_somewm_module_found
 test_require_library_not_scanned
+test_bare_filename_walks_requires
 test_require_method_skipped
 test_require_local_module
 test_require_init_module

--- a/tests/test-client-content-pattern.lua
+++ b/tests/test-client-content-pattern.lua
@@ -10,7 +10,9 @@
 --- The Lua driver samples one pixel near the center of each logical
 --- quadrant via FFI to cairo and asserts the dominant color.
 ---
---- Runs at scale=1 (guards the src==dst fast path) and scale=2 (HiDPI).
+--- Runs at scale=1, at scale=2 (HiDPI), and once more at scale=1 with the
+--- client attaching a transparent shadow margin around a smaller xdg window
+--- geometry, the way a client-side-decorated app does.
 --- Exercises the SHM fast path of luaA_client_get_content; the GPU texture
 --- path uses identical composite logic but exercising it requires a
 --- DMA-BUF client.
@@ -98,12 +100,16 @@ local function dominant_color(r, g, b)
     return string.format("rgb(%d,%d,%d)", r, g, b)
 end
 
-local function run_at_scale(target_scale, pids)
+local function run_at_scale(target_scale, pids, margin)
     local s = screen[1]
     s.scale = target_scale
     async.sleep(0.05)   -- let the scale change propagate to outputs
 
-    local pid = awful.spawn({BINARY})
+    local cmd = {BINARY}
+    if margin then
+        cmd[2], cmd[3] = "--margin", tostring(margin)
+    end
+    local pid = awful.spawn(cmd)
     assert(type(pid) == "number" and pid > 0,
         "Failed to spawn binary: " .. tostring(pid))
     table.insert(pids, pid)
@@ -146,13 +152,22 @@ local function run_at_scale(target_scale, pids)
     local br = dominant_color(pixel_rgb(raw, qx2, qy2))
 
     io.stderr:write(string.format(
-        "[content-pattern] scale=%s surface=%dx%d TL=%s TR=%s BL=%s BR=%s\n",
-        tostring(target_scale), w, h, tl, tr, bl, br))
+        "[content-pattern] scale=%s margin=%s surface=%dx%d TL=%s TR=%s BL=%s BR=%s\n",
+        tostring(target_scale), tostring(margin), w, h, tl, tr, bl, br))
 
     assert(tl == "red"   , "TL quadrant should be red, got "    .. tl)
     assert(tr == "green" , "TR quadrant should be green, got "  .. tr)
     assert(bl == "blue"  , "BL quadrant should be blue, got "   .. bl)
     assert(br == "yellow", "BR quadrant should be yellow, got " .. br)
+
+    if margin then
+        -- The shadow margin must be cropped out, not squeezed into the
+        -- content rect, so the very corner is pattern rather than the
+        -- transparent ring.
+        local corner = dominant_color(pixel_rgb(raw, 1, 1))
+        assert(corner == "red",
+            "margin run: pixel (1,1) should be red, got " .. corner)
+    end
 
     c:kill()
     async.wait_for_no_clients(3)
@@ -166,6 +181,7 @@ runner.run_async(function()
     local ok, err = pcall(function()
         run_at_scale(1.0, pids)
         run_at_scale(2.0, pids)
+        run_at_scale(1.0, pids, 40)
     end)
 
     -- Always-run cleanup

--- a/tests/test-client-content-pattern.lua
+++ b/tests/test-client-content-pattern.lua
@@ -12,7 +12,9 @@
 ---
 --- Runs at scale=1, at scale=2 (HiDPI), and once more at scale=1 with the
 --- client attaching a transparent shadow margin around a smaller xdg window
---- geometry, the way a client-side-decorated app does.
+--- geometry, the way a client-side-decorated app does. Eight more runs
+--- commit the buffer with each wl_surface.set_buffer_transform, which
+--- permutes the on-screen quadrants; c.content must permute with them.
 --- Exercises the SHM fast path of luaA_client_get_content; the GPU texture
 --- path uses identical composite logic but exercising it requires a
 --- DMA-BUF client.
@@ -89,7 +91,32 @@ local function pixel_rgb(raw_surface, x, y)
     local data   = ffi.C.cairo_image_surface_get_data(raw_surface)
     local stride = ffi.C.cairo_image_surface_get_stride(raw_surface)
     local off = y * stride + x * 4
-    return data[off + 2], data[off + 1], data[off + 0]   -- R, G, B
+    return data[off + 2], data[off + 1], data[off + 0], data[off + 3]
+end
+
+-- Re-fetch c.content until every quadrant sample is opaque. A commit that has
+-- landed in the marker file has not necessarily reached the scene graph, and
+-- the geometry change above can retrigger one, so a capture taken too early
+-- comes back part transparent. Gates on paintedness only, never on colour, so
+-- a genuinely wrong orientation still fails rather than spinning.
+local function content_when_painted(c, timeout_secs)
+    local raw
+    async.wait_for_condition(function()
+        raw = c.content
+        if not raw then return false end
+        -- Dimensions via FFI, not gears.surface: an lgi wrapper owns the
+        -- surface and would destroy it here, leaving the caller a dangling
+        -- pointer.
+        local w = ffi.C.cairo_image_surface_get_width(raw)
+        local h = ffi.C.cairo_image_surface_get_height(raw)
+        if w <= 4 or h <= 4 then return false end
+        for _, p in ipairs({{0.25, 0.25}, {0.75, 0.25}, {0.25, 0.75}, {0.75, 0.75}}) do
+            local _, _, _, a = pixel_rgb(raw, math.floor(w * p[1]), math.floor(h * p[2]))
+            if a < 200 then return false end
+        end
+        return true
+    end, timeout_secs or 5, 0.02)
+    return raw
 end
 
 local function dominant_color(r, g, b)
@@ -100,14 +127,40 @@ local function dominant_color(r, g, b)
     return string.format("rgb(%d,%d,%d)", r, g, b)
 end
 
-local function run_at_scale(target_scale, pids, margin)
+-- On-screen quadrant order per wl_surface.set_buffer_transform. Each row was
+-- read off a grim capture of the compositor's own output, so the expectations
+-- are independent of how root.c builds its matrices.
+local TRANSFORM_QUADRANTS = {
+    [0] = {"red",    "green",  "blue",   "yellow"},
+    [1] = {"blue",   "red",    "yellow", "green"},
+    [2] = {"yellow", "blue",   "green",  "red"},
+    [3] = {"green",  "yellow", "red",    "blue"},
+    [4] = {"green",  "red",    "yellow", "blue"},
+    [5] = {"red",    "blue",   "green",  "yellow"},
+    [6] = {"blue",   "yellow", "red",    "green"},
+    [7] = {"yellow", "green",  "blue",   "red"},
+}
+local CORNERS = {"TL", "TR", "BL", "BR"}
+
+-- Spawned client pids, drained by the cleanup block at the end.
+local pids = {}
+
+local function run_case(args)
     local s = screen[1]
-    s.scale = target_scale
-    async.sleep(0.05)   -- let the scale change propagate to outputs
+    local margin, transform = args.margin, args.transform
+    if s.scale ~= args.scale then
+        s.scale = args.scale
+        async.sleep(0.05)   -- let the scale change propagate to outputs
+    end
 
     local cmd = {BINARY}
     if margin then
-        cmd[2], cmd[3] = "--margin", tostring(margin)
+        table.insert(cmd, "--margin")
+        table.insert(cmd, tostring(margin))
+    end
+    if transform then
+        table.insert(cmd, "--transform")
+        table.insert(cmd, tostring(transform))
     end
     local pid = awful.spawn(cmd)
     assert(type(pid) == "number" and pid > 0,
@@ -115,7 +168,7 @@ local function run_at_scale(target_scale, pids, margin)
     table.insert(pids, pid)
 
     local c = async.wait_for_client(APP_ID, 5)
-    assert(c, "Client never appeared at scale=" .. tostring(target_scale))
+    assert(c, "Client never appeared at scale=" .. tostring(args.scale))
 
     -- Move the client off the scene origin so c.content's scene-tree walk
     -- exercises non-zero buffer positions. A regression here (commit
@@ -129,19 +182,19 @@ local function run_at_scale(target_scale, pids, margin)
     -- Wait for the buffer at the target scale to actually be committed.
     -- At scale=1 this is the first commit; at scale=2 the C client first
     -- commits at scale=1 (default) then re-renders after preferred_buffer_scale.
-    local ok = wait_for_scale_commit(pid, target_scale, 5)
+    local ok = wait_for_scale_commit(pid, args.scale, 5)
     assert(ok, string.format(
-        "C client never committed scale=%d (marker file never matched)", target_scale))
+        "C client never committed scale=%d (marker file never matched)", args.scale))
 
     -- Surface dims should now match logical content dimensions.
-    local raw = c.content
-    assert(raw, "c.content returned nil at scale=" .. tostring(target_scale))
+    local raw = content_when_painted(c, 5)
+    assert(raw, "c.content returned nil at scale=" .. tostring(args.scale))
 
     local img = gears.surface(raw)
     local w = img:get_width()
     local h = img:get_height()
     assert(w > 4 and h > 4, string.format(
-        "c.content surface too small (%dx%d) at scale=%d", w, h, target_scale))
+        "c.content surface too small (%dx%d) at scale=%d", w, h, args.scale))
 
     -- Sample one pixel near the center of each logical quadrant.
     local qx1, qx2 = math.floor(w * 0.25), math.floor(w * 0.75)
@@ -151,22 +204,27 @@ local function run_at_scale(target_scale, pids, margin)
     local bl = dominant_color(pixel_rgb(raw, qx1, qy2))
     local br = dominant_color(pixel_rgb(raw, qx2, qy2))
 
-    io.stderr:write(string.format(
-        "[content-pattern] scale=%s margin=%s surface=%dx%d TL=%s TR=%s BL=%s BR=%s\n",
-        tostring(target_scale), tostring(margin), w, h, tl, tr, bl, br))
+    local want = TRANSFORM_QUADRANTS[transform or 0]
+    assert(want, "no expected quadrants for transform " .. tostring(transform))
 
-    assert(tl == "red"   , "TL quadrant should be red, got "    .. tl)
-    assert(tr == "green" , "TR quadrant should be green, got "  .. tr)
-    assert(bl == "blue"  , "BL quadrant should be blue, got "   .. bl)
-    assert(br == "yellow", "BR quadrant should be yellow, got " .. br)
+    io.stderr:write(string.format(
+        "[content-pattern] scale=%s margin=%s transform=%s surface=%dx%d TL=%s TR=%s BL=%s BR=%s\n",
+        tostring(args.scale), tostring(margin), tostring(transform),
+        w, h, tl, tr, bl, br))
+
+    for i, got in ipairs({tl, tr, bl, br}) do
+        assert(got == want[i], string.format(
+            "%s quadrant should be %s, got %s (transform=%s)",
+            CORNERS[i], want[i], got, tostring(transform)))
+    end
 
     if margin then
         -- The shadow margin must be cropped out, not squeezed into the
         -- content rect, so the very corner is pattern rather than the
         -- transparent ring.
         local corner = dominant_color(pixel_rgb(raw, 1, 1))
-        assert(corner == "red",
-            "margin run: pixel (1,1) should be red, got " .. corner)
+        assert(corner == want[1],
+            "margin run: pixel (1,1) should be " .. want[1] .. ", got " .. corner)
     end
 
     c:kill()
@@ -176,12 +234,14 @@ end
 runner.run_async(function()
     local s = screen[1]
     local original_scale = s.scale
-    local pids = {}
 
     local ok, err = pcall(function()
-        run_at_scale(1.0, pids)
-        run_at_scale(2.0, pids)
-        run_at_scale(1.0, pids, 40)
+        run_case { scale = 1.0 }
+        run_case { scale = 2.0 }
+        run_case { scale = 1.0, margin = 40 }
+        for t = 1, 7 do
+            run_case { scale = 1.0, transform = t }
+        end
     end)
 
     -- Always-run cleanup

--- a/tests/test-content-pattern-client.c
+++ b/tests/test-content-pattern-client.c
@@ -19,6 +19,9 @@
  * pattern and the xdg window geometry points at the pattern, mimicking a
  * client-side-decoration shadow margin.
  *
+ * With --transform N the buffer is committed with wl_surface.set_buffer_transform
+ * N, so the compositor re-orients it and the on-screen quadrants permute.
+ *
  * Lifecycle: SIGTERM/SIGINT for clean exit. App ID: "content_pattern_test".
  */
 
@@ -50,6 +53,7 @@ static struct wl_buffer *g_current_buffer;
 
 static int g_logical_w = 200, g_logical_h = 200;
 static int g_margin = 0;
+static int g_transform = 0;
 static int g_pending_scale = 1;
 static int g_current_scale = 0;     /* 0 = nothing committed yet */
 static char g_marker_path[256];
@@ -135,6 +139,7 @@ static void render_pattern(void) {
     }
 
     wl_surface_set_buffer_scale(g_surface, scale);
+    wl_surface_set_buffer_transform(g_surface, g_transform);
     if (g_margin > 0)
         xdg_surface_set_window_geometry(g_xdg_surface, g_margin, g_margin,
                                         g_logical_w, g_logical_h);
@@ -276,10 +281,22 @@ static const struct wl_registry_listener registry_listener = {
 };
 
 int main(int argc, char *argv[]) {
-    if (argc == 3 && strcmp(argv[1], "--margin") == 0)
-        g_margin = atoi(argv[2]);
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--margin") == 0 && i + 1 < argc)
+            g_margin = atoi(argv[++i]);
+        else if (strcmp(argv[i], "--transform") == 0 && i + 1 < argc)
+            g_transform = atoi(argv[++i]);
+        else {
+            fprintf(stderr, "Usage: %s [--margin N] [--transform N]\n", argv[0]);
+            return 1;
+        }
+    }
     if (g_margin < 0)
         g_margin = 0;
+    if (g_transform < 0 || g_transform > 7) {
+        fprintf(stderr, "--transform must be 0..7\n");
+        return 1;
+    }
 
     snprintf(g_marker_path, sizeof(g_marker_path),
              "/tmp/test-content-pattern-%d.scale", (int)getpid());

--- a/tests/test-content-pattern-client.c
+++ b/tests/test-content-pattern-client.c
@@ -15,6 +15,10 @@
  *   TL = red    (0xFFFF0000)   TR = green  (0xFF00FF00)
  *   BL = blue   (0xFF0000FF)   BR = yellow (0xFFFFFF00)
  *
+ * With --margin N a transparent ring N logical pixels wide surrounds the
+ * pattern and the xdg window geometry points at the pattern, mimicking a
+ * client-side-decoration shadow margin.
+ *
  * Lifecycle: SIGTERM/SIGINT for clean exit. App ID: "content_pattern_test".
  */
 
@@ -45,6 +49,7 @@ static struct xdg_toplevel *g_toplevel;
 static struct wl_buffer *g_current_buffer;
 
 static int g_logical_w = 200, g_logical_h = 200;
+static int g_margin = 0;
 static int g_pending_scale = 1;
 static int g_current_scale = 0;     /* 0 = nothing committed yet */
 static char g_marker_path[256];
@@ -56,14 +61,17 @@ static void handle_term(int sig) {
     g_running = 0;
 }
 
-/* Create an SHM-backed wl_buffer at the given physical dims, filled with the
- * 4-quadrant ARGB8888 pattern. Caller owns the returned buffer. */
-static struct wl_buffer *create_pattern_buffer(int w, int h) {
+/* Create an SHM-backed wl_buffer holding the 4-quadrant ARGB8888 pattern at
+ * the given physical dims, inset by a transparent ring of m physical pixels.
+ * Caller owns the returned buffer. */
+static struct wl_buffer *create_pattern_buffer(int w, int h, int m) {
     if (w <= 0 || h <= 0)
         return NULL;
 
-    int stride = w * 4;
-    size_t size = (size_t)stride * (size_t)h;
+    int buf_w = w + 2 * m;
+    int buf_h = h + 2 * m;
+    int stride = buf_w * 4;
+    size_t size = (size_t)stride * (size_t)buf_h;
 
     char tmpl[] = "/tmp/test-content-pattern-buf-XXXXXX";
     int fd = mkstemp(tmpl);
@@ -86,6 +94,8 @@ static struct wl_buffer *create_pattern_buffer(int w, int h) {
         return NULL;
     }
 
+    memset(data, 0, size);
+
     int half_w = w / 2;
     int half_h = h / 2;
     for (int y = 0; y < h; y++) {
@@ -95,14 +105,14 @@ static struct wl_buffer *create_pattern_buffer(int w, int h) {
             else if (x >= half_w && y <  half_h) color = 0xFF00FF00; /* TR green  */
             else if (x <  half_w && y >= half_h) color = 0xFF0000FF; /* BL blue   */
             else                                 color = 0xFFFFFF00; /* BR yellow */
-            data[y * w + x] = color;
+            data[(y + m) * buf_w + (x + m)] = color;
         }
     }
     munmap(data, size);
 
     struct wl_shm_pool *pool = wl_shm_create_pool(g_shm, fd, size);
     struct wl_buffer *buf = wl_shm_pool_create_buffer(
-        pool, 0, w, h, stride, WL_SHM_FORMAT_ARGB8888);
+        pool, 0, buf_w, buf_h, stride, WL_SHM_FORMAT_ARGB8888);
     wl_shm_pool_destroy(pool);
     close(fd);
 
@@ -115,8 +125,9 @@ static void render_pattern(void) {
     int scale = g_pending_scale > 0 ? g_pending_scale : 1;
     int phys_w = g_logical_w * scale;
     int phys_h = g_logical_h * scale;
+    int phys_m = g_margin * scale;
 
-    struct wl_buffer *buf = create_pattern_buffer(phys_w, phys_h);
+    struct wl_buffer *buf = create_pattern_buffer(phys_w, phys_h, phys_m);
     if (!buf) {
         fprintf(stderr, "[content-pattern-client] buffer alloc failed (%dx%d)\n",
                 phys_w, phys_h);
@@ -124,8 +135,11 @@ static void render_pattern(void) {
     }
 
     wl_surface_set_buffer_scale(g_surface, scale);
+    if (g_margin > 0)
+        xdg_surface_set_window_geometry(g_xdg_surface, g_margin, g_margin,
+                                        g_logical_w, g_logical_h);
     wl_surface_attach(g_surface, buf, 0, 0);
-    wl_surface_damage_buffer(g_surface, 0, 0, phys_w, phys_h);
+    wl_surface_damage_buffer(g_surface, 0, 0, INT32_MAX, INT32_MAX);
     wl_surface_commit(g_surface);
     wl_display_flush(g_display);
 
@@ -262,7 +276,10 @@ static const struct wl_registry_listener registry_listener = {
 };
 
 int main(int argc, char *argv[]) {
-    (void)argc; (void)argv;
+    if (argc == 3 && strcmp(argv[1], "--margin") == 0)
+        g_margin = atoi(argv[2]);
+    if (g_margin < 0)
+        g_margin = 0;
 
     snprintf(g_marker_path, sizeof(g_marker_path),
              "/tmp/test-content-pattern-%d.scale", (int)getpid());

--- a/tests/test-input-rules-region-parsing.lua
+++ b/tests/test-input-rules-region-parsing.lua
@@ -1,0 +1,64 @@
+--- Test that a "0"-leading map_from_region/map_to_region string parses.
+--
+-- input_rule_get_region() parsed "X1xY1 X2xY2" strings with
+-- sscanf(raw, "%lfx%lf %lfx%lf", ...). glibc's %lf conversion also accepts
+-- C99 hex-float syntax, and permissively treats a bare "0x0" (no required
+-- 'p' exponent) as the complete value 0.0 - so the first %lf silently
+-- swallowed the "0x" of a "0x0 ..." string as a hex-float lead-in instead
+-- of stopping at the intended 'x' separator, breaking any region string
+-- whose first coordinate is 0 - the natural top-left corner, so the single
+-- most common value anyone would type (#692).
+
+local input = require("awful.input")
+
+local steps = {}
+
+table.insert(steps, function()
+    local ok, err = pcall(function()
+        input.rules = {
+            { rule = { type = "tablet" },
+              properties = { map_from_region = "0x0 0.5x0.5" } },
+        }
+    end)
+
+    assert(ok, "regression: a '0x0 ...' map_from_region string raised an "
+        .. "error: " .. tostring(err))
+
+    return true
+end)
+
+table.insert(steps, function()
+    -- map_to_region shares the same parser - same coverage.
+    local ok, err = pcall(function()
+        input.rules = {
+            { rule = { type = "tablet" },
+              properties = { map_to_region = "0x0 100x100" } },
+        }
+    end)
+
+    assert(ok, "regression: a '0x0 ...' map_to_region string raised an "
+        .. "error: " .. tostring(err))
+
+    return true
+end)
+
+table.insert(steps, function()
+    -- The parser should still reject genuinely malformed strings.
+    local ok = pcall(function()
+        input.rules = {
+            { rule = { type = "tablet" },
+              properties = { map_from_region = "garbage" } },
+        }
+    end)
+
+    assert(not ok, "malformed map_from_region string should still error")
+
+    -- Clear the rule so it doesn't leak into later tests.
+    input.rules = {}
+
+    return true
+end)
+
+require("_runner").run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-screen-primary-setter.lua
+++ b/tests/test-screen-primary-setter.lua
@@ -1,0 +1,69 @@
+---------------------------------------------------------------------------
+-- Tests for assigning screen.primary:
+--   1. screen.primary = s updates screen.primary
+--   2. Assigning emits primary_changed on the new primary screen
+--   3. Assigning the current primary is a no-op (no signal)
+--   4. Unrelated keys on the screen table still assign normally
+---------------------------------------------------------------------------
+
+local runner = require("_runner")
+
+local original_primary = nil
+local fake_screen = nil
+local changed = 0
+
+local function on_changed()
+    changed = changed + 1
+end
+
+local steps = {
+    -- Step 1: Add a second screen so there is something to switch to
+    function()
+        original_primary = screen.primary
+        assert(original_primary, "no primary screen")
+
+        fake_screen = screen.fake_add(1400, 0, 400, 300)
+        assert(fake_screen ~= original_primary, "fake screen is already primary")
+
+        screen.connect_signal("primary_changed", on_changed)
+        return true
+    end,
+
+    -- Step 2: Assigning a new primary takes effect and signals
+    function()
+        screen.primary = fake_screen
+        assert(screen.primary == fake_screen,
+            "screen.primary was not updated by assignment")
+        assert(changed == 1,
+            "primary_changed fired " .. changed .. " times, expected 1")
+        return true
+    end,
+
+    -- Step 3: Re-assigning the same screen is a no-op
+    function()
+        screen.primary = fake_screen
+        assert(changed == 1,
+            "primary_changed fired again for an unchanged primary")
+        return true
+    end,
+
+    -- Step 4: Other keys still assign normally
+    function()
+        screen.some_test_key = "value"
+        assert(screen.some_test_key == "value",
+            "assigning an unrelated key on the screen table broke")
+        return true
+    end,
+
+    -- Step 5: Restore
+    function()
+        screen.primary = original_primary
+        screen.disconnect_signal("primary_changed", on_changed)
+        fake_screen:fake_remove()
+        return true
+    end,
+}
+
+runner.run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-wibar-margins.lua
+++ b/tests/test-wibar-margins.lua
@@ -1,0 +1,71 @@
+--- Test that fractional margins do not make a wibar grow.
+--
+-- The placement code adds the margins to the geometry it reads and removes
+-- them from the geometry it writes. The drawin geometry is rounded to whole
+-- pixels, so a fractional margin used to make the wibar one pixel taller every
+-- time the attached placement ran, until the C stack overflowed (#4121).
+
+local wibar = require("awful.wibar")
+
+local steps = {}
+
+-- A fractional margin, as half of an odd theme size gives. It is rounded to 11.
+local margin, rounded = 10.5, 11
+
+local height = 24
+local sgeo   = screen.primary.geometry
+
+local expected = {
+    x      = sgeo.x + rounded,
+    y      = sgeo.y + rounded,
+    width  = sgeo.width - 2 * rounded,
+    height = height,
+}
+
+local w
+
+-- The top and bottom margins are on the same axis as the height of a top
+-- wibar. Only the top one is set, so their sum is fractional.
+table.insert(steps, function()
+    -- Without the fix, this alone overflows the C stack.
+    w = wibar {
+        position = "top",
+        screen   = screen.primary,
+        height   = height,
+        margins  = { top = margin, left = margin, right = margin },
+    }
+
+    return true
+end)
+
+-- The placement is re-applied every time the size changes, so keep checking
+-- the geometry for a while to make sure it stays put.
+for _=1, 3 do
+    table.insert(steps, function()
+        local geo = w:geometry()
+
+        for _, key in ipairs {"x", "y", "width", "height"} do
+            assert(geo[key] == expected[key], string.format(
+                "regression: fractional margins changed the %s to %d, "..
+                "expected %d", key, geo[key], expected[key]
+            ))
+        end
+
+        return true
+    end)
+end
+
+table.insert(steps, function()
+    -- The strut covers the wibar and the margin above it.
+    local expected_y = expected.y + expected.height
+
+    assert(screen.primary.workarea.y == expected_y, string.format(
+        "regression: the workarea starts at %d, expected %d",
+        screen.primary.workarea.y, expected_y))
+
+    return true
+end)
+
+require("_runner").run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
## Description
Forward-ports 14 commits from release/1.4 that had not landed on main. 

Six needed hand-porting because the code they touch moved from somewm.c to input.c in the 2.0 split. 

Two other 1.4 commits (KeyRelease handling & switch toggle signal) are already on main under different commits and were skipped.