### PR TITLE
clay: convert the widget layouts, with a tree and per-subtree leaves

### DIFF
--- a/DEVIATIONS.md
+++ b/DEVIATIONS.md
@@ -190,19 +190,30 @@ A client's `zIndex` follows `ontop`, `above`, `below` and `fullscreen`. A transi
 
 ## Converted Widget Containers (somewm 2.1)
 
-A drawable's widget tree is compiled to Clay declarations from the root down, and the first widget the compile step cannot express keeps drawing itself with cairo into the drawable's surface, which the renderer shows as one image on top of the converted containers. `wibox.container.margin` and `wibox.container.background` convert; everything else, for now, does not. Widget code, signals and boxes are unchanged either way, and so is what a wibar looks like.
+A drawable's widget tree is compiled to Clay declarations from the root down. Every widget the compile step can express becomes one Clay element, and every subtree it cannot keeps drawing itself with cairo, into a surface of its own that the renderer shows at the box Clay solves for it. `wibox.container.margin`, `wibox.container.background`, `wibox.container.place`, `wibox.layout.fixed`, `wibox.layout.flex`, `wibox.layout.align` and `wibox.layout.stack` convert; everything else, for now, does not. Widget code, signals and boxes are unchanged either way, and so is what a wibar looks like, with the one-pixel exceptions below.
 
-A container stays on the cairo path when it carries something a Clay declaration does not say:
+A widget stays on the cairo path, with its whole subtree, when it carries something a Clay declaration does not say:
 
-- a subclass that overrides `:fit`, `:layout`, `:draw`, `before_draw_children` or `after_draw_children`
+- a subclass that overrides `:fit`, `:layout`, `:draw`, `before_draw_children` or `after_draw_children` (the systray widget is one, and so is any widget built with a custom `:layout`)
 - `visible = false`, an `opacity` other than 1, or a forced width or height
-- a background gradient, surface pattern or `bgimage`
-- a shape other than `gears.shape.rectangle` or `gears.shape.rounded_rect`, and a rounded shape together with a border width
-- a margin with `draw_empty = false`
+- `background`: a gradient, a surface pattern or a `bgimage`; a shape other than `gears.shape.rectangle` or `gears.shape.rounded_rect`; a rounded shape together with a border width; a rounded shape over a child that converts (a layout or container), since Clay clips to rectangles and only a leaf at the same box can carry the corners
+- `margin`: `draw_empty = false`, or a color that is not solid
+- `fixed` and `flex`: a `spacing_widget` with a spacing other than 0, a negative or fractional spacing
+- `align`: `expand = "outside"` with no second widget, which places the first and third over each other at full size
+- `stack`: a negative or fractional offset or spacing
+- `place`: nothing beyond the common list
 
-The whole drawable stays on the cairo path when its own background is not a solid color, when it has a background image, or when the drawin is shaped (`shape_bounding`, `shape_clip` or `shape_input`): those masks apply to the drawable's own pixels, which a converted container is no longer part of.
+The whole drawable stays on the cairo path when its own background is not a solid color or is fully transparent, when it has a background image, when the drawin is shaped (`shape_bounding`, `shape_clip` or `shape_input`), when the drawin's `opacity` is below 1, or when the drawin hosts the legacy `awesome.systray`. Shapes, opacity and the tray composite apply to the drawable's own pixels as one layer, which a converted tree no longer is.
+
+**Odd leftovers round differently.** The engine floors: `flex` hands out its leftover pixels one at a time from the left, `align` with `expand = "outside"` or `"none"` floors the half beside the middle widget, and `place` floors a centered child's offset. Clay solves in float and rounds at the boundary, so when the space to split is odd a box can sit one pixel to the right of, or one pixel wider than, where the engine put it. Sizes that divide evenly are identical.
+
+**A slot that grows keeps content wider than its share.** The engine gives every `flex` child the same share whatever it holds, and gives `align`'s expanded slots what the fixed ones leave. Clay grows an element up from the size of its own content and never compresses it below that, so a slot whose converted subtree is already wider than its share keeps that width and the slots beside it get what is left. A slot holding a raster leaf has no content of its own and always takes exactly its share, which is every slot whose subtree did not convert.
+
+**A widget that draws outside its own box is clipped to it.** Each degraded subtree draws into a surface the size of its box. The drawable surface used to catch anything a widget painted past its edges; a leaf's surface does not. Where the box the surface was made for and the box Clay solved differ by the pixel above, the surface is placed at the box's top left and the odd row or column is cropped or left transparent, rather than the whole subtree being resampled to fit.
 
 **A margin's `color` draws above its child instead of below it.** The ring is the margin band, and the child is placed inside it, so the two do not overlap unless a widget draws outside its own box.
+
+**A fixed layout that overflows is clipped, not truncated.** The engine stops placing children once one starts past the edge and clamps the last one it places to what is left; Clay places the same children at the same sizes, and the drawin clips them. Nothing visible changes.
 
 **Screenshots include what the renderer draws as a flat color.** `root.content()` and `screen.content` now walk the scene for rectangles as well as buffers, so a converted container's background is in the capture. The same walk replaced `screen.content`'s own buffer pass, which ignored a scene buffer's destination size and scaled HiDPI captures wrong.
 

--- a/declare.c
+++ b/declare.c
@@ -492,38 +492,63 @@ declare_layer_surfaces(Monitor *m)
 	}
 }
 
-/* --- the converted widget chain (widget.h) ---
+/* --- the converted widget tree (widget.h) ---
  *
- * One element per node, each the previous one's only child, so the chain
- * nests exactly as lua/wibox/clay.lua walked it. The outermost is the
- * drawin's own box, fixed and floating like any other leaf here; the rest
- * grow into whatever their parent's padding leaves them, which is the
- * layout wibox's :fit and :layout used to compute.
+ * One element per node, nested as lua/wibox/clay.lua compiled them. The
+ * root is the drawin's own box, fixed and floating like any other leaf here,
+ * and it clips on both axes so a layout that overflows draws nothing outside
+ * the drawin: Clay emits the clip as a SCISSOR pair around the subtree
+ * (clay.h:2121-2123, 2806-2807, 3029-3033) and render.c crops every leaf to it
+ * (buffer_apply_clip). A clip parent also leaves overflowing children at
+ * their size instead of compressing them (clay.h:2305-2311).
  *
- * The id mixes the drawin's registry id with the node's depth, so a chain
- * that grows or shrinks renames nothing above the change and the reconciler
- * keeps the nodes it already has.
+ * Ids follow the path from the root: the root hashes the drawin's registry
+ * id, and a child hashes its index seeded with its parent's id, the shape of
+ * CLAY_IDI_LOCAL (clay.h:92). A widget inserted among its siblings renames
+ * the siblings after it and their subtrees and nothing else, so the rest of
+ * the tree keeps its retained nodes; a preorder index would rename every
+ * node after the insertion point.
+ *
+ * Every node carries the drawin's handle in userData, containers included:
+ * the pointer over a gap between leaves lands on a container's rectangle,
+ * and declare_hit has to resolve that node to the drawin (input.c then takes
+ * drawin-local coordinates from the drawin's own box, not the node's).
  */
 static Clay_ElementId
-widget_node_id(uint32_t id, size_t depth)
+widget_root_id(uint32_t id)
 {
-	return Clay__HashString(CLAY_STRING("drawin.widget"), id,
-		(uint32_t)depth);
+	return Clay__HashString(CLAY_STRING("drawin.widget"), id, 0);
+}
+
+static Clay_ElementId
+widget_child_id(Clay_ElementId parent, uint16_t index)
+{
+	return Clay__HashString(CLAY_STRING("drawin.widget"), index, parent.id);
+}
+
+static Clay_SizingAxis
+widget_sizing(const struct widget_node *n, int axis)
+{
+	return n->fixed[axis] ? CLAY_SIZING_FIXED(n->size[axis])
+		: CLAY_SIZING_GROW(0, n->max[axis]);
 }
 
 static Clay_ElementDeclaration
-widget_node_decl(const struct widget_node *n, uint32_t id, size_t depth)
+widget_node_decl(const struct widget_node *n, Clay_ElementId id, int16_t z,
+	void *userdata)
 {
 	Clay_ElementDeclaration e = {
-		.id = widget_node_id(id, depth),
+		.id = id,
 		.layout = {
-			.sizing = {
-				.width = CLAY_SIZING_GROW(0),
-				.height = CLAY_SIZING_GROW(0),
-			},
+			.sizing = { widget_sizing(n, 0), widget_sizing(n, 1) },
 			.padding = { n->pad[0], n->pad[1], n->pad[2], n->pad[3] },
+			.childGap = n->gap,
+			.childAlignment = { n->align[0], n->align[1] },
+			.layoutDirection = n->vertical
+				? CLAY_TOP_TO_BOTTOM : CLAY_LEFT_TO_RIGHT,
 		},
 		.cornerRadius = { n->radius, n->radius, n->radius, n->radius },
+		.userData = userdata,
 	};
 
 	if (n->bg[3] > 0)
@@ -533,32 +558,52 @@ widget_node_decl(const struct widget_node *n, uint32_t id, size_t depth)
 		e.border.width = (Clay_BorderWidth) {
 			n->bw[0], n->bw[1], n->bw[2], n->bw[3], 0 };
 	}
+	if (n->floating) {
+		/* A stack child: off the flow, at the parent's top left, in the
+		 * drawin's band (a floating element is its own tree root, sorted
+		 * by zIndex and then declaration order, clay.h:2603-2615),
+		 * clipped to the drawin like its siblings (clay.h:2074-2079). */
+		e.floating.attachTo = CLAY_ATTACH_TO_PARENT;
+		e.floating.clipTo = CLAY_CLIP_TO_ATTACHED_PARENT;
+		e.floating.zIndex = z;
+	}
 	return e;
 }
 
-static void
-declare_widget_chain(drawin_t *d, uint32_t id, int16_t z, int x, int y,
-	void *leaf_userdata)
+static size_t
+declare_widget_subtree(drawin_t *d, size_t i, Clay_ElementId id, int16_t z,
+	int x, int y, void *userdata, size_t *leaf)
 {
-	size_t len = d->widget_nodes_len;
+	const struct widget_node *n = &d->widget_nodes[i];
+	Clay_ElementDeclaration e = widget_node_decl(n, id, z, userdata);
+	size_t next = i + 1;
+
+	if (i == 0) {
+		place_fixed(&e, z, x, y, d->width, d->height);
+		e.clip = (Clay_ClipElementConfig) {
+			.horizontal = true, .vertical = true };
+	}
+	if (n->raster && *leaf < d->widget_leaves_len)
+		e.image.imageData = &d->widget_leaves[(*leaf)++];
+
+	Clay__OpenElement();
+	Clay__ConfigureOpenElementPtr(&e);
+	for (uint16_t k = 0; k < n->children; k++)
+		next = declare_widget_subtree(d, next, widget_child_id(id, k),
+			z, x, y, userdata, leaf);
+	Clay__CloseElement();
+	return next;
+}
+
+static void
+declare_widget_tree(drawin_t *d, uint32_t id, int16_t z, int x, int y,
+	void *userdata)
+{
+	size_t leaf = 0;
 
 	d->widget_nodes_declared = true;
-
-	for (size_t i = 0; i < len; i++) {
-		const struct widget_node *n = &d->widget_nodes[i];
-		Clay_ElementDeclaration e = widget_node_decl(n, id, i);
-
-		if (i == 0)
-			place_fixed(&e, z, x, y, d->width, d->height);
-		if (n->raster) {
-			e.image.imageData = &d->content_entry;
-			e.userData = leaf_userdata;
-		}
-		Clay__OpenElement();
-		Clay__ConfigureOpenElementPtr(&e);
-	}
-	while (len-- > 0)
-		Clay__CloseElement();
+	declare_widget_subtree(d, 0, widget_root_id(id), z, x, y, userdata,
+		&leaf);
 }
 
 /* --- drawins as whole-buffer image leaves ---
@@ -598,13 +643,11 @@ declare_drawin(drawin_t *d, Monitor *m, int16_t z)
 		declare_leaf(&b);
 	}
 
-	/* A converted widget chain declares the content leaf itself, inside the
-	 * containers lua/wibox/clay.lua peeled off it. Those draw below the
-	 * leaf, which still covers the whole drawin and is transparent wherever
-	 * they show through. */
+	/* A converted widget tree declares its own leaves, each carrying the
+	 * pixels of one subtree lua/wibox/clay.lua could not express, at the
+	 * box Clay solves for it. */
 	if (d->widget_nodes_len > 0) {
-		declare_widget_chain(d, id, z, x, y,
-			leaf_userdata(handle, opacity));
+		declare_widget_tree(d, id, z, x, y, leaf_userdata(handle, opacity));
 		return;
 	}
 
@@ -685,17 +728,46 @@ declare_scene(Monitor *m)
 	 * C-owned scene nodes in LyrBlock, above this whole band. */
 }
 
+/* The boxes of one subtree, in the preorder the tree table uses, rounded
+ * against the root's own box so a box crossing into Lua is the whole
+ * drawin-local pixel the layout engine would have placed. Edges round, not
+ * the size, so two boxes that share an edge in Clay share it here. */
+static size_t
+widget_boxes_walk(drawin_t *d, size_t i, Clay_ElementId id, int (*boxes)[4],
+	int *n, Clay_BoundingBox root)
+{
+	const struct widget_node *node = &d->widget_nodes[i];
+	Clay_ElementData data = Clay_GetElementData(id);
+	size_t next = i + 1;
+
+	if (data.found && node->widget) {
+		Clay_BoundingBox b = data.boundingBox;
+		int x0 = (int)floorf(b.x - root.x + 0.5f);
+		int y0 = (int)floorf(b.y - root.y + 0.5f);
+
+		boxes[*n][0] = x0;
+		boxes[*n][1] = y0;
+		boxes[*n][2] = (int)floorf(b.x + b.width - root.x + 0.5f) - x0;
+		boxes[*n][3] = (int)floorf(b.y + b.height - root.y + 0.5f) - y0;
+		(*n)++;
+	}
+	for (uint16_t k = 0; k < node->children; k++)
+		next = widget_boxes_walk(d, next, widget_child_id(id, k), boxes,
+			n, root);
+	return next;
+}
+
 int
 declare_widget_boxes(drawin_t *d, int (*boxes)[4])
 {
 	Monitor *m = d->screen ? d->screen->monitor : NULL;
 	struct declare_output *dout = m ? m->declare : NULL;
 	Clay_Context *previous;
-	Clay_BoundingBox root = { 0 };
-	uint32_t id;
+	Clay_ElementId root_id;
+	Clay_ElementData root;
 	int n = 0;
 
-	/* Clay's hashmap answers with the last box an id ever had, so a chain
+	/* Clay's hashmap answers with the last box an id ever had, so a tree
 	 * the declare pass has not reached yet would read back the boxes of
 	 * the one it replaced. Report nothing until it has. */
 	if (!dout || !d->widget_nodes_declared)
@@ -706,25 +778,10 @@ declare_widget_boxes(drawin_t *d, int (*boxes)[4])
 	 * is one lookup per node against the boxes the output drew. */
 	previous = Clay_GetCurrentContext();
 	Clay_SetCurrentContext(dout->desktop.clay);
-	id = (uint32_t)handle_for(d, DECLARE_KIND_DRAWIN);
-
-	for (size_t i = 0; i < d->widget_nodes_len && n < WIDGET_NODES_MAX; i++) {
-		Clay_ElementData data = Clay_GetElementData(widget_node_id(id, i));
-
-		if (!data.found)
-			break;
-		if (i == 0)
-			root = data.boundingBox;
-		/* Clay solves float32; round here, and against the chain's own
-		 * root, so a box crossing into Lua is the whole drawin-local
-		 * pixel the old layout would have placed. */
-		boxes[n][0] = (int)floorf(data.boundingBox.x - root.x + 0.5f);
-		boxes[n][1] = (int)floorf(data.boundingBox.y - root.y + 0.5f);
-		boxes[n][2] = (int)floorf(data.boundingBox.width + 0.5f);
-		boxes[n][3] = (int)floorf(data.boundingBox.height + 0.5f);
-		n++;
-	}
-
+	root_id = widget_root_id((uint32_t)handle_for(d, DECLARE_KIND_DRAWIN));
+	root = Clay_GetElementData(root_id);
+	if (root.found)
+		widget_boxes_walk(d, 0, root_id, boxes, &n, root.boundingBox);
 	Clay_SetCurrentContext(previous);
 	return n;
 }

--- a/declare.h
+++ b/declare.h
@@ -67,11 +67,12 @@ void *declare_handle_get(uint64_t handle, enum declare_kind *kind);
 void declare_handle_drop(void *object);
 
 /* Test hook (awesome._test_widget_boxes): the boxes the last solve gave a
- * drawin's converted widget chain (widget.h), outermost first, drawin-local
- * and rounded. Reads the output's own context, so it reports what the frame
- * drew rather than a second solve of its own, and reports nothing until the
- * declare pass has put the current chain in front of Clay. Writes at most
- * WIDGET_NODES_MAX entries and returns how many. */
+ * drawin's converted widget tree (widget.h), in the tree's preorder, one per
+ * node that stands for a widget, drawin-local and rounded. Reads the output's
+ * own context, so it reports what the frame drew rather than a second solve
+ * of its own, and reports nothing until the declare pass has put the current
+ * tree in front of Clay. Writes at most WIDGET_NODES_MAX entries and returns
+ * how many. */
 int declare_widget_boxes(drawin_t *d, int (*boxes)[4]);
 
 /* Test hook (awesome._test_declare_order): the desktop band's draw order for

--- a/lua/wibox/clay.lua
+++ b/lua/wibox/clay.lua
@@ -1,27 +1,37 @@
 ---------------------------------------------------------------------------
 --- Compile a drawable's widget tree into Clay declarations.
 --
--- The declare pass (declare.c) draws a drawin as one image leaf holding the
--- whole drawable surface. This module peels containers off the front of that
--- leaf: walking down from the root, every widget whose class and properties
--- map onto a Clay declaration becomes one, and the first widget that does not
--- stops the walk. Whatever is left rasters into the same drawable surface it
--- always did and rides as the leaf, now declared inside the converted chain
--- instead of alone.
+-- The declare pass (declare.c) draws a drawin from the tree this module
+-- returns: one Clay element per widget the compile step can express, and one
+-- raster leaf per subtree it cannot, drawn by cairo into the leaf's own
+-- surface (widget.c) and shown at the box Clay solves for it. When nothing
+-- converts the drawable paints itself whole, as it always did.
 --
 -- The walk descends the drawable's `wibox.hierarchy`, which is the structure
--- that will draw the leaf, so the chain can never name a widget the drawing
--- does not reach. It reads no box from it: a node is pure description, Clay
--- solves the chain, and `compile` only says what the chain is.
+-- that draws the leaves, so the tree can never name a widget the drawing does
+-- not reach. It reads no position or size for a node from it: a node is pure
+-- description, Clay solves the tree, and `compile` only says what the tree
+-- is. A raster leaf is described by its preferred size, which is the `:fit`
+-- answer of the widget at the top of the degraded subtree, asked with the
+-- bound its parent's layout would have offered; that bound is the only box
+-- the walk takes from the hierarchy, and only because the engine took the
+-- same one from its own parent.
 --
 -- @module wibox.clay
 ---------------------------------------------------------------------------
 
+local base = require("wibox.widget.base")
 local beautiful = require("beautiful")
 local gcolor = require("gears.color")
 local gshape = require("gears.shape")
+local gtable = require("gears.table")
 local margin_class = require("wibox.container.margin")
 local background_class = require("wibox.container.background")
+local place_class = require("wibox.container.place")
+local fixed_class = require("wibox.layout.fixed")
+local flex_class = require("wibox.layout.flex")
+local align_class = require("wibox.layout.align")
+local stack_class = require("wibox.layout.stack")
 
 local clay = {}
 
@@ -48,24 +58,18 @@ local function solid_rgba(col)
     return { r, g, b, a }
 end
 
---- Clay pads and border widths are whole uint16 pixels.
+--- Clay pads, gaps and border widths are whole uint16 pixels
+-- (clay.h:330-335 padding, 344 childGap, 533-541 border widths).
 local function whole(v)
     return type(v) == "number" and v >= 0 and v <= 65535 and v % 1 == 0
-end
-
-local function padded(node)
-    local pad = node.pad
-
-    return pad ~= nil
-        and (pad[1] > 0 or pad[2] > 0 or pad[3] > 0 or pad[4] > 0)
 end
 
 --- Properties every widget carries that a converted node cannot express.
 --
 -- `visible` and `opacity` are applied by `wibox.hierarchy`, which a converted
 -- node no longer passes through, and a forced size is a `:fit` answer, which
--- a chain of grow-sized elements never asks for. Each stops the walk, so the
--- widget keeps drawing itself.
+-- a node sized by its parent's rule never asks for. Each keeps the widget
+-- drawing itself.
 local function common_convertible(w)
     local p = w._private
 
@@ -101,7 +105,7 @@ local function describe_margin(w)
         return nil
     end
     -- draw_empty=false makes the margin's own size depend on what the child
-    -- fits to. The chain grows instead of fitting, so it has no answer.
+    -- fits to, which is a :fit answer the node never gives.
     if p.draw_empty == false then
         return nil
     end
@@ -143,7 +147,7 @@ local function describe_background(w)
         return nil
     end
     -- A background image is a painter over the whole box, with no Clay
-    -- equivalent short of rastering it, which is what the leaf already does.
+    -- equivalent short of rastering it, which is what a leaf does.
     if p.bgimage then
         return nil
     end
@@ -189,100 +193,449 @@ local function describe_background(w)
     end
 
     -- A background's fg is the source its children draw with, so it rides
-    -- alongside the node rather than in it: the leaf takes the innermost one.
+    -- alongside the node rather than in it: a leaf takes the innermost one.
     return node, p.foreground
 end
 
---- Whether a widget is one of the classes the chain knows at all. Cheap, and
--- separate from `describe` so a tree that can never convert costs two table
--- lookups rather than a walk.
-local function convertible_class(w)
-    return w.fit == margin_class.fit or w.fit == background_class.fit
+--- The hierarchy children of a layout that places its widgets in order, or
+-- nil when they are not the first widgets of the list: a layout that stopped
+-- early still matches, one whose `:layout` is not the class's own does not.
+local function children_in_order(hier, widgets)
+    local children = hier:get_children()
+
+    for i, child in ipairs(children) do
+        if child:get_widget() ~= widgets[i] then
+            return nil
+        end
+    end
+    return children
 end
 
---- The node a widget compiles to, plus any foreground it puts in force, or
--- nil for a widget that keeps drawing itself.
-local function describe(w)
-    if not common_convertible(w) then
+--- What wibox.layout.fixed and flex share: a layout direction and a child
+-- gap, which Clay's childGap (clay.h:344) carries only when the spacing is
+-- whole, not negative, and not a spacing widget, which is a widget placed
+-- between the children rather than a gap.
+-- Returns the node, the placed children and whether the direction is
+-- vertical, or nil when the layout keeps drawing itself.
+local function describe_linear(w, hier, class)
+    local p = w._private
+    local spacing = p.spacing or 0
+
+    if w.layout ~= class.layout or not whole(spacing)
+            or (spacing ~= 0 and p.spacing_widget) then
         return nil
     end
-    if w.fit == margin_class.fit then
-        return describe_margin(w)
+
+    local children = children_in_order(hier, p.widgets)
+
+    if not children then
+        return nil
     end
-    return describe_background(w)
+    return { dir = p.dir, gap = spacing, specs = {} }, children, p.dir == "y"
 end
 
---- Compile the front of a drawable's laid-out widget tree.
+--- wibox.layout.fixed: every child fixed at its `:fit` along the direction,
+-- asked with the space left after the children and gaps before it, and
+-- growing across. The last child grows along too when `fill_space` is set.
 --
--- Returns the node chain outermost first, always ending in the raster leaf,
--- plus the hierarchy the leaf draws (nil when the chain consumed the whole
--- tree), that hierarchy's parent, and the foreground in force where the leaf
--- starts. Returns nil when nothing converts, which leaves the drawable on the
--- path it has always taken: one leaf, painted whole.
+-- A child whose `:fit` is zero along the direction is left out: the engine
+-- places it at zero size and skips its spacing, and Clay's childGap is
+-- added between every pair of children whatever their size
+-- (clay.h:3080-3082). The engine also stops placing children once one
+-- starts past the edge; those are not in the hierarchy, so they are not
+-- here either.
+local function describe_fixed(w, hier, ctx)
+    local node, children, is_y = describe_linear(w, hier, fixed_class)
+
+    if not node then
+        return nil
+    end
+
+    local p = w._private
+    local width, height = hier:get_size()
+    local pos = 0
+
+    for i, child in ipairs(children) do
+        if i == #p.widgets and p.fill_space then
+            node.specs[#node.specs + 1] = { hier = child }
+        else
+            local fw, fh = base.fit_widget(w, ctx, child:get_widget(),
+                is_y and width or width - pos, is_y and height - pos or height)
+            local along = is_y and fh or fw
+
+            if along > 0 then
+                node.specs[#node.specs + 1] =
+                    { hier = child, [is_y and "h" or "w"] = along }
+                pos = pos + along + node.gap
+            end
+        end
+    end
+    return node
+end
+
+--- wibox.layout.flex: every child grows along the direction, with
+-- `max_widget_size` as the ceiling, and across. Clay grows the smallest
+-- children first until they are all equal and then all together
+-- (clay.h:2357-2391), so children of one size share the space evenly; the
+-- engine gives every child the same share whatever its content, so a child
+-- whose converted content is wider than its share keeps that width here and
+-- takes it from the others.
+local function describe_flex(w, hier)
+    local node, children, is_y = describe_linear(w, hier, flex_class)
+    local p = w._private
+
+    if not node or #children ~= #p.widgets then
+        return nil
+    end
+    for i, child in ipairs(children) do
+        node.specs[i] =
+            { hier = child, [is_y and "hmax" or "wmax"] = p.max_widget_size }
+    end
+    return node
+end
+
+--- wibox.layout.align -> three children along the direction, sized as the
+-- `expand` mode says. Empty elements stand in where the engine leaves space:
+-- a grow spacer where a missing second widget would have been, and in
+-- "none" mode a grow wrapper around each outer widget, aligned to its edge,
+-- so the second centers in the whole width as the engine centers it.
 --
--- A node is a table with any of `pad`, `bg`, `border`, `bw`, `radius`; the
--- last one is `{ raster = true }`, the leaf.
+-- A slot that grows starts at the size of what it holds and is only ever
+-- given more (clay.h:1815-1827 sums a child's content, 2357-2391 grows),
+-- and the compress pass will not take it below that content
+-- (clay.h:2334-2338). So a grown slot whose own subtree converted, and
+-- therefore carries fixed children, keeps a content width larger than the
+-- share the engine would have given it, and takes that width from the
+-- slots beside it. A slot holding a raster leaf has no content of its own
+-- and takes exactly its share.
+local function describe_align(w, hier, ctx)
+    local p = w._private
+
+    if w.layout ~= align_class.layout then
+        return nil
+    end
+
+    local is_y = p.dir == "y"
+    local width, height = hier:get_size()
+    local total = is_y and height or width
+    local along = is_y and "h" or "w"
+    local slots = {}
+
+    for _, child in ipairs(hier:get_children()) do
+        local cw = child:get_widget()
+        local slot = cw == p.first and "first" or cw == p.second and "second"
+            or cw == p.third and "third"
+
+        if not slot or slots[slot] then
+            return nil
+        end
+        slots[slot] = child
+    end
+
+    local function fit_along(widget, bound)
+        local fw, fh = base.fit_widget(w, ctx, widget,
+            is_y and width or bound, is_y and bound or height)
+
+        return is_y and fh or fw
+    end
+
+    local specs = {}
+    local node = { dir = p.dir, specs = specs }
+
+    -- "outside" with no second widget gives both outer widgets the whole
+    -- length, one over the other, which two elements in a row cannot say.
+    if p.expand == "outside" and not p.second then
+        if slots.first or slots.third then
+            return nil
+        end
+        return node
+    end
+
+    if p.expand == "inside" or not p.second then
+        -- The outer widgets at their fit, the first bounded by the whole and
+        -- the third by what the first left; the second grows between. With
+        -- no second widget the third still sits at the far edge.
+        local remains = total
+
+        if slots.first then
+            local size = fit_along(p.first, remains)
+
+            remains = remains - size
+            specs[#specs + 1] = { hier = slots.first, [along] = size }
+        end
+        if slots.second then
+            specs[#specs + 1] = { hier = slots.second }
+        elseif not p.second and slots.third then
+            specs[#specs + 1] = {}
+        end
+        if slots.third then
+            specs[#specs + 1] = { hier = slots.third,
+                [along] = fit_along(p.third, remains) }
+        end
+        return node
+    end
+
+    -- "outside" and "none" size the second first, at its fit within the
+    -- whole; a second that wants it all is placed alone at full size.
+    local second = fit_along(p.second, total)
+
+    if second >= total then
+        if slots.second then
+            specs[1] = { hier = slots.second }
+        end
+        return node
+    end
+
+    if p.expand == "outside" then
+        -- The outer widgets take what the second leaves, splitting it
+        -- evenly unless one of them holds converted content wider than its
+        -- half; a missing one leaves its half empty.
+        specs[1] = slots.first and { hier = slots.first } or {}
+        specs[2] = { hier = slots.second, [along] = second }
+        specs[3] = slots.third and { hier = slots.third } or {}
+        return node
+    end
+
+    -- "none": the outer widgets at their fit within half of what the second
+    -- leaves, each pinned to its edge of a half that grows.
+    local half = math.floor((total - second) / 2)
+    local first = slots.first and { hier = slots.first,
+        [along] = fit_along(p.first, half) } or nil
+    local third = slots.third and { hier = slots.third,
+        [along] = fit_along(p.third, half) } or nil
+
+    specs[1] = { children = { first }, align = { x = "left", y = "top" } }
+    specs[2] = { hier = slots.second, [along] = second }
+    specs[3] = { children = { third }, align = is_y
+        and { x = "left", y = "bottom" } or { x = "right", y = "top" } }
+    return node
+end
+
+--- wibox.layout.stack -> one floating element per child, attached to the
+-- stack's top left and sized to it (clay.h:2230-2234 sizes a floating root
+-- with grow sizing to its parent), each drawn over the one before (equal
+-- zIndex, declaration order, clay.h:2603-2615). The stack's spacing and the
+-- accumulated offsets are that element's padding around the child, which is
+-- how the engine shrinks each child: by twice the spacing and by the offset
+-- times the child count. A negative offset would need negative padding, so
+-- it keeps the stack drawing itself.
+local function describe_stack(w, hier)
+    local p = w._private
+    local spacing, ho, vo = p.spacing or 0, p.h_offset or 0, p.v_offset or 0
+
+    if w.layout ~= stack_class.layout
+            or not whole(spacing) or not whole(ho) or not whole(vo) then
+        return nil
+    end
+
+    local children = children_in_order(hier, p.widgets)
+
+    if not children then
+        return nil
+    end
+
+    local n = #p.widgets
+    local specs = {}
+
+    for i, child in ipairs(children) do
+        local k = i - 1
+
+        specs[i] = {
+            float = true,
+            pad = { spacing + k * ho, spacing + (n - k) * ho,
+                spacing + k * vo, spacing + (n - k) * vo },
+            children = { { hier = child } },
+        }
+    end
+
+    return { specs = specs }
+end
+
+--- wibox.container.place -> child alignment, with the child fixed at its
+-- `:fit` on each axis unless `content_fill_*` makes it grow there.
+-- `fill_horizontal` and `fill_vertical` only change the place's own `:fit`,
+-- which is the parent's to ask.
+local function describe_place(w, hier, ctx)
+    local p = w._private
+
+    if w.layout ~= place_class.layout then
+        return nil
+    end
+
+    local node = { specs = {},
+        align = { x = p.halign or "center", y = p.valign or "center" } }
+    local children = hier:get_children()
+
+    if #children == 0 then
+        return node
+    end
+    if #children ~= 1 or children[1]:get_widget() ~= p.widget then
+        return nil
+    end
+
+    local fw, fh = base.fit_widget(w, ctx, p.widget, hier:get_size())
+
+    node.specs[1] = {
+        hier = children[1],
+        w = not p.content_fill_horizontal and fw or nil,
+        h = not p.content_fill_vertical and fh or nil,
+    }
+    return node
+end
+
+--- The classes the tree knows, by the `:fit` they share with every instance.
+-- A subclass that overrides `:fit` is not in here, and one that overrides
+-- `:layout` or a draw callback fails its class's own identity check, which
+-- is why no describer checks `:fit` itself.
+local classes = {
+    [margin_class.fit] = describe_margin,
+    [background_class.fit] = describe_background,
+    [fixed_class.fit] = describe_fixed,
+    [flex_class.fit] = describe_flex,
+    [align_class.fit] = describe_align,
+    [stack_class.fit] = describe_stack,
+    [place_class.fit] = describe_place,
+}
+
+--- The node a widget compiles to, plus any foreground it puts in force, or
+-- nil for a widget that keeps drawing itself. `node.specs`, when set, is how
+-- the widget sizes its children; a container without it gives its children
+-- the whole padded box.
+local function describe(w, hier, ctx)
+    local describe_class = classes[w.fit]
+
+    if not describe_class or not common_convertible(w) then
+        return nil
+    end
+    return describe_class(w, hier, ctx)
+end
+
+--- A raster leaf for the subtree at `hier`: the widget draws itself, with
+-- its parent's transform placing it and `fg` as its source.
+local function leaf(st, hier, parent, fg)
+    st.leaves[#st.leaves + 1] = { hierarchy = hier, parent = parent, fg = fg }
+    return { raster = true }
+end
+
+local compile_node
+
+--- The nodes for a list of child specs: a widget's node with the sizing its
+-- parent decided, or an empty element the parent asked for, which stands for
+-- no widget and is left out of the box readback.
+local function compile_specs(st, specs, hier, fg)
+    local nodes = {}
+
+    for i, spec in ipairs(specs) do
+        local node
+
+        if spec.hier then
+            node = compile_node(st, spec.hier, hier, fg)
+            spec.hier = nil
+            gtable.crush(node, spec)
+        else
+            node = spec
+            node.spacer = true
+            node.children = spec.children
+                and compile_specs(st, spec.children, hier, fg) or nil
+        end
+        nodes[i] = node
+    end
+    return nodes
+end
+
+--- The node tree for the widget at `hier`.
+function compile_node(st, hier, parent, fg)
+    local node, node_fg = describe(hier:get_widget(), hier, st.context)
+
+    if not node then
+        return leaf(st, hier, parent, fg)
+    end
+
+    local specs = node.specs
+    local mark, children = #st.leaves, {}
+
+    node.specs = nil
+    if specs then
+        children = compile_specs(st, specs, hier, node_fg or fg)
+    else
+        -- A container with no sizing rule of its own gives every child the
+        -- whole padded box, which is what a node grows into by default.
+        for i, child in ipairs(hier:get_children()) do
+            children[i] = compile_node(st, child, hier, node_fg or fg)
+        end
+    end
+
+    -- A rounded background clips its children to its shape, and Clay clips
+    -- to rectangles: a SCISSOR command carries a box and nothing else
+    -- (clay.h:2806-2807). A leaf at the same box can carry the radius;
+    -- anything else under a rounded corner keeps the whole widget drawing
+    -- itself, so the leaves its subtree produced go too.
+    if (node.radius or 0) > 0 and #children > 0 then
+        if #children == 1 and children[1].raster and not node.pad then
+            children[1].radius = node.radius
+        else
+            for i = #st.leaves, mark + 1, -1 do
+                st.leaves[i] = nil
+            end
+            return leaf(st, hier, parent, fg)
+        end
+    end
+
+    node.children = children
+    return node
+end
+
+--- Compile a drawable's laid-out widget tree.
+--
+-- Returns the node tree, rooted at the drawable's own background, and the
+-- raster leaves in the tree's preorder, each with the hierarchy it draws,
+-- that hierarchy's parent and the foreground in force. Returns nil when
+-- nothing converts, which leaves the drawable on the path it has always
+-- taken: painted whole.
+--
+-- A node is a table with any of `pad`, `bg`, `border`, `bw`, `radius`, the
+-- sizing `w` and `h` (a fixed number, else the node grows) with `wmax` and
+-- `hmax` as grow ceilings, `dir` ("y" for top to bottom), `gap`, `align`
+-- (`x` and `y`, as wibox.container.place names them), `float` (attached to
+-- the parent's top left, off the flow), `raster` for a leaf, `spacer` for an
+-- element that stands for no widget, and `children`.
 --
 -- @tparam table self The drawable, for its own background, background image
 --  and foreground.
 -- @tparam wibox.hierarchy|nil root The drawable's laid-out widget tree.
--- @treturn[1] table The node chain.
--- @treturn[1] wibox.hierarchy The hierarchy the raster leaf draws.
--- @treturn[1] wibox.hierarchy The leaf's parent, whose transform places it.
--- @treturn[1] cairo.Pattern The foreground in force at the leaf.
+-- @tparam table context The widget context the tree was laid out in.
+-- @treturn[1] table The node tree.
+-- @treturn[1] table The raster leaves, in preorder.
 -- @treturn[2] nil Nothing converted.
-function clay.compile(self, root)
+function clay.compile(self, root, context)
     -- A background image is a painter over the whole drawable, with no Clay
-    -- equivalent short of rastering it, which is what the leaf already does.
+    -- equivalent short of rastering it, which is what painting whole does.
     if not root or self.background_image
-            or not convertible_class(root:get_widget()) then
+            or not classes[root:get_widget().fit] then
         return nil
     end
 
     -- The drawable's own background becomes the outermost rectangle, so it
     -- has to be one Clay can name before anything inside it can convert.
-    local base = solid_rgba(self.background_color)
+    -- It also has to draw: the pointer over a gap between leaves lands on
+    -- it, and a fully transparent rectangle is no element at all.
+    local base_rgba = solid_rgba(self.background_color)
 
-    if not base then
+    if not base_rgba or base_rgba[4] <= 0 then
         return nil
     end
 
-    local chain, h, parent = { { bg = base, radius = 0 } }, root, nil
-    local fg = self.foreground_color
-    -- A rounded background clips its children to its shape. The leaf carries
-    -- that radius instead, which is the same clip only while the leaf's box
-    -- is the rounded element's box, so padding on either side of one ends the
-    -- walk.
-    local radius, padding = 0, false
-
-    while h do
-        local node, node_fg = describe(h:get_widget())
-
-        if not node then
-            break
-        end
-        if (radius > 0 and padded(node))
-                or ((node.radius or 0) > 0 and padding) then
-            break
-        end
-
-        padding = padding or padded(node)
-        radius = math.max(radius, node.radius or 0)
-        fg = node_fg or fg
-        chain[#chain + 1] = node
-        parent, h = h, h:get_children()[1]
-    end
+    local st = { leaves = {}, context = context }
+    local node = compile_node(st, root, nil, self.foreground_color)
 
     -- The root's class matched but its properties did not: the leaf still
     -- covers every pixel it did, so there is nothing to gain and a whole
     -- path to keep off.
-    if #chain == 1 then
+    if node.raster then
         return nil
     end
 
-    chain[#chain + 1] = { raster = true, radius = radius }
-
-    return chain, h, parent, fg
+    return { bg = base_rgba, radius = 0, children = { node } }, st.leaves
 end
 
 return clay

--- a/lua/wibox/drawable.lua
+++ b/lua/wibox/drawable.lua
@@ -64,6 +64,91 @@ local function get_widget_context(self)
     return context
 end
 
+-- The box the layout engine gave each raster leaf, in drawable coordinates:
+-- what sizes the leaf's surface (widget.c), and what Clay has to agree with.
+local function leaf_boxes(leaves)
+    local boxes = {}
+
+    for i, leaf in ipairs(leaves) do
+        local hier = leaf.hierarchy
+        local x, y, w, h = matrix.transform_rectangle(
+            hier:get_matrix_to_device(), 0, 0, hier:get_size())
+
+        boxes[i] = { x = x, y = y, width = w, height = h }
+    end
+    return boxes
+end
+
+-- Whether a leaf's box meets the dirty region, both in drawable
+-- coordinates. The region's rectangles are read once per redraw, so this
+-- costs no allocation per leaf.
+local function touches(rects, box)
+    for _, r in ipairs(rects) do
+        if r[1] < box.x + box.width and box.x < r[1] + r[3]
+                and r[2] < box.y + box.height and box.y < r[2] + r[4] then
+            return true
+        end
+    end
+    return false
+end
+
+-- Paint the raster leaves into their own surfaces, only where the dirty
+-- region touches them, so a clock tick re-rasters the clock and nothing
+-- else. A leaf keeps its surface by its index in the tree, so a subtree
+-- that moved to another index paints whole; its surface may have been
+-- another widget's. A leaf's own matrix is relative to its parent, so the
+-- parent's matrix to the drawable goes on first, after moving the
+-- drawable's origin to the leaf's. The surfaces hold device pixels.
+local function draw_leaves(self, context, leaves, boxes, scale, dirty)
+    local indices = setmetatable({}, { __mode = "k" })
+    local rects, drawn = {}, {}
+
+    for r = 0, dirty:num_rectangles() - 1 do
+        local d = dirty:get_rectangle(r)
+
+        rects[r + 1] = { d.x, d.y, d.width, d.height }
+    end
+
+    for i, leaf in ipairs(leaves) do
+        local box = boxes[i]
+        local whole = self._clay_leaf_indices[leaf.hierarchy] ~= i
+
+        indices[leaf.hierarchy] = i
+        if whole or touches(rects, box) then
+            -- A widget's own draw can make its drawin paint whole (it
+            -- hosts the systray now, its opacity changed), which drops
+            -- every leaf surface from under this loop. That flip asks for
+            -- a complete repaint of its own, so stop and let it run.
+            local native = self.drawable:_clay_leaf_surface(i)
+
+            if not native then
+                break
+            end
+
+            local lcr = cairo.Context(surface.load_silently(native, false))
+
+            lcr:scale(scale, scale)
+            if not whole then
+                for _, r in ipairs(rects) do
+                    lcr:rectangle(r[1] - box.x, r[2] - box.y, r[3], r[4])
+                end
+                lcr:clip()
+            end
+            lcr.operator = cairo.Operator.SOURCE
+            lcr:set_source_rgba(0, 0, 0, 0)
+            lcr:paint()
+            lcr.operator = cairo.Operator.OVER
+            lcr:set_source(leaf.fg)
+            lcr:translate(-box.x, -box.y)
+            lcr:transform(leaf.parent:get_matrix_to_device():to_cairo_matrix())
+            leaf.hierarchy:draw(context, lcr)
+            drawn[i] = true
+        end
+    end
+    self._clay_leaf_indices = indices
+    self.drawable:_clay_leaves_drawn(drawn)
+end
+
 local function do_redraw(self)
     if not self.drawable.valid then
         return
@@ -123,36 +208,52 @@ local function do_redraw(self)
         end
     end
 
-    -- Clip to the dirty area
-    if self._dirty_area:is_empty() then
+    local dirty = self._dirty_area
+    if dirty:is_empty() then
         return
     end
-    for i = 0, self._dirty_area:num_rectangles() - 1 do
-        local rect = self._dirty_area:get_rectangle(i)
+    self._dirty_area = cairo.Region.create()
+
+    -- Compile the widget tree into Clay declarations. The renderer draws
+    -- what converted, and every subtree that did not is a raster leaf with
+    -- a surface of its own; this surface is then not drawn at all. Below
+    -- the empty region check because every property that feeds a node
+    -- dirties the region on its way here.
+    local tree, leaves = wclay.compile(self, self._widget_hierarchy, context)
+    local boxes = tree and leaf_boxes(leaves)
+    local scale = self.drawable:_clay_nodes(tree, boxes)
+    local converted = scale and true or false
+
+    -- Crossing between the two paths invalidates every pixel: this surface
+    -- was never painted while the leaves were drawing, and the leaves are
+    -- new surfaces when the tree converts again, so neither holds what this
+    -- frame's region says it does.
+    if converted ~= self._clay_converted then
+        self._clay_converted = converted
+        self._clay_leaf_indices = {}
+        dirty = cairo.Region.create()
+        dirty:union_rectangle(cairo.RectangleInt {
+            x = 0, y = 0, width = width, height = height
+        })
+    end
+
+    if scale then
+        draw_leaves(self, context, leaves, boxes, scale, dirty)
+        self.drawable:refresh()
+        return
+    end
+
+    -- Clip to the dirty area
+    for i = 0, dirty:num_rectangles() - 1 do
+        local rect = dirty:get_rectangle(i)
         cr:rectangle(rect.x, rect.y, rect.width, rect.height)
     end
-    self._dirty_area = cairo.Region.create()
     cr:clip()
-
-    -- Compile the front of the widget tree into Clay declarations. The
-    -- renderer draws what converted; the rest keeps painting into this
-    -- surface, which rides as the chain's innermost leaf. Below the empty
-    -- region check because every property that feeds a node dirties the
-    -- region on its way here.
-    local chain, leaf, leaf_parent, leaf_fg =
-        wclay.compile(self, self._widget_hierarchy)
-    local converted = self.drawable:_clay_nodes(chain)
 
     -- Draw the background
     cr:save()
 
-    if converted then
-        -- The chain's outermost node is this background, drawn by the
-        -- renderer. What is left here is the leaf, so the surface starts
-        -- empty and shows the chain through wherever the leaf does not draw.
-        cr.operator = cairo.Operator.SOURCE
-        cr:set_source_rgba(0, 0, 0, 0)
-    elseif not capi.awesome.composite_manager_running then
+    if not capi.awesome.composite_manager_running then
         -- This is pseudo-transparency: We draw the wallpaper in the background
         local wallpaper = surface.load_silently(capi.root.wallpaper(), false)
         cr.operator = cairo.Operator.SOURCE
@@ -188,18 +289,7 @@ local function do_redraw(self)
     end
 
     -- Draw the widget
-    if converted then
-        -- Only the leaf: every container above it is a Clay declaration now.
-        -- The leaf's own matrix is relative to its parent, so the parent's
-        -- matrix to the surface goes on first.
-        if leaf then
-            cr:save()
-            cr:set_source(leaf_fg)
-            cr:transform(leaf_parent:get_matrix_to_device():to_cairo_matrix())
-            leaf:draw(context, cr)
-            cr:restore()
-        end
-    elseif self._widget_hierarchy then
+    if self._widget_hierarchy then
         cr:set_source(self.foreground_color)
         self._widget_hierarchy:draw(context, cr)
     end
@@ -425,6 +515,8 @@ function drawable.new(d, widget_context_skeleton, drawable_name)
     ret._need_complete_repaint = true
     ret._need_relayout = true
     ret._dirty_area = cairo.Region.create()
+    ret._clay_leaf_indices = {}
+    ret._clay_converted = false
     setup_signals(ret)
 
     for k, v in pairs(drawable) do

--- a/lua/wibox/init.lua
+++ b/lua/wibox/init.lua
@@ -406,24 +406,6 @@ local function new(args)
     -- Make sure the wibox is drawn at least once
     ret.draw()
 
-    -- Gaining or losing a shape is the one thing that changes whether the
-    -- renderer takes a converted widget chain (widget.c) without also
-    -- redrawing a widget, so it has to ask for the repaint itself. The test
-    -- is on the masks rather than the signal because _apply_shape re-sets
-    -- them on every geometry change, unchanged.
-    local was_shaped = false
-    local function shape_changed()
-        local shaped = (w.shape_bounding or w.shape_clip or w.shape_input) ~= nil
-
-        if shaped ~= was_shaped then
-            was_shaped = shaped
-            ret._drawable._do_complete_repaint()
-        end
-    end
-    for _, prop in ipairs { "shape_bounding", "shape_clip", "shape_input" } do
-        w:connect_signal("property::" .. prop, shape_changed)
-    end
-
     ret:connect_signal("property::geometry", ret._apply_shape)
     ret:connect_signal("property::border_width", ret._apply_shape)
     ret:connect_signal("property::border_color", ret._apply_shape)

--- a/objects/drawable.c
+++ b/objects/drawable.c
@@ -660,38 +660,84 @@ luaA_drawable_refresh(lua_State *L)
 	return 0;
 }
 
-/** Hand the drawable's compiled widget chain to the renderer.
- *
- * lua/wibox/drawable.lua calls this once per redraw with what
- * lua/wibox/clay.lua compiled, or with nil when nothing converted. A false
- * return means the chain was refused (this drawable has no drawin, or the
- * drawin is shaped), and the caller has to paint every pixel itself, which
- * is the path every drawable took before any container converted.
+/** Hand the renderer the converted widget tree.
+ * lua/wibox/drawable.lua calls this once per redraw with the tree
+ * lua/wibox/clay.lua compiled and the layout engine's box for each raster
+ * leaf, or with nil when nothing converted. Returns the scale the leaf
+ * surfaces hold their pixels at, or false when the tree was refused (this
+ * drawable has no drawin, or the drawin paints itself whole), in which case
+ * the caller paints every pixel itself, which is the path every drawable
+ * took before any container converted.
  *
  * \param L The Lua VM state.
- * \param nodes The node chain, or nil.
- * \return true when the renderer took the chain.
+ * \param tree The node tree, or nil.
+ * \param leaves The leaf boxes, drawin-local, in the tree's preorder.
+ * \return The leaf surface scale, or false.
  */
+static drawin_t *
+drawable_drawin(lua_State *L)
+{
+	drawable_t *d = (drawable_t *)lua_touserdata(L, 1);
+
+	return d && d->owner_type == DRAWABLE_OWNER_DRAWIN ? d->owner.drawin : NULL;
+}
+
 static int
 luaA_drawable_clay_nodes(lua_State *L)
 {
 	drawable_t *d = (drawable_t *)lua_touserdata(L, 1);
-	drawin_t *drawin;
+	drawin_t *drawin = drawable_drawin(L);
+	float scale;
 
 	if (!d) {
 		return luaL_error(L, "expected drawable, got %s",
 			lua_typename(L, lua_type(L, 1)));
 	}
 
-	drawin = d->owner_type == DRAWABLE_OWNER_DRAWIN ? d->owner.drawin : NULL;
-	if (!drawin) {
+	scale = d->surface_scale > 0 ? d->surface_scale : 1.0f;
+	/* nil is not a tree, so widget_nodes_set drops whatever was stored
+	 * and answers false, which is the whole of "paint it yourself". */
+	if (!drawin || !widget_nodes_set(L, drawin, 2, 3, scale)) {
 		lua_pushboolean(L, false);
 		return 1;
 	}
-	/* nil is not a chain, so widget_nodes_set drops whatever was stored
-	 * and answers false, which is the whole of "paint it yourself". */
-	lua_pushboolean(L, widget_nodes_set(L, drawin, 2));
+	lua_pushnumber(L, scale);
 	return 1;
+}
+
+/** A leaf's surface, for Lua to draw into: a new reference, owned by the
+ * wrapper Lua makes of it, as with drawable.surface.
+ * \param L The Lua VM state.
+ * \param i The leaf's index in the tree's preorder, from 1.
+ * \return The surface, or nil past the last leaf.
+ */
+static int
+luaA_drawable_clay_leaf_surface(lua_State *L)
+{
+	drawin_t *drawin = drawable_drawin(L);
+	lua_Integer i = luaL_checkinteger(L, 2);
+	cairo_surface_t *s = drawin && i >= 1
+		? widget_leaf_surface(drawin, (size_t)i - 1) : NULL;
+
+	if (s)
+		lua_pushlightuserdata(L, s);
+	else
+		lua_pushnil(L);
+	return 1;
+}
+
+/** Mark the leaves Lua just drew, so the renderer re-rasters exactly those.
+ * \param L The Lua VM state.
+ * \param drawn A table whose keys are the indices of the redrawn leaves.
+ */
+static int
+luaA_drawable_clay_leaves_drawn(lua_State *L)
+{
+	drawin_t *drawin = drawable_drawin(L);
+
+	if (drawin && lua_istable(L, 2))
+		widget_leaves_drawn(L, drawin, 2);
+	return 0;
 }
 
 /* ============================================================================
@@ -798,6 +844,8 @@ drawable_class_setup(lua_State *L)
 		{ "refresh", luaA_drawable_refresh },
 		{ "geometry", luaA_drawable_geometry },
 		{ "_clay_nodes", luaA_drawable_clay_nodes },
+		{ "_clay_leaf_surface", luaA_drawable_clay_leaf_surface },
+		{ "_clay_leaves_drawn", luaA_drawable_clay_leaves_drawn },
 		LUA_OBJECT_META(drawable)
 		{ NULL, NULL }
 	};

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -349,6 +349,14 @@ drawin_update_shadow_entry(drawin_t *d, const shadow_config_t *config)
 }
 
 void
+drawin_mark_dirty(drawin_t *drawin)
+{
+	if (drawin->screen && drawin->screen->monitor
+			&& drawin->screen->monitor->declare)
+		declare_output_mark_dirty(drawin->screen->monitor->declare);
+}
+
+void
 drawin_refresh_drawable(drawin_t *drawin)
 {
 	drawable_t *d;
@@ -367,6 +375,13 @@ drawin_refresh_drawable(drawin_t *drawin)
 	if (!d->surface || !d->refreshed) {
 		return;
 	}
+
+	/* A converted tree draws through its leaves (widget.c): the drawable
+	 * surface holds nothing for the renderer, and the entry only has to
+	 * exist for the declare filter. The frame path is woken by whichever
+	 * of the tree and the leaves changed, not from here. */
+	if (drawin->widget_nodes_len > 0 && drawin->content_entry.native)
+		return;
 
 	work_surface = d->surface;
 
@@ -432,9 +447,7 @@ drawin_refresh_drawable(drawin_t *drawin)
 	/* Wake the frame path: the gen bump above changed declared content.
 	 * Map-then-draw holds through the declare filter, which skips a
 	 * drawin until its entry has pixels. */
-	if (drawin->screen && drawin->screen->monitor
-			&& drawin->screen->monitor->declare)
-		declare_output_mark_dirty(drawin->screen->monitor->declare);
+	drawin_mark_dirty(drawin);
 }
 
 /** Assign screen to drawin based on its position
@@ -1263,8 +1276,7 @@ drawin_border_refresh_single(drawin_t *d)
 	border_surface = d->border_width > 0 ? drawin_render_border(d) : NULL;
 	drawin_entry_set(&d->border_entry, border_surface);
 
-	if (d->screen && d->screen->monitor && d->screen->monitor->declare)
-		declare_output_mark_dirty(d->screen->monitor->declare);
+	drawin_mark_dirty(d);
 }
 
 /** Refresh all visible drawins (AwesomeWM compatibility)
@@ -1542,6 +1554,7 @@ luaA_drawin_set_opacity(lua_State *L, drawin_t *drawin)
 		drawin->opacity = opacity;
 		/* Opacity rides the content leaf's userData word (declare.c) */
 		declare_mark_all_dirty();
+		widget_nodes_gate(L, drawin);
 		luaA_object_emit_signal(L, -3, "property::opacity", 0);
 	}
 	return 0;
@@ -1668,6 +1681,7 @@ luaA_drawin_set_shape_bounding(lua_State *L, drawin_t *drawin)
 		cairo_surface_destroy(drawin->shape_bounding);
 
 	drawin->shape_bounding = copy;
+	widget_nodes_gate(L, drawin);
 
 	/* Trigger redraw to apply shape (Wayland equivalent of xwindow_set_shape) */
 	if (drawin->visible)
@@ -1718,6 +1732,7 @@ luaA_drawin_set_shape_clip(lua_State *L, drawin_t *drawin)
 		cairo_surface_destroy(drawin->shape_clip);
 
 	drawin->shape_clip = copy;
+	widget_nodes_gate(L, drawin);
 
 	/* Trigger redraw to apply shape (Wayland equivalent of xwindow_set_shape) */
 	if (drawin->visible)
@@ -1765,6 +1780,7 @@ luaA_drawin_set_shape_input(lua_State *L, drawin_t *drawin)
 		cairo_surface_destroy(drawin->shape_input);
 
 	drawin->shape_input = copy;
+	widget_nodes_gate(L, drawin);
 
 	/* Note: No redraw needed for input shape - it's checked at input time.
 	 * A 0x0 surface means pass through ALL input (AwesomeWM convention). */

--- a/objects/drawin.h
+++ b/objects/drawin.h
@@ -85,15 +85,19 @@ typedef struct drawin_t {
 	struct image_entry shadow_entry;
 	shadow_config_t shadow_entry_config;
 
-	/* The converted widget chain (widget.h), outermost first and always
-	 * ending in the raster leaf that carries content_entry. NULL while the
-	 * drawable paints itself whole, which is every drawin lua/wibox/clay.lua
-	 * finds nothing to convert in. */
+	/* The converted widget tree (widget.h), in preorder, and its raster
+	 * leaves, in preorder too. NULL while the drawable paints itself whole,
+	 * which is every drawin lua/wibox/clay.lua finds nothing to convert in. */
 	struct widget_node *widget_nodes;
 	size_t widget_nodes_len;
-	/* Whether the declare pass has put this chain in front of Clay yet.
+	struct image_entry *widget_leaves;
+	size_t widget_leaves_len;
+	/* The last answer of widget_nodes_refused(), so a setter that changes
+	 * it can ask for the repaint that moves the drawable across. */
+	bool widget_nodes_refused;
+	/* Whether the declare pass has put this tree in front of Clay yet.
 	 * Clay's element hashmap is persistent and answers a lookup with the
-	 * last box an id ever had, so without this a chain that changed since
+	 * last box an id ever had, so without this a tree that changed since
 	 * the last frame would read back the boxes of the one it replaced. */
 	bool widget_nodes_declared;
 } drawin_t;
@@ -132,6 +136,10 @@ void luaA_drawin_set_strut(lua_State *L, drawin_t *drawin, strut_t strut);
 void luaA_drawin_apply_geometry(drawin_t *drawin);
 /* Hand a renderer image entry a new owned surface (NULL clears it) */
 void drawin_entry_set(struct image_entry *entry, cairo_surface_t *owned);
+
+/* Mark the output this drawin is on stale, so the next frame re-declares it.
+ * A no-op for a drawin with no screen yet, or a screen with no monitor. */
+void drawin_mark_dirty(drawin_t *drawin);
 
 /* Drawin refresh cycle (called from main event loop) */
 void drawin_refresh(void);

--- a/render.c
+++ b/render.c
@@ -226,10 +226,12 @@ void render_set_scale(struct render_state *rs, float scale) {
  * sample 1:1 (no upscale blur) and two tiles sharing a logical edge land on the
  * same device pixel (no seam). origin is the node's output-local logical position
  * ((int)box coordinate); wlroots derives the same offset. At scale 1 this is len. */
-static int device_len(int origin, int len, float scale) {
+int render_device_len(int origin, int len, float scale) {
 	return (int)(round((double)(origin + len) * scale) -
 		round((double)origin * scale));
 }
+
+#define device_len render_device_len
 
 /* Corner radii in device pixels: a rounded corner drawn into a device-sized
  * buffer must scale its arc, or it shrinks (in logical terms) as scale grows. */
@@ -1101,7 +1103,12 @@ static struct cairo_buffer *rasterize_image(Clay_RenderCommand *cmd,
 		rounded_rect_path(cr, 0, 0, w, h, radius);
 		cairo_clip(cr);
 	}
-	cairo_scale(cr, (double)w / entry->width, (double)h / entry->height);
+	/* An exact entry is placed one to one: a box the solver rounded a pixel
+	 * away from the size the surface was made for crops a column or leaves
+	 * one transparent, where scaling would resample the whole leaf. */
+	if (!entry->exact) {
+		cairo_scale(cr, (double)w / entry->width, (double)h / entry->height);
+	}
 	Clay_Color ink = cmd->renderData.image.backgroundColor;
 	if (ink.a > 0) {
 		cairo_set_source_rgba(cr, clay_srgb(ink.r), clay_srgb(ink.g),

--- a/render.h
+++ b/render.h
@@ -76,6 +76,11 @@ void render_set_position(struct render_state *rs, int x, int y);
  * this output's nodes (scale joins the raster cache key). */
 void render_set_scale(struct render_state *rs, float scale);
 
+/* The device length of a logical span, rounded at both edges: what every
+ * raster buffer is sized by, so a surface sized with it lands in its box
+ * without resampling. */
+int render_device_len(int origin, int len, float scale);
+
 /* The userData channel: Clay carries each element's userData word into its
  * render commands untouched, and the renderer retains it per node. The word
  * is a packed integer, never a pointer, so a retained command can never

--- a/render_image.h
+++ b/render_image.h
@@ -32,6 +32,13 @@ struct image_entry {
 	size_t bytes;
 	uint64_t touch;
 	bool decoded, failed;
+	/* The surface already holds its box's pixels at the output scale, so
+	 * the renderer places them one to one instead of scaling them into the
+	 * solved box. A decoded file has a size of its own and is scaled; a
+	 * surface somewm rendered for one box is not, because the solver and
+	 * the layout that sized the surface can round a shared edge a pixel
+	 * apart, and resampling every pixel to absorb that blurs the glyphs. */
+	bool exact;
 };
 
 struct image_cache;

--- a/spec/wibox/clay_spec.lua
+++ b/spec/wibox/clay_spec.lua
@@ -13,8 +13,9 @@ local wclay = require("wibox.clay")
 
 local BG = gcolor("#102030")
 local BG_RGBA = { 0x10/255, 0x20/255, 0x30/255, 1 }
+local context = { dpi = 96 }
 
--- A widget the chain can never convert, so it always ends up on the leaf.
+-- A widget the tree can never convert, so it always ends up on a leaf.
 local function leaf_widget()
     return utils.widget_stub(10, 10)
 end
@@ -27,10 +28,34 @@ local function compile(bg, root, fg)
         foreground_color = fg,
         background_image = nil,
     }
-    local h = root and hierarchy.new({ dpi = 96 }, root, 100, 100,
+    local h = root and hierarchy.new(context, root, 100, 100,
         function() end, function() end, {})
 
-    return wclay.compile(drawable, h)
+    return wclay.compile(drawable, h, context)
+end
+
+-- The node for a widget put under a converted margin, so a widget that
+-- degrades shows up as the margin's raster leaf instead of a nil tree.
+local function layout_node(w)
+    local tree = compile(BG, margin(w, 1, 1, 1, 1), BG)
+
+    return tree.children[1].children[1]
+end
+
+local function degraded(w)
+    return layout_node(w).raster == true
+end
+
+-- The tree's nodes, outermost first, following the only child down: what
+-- the stage 5 chain was, for trees that are still one.
+local function chain(tree)
+    local nodes = {}
+
+    while tree do
+        nodes[#nodes + 1] = tree
+        tree = tree.children and tree.children[1]
+    end
+    return nodes
 end
 
 describe("wibox.clay", function()
@@ -39,17 +64,19 @@ describe("wibox.clay", function()
         assert.is_nil(compile(
             gcolor("linear:0,0:10,0:0,#000000:1,#ffffff"),
             margin(leaf_widget(), 1, 1, 1, 1), BG))
+        assert.is_nil(compile(gcolor("#00000000"),
+            margin(leaf_widget(), 1, 1, 1, 1), BG))
     end)
 
     it("refuses a drawable with a background image", function()
-        local h = hierarchy.new({ dpi = 96 }, margin(leaf_widget(), 1, 1, 1, 1),
+        local h = hierarchy.new(context, margin(leaf_widget(), 1, 1, 1, 1),
             100, 100, function() end, function() end, {})
 
         assert.is_nil(wclay.compile({
             background_color = BG,
             foreground_color = BG,
             background_image = "anything",
-        }, h))
+        }, h, context))
     end)
 
     it("refuses a tree whose root converts nothing", function()
@@ -59,23 +86,26 @@ describe("wibox.clay", function()
 
     it("maps margins onto padding", function()
         local w = leaf_widget()
-        local chain, rest = compile(BG, margin(w, 1, 2, 3, 4), BG)
+        local tree, leaves = compile(BG, margin(w, 1, 2, 3, 4), BG)
+        local nodes = chain(tree)
 
-        assert.is_equal(3, #chain)
-        assert.is_same(BG_RGBA, chain[1].bg)
-        assert.is_same({ 1, 2, 3, 4 }, chain[2].pad)
-        assert.is_nil(chain[2].border)
-        assert.is_true(chain[3].raster)
-        assert.is_equal(w, rest:get_widget())
+        assert.is_equal(3, #nodes)
+        assert.is_same(BG_RGBA, nodes[1].bg)
+        assert.is_same({ 1, 2, 3, 4 }, nodes[2].pad)
+        assert.is_nil(nodes[2].border)
+        assert.is_true(nodes[3].raster)
+        assert.is_equal(1, #leaves)
+        assert.is_equal(w, leaves[1].hierarchy:get_widget())
+        assert.is_equal(BG, leaves[1].fg)
     end)
 
     it("maps a margin color onto a border of the same widths", function()
-        local chain = compile(BG,
-            margin(leaf_widget(), 1, 2, 3, 4, "#ff0000"), BG)
+        local nodes = chain(compile(BG,
+            margin(leaf_widget(), 1, 2, 3, 4, "#ff0000"), BG))
 
-        assert.is_same({ 1, 2, 3, 4 }, chain[2].pad)
-        assert.is_same({ 1, 2, 3, 4 }, chain[2].bw)
-        assert.is_same({ 1, 0, 0, 1 }, chain[2].border)
+        assert.is_same({ 1, 2, 3, 4 }, nodes[2].pad)
+        assert.is_same({ 1, 2, 3, 4 }, nodes[2].bw)
+        assert.is_same({ 1, 0, 0, 1 }, nodes[2].border)
     end)
 
     it("maps a background color and a square border", function()
@@ -84,13 +114,13 @@ describe("wibox.clay", function()
         w.border_width = 2
         w.border_color = "#0000ff"
 
-        local chain = compile(BG, w, BG)
+        local nodes = chain(compile(BG, w, BG))
 
-        assert.is_same({ 0, 1, 0, 1 }, chain[2].bg)
-        assert.is_same({ 0, 0, 1, 1 }, chain[2].border)
-        assert.is_same({ 2, 2, 2, 2 }, chain[2].bw)
-        assert.is_equal(0, chain[2].radius)
-        assert.is_nil(chain[2].pad)
+        assert.is_same({ 0, 1, 0, 1 }, nodes[2].bg)
+        assert.is_same({ 0, 0, 1, 1 }, nodes[2].border)
+        assert.is_same({ 2, 2, 2, 2 }, nodes[2].bw)
+        assert.is_equal(0, nodes[2].radius)
+        assert.is_nil(nodes[2].pad)
     end)
 
     it("pads a background whose border strategy shrinks its child", function()
@@ -100,43 +130,64 @@ describe("wibox.clay", function()
         w.border_color = "#0000ff"
         w.border_strategy = "inner"
 
-        local chain = compile(BG, w, BG)
+        local nodes = chain(compile(BG, w, BG))
 
-        assert.is_same({ 2, 2, 2, 2 }, chain[2].pad)
+        assert.is_same({ 2, 2, 2, 2 }, nodes[2].pad)
     end)
 
     it("maps a rounded rectangle onto a corner radius the leaf shares", function()
-        local chain = compile(BG,
+        local tree = compile(BG,
             background(leaf_widget(), "#00ff00", function(cr, cw, ch)
                 return gshape.rounded_rect(cr, cw, ch)
             end), BG)
 
         -- An inline shape function is not gears.shape.rounded_rect, so it
         -- draws itself: nothing above the leaf converted.
-        assert.is_nil(chain)
+        assert.is_nil(tree)
 
         local w = background(leaf_widget(), "#00ff00")
 
         w:set_shape(gshape.rounded_rect, 8)
-        chain = compile(BG, w, BG)
 
-        assert.is_equal(8, chain[2].radius)
-        assert.is_equal(8, chain[3].radius)
-        assert.is_true(chain[3].raster)
+        local nodes = chain(compile(BG, w, BG))
+
+        assert.is_equal(8, nodes[2].radius)
+        assert.is_equal(8, nodes[3].radius)
+        assert.is_true(nodes[3].raster)
     end)
 
-    it("keeps a rounded background off the chain once a box comes between", function()
+    it("carries a rounded background's radius to a leaf under a margin", function()
         local w = background(leaf_widget(), "#00ff00")
 
         w:set_shape(gshape.rounded_rect, 8)
 
-        local chain = compile(BG, margin(w, 5, 5, 5, 5), BG)
+        local tree, leaves = compile(BG, margin(w, 5, 5, 5, 5), BG)
+        local nodes = chain(tree)
 
-        -- The margin converts; the rounded background under it would clip its
-        -- children to a box the leaf no longer shares, so it stops the walk.
-        assert.is_equal(3, #chain)
-        assert.is_same({ 5, 5, 5, 5 }, chain[2].pad)
-        assert.is_equal(0, chain[3].radius)
+        -- The margin converts, and so does the rounded background under it:
+        -- its leaf sits at the same box, so the leaf's corners are its clip.
+        assert.is_equal(4, #nodes)
+        assert.is_same({ 5, 5, 5, 5 }, nodes[2].pad)
+        assert.is_equal(8, nodes[3].radius)
+        assert.is_true(nodes[4].raster)
+        assert.is_equal(8, nodes[4].radius)
+        assert.is_equal(1, #leaves)
+        assert.is_equal(w, leaves[1].parent:get_widget())
+    end)
+
+    it("keeps a rounded background whole when its child converts", function()
+        local inner = margin(leaf_widget(), 2, 2, 2, 2)
+        local w = background(inner, "#00ff00")
+
+        w:set_shape(gshape.rounded_rect, 8)
+
+        local tree, leaves = compile(BG, w, BG)
+
+        -- The background converts as a class, but its child would be a
+        -- converted margin under a rounded corner: nothing converts, and the
+        -- leaf the margin's subtree produced is gone with it.
+        assert.is_nil(tree)
+        assert.is_nil(leaves)
     end)
 
     it("refuses a rounded background that also has a border", function()
@@ -149,19 +200,21 @@ describe("wibox.clay", function()
         assert.is_nil(compile(BG, w, BG))
     end)
 
-    it("converts a chain of containers down to the first it cannot", function()
+    it("converts containers down to the first it cannot", function()
         local w = leaf_widget()
         local stopper = constraint(margin(w, 2, 2, 2, 2))
-        local chain, rest = compile(BG,
+        local tree, leaves = compile(BG,
             background(margin(stopper, 4, 4, 4, 4), "#00ff00"), BG)
+        local nodes = chain(tree)
 
-        -- background, margin, then the constraint stops the walk; the margin
+        -- background, margin, then the constraint is the leaf; the margin
         -- inside it stays on the leaf with everything below.
-        assert.is_equal(4, #chain)
-        assert.is_same({ 0, 1, 0, 1 }, chain[2].bg)
-        assert.is_same({ 4, 4, 4, 4 }, chain[3].pad)
-        assert.is_true(chain[4].raster)
-        assert.is_equal(stopper, rest:get_widget())
+        assert.is_equal(4, #nodes)
+        assert.is_same({ 0, 1, 0, 1 }, nodes[2].bg)
+        assert.is_same({ 4, 4, 4, 4 }, nodes[3].pad)
+        assert.is_true(nodes[4].raster)
+        assert.is_equal(stopper, leaves[1].hierarchy:get_widget())
+        assert.is_equal(4, leaves[1].parent:get_widget().left)
     end)
 
     it("carries the innermost background foreground to the leaf", function()
@@ -170,12 +223,12 @@ describe("wibox.clay", function()
 
         w.fg = fg
 
-        local _, _, _, leaf_fg = compile(BG, w, BG)
+        local _, leaves = compile(BG, w, BG)
 
-        assert.is_equal(fg, leaf_fg)
+        assert.is_equal(fg, leaves[1].fg)
     end)
 
-    it("stops at a widget whose drawing the chain does not carry", function()
+    it("stops at a widget whose drawing the tree does not carry", function()
         for prop, value in pairs {
             visible = false, opacity = 0.5, forced_width = 20, forced_height = 20,
         } do
@@ -198,6 +251,376 @@ describe("wibox.clay", function()
 
         w.draw_empty = false
         assert.is_nil(compile(BG, w, BG))
+    end)
+end)
+
+describe("wibox.clay fixed", function()
+    local fixed = require("wibox.layout.fixed")
+
+
+    it("maps direction and spacing, children fixed at their fit along it", function()
+        local l = fixed.horizontal(utils.widget_stub(10, 5), utils.widget_stub(20, 5))
+
+        l.spacing = 4
+
+        local node = layout_node(l)
+
+        assert.is_equal("x", node.dir)
+        assert.is_equal(4, node.gap)
+        assert.is_equal(2, #node.children)
+        assert.is_equal(10, node.children[1].w)
+        assert.is_nil(node.children[1].h)
+        assert.is_equal(20, node.children[2].w)
+        assert.is_true(node.children[2].raster)
+
+        local v = layout_node(fixed.vertical(utils.widget_stub(5, 10)))
+
+        assert.is_equal("y", v.dir)
+        assert.is_equal(10, v.children[1].h)
+        assert.is_nil(v.children[1].w)
+    end)
+
+    it("grows the last child when fill_space is set", function()
+        local l = fixed.horizontal(utils.widget_stub(10, 5), utils.widget_stub(20, 5))
+
+        l:fill_space(true)
+
+        local node = layout_node(l)
+
+        assert.is_equal(10, node.children[1].w)
+        assert.is_nil(node.children[2].w)
+    end)
+
+    it("bounds each child's fit by what the ones before it left", function()
+        -- 98 wide inside the margin: the second child is clamped to what is
+        -- left, and the third starts past the edge, so the engine never
+        -- placed it.
+        local l = fixed.horizontal(utils.widget_stub(60, 5),
+            utils.widget_stub(60, 5), utils.widget_stub(60, 5))
+        local node = layout_node(l)
+
+        assert.is_equal(2, #node.children)
+        assert.is_equal(60, node.children[1].w)
+        assert.is_equal(38, node.children[2].w)
+    end)
+
+    it("leaves out a child whose fit is zero along the direction", function()
+        local hidden = utils.widget_stub(10, 5)
+
+        hidden._private.visible = false
+
+        local l = fixed.horizontal(utils.widget_stub(10, 5), hidden,
+            utils.widget_stub(0, 5), utils.widget_stub(20, 5))
+        local node = layout_node(l)
+
+        assert.is_equal(2, #node.children)
+        assert.is_equal(20, node.children[2].w)
+    end)
+
+    it("degrades for a spacing widget, negative spacing and overrides", function()
+        local l = fixed.horizontal(utils.widget_stub(10, 5), utils.widget_stub(10, 5))
+
+        l.spacing = 3
+        l.spacing_widget = utils.widget_stub(3, 5)
+        assert.is_true(degraded(l))
+
+        l = fixed.horizontal(utils.widget_stub(10, 5), utils.widget_stub(10, 5))
+        l.spacing = -2
+        assert.is_true(degraded(l))
+
+        l = fixed.horizontal(utils.widget_stub(10, 5))
+        rawset(l, "layout", function(self, ...) return fixed.layout(self, ...) end)
+        assert.is_true(degraded(l))
+
+        l = fixed.horizontal(utils.widget_stub(10, 5))
+        rawset(l, "fit", function(self, ...) return fixed.fit(self, ...) end)
+        assert.is_true(degraded(l))
+    end)
+end)
+
+describe("wibox.clay flex", function()
+    local flex = require("wibox.layout.flex")
+
+
+    it("grows every child along the direction, with max_widget_size as the ceiling", function()
+        local l = flex.horizontal(utils.widget_stub(10, 5), utils.widget_stub(50, 5))
+
+        l.spacing = 2
+
+        local node = layout_node(l)
+
+        assert.is_equal("x", node.dir)
+        assert.is_equal(2, node.gap)
+        assert.is_equal(2, #node.children)
+        assert.is_nil(node.children[1].w)
+        assert.is_nil(node.children[1].wmax)
+        assert.is_true(node.children[2].raster)
+
+        l.max_widget_size = 30
+        node = layout_node(l)
+        assert.is_equal(30, node.children[1].wmax)
+        assert.is_equal(30, node.children[2].wmax)
+        assert.is_nil(node.children[2].hmax)
+
+        local v = flex.vertical(utils.widget_stub(5, 10))
+
+        v.max_widget_size = 12
+        node = layout_node(v)
+        assert.is_equal("y", node.dir)
+        assert.is_equal(12, node.children[1].hmax)
+    end)
+
+    it("degrades for a spacing widget, negative spacing and overrides", function()
+        local l = flex.horizontal(utils.widget_stub(10, 5), utils.widget_stub(10, 5))
+
+        l.spacing = 3
+        l.spacing_widget = utils.widget_stub(3, 5)
+        assert.is_true(degraded(l))
+
+        l = flex.horizontal(utils.widget_stub(10, 5), utils.widget_stub(10, 5))
+        l.spacing = -2
+        assert.is_true(degraded(l))
+
+        l = flex.horizontal(utils.widget_stub(10, 5))
+        rawset(l, "layout", function(self, ...) return flex.layout(self, ...) end)
+        assert.is_true(degraded(l))
+    end)
+end)
+
+describe("wibox.clay align", function()
+    local align = require("wibox.layout.align")
+
+    -- 98 wide inside the margin.
+
+    local function stub(w)
+        return utils.widget_stub(w, 5)
+    end
+
+    it("inside: outer widgets at their fit, the second grows between", function()
+        local node = layout_node(align.horizontal(stub(10), stub(200), stub(20)))
+
+        assert.is_equal("x", node.dir)
+        assert.is_equal(3, #node.children)
+        assert.is_equal(10, node.children[1].w)
+        assert.is_nil(node.children[2].w)
+        assert.is_equal(20, node.children[3].w)
+        for _, child in ipairs(node.children) do
+            assert.is_true(child.raster)
+            assert.is_nil(child.h)
+        end
+
+        local v = layout_node(align.vertical(utils.widget_stub(5, 10), stub(5), nil))
+
+        assert.is_equal("y", v.dir)
+        assert.is_equal(10, v.children[1].h)
+        assert.is_nil(v.children[1].w)
+    end)
+
+    it("inside: the third's fit is bounded by what the first left", function()
+        local node = layout_node(align.horizontal(stub(60), nil, stub(60)))
+
+        -- No second widget: a grow spacer keeps the third at the far edge.
+        assert.is_equal(3, #node.children)
+        assert.is_equal(60, node.children[1].w)
+        assert.is_true(node.children[2].spacer)
+        assert.is_nil(node.children[2].w)
+        assert.is_equal(38, node.children[3].w)
+    end)
+
+    it("inside: a first that takes everything leaves the rest unplaced", function()
+        local node = layout_node(align.horizontal(stub(200), stub(10), stub(10)))
+
+        assert.is_equal(1, #node.children)
+        assert.is_equal(98, node.children[1].w)
+    end)
+
+    it("outside: the second at its fit, the outer widgets grow", function()
+        local node = layout_node(align.horizontal(stub(10), stub(20), stub(30)))
+        local l = align.horizontal(stub(10), stub(20), stub(30))
+
+        l.expand = "outside"
+        node = layout_node(l)
+        assert.is_equal(3, #node.children)
+        assert.is_nil(node.children[1].w)
+        assert.is_equal(20, node.children[2].w)
+        assert.is_nil(node.children[3].w)
+
+        -- A missing outer widget leaves its half empty.
+        l = align.horizontal(nil, stub(20), stub(30))
+        l.expand = "outside"
+        node = layout_node(l)
+        assert.is_true(node.children[1].spacer)
+        assert.is_nil(node.children[1].w)
+        assert.is_equal(20, node.children[2].w)
+        assert.is_true(node.children[3].raster)
+    end)
+
+    it("outside and none: a second that wants it all is placed alone", function()
+        for _, mode in ipairs { "outside", "none" } do
+            local l = align.horizontal(stub(10), stub(200), stub(30))
+
+            l.expand = mode
+
+            local node = layout_node(l)
+
+            assert.is_equal(1, #node.children, mode)
+            assert.is_true(node.children[1].raster, mode)
+            assert.is_nil(node.children[1].w, mode)
+        end
+    end)
+
+    it("outside without a second widget degrades", function()
+        local l = align.horizontal(stub(10), nil, stub(30))
+
+        l.expand = "outside"
+        assert.is_true(layout_node(l).raster)
+
+        l = align.horizontal(nil, nil, nil)
+        l.expand = "outside"
+        assert.is_equal(0, #layout_node(l).children)
+    end)
+
+    it("none: the second centers in the whole, the outer widgets pinned to their edges", function()
+        local l = align.horizontal(stub(10), stub(20), stub(30))
+
+        l.expand = "none"
+
+        local node = layout_node(l)
+
+        assert.is_equal(3, #node.children)
+        -- Two grow wrappers around the second, each holding one outer widget.
+        assert.is_true(node.children[1].spacer)
+        assert.is_same({ x = "left", y = "top" }, node.children[1].align)
+        assert.is_equal(10, node.children[1].children[1].w)
+        assert.is_equal(20, node.children[2].w)
+        assert.is_same({ x = "right", y = "top" }, node.children[3].align)
+        assert.is_equal(30, node.children[3].children[1].w)
+
+        -- The outer widgets are bounded by half of what the second leaves.
+        l = align.horizontal(stub(60), stub(20), stub(60))
+        l.expand = "none"
+        node = layout_node(l)
+        assert.is_equal(39, node.children[1].children[1].w)
+        assert.is_equal(39, node.children[3].children[1].w)
+
+        -- A missing outer widget leaves its wrapper empty.
+        l = align.horizontal(nil, stub(20), stub(30))
+        l.expand = "none"
+        node = layout_node(l)
+        assert.is_equal(0, #node.children[1].children)
+
+        l = align.vertical(utils.widget_stub(5, 10), utils.widget_stub(5, 20), nil)
+        l.expand = "none"
+        node = layout_node(l)
+        assert.is_same({ x = "left", y = "bottom" }, node.children[3].align)
+        assert.is_equal(10, node.children[1].children[1].h)
+    end)
+
+    it("degrades for an override", function()
+        local l = align.horizontal(stub(10), stub(20), stub(30))
+
+        rawset(l, "layout", function(self, ...) return align.layout(self, ...) end)
+        assert.is_true(layout_node(l).raster)
+    end)
+end)
+
+describe("wibox.clay stack", function()
+    local stack = require("wibox.layout.stack")
+
+
+    it("floats each child over the one before, sized to the stack", function()
+        local a, b = utils.widget_stub(10, 5), utils.widget_stub(20, 5)
+        local node = layout_node(stack(a, b))
+
+        assert.is_equal(2, #node.children)
+        for _, wrapper in ipairs(node.children) do
+            assert.is_true(wrapper.float)
+            assert.is_same({ 0, 0, 0, 0 }, wrapper.pad)
+            assert.is_true(wrapper.spacer)
+            assert.is_equal(1, #wrapper.children)
+            assert.is_true(wrapper.children[1].raster)
+            assert.is_nil(wrapper.children[1].w)
+        end
+
+        local _, leaves = compile(BG, margin(stack(a, b), 1, 1, 1, 1), BG)
+
+        assert.is_equal(a, leaves[1].hierarchy:get_widget())
+        assert.is_equal(b, leaves[2].hierarchy:get_widget())
+    end)
+
+    it("turns spacing and offsets into padding around each child", function()
+        local l = stack(utils.widget_stub(10, 5), utils.widget_stub(20, 5))
+
+        l.spacing = 3
+        l.horizontal_offset = 4
+        l.vertical_offset = 1
+
+        local node = layout_node(l)
+
+        assert.is_same({ 3, 3 + 2 * 4, 3, 3 + 2 * 1 }, node.children[1].pad)
+        assert.is_same({ 3 + 4, 3 + 4, 3 + 1, 3 + 1 }, node.children[2].pad)
+    end)
+
+    it("declares only the first child with top_only", function()
+        local l = stack(utils.widget_stub(10, 5), utils.widget_stub(20, 5))
+
+        l.top_only = true
+
+        local node = layout_node(l)
+
+        assert.is_equal(1, #node.children)
+    end)
+
+    it("degrades for a negative offset and an override", function()
+        local l = stack(utils.widget_stub(10, 5), utils.widget_stub(20, 5))
+
+        l.horizontal_offset = -2
+        assert.is_true(layout_node(l).raster)
+
+        l = stack(utils.widget_stub(10, 5))
+        rawset(l, "layout", function(self, ...) return stack.layout(self, ...) end)
+        assert.is_true(layout_node(l).raster)
+    end)
+end)
+
+describe("wibox.clay place", function()
+    local place = require("wibox.container.place")
+
+
+    it("aligns a child fixed at its fit on both axes", function()
+        local node = layout_node(place(utils.widget_stub(10, 20)))
+
+        assert.is_same({ x = "center", y = "center" }, node.align)
+        assert.is_equal(1, #node.children)
+        assert.is_equal(10, node.children[1].w)
+        assert.is_equal(20, node.children[1].h)
+
+        node = layout_node(place(utils.widget_stub(10, 20), "right", "bottom"))
+        assert.is_same({ x = "right", y = "bottom" }, node.align)
+    end)
+
+    it("grows the child on an axis content_fill_* names", function()
+        local c = place(utils.widget_stub(10, 20))
+
+        c.content_fill_horizontal = true
+
+        local node = layout_node(c)
+
+        assert.is_nil(node.children[1].w)
+        assert.is_equal(20, node.children[1].h)
+
+        c.content_fill_vertical = true
+        node = layout_node(c)
+        assert.is_nil(node.children[1].h)
+    end)
+
+    it("converts with no child, and degrades for an override", function()
+        assert.is_equal(0, #layout_node(place()).children)
+
+        local c = place(utils.widget_stub(10, 20))
+
+        rawset(c, "layout", function(self, ...) return place.layout(self, ...) end)
+        assert.is_true(layout_node(c).raster)
     end)
 end)
 

--- a/systray.c
+++ b/systray.c
@@ -21,6 +21,7 @@
  */
 
 #include "systray.h"
+#include "widget.h"
 #include "globalconf.h"
 #include "color.h"
 #include "objects/drawin.h"
@@ -228,6 +229,7 @@ luaA_systray(lua_State *L)
 
 	if (nargs == 1) {
 		systray_kickout(drawin);
+		widget_nodes_gate(L, drawin);
 		lua_pushinteger(L, systray_count_visible());
 		lua_pushnil(L);
 		return 2;
@@ -243,9 +245,16 @@ luaA_systray(lua_State *L)
 	rows = luaL_optinteger(L, 9, 1);
 
 	if (globalconf.systray.parent != drawin) {
-		if (globalconf.systray.parent)
-			systray_kickout(globalconf.systray.parent);
+		drawin_t *old = globalconf.systray.parent;
+
+		if (old)
+			systray_kickout(old);
 		globalconf.systray.parent = drawin;
+		/* The host paints itself whole (widget.c); the tree is refused
+		 * on the new one and allowed again on the old. */
+		if (old)
+			widget_nodes_gate(L, old);
+		widget_nodes_gate(L, drawin);
 	}
 
 	if (color_init_from_string(&bg, bg_color)) {

--- a/tests/_widget_capture.lua
+++ b/tests/_widget_capture.lua
@@ -1,0 +1,173 @@
+-- Pixel readback for the converted-widget tests: a box of a screen's content
+-- as one string, single pixels out of it, and the comparison of two captures.
+--
+-- Two ways to draw one wibox have to land the same pixels: the converted tree
+-- (Clay rectangles plus raster leaves) and the whole surface painted by cairo.
+-- The drawable goes back to painting whole when it gains a shape or a
+-- background image, so a test converts, captures, sets one of those, and
+-- compares.
+
+local ffi = require("ffi")
+
+ffi.cdef [[
+    void cairo_surface_flush(void *surface);
+    unsigned char *cairo_image_surface_get_data(void *surface);
+    int cairo_image_surface_get_stride(void *surface);
+]]
+
+local base = require("wibox.widget.base")
+local gcolor = require("gears.color")
+local matrix = require("gears.matrix")
+local utils = require("_utils")
+
+local capture = {}
+
+-- A widget the compile step can never convert, with a preferred size: as
+-- wide as asked (or as offered, for math.huge), as tall as offered unless
+-- given, so a fixed layout sizes it and an align or a place has something
+-- to center. Draws one flat color.
+function capture.leaf_widget(width, height, color)
+    local w = base.make_widget()
+
+    rawset(w, "fit", function(_, _, avail_w, avail_h)
+        return math.min(width, avail_w), math.min(height or avail_h, avail_h)
+    end)
+    rawset(w, "draw", function(_, _, cr, w2, h2)
+        cr:set_source(gcolor(color))
+        cr:rectangle(0, 0, w2, h2)
+        cr:fill()
+    end)
+    return w
+end
+
+-- Every widget box in a hierarchy, in the preorder the compile step
+-- declares (an align's children in slot order, because its :layout places
+-- the third before the second), in drawable coordinates. This is what the
+-- layout engine places, and what Clay has to agree with.
+function capture.hierarchy_boxes(h, out)
+    out = out or {}
+
+    local x, y, w, hh = matrix.transform_rectangle(h:get_matrix_to_device(),
+        0, 0, h:get_size())
+
+    out[#out + 1] = { x = x, y = y, width = w, height = hh }
+
+    local children = h:get_children()
+    local widget = h:get_widget()
+
+    if widget.get_first then
+        local by_widget = {}
+
+        for _, child in ipairs(children) do
+            by_widget[child:get_widget()] = child
+        end
+        children = {}
+        for _, slot in ipairs { widget.first, widget.second, widget.third } do
+            children[#children + 1] = by_widget[slot]
+        end
+    end
+    for _, child in ipairs(children) do
+        capture.hierarchy_boxes(child, out)
+    end
+    return out
+end
+
+function capture.assert_box(got, want, what)
+    assert(got, what .. ": no box")
+
+    local ok, err = pcall(utils.assert_geometry, got, want)
+
+    assert(ok, what .. ": " .. tostring(err))
+end
+
+-- A step that runs `setup` once and then waits for the readback to say the
+-- tree did or did not convert. The fallbacks repaint a frame or two later,
+-- so every one of these polls.
+function capture.step_until(get_bar, converted, setup, what)
+    return function(count)
+        if count == 1 then
+            setup()
+        end
+        if (#awesome._test_widget_boxes(get_bar().drawin) > 0) == converted then
+            return true
+        end
+        assert(count < 20, what)
+    end
+end
+
+-- A capture of the box (x, y, width, height) of screen s.
+function capture.new(s, x, y, width, height)
+    local self = { screen = s, x = x, y = y, width = width, height = height }
+
+    return setmetatable(self, { __index = capture })
+end
+
+-- The box's pixels out of a screen capture, as one string.
+function capture:shot()
+    local surface = self.screen.content
+
+    assert(surface, "screen.content returned nothing")
+
+    -- screen.content comes back as an lgi record; the FFI wants the pointer.
+    local raw = surface._native or surface
+
+    ffi.C.cairo_surface_flush(raw)
+
+    local data = ffi.C.cairo_image_surface_get_data(raw)
+    local stride = ffi.C.cairo_image_surface_get_stride(raw)
+    local rows = {}
+
+    for row = self.y, self.y + self.height - 1 do
+        rows[#rows + 1] = ffi.string(data + row * stride + self.x * 4, self.width * 4)
+    end
+    return table.concat(rows)
+end
+
+-- R, G, B of one pixel of a shot, box-local.
+function capture:pixel(shot, x, y)
+    local off = (y * self.width + x) * 4
+
+    return shot:byte(off + 3), shot:byte(off + 2), shot:byte(off + 1)
+end
+
+function capture:assert_pixel(shot, x, y, hex, what)
+    local r, g, b = self:pixel(shot, x, y)
+    local want_r = tonumber(hex:sub(2, 3), 16)
+    local want_g = tonumber(hex:sub(4, 5), 16)
+    local want_b = tonumber(hex:sub(6, 7), 16)
+
+    assert(math.abs(r - want_r) <= 1 and math.abs(g - want_g) <= 1
+        and math.abs(b - want_b) <= 1,
+        string.format("%s at %d,%d: got #%02x%02x%02x, want %s",
+            what, x, y, r, g, b, hex))
+end
+
+-- A step body: the box looks the same now as in `captured`. Retried because
+-- the repaint the fallback needs lands a frame or two later; after twenty
+-- tries the first differing pixel is the failure.
+function capture:compare(count, captured, what)
+    local shot = self:shot()
+
+    if shot == captured then
+        io.stderr:write("[PASS] " .. what .. " draws what the tree drew\n")
+        return true
+    end
+    if count < 20 then
+        return
+    end
+    for y = 0, self.height - 1 do
+        for x = 0, self.width - 1 do
+            local r, g, b = self:pixel(shot, x, y)
+            local wr, wg, wb = self:pixel(captured, x, y)
+
+            assert(r == wr and g == wg and b == wb, string.format(
+                "%s differs at %d,%d: #%02x%02x%02x, converted #%02x%02x%02x",
+                what, x, y, r, g, b, wr, wg, wb))
+        end
+    end
+    error(what .. " differs outside the compared channels")
+end
+
+return capture
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/tests/test-clay-widget-containers.lua
+++ b/tests/test-clay-widget-containers.lua
@@ -11,143 +11,24 @@
 --
 -- Run: make test-one TEST=tests/test-clay-widget-containers.lua
 
-local ffi = require("ffi")
 local runner = require("_runner")
-local utils = require("_utils")
+local capture = require("_widget_capture")
 local wibox = require("wibox")
-local base = require("wibox.widget.base")
 local cairo = require("lgi").cairo
 local gshape = require("gears.shape")
-local matrix = require("gears.matrix")
-
-ffi.cdef [[
-    void cairo_surface_flush(void *surface);
-    unsigned char *cairo_image_surface_get_data(void *surface);
-    int cairo_image_surface_get_stride(void *surface);
-]]
 
 local s = screen[1]
 local BX, BY, BW, BH = 0, 0, 200, 40
 local OUTER, INNER, BORDER = 4, 6, 2
 local BAR_BG, BOX_BG, BORDER_COLOR = "#101010", "#204080", "#ff8000"
 
+local cap = capture.new(s, BX, BY, BW, BH)
 local bar, captured
 
--- A widget the compile step can never convert, so the chain always ends here.
-local function leaf_widget()
-    local w = base.make_widget()
-
-    rawset(w, "fit", function(_, _, width, height) return width, height end)
-    rawset(w, "draw", function(_, _, cr, width, height)
-        cr:set_source_rgb(1, 0, 0)
-        cr:rectangle(0, 0, width, height)
-        cr:fill()
-    end)
-    return w
-end
-
--- Every widget box in the drawable's hierarchy, outermost first, in drawable
--- coordinates. This is what the old layout engine places, and what Clay has
--- to agree with.
-local function hierarchy_boxes()
-    local boxes, h = {}, bar._drawable._widget_hierarchy
-
-    while h do
-        local x, y, w, hh = matrix.transform_rectangle(
-            h:get_matrix_to_device(), 0, 0, h:get_size())
-
-        boxes[#boxes + 1] = { x = x, y = y, width = w, height = hh }
-        h = h:get_children()[1]
-    end
-    return boxes
-end
-
-local function assert_box(got, want, what)
-    assert(got, what .. ": no box")
-
-    local ok, err = pcall(utils.assert_geometry, got, want)
-
-    assert(ok, what .. ": " .. tostring(err))
-end
-
--- The wibar's pixels out of a screen capture, as one string.
-local function capture()
-    local surface = s.content
-
-    assert(surface, "screen.content returned nothing")
-
-    -- screen.content comes back as an lgi record; the FFI wants the pointer.
-    local raw = surface._native or surface
-
-    ffi.C.cairo_surface_flush(raw)
-
-    local data = ffi.C.cairo_image_surface_get_data(raw)
-    local stride = ffi.C.cairo_image_surface_get_stride(raw)
-    local rows = {}
-
-    for y = BY, BY + BH - 1 do
-        rows[#rows + 1] = ffi.string(data + y * stride + BX * 4, BW * 4)
-    end
-    return table.concat(rows)
-end
-
--- R, G, B of one pixel of a capture, drawable-local.
-local function pixel(shot, x, y)
-    local off = (y * BW + x) * 4
-
-    return shot:byte(off + 3), shot:byte(off + 2), shot:byte(off + 1)
-end
-
-local function assert_pixel(shot, x, y, hex, what)
-    local r, g, b = pixel(shot, x, y)
-    local want_r = tonumber(hex:sub(2, 3), 16)
-    local want_g = tonumber(hex:sub(4, 5), 16)
-    local want_b = tonumber(hex:sub(6, 7), 16)
-
-    assert(math.abs(r - want_r) <= 1 and math.abs(g - want_g) <= 1
-        and math.abs(b - want_b) <= 1,
-        string.format("%s at %d,%d: got #%02x%02x%02x, want %s",
-            what, x, y, r, g, b, hex))
-end
-
--- The wibar looks the same painted whole as it does converted. Retried
--- because the repaint the fallback needs lands a frame or two later.
-local function compare(count, what)
-    local shot = capture()
-
-    if shot == captured then
-        io.stderr:write("[PASS] " .. what .. " draws what the chain drew\n")
-        return true
-    end
-    if count < 20 then
-        return
-    end
-    for y = 0, BH - 1 do
-        for x = 0, BW - 1 do
-            local r, g, b = pixel(shot, x, y)
-            local wr, wg, wb = pixel(captured, x, y)
-
-            assert(r == wr and g == wg and b == wb, string.format(
-                "%s differs at %d,%d: #%02x%02x%02x, converted #%02x%02x%02x",
-                what, x, y, r, g, b, wr, wg, wb))
-        end
-    end
-    error(what .. " differs outside the compared channels")
-end
-
 -- A step that runs `setup` once and then waits for the readback to say the
--- tree did or did not convert. The fallbacks repaint a frame or two later,
--- so every one of these polls.
+-- tree did or did not convert.
 local function step_until(converted, setup, what)
-    return function(count)
-        if count == 1 then
-            setup()
-        end
-        if (#awesome._test_widget_boxes(bar.drawin) > 0) == converted then
-            return true
-        end
-        assert(count < 20, what)
-    end
+    return capture.step_until(function() return bar end, converted, setup, what)
 end
 
 local steps = {
@@ -168,7 +49,7 @@ local steps = {
                     {
                         widget = wibox.container.margin,
                         margins = INNER,
-                        leaf_widget(),
+                        capture.leaf_widget(math.huge, nil, "#ff0000"),
                     },
                 },
             }
@@ -182,6 +63,8 @@ local steps = {
     -- Clay's boxes for the chain, against wibox's own.
     function()
         local boxes = awesome._test_widget_boxes(bar.drawin)
+
+        local assert_box = capture.assert_box
 
         assert(#boxes == 5, "expected five nodes, got " .. #boxes)
         assert_box(boxes[1], { x = 0, y = 0, width = BW, height = BH },
@@ -199,7 +82,7 @@ local steps = {
 
         -- The chain's widget nodes are boxes 2 to 5; the hierarchy holds the
         -- same widgets, starting at the outer margin.
-        local want = hierarchy_boxes()
+        local want = capture.hierarchy_boxes(bar._drawable._widget_hierarchy)
 
         for i = 1, #want do
             assert_box(boxes[i + 1], want[i],
@@ -211,14 +94,14 @@ local steps = {
 
     -- What the converted chain draws.
     function()
-        local shot = capture()
+        local shot = cap:shot()
 
-        assert_pixel(shot, 1, 1, BAR_BG, "the drawable's own background")
-        assert_pixel(shot, OUTER + 1, OUTER + 1, BORDER_COLOR,
+        cap:assert_pixel(shot, 1, 1, BAR_BG, "the drawable's own background")
+        cap:assert_pixel(shot, OUTER + 1, OUTER + 1, BORDER_COLOR,
             "the background's border")
-        assert_pixel(shot, OUTER + BORDER + 2, OUTER + BORDER + 2, BOX_BG,
+        cap:assert_pixel(shot, OUTER + BORDER + 2, OUTER + BORDER + 2, BOX_BG,
             "the background's fill")
-        assert_pixel(shot, math.floor(BW / 2), math.floor(BH / 2), "#ff0000",
+        cap:assert_pixel(shot, math.floor(BW / 2), math.floor(BH / 2), "#ff0000",
             "the raster leaf")
         captured = shot
         io.stderr:write("[PASS] the converted chain draws where it should\n")
@@ -232,7 +115,7 @@ local steps = {
         "a shape did not put the drawable back on cairo"),
 
     function(count)
-        return compare(count, "a shaped drawable")
+        return cap:compare(count, captured, "a shaped drawable")
     end,
 
     -- And a background image, the other thing the chain cannot carry.
@@ -244,7 +127,7 @@ local steps = {
     end, "a background image did not put the drawable back"),
 
     function(count)
-        return compare(count, "a background image")
+        return cap:compare(count, captured, "a background image")
     end,
 
     function()

--- a/tests/test-clay-widget-layouts.lua
+++ b/tests/test-clay-widget-layouts.lua
@@ -1,0 +1,187 @@
+-- Test: the bundled bar's layouts convert to Clay declarations and draw what
+-- the layout engine draws.
+--
+-- The tree is the shape of somewmrc.lua's wibar: a stack of an align of two
+-- fixed layouts and a background, and a centered place, with a widget the
+-- compile step can never convert standing in for every textbox and imagebox.
+-- Four things are checked: the tree converts; Clay's box for every node is
+-- the box wibox's own :fit/:layout protocol placed, read back through
+-- awesome._test_widget_boxes(); the pointer over a gap between two leaves
+-- still reaches the wibox; and the screen looks the same converted as it
+-- does painted whole (a shape puts the drawable back on the path where cairo
+-- paints every pixel, and a full-rectangle shape masks nothing away).
+--
+-- Run: make test-one TEST=tests/test-clay-widget-layouts.lua
+
+local runner = require("_runner")
+local capture = require("_widget_capture")
+local wibox = require("wibox")
+local gshape = require("gears.shape")
+
+local s = screen[1]
+local BX, BY, BW, BH = 0, 0, 400, 24
+local GAP = 6
+local BAR_BG, MID_BG = "#101010", "#204080"
+
+local cap = capture.new(s, BX, BY, BW, BH)
+local leaf_widget, assert_box = capture.leaf_widget, capture.assert_box
+local bar, captured
+
+-- Every leaf's own color, well inside its box, plus the gap between two of
+-- them: what the bar looks like whichever path drew it.
+local function assert_bar(shot, what)
+    cap:assert_pixel(shot, 20, 12, "#ff0000", what .. ": the first leaf")
+    cap:assert_pixel(shot, 43, 12, BAR_BG, what .. ": the gap between leaves")
+    cap:assert_pixel(shot, 100, 12, "#00ff00", what .. ": the second leaf")
+    cap:assert_pixel(shot, 200, 2, MID_BG, what .. ": the middle background")
+    cap:assert_pixel(shot, 200, 12, "#00ffff", what .. ": the clock")
+    cap:assert_pixel(shot, 340, 12, "#ffff00", what .. ": the right fixed")
+    cap:assert_pixel(shot, 390, 12, "#ff00ff", what .. ": the last leaf")
+end
+
+local steps = {
+    function(count)
+        if count == 1 then
+            bar = wibox {
+                x = BX, y = BY, width = BW, height = BH,
+                visible = true, screen = s, bg = BAR_BG,
+            }
+            bar:setup {
+                layout = wibox.layout.stack,
+                {
+                    layout = wibox.layout.align.horizontal,
+                    {
+                        layout = wibox.layout.fixed.horizontal,
+                        spacing = GAP,
+                        leaf_widget(40, nil, "#ff0000"),
+                        leaf_widget(60, nil, "#00ff00"),
+                        leaf_widget(30, nil, "#0000ff"),
+                    },
+                    { widget = wibox.container.background, bg = MID_BG },
+                    {
+                        layout = wibox.layout.fixed.horizontal,
+                        leaf_widget(50, nil, "#ffff00"),
+                        leaf_widget(24, nil, "#ff00ff"),
+                    },
+                },
+                {
+                    leaf_widget(70, 16, "#00ffff"),
+                    halign = "center",
+                    widget = wibox.container.place,
+                },
+            }
+        end
+        if #awesome._test_widget_boxes(bar.drawin) > 0 then
+            return true
+        end
+        assert(count < 20, "the bar never converted")
+    end,
+
+    -- Clay's boxes against wibox's own, node for node.
+    function()
+        local boxes = awesome._test_widget_boxes(bar.drawin)
+        local want = capture.hierarchy_boxes(bar._drawable._widget_hierarchy)
+
+        assert(#boxes == #want + 1, string.format(
+            "%d boxes for %d hierarchy nodes and the drawable", #boxes, #want))
+        assert_box(boxes[1], { x = 0, y = 0, width = BW, height = BH },
+            "the drawable's own background")
+        for i = 1, #want do
+            assert_box(boxes[i + 1], want[i],
+                "Clay and wibox disagree at preorder node " .. i)
+        end
+
+        -- The shape: left fixed 40+6+60+6+30 wide, the background between,
+        -- the right fixed 50+24 at the far edge, the clock centered.
+        assert_box(boxes[4], { x = 0, y = 0, width = 142, height = BH }, "the left fixed")
+        assert_box(boxes[8], { x = 142, y = 0, width = 184, height = BH }, "the middle")
+        assert_box(boxes[9], { x = 326, y = 0, width = 74, height = BH }, "the right fixed")
+        assert_box(boxes[13], { x = 165, y = 4, width = 70, height = 16 }, "the clock")
+        io.stderr:write("[PASS] Clay solves the boxes wibox places\n")
+        return true
+    end,
+
+    -- What the converted tree draws.
+    function()
+        local shot = cap:shot()
+
+        assert_bar(shot, "the converted tree")
+        captured = shot
+        io.stderr:write("[PASS] the converted tree draws where it should\n")
+        return true
+    end,
+
+    -- The pointer over the gap between two leaves is over the wibox: the
+    -- container behind the gap resolves to the drawin. Warped twice, since
+    -- the hit test runs against the position before the move.
+    function()
+        mouse.coords({ x = BX + 43, y = BY + 12 })
+        mouse.coords({ x = BX + 43, y = BY + 12 })
+
+        local obj = mouse.object_under_pointer()
+
+        assert(obj == bar.drawin, "over the gap: got " .. tostring(obj) .. ", want the wibox")
+        io.stderr:write("[PASS] a gap between leaves reaches the wibox\n")
+        mouse.coords({ x = 100, y = 100 })
+        return true
+    end,
+
+    -- A settled bar re-declares to nothing.
+    function()
+        awesome._test_redeclare()
+
+        local n = awesome._test_redeclare()
+
+        assert(n == 0, "re-declaring the settled bar mutated " .. n .. " nodes")
+        io.stderr:write("[PASS] an identical frame reconciles to 0 mutations\n")
+        return true
+    end,
+
+    -- A refusal only the compile step sees: a fractional stack spacing is
+    -- not a whole childGap, so nothing converts. Nothing asks for a
+    -- complete repaint on that path, and this surface holds no pixels at
+    -- all while the leaves are drawing, so it has to repaint every one.
+    capture.step_until(function() return bar end, false,
+        function() bar.widget.spacing = 0.5 end,
+        "a fractional spacing did not put the drawable back on cairo"),
+
+    function(count)
+        if pcall(assert_bar, cap:shot(), "the whole-painted bar") then
+            io.stderr:write("[PASS] leaving the converted path repaints whole\n")
+            return true
+        end
+        assert(count < 20, "the bar has holes after it stopped converting")
+    end,
+
+    -- And back: the leaf surfaces are new, so every leaf paints whole even
+    -- where the dirty region does not reach it.
+    capture.step_until(function() return bar end, true,
+        function() bar.widget.spacing = 0 end,
+        "a whole spacing did not convert the tree again"),
+
+    function(count)
+        if pcall(assert_bar, cap:shot(), "the reconverted bar") then
+            io.stderr:write("[PASS] returning to the tree paints every leaf\n")
+            return true
+        end
+        assert(count < 20, "a leaf is blank after the tree converted again")
+    end,
+
+    -- The same tree painted whole.
+    capture.step_until(function() return bar end, false,
+        function() bar.shape = gshape.rectangle end,
+        "a shape did not put the drawable back on cairo"),
+
+    function(count)
+        return cap:compare(count, captured, "a shaped drawable")
+    end,
+
+    function()
+        bar.visible = false
+        return true
+    end,
+}
+
+runner.run_steps(steps)
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/widget.c
+++ b/widget.c
@@ -1,11 +1,12 @@
 /*
- * widget.c - the widget chain lua/wibox/clay.lua compiles
+ * widget.c - the widget tree lua/wibox/clay.lua compiles
  *
- * lua/wibox/clay.lua walks a drawable's widget tree and describes the front
- * of it as a chain of containers Clay can solve. This file reads that
- * description off the Lua stack and stores it on the drawin. It holds no
- * Clay: declaring the chain is declare.c's and drawing it is the renderer's,
- * so a node here is nothing but the numbers Lua handed over.
+ * lua/wibox/clay.lua walks a drawable's widget tree and describes what Clay
+ * can solve as a tree of nodes, with every subtree it cannot express as a
+ * raster leaf. This file reads that description off the Lua stack, stores it
+ * on the drawin, and owns the leaf surfaces Lua draws into. It holds no Clay:
+ * declaring the tree is declare.c's and drawing it is the renderer's, so a
+ * node here is nothing but the numbers Lua handed over.
  */
 
 #include <string.h>
@@ -17,7 +18,10 @@
 #include "widget.h"
 #include "common/util.h"
 #include "declare.h"
+#include "globalconf.h"
 #include "monitor.h"
+#include "render.h"
+#include "objects/drawable.h"
 #include "objects/drawin.h"
 #include "objects/screen.h"
 
@@ -50,10 +54,74 @@ read_quad(lua_State *L, int idx, const char *name, float *out)
 	return ok;
 }
 
+/* An optional number field inside a range, false for one outside it or of
+ * the wrong type. Refusing rather than raising is what lets a malformed
+ * tree fall back to painting whole: an error here unwinds through the
+ * redraw that already dropped its dirty region, leaving the last tree
+ * declared and nothing repainting it. */
+static bool
+read_number(lua_State *L, int idx, const char *name, double min, double max,
+	float *out)
+{
+	bool ok;
+
+	lua_getfield(L, idx, name);
+	if (lua_isnumber(L, -1)) {
+		double v = lua_tonumber(L, -1);
+
+		ok = v >= min && v <= max;
+		*out = (float)v;
+	} else {
+		ok = lua_isnil(L, -1);
+	}
+	lua_pop(L, 1);
+	return ok;
+}
+
+/* One axis of sizing: a number for a fixed size, absent to grow, which is
+ * what a container's only child does. */
+static bool
+read_sizing(lua_State *L, int idx, const char *name, bool *fixed, float *size)
+{
+	bool ok;
+
+	lua_getfield(L, idx, name);
+	*fixed = lua_type(L, -1) == LUA_TNUMBER;
+	*size = *fixed ? (float)lua_tonumber(L, -1) : 0.0f;
+	ok = lua_isnil(L, -1) || (*fixed && *size >= 0);
+	lua_pop(L, 1);
+	return ok;
+}
+
+/* Child alignment on one axis, named as wibox.container.place names it, as
+ * Clay's own enum value: Clay_LayoutAlignmentX and Y both order their
+ * enumerators start, end, center. */
+static bool
+read_align(lua_State *L, int idx, const char *name, uint8_t *out)
+{
+	const char *s;
+	bool ok = true;
+
+	lua_getfield(L, idx, name);
+	s = lua_tostring(L, -1);
+	if (!s || strcmp(s, "left") == 0 || strcmp(s, "top") == 0)
+		*out = 0;
+	else if (strcmp(s, "right") == 0 || strcmp(s, "bottom") == 0)
+		*out = 1;
+	else if (strcmp(s, "center") == 0)
+		*out = 2;
+	else
+		ok = false;
+	lua_pop(L, 1);
+	return ok;
+}
+
 static bool
 read_node(lua_State *L, int idx, struct widget_node *n)
 {
-	float pad[4] = { 0 }, bw[4] = { 0 };
+	float pad[4] = { 0 }, bw[4] = { 0 }, gap = 0;
+	const char *dir;
+	bool ok;
 
 	if (!lua_istable(L, idx))
 		return false;
@@ -69,67 +137,174 @@ read_node(lua_State *L, int idx, struct widget_node *n)
 		n->bw[i] = (uint16_t)bw[i];
 	}
 
-	lua_getfield(L, idx, "radius");
-	n->radius = lua_isnumber(L, -1) ? (float)lua_tonumber(L, -1) : 0.0f;
+	if (!read_number(L, idx, "radius", 0, 1e6, &n->radius)
+			|| !read_number(L, idx, "gap", 0, UINT16_MAX, &gap)
+			|| !read_number(L, idx, "wmax", 0, 1e6, &n->max[0])
+			|| !read_number(L, idx, "hmax", 0, 1e6, &n->max[1]))
+		return false;
+	n->gap = (uint16_t)gap;
+	if (!read_sizing(L, idx, "w", &n->fixed[0], &n->size[0])
+			|| !read_sizing(L, idx, "h", &n->fixed[1], &n->size[1]))
+		return false;
+
+	lua_getfield(L, idx, "align");
+	ok = lua_isnil(L, -1) || (lua_istable(L, -1)
+		&& read_align(L, lua_gettop(L), "x", &n->align[0])
+		&& read_align(L, lua_gettop(L), "y", &n->align[1]));
 	lua_pop(L, 1);
 
+	lua_getfield(L, idx, "dir");
+	dir = lua_tostring(L, -1);
+	n->vertical = dir && strcmp(dir, "y") == 0;
+	lua_pop(L, 1);
+
+	lua_getfield(L, idx, "float");
+	n->floating = lua_toboolean(L, -1);
+	lua_pop(L, 1);
 	lua_getfield(L, idx, "raster");
 	n->raster = lua_toboolean(L, -1);
 	lua_pop(L, 1);
+	lua_getfield(L, idx, "spacer");
+	n->widget = !lua_toboolean(L, -1);
+	lua_pop(L, 1);
 
-	return n->radius >= 0;
+	return ok;
 }
 
-/* The whole array at idx into nodes, or false for anything that is not a
- * chain: a chain holds at least a root and the raster leaf that carries the
- * drawable's own pixels, and the leaf is always last. */
+/* The subtree rooted at the table at idx, in preorder, into nodes. A leaf
+ * has no children; anything else lists them under `children`. */
 static bool
-read_chain(lua_State *L, int idx, struct widget_node *nodes, size_t *out_len)
+read_tree(lua_State *L, int idx, struct widget_node *nodes, size_t *len,
+	size_t *leaves)
 {
-	size_t len;
+	struct widget_node *n;
+	size_t count;
+	bool ok;
 
-	if (!lua_istable(L, idx))
+	/* Two slots per level are live across the recursion (the children
+	 * table and the child), plus what read_node needs at the bottom; a C
+	 * function is only guaranteed LUA_MINSTACK. */
+	if (*len == WIDGET_NODES_MAX || !lua_checkstack(L, 4))
+		return false;
+	n = &nodes[(*len)++];
+	memset(n, 0, sizeof(*n));
+	if (!read_node(L, idx, n))
+		return false;
+	if (n->raster)
+		(*leaves)++;
+
+	lua_getfield(L, idx, "children");
+	ok = lua_isnil(L, -1) || (lua_istable(L, -1) && !n->raster);
+	count = ok ? luaA_rawlen(L, -1) : 0;
+	n->children = (uint16_t)count;
+	for (size_t i = 0; ok && i < count; i++) {
+		lua_rawgeti(L, -1, (int)i + 1);
+		ok = read_tree(L, lua_gettop(L), nodes, len, leaves);
+		lua_pop(L, 1);
+	}
+	lua_pop(L, 1);
+	return ok;
+}
+
+/* Size each leaf's surface for its box, in device pixels rounded at both
+ * edges the way the renderer sizes its buffers. The two cannot always agree
+ * to the pixel: the renderer rounds against the box's output-local origin
+ * and the solver may place the box a fraction from where the layout engine
+ * did, so the entry is marked exact and the renderer places it one to one
+ * rather than resampling it into whatever it solved. A surface whose device
+ * size did not change is kept. */
+static bool
+leaves_set(lua_State *L, drawin_t *d, int idx, size_t count, float scale)
+{
+	if (!lua_istable(L, idx) || luaA_rawlen(L, idx) != count)
 		return false;
 
-	len = luaA_rawlen(L, idx);
-	if (len < 2 || len > WIDGET_NODES_MAX)
-		return false;
+	if (count != d->widget_leaves_len) {
+		for (size_t i = count; i < d->widget_leaves_len; i++)
+			drawin_entry_set(&d->widget_leaves[i], NULL);
+		p_realloc(&d->widget_leaves, count);
+		if (count > d->widget_leaves_len)
+			memset(&d->widget_leaves[d->widget_leaves_len], 0,
+				(count - d->widget_leaves_len)
+					* sizeof(*d->widget_leaves));
+		d->widget_leaves_len = count;
+	}
 
-	memset(nodes, 0, len * sizeof(*nodes));
-	for (size_t i = 0; i < len; i++) {
+	for (size_t i = 0; i < count; i++) {
+		struct image_entry *leaf = &d->widget_leaves[i];
+		float box[4] = { 0 };
 		bool ok;
+		int w, h;
 
 		lua_rawgeti(L, idx, (int)i + 1);
-		ok = read_node(L, lua_gettop(L), &nodes[i]);
+		ok = lua_istable(L, -1)
+			&& read_number(L, -1, "x", -1e6, 1e6, &box[0])
+			&& read_number(L, -1, "y", -1e6, 1e6, &box[1])
+			&& read_number(L, -1, "width", 0, 1e6, &box[2])
+			&& read_number(L, -1, "height", 0, 1e6, &box[3]);
 		lua_pop(L, 1);
 		if (!ok)
 			return false;
+		leaf->exact = true;
+		w = MAX(1, render_device_len((int)box[0], (int)box[2], scale));
+		h = MAX(1, render_device_len((int)box[1], (int)box[3], scale));
+		if (leaf->native && leaf->width == w && leaf->height == h)
+			continue;
+		drawin_entry_set(leaf, cairo_image_surface_create(
+			CAIRO_FORMAT_ARGB32, w, h));
 	}
-	if (!nodes[len - 1].raster)
-		return false;
-
-	*out_len = len;
 	return true;
 }
 
 void
 widget_nodes_clear(drawin_t *d)
 {
+	for (size_t i = 0; i < d->widget_leaves_len; i++)
+		drawin_entry_set(&d->widget_leaves[i], NULL);
+	p_delete(&d->widget_leaves);
+	d->widget_leaves_len = 0;
 	p_delete(&d->widget_nodes);
 	d->widget_nodes_len = 0;
 	d->widget_nodes_declared = false;
 }
 
 bool
-widget_nodes_set(lua_State *L, drawin_t *d, int idx)
+widget_nodes_refused(drawin_t *d)
 {
-	struct widget_node nodes[WIDGET_NODES_MAX];
-	size_t len;
+	return d->shape_bounding || d->shape_clip || d->shape_input
+		|| (d->opacity >= 0 && d->opacity < 1)
+		|| d == globalconf.systray.parent;
+}
 
-	/* A shape is applied to the drawable's own pixels, and a converted
-	 * container is no longer among them. */
-	if (d->shape_bounding || d->shape_clip || d->shape_input
-			|| !read_chain(L, idx, nodes, &len)) {
+void
+widget_nodes_gate(lua_State *L, drawin_t *d)
+{
+	bool refused = widget_nodes_refused(d);
+
+	if (refused == d->widget_nodes_refused)
+		return;
+	d->widget_nodes_refused = refused;
+	if (refused)
+		widget_nodes_clear(d);
+	luaA_object_push(L, d);
+	luaA_object_push_item(L, -1, d->drawable);
+	luaA_object_emit_signal(L, -1, "property::surface", 0);
+	lua_pop(L, 2);
+}
+
+bool
+widget_nodes_set(lua_State *L, drawin_t *d, int idx, int leaves_idx,
+	float scale)
+{
+	/* One scratch tree for every drawin: a redraw reads into it and
+	 * usually finds the stored tree unchanged. */
+	static struct widget_node nodes[WIDGET_NODES_MAX];
+	size_t len = 0, leaves = 0;
+
+	d->widget_nodes_refused = widget_nodes_refused(d);
+	if (d->widget_nodes_refused || !lua_istable(L, idx)
+			|| !read_tree(L, idx, nodes, &len, &leaves)
+			|| !leaves_set(L, d, leaves_idx, leaves, scale)) {
 		widget_nodes_clear(d);
 		return false;
 	}
@@ -138,14 +313,40 @@ widget_nodes_set(lua_State *L, drawin_t *d, int idx)
 			&& memcmp(d->widget_nodes, nodes, len * sizeof(*nodes)) == 0)
 		return true;
 
-	widget_nodes_clear(d);
+	p_delete(&d->widget_nodes);
 	d->widget_nodes = p_new(struct widget_node, len);
 	memcpy(d->widget_nodes, nodes, len * sizeof(*nodes));
 	d->widget_nodes_len = len;
-	/* A container's color or margin can change with no pixel in the
-	 * drawable's surface changing, so the chain has to wake the frame path
-	 * on its own; drawable:refresh() only speaks for the leaf. */
-	if (d->screen && d->screen->monitor && d->screen->monitor->declare)
-		declare_output_mark_dirty(d->screen->monitor->declare);
+	d->widget_nodes_declared = false;
+	/* A container's color or margin can change with no pixel in any leaf
+	 * changing, so the tree has to wake the frame path on its own;
+	 * drawable:refresh() only speaks for the pixels. */
+	drawin_mark_dirty(d);
 	return true;
+}
+
+cairo_surface_t *
+widget_leaf_surface(drawin_t *d, size_t i)
+{
+	if (i >= d->widget_leaves_len)
+		return NULL;
+	return cairo_surface_reference(d->widget_leaves[i].native);
+}
+
+void
+widget_leaves_drawn(lua_State *L, drawin_t *d, int idx)
+{
+	bool any = false;
+
+	for (size_t i = 0; i < d->widget_leaves_len; i++) {
+		lua_rawgeti(L, idx, (int)i + 1);
+		if (lua_toboolean(L, -1)) {
+			cairo_surface_flush(d->widget_leaves[i].native);
+			d->widget_leaves[i].gen++;
+			any = true;
+		}
+		lua_pop(L, 1);
+	}
+	if (any)
+		drawin_mark_dirty(d);
 }

--- a/widget.h
+++ b/widget.h
@@ -5,16 +5,19 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <cairo.h>
 #include <lua.h>
 
 typedef struct drawin_t drawin_t;
 
-/* One converted widget container, as lua/wibox/clay.lua describes it.
+/* One converted widget node, as lua/wibox/clay.lua describes it.
  *
- * The chain is a list, not a tree: conversion walks down from the drawable's
- * root widget and stops at the first node it cannot express, so every node
- * has exactly one child and the last node is always the raster leaf, the
- * drawable's own surface holding whatever the walk did not reach.
+ * The tree is stored in preorder: a node's subtree is the `children` nodes
+ * that follow it, each with its own subtree. A node is pure description: what
+ * it is (direction, sizing, gap, alignment, padding, colors, radius), never
+ * where it is. A raster leaf carries a widget subtree the compile step could
+ * not express, drawn by Lua into a surface of its own (the drawin's
+ * widget_leaves, numbered in preorder too).
  *
  * Colors are straight alpha, 0-1, as everywhere else on this side; an alpha
  * of zero means the node draws no fill or no ring. */
@@ -24,25 +27,55 @@ struct widget_node {
 	float bg[4];
 	float border[4];
 	float radius;
-	bool raster;
+	bool fixed[2];       /* sized to size[] on this axis, else grows */
+	float size[2];
+	float max[2];        /* the grow ceiling per axis, 0 for none */
+	uint8_t align[2];    /* child alignment per axis, Clay_LayoutAlignmentX/Y */
+	uint16_t gap;        /* between children, along the direction */
+	bool vertical;       /* children top to bottom, else left to right */
+	bool floating;       /* attached to the parent's top left, off the flow */
+	bool raster;         /* an image leaf */
+	bool widget;         /* stands for a widget the layout engine also placed */
+	uint16_t children;
 };
 
-/* A chain longer than this is refused rather than truncated. Deep enough
- * that no real config reaches it, and it bounds the per-drawin element
- * count the output's Clay arena has to hold. */
-#define WIDGET_NODES_MAX 32
+/* A tree with more nodes than this is refused rather than truncated. A busy
+ * bar (taglist plus tasklist) is a few hundred nodes; Clay's default context
+ * holds 8192 elements (clay.h:1019), shared by every drawin on the output. */
+#define WIDGET_NODES_MAX 1024
 
-/* Read a chain from the array at absolute stack index idx (what
- * lua/wibox/clay.lua returns) and store it on d, replacing whatever was
- * there. Returns false
- * and stores nothing when the chain is malformed or the drawin cannot take
- * one, which is Lua's signal to paint the whole drawable itself.
- *
- * A shaped drawin is refused: shape_bounding and shape_clip are applied to
- * the drawable's own pixels (objects/drawin.c), which a converted container
- * is no longer part of, and shape_input's pass-through would be swallowed by
- * the converted node's scene rect, which takes input everywhere it draws. */
-bool widget_nodes_set(lua_State *L, drawin_t *d, int idx);
+/* Whether d has to paint itself whole: shape_bounding and shape_clip are
+ * applied to the drawable's own pixels (objects/drawin.c), which a converted
+ * node is no longer part of; shape_input's pass-through would be swallowed by
+ * a converted node's scene rect, which takes input everywhere it draws; a
+ * translucent drawin blends once as one layer, where a tree of nodes each
+ * carrying the opacity would blend every overlap twice; and the legacy tray
+ * (awesome.systray) composites into the drawable's pixels. */
+bool widget_nodes_refused(drawin_t *d);
+
+/* For the setters that change that answer: when it flips, drop the tree and
+ * ask Lua for a complete repaint (property::surface on the drawable), so the
+ * drawable moves between painting whole and converting without a widget
+ * having to redraw first. */
+void widget_nodes_gate(lua_State *L, drawin_t *d);
+
+/* Read a tree from the table at absolute stack index idx (what
+ * lua/wibox/clay.lua returns) and the leaf boxes at leaves_idx, and store
+ * them on d, replacing whatever was there. Returns false and stores nothing
+ * when the tree is malformed or the drawin is refused, which is Lua's signal
+ * to paint the whole drawable itself. Leaf surfaces hold device pixels with
+ * no device scale set, like every other image entry; a kept surface keeps
+ * its pixels, so Lua repaints only what its dirty region says. */
+bool widget_nodes_set(lua_State *L, drawin_t *d, int idx, int leaves_idx,
+	float scale);
 void widget_nodes_clear(drawin_t *d);
+
+/* A new reference to leaf i's surface, for Lua to draw into and own the
+ * reference of (the drawable.surface convention); NULL past the last leaf. */
+cairo_surface_t *widget_leaf_surface(drawin_t *d, size_t i);
+
+/* Bump the generation of every leaf whose index is a key in the table at
+ * idx, so the renderer re-rasters exactly the leaves Lua redrew. */
+void widget_leaves_drawn(lua_State *L, drawin_t *d, int idx);
 
 #endif


### PR DESCRIPTION
## Description
A drawable's widget tree compiles to a Clay tree with branching. Every subtree the compile step cannot express draws itself into a raster leaf, placed at the box Clay solves for it. The bundled bar converts, and a converted bar draws the same pixels as that bar painted whole.

Converts:
- `wibox.layout.fixed`, `wibox.layout.flex`, `wibox.container.place`: direct mapping.
- `wibox.layout.align`: empty grow elements stand in for the space the engine leaves; `"none"` pins each outer widget inside a grow element.
- `wibox.layout.stack`: one floating element per child, sized to the stack, with spacing and offsets as padding.

Paints itself instead, with no deprecation warning:
- any subclass overriding `:fit`, `:layout` or a draw callback, the systray widget included
- a `spacing_widget`, negative spacing or offsets, `align` with `expand = "outside"` and no second widget
- a drawin that is shaped, translucent, or hosts the legacy `awesome.systray`
